### PR TITLE
Remove unnecessary checks from `liquidityMathAddDelta` function

### DIFF
--- a/pool/liquidity_math.gno
+++ b/pool/liquidity_math.gno
@@ -3,15 +3,11 @@ package pool
 import "gno.land/p/demo/ufmt"
 
 func liquidityMathAddDelta(x bigint, y bigint) bigint {
-	if y < 0 {
-		z := x - (-y)
-		requireUnsigned(z, ufmt.Sprintf("[POOL] liquidity_math.gno__liquidityMathAddDelta() #1 || expected z(%d) >= 0", z))
-		require(z < x, ufmt.Sprintf("[POOL] liquidity_math.gno__liquidityMathAddDelta() || expected z(%d) < x(%d)", z, x))
-		return z
-	} else {
-		z := x + y
-		requireUnsigned(z, ufmt.Sprintf("[POOL] liquidity_math.gno__liquidityMathAddDelta() #2 || expected z(%d) >= 0", z))
-		require(z >= x, ufmt.Sprintf("[POOL] liquidity_math.gno__liquidityMathAddDelta() || expected z(%d) >= x(%d)", z, x))
-		return z
-	}
+    z := x + y
+
+    if z < 0 {
+        panic(ufmt.Sprintf("[POOL] liquidity_math.gno__liquidityMathAddDelta() || Expected z(%d) to be non-negative", z))
+    }
+
+    return z
 }

--- a/pool/liquidity_math_test.gno
+++ b/pool/liquidity_math_test.gno
@@ -1,0 +1,53 @@
+package pool
+
+import (
+    "testing"
+    "gno.land/p/demo/ufmt"
+)
+
+func TestLiquidityMathAddDelta(t *testing.T) {
+    testCases := []struct {
+        x bigint
+        y bigint
+        expected bigint
+		isErr bool
+    }{
+		{-1000, -500, -1500, true},
+		{-1000, 500, -500, true},
+		{-200, -100, -300, true},
+		{-200, 100, -100, true},
+		{-100, -50, -150, true},
+		{-100, 50, -50, true},
+		{0, -100, -100, true},
+		{0, 0, 0, false},
+		{10, -5, 5, false},
+		{10, 5, 15, false},
+		{100, -50, 50, false},
+		{100, 50, 150, false},
+		{200, -100, 100, false},
+		{200, 100, 300, false},
+		{1000, -500, 500, false},
+		{1000, 500, 1500, false},
+	}
+
+    for i, tc := range testCases {
+        func() {
+            defer func() {
+                if r := recover(); r != nil {
+                    if !tc.isErr {
+                        t.Errorf("Test case %d failed: x=%d, y=%d, expected=%d, got panic but didn't expect one", i+1, tc.x, tc.y, tc.expected)
+                    }
+                } else {
+                    if tc.isErr {
+                        t.Errorf("Test case %d failed: x=%d, y=%d, expected panic but didn't get one", i+1, tc.x, tc.y)
+                    }
+                }
+            }()
+
+            result := liquidityMathAddDelta(tc.x, tc.y)
+            if result != tc.expected && !tc.isErr {
+                t.Errorf("Test case %d failed: x=%d, y=%d, expected=%d, got=%d", i+1, tc.x, tc.y, tc.expected, result)
+            }
+        }()
+    }
+}


### PR DESCRIPTION
## Description

When the result(`z`) became negative is generally due to the incorrect input values. For example, if `x` is negative and `y` is a positive number that is less than the absolute value of that negative number (e.g., x=-100, y=50). Here, `z` turn out to be negative value(-50). Another case is when both input values are negative.

So I think it's sufficient to simply check that `z` is negative.

