### PR TITLE
hotfix: remove unused variable (results deploy error)

### DIFF
--- a/position/position.gno
+++ b/position/position.gno
@@ -551,9 +551,6 @@ func CollectFee(tokenId uint64) (uint64, string, string, string) { // tokenId, t
 		consts.MAX_UINT64,
 	)
 
-	amount0Uint := u256.MustFromDecimal(amount0)
-	amount1Uint := u256.MustFromDecimal(amount1)
-
 	positions[tokenId] = position
 
 	// handle withdrawal fee


### PR DESCRIPTION
## fix
1. remove unused variable (results deploy error)
> it was used, but was meant to be removed from previous pr #234 