### PR TITLE
GSW-1195 fix: cannot increase liquidity for burned position

### DIFF
--- a/position/_TEST_/__TEST_0_INIT_VARS_HELPERS_test.gno
+++ b/position/_TEST_/__TEST_0_INIT_VARS_HELPERS_test.gno
@@ -61,6 +61,19 @@ func shouldPanic(t *testing.T, f func()) {
 	f()
 }
 
+func shouldPanicWithMsg(t *testing.T, f func(), msg string) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("The code did not panic")
+		} else {
+			if r != msg {
+				t.Errorf("excepted panic(%v), got(%v)", msg, r)
+			}
+		}
+	}()
+	f()
+}
+
 func ugnotBalanceOf(addr std.Address) uint64 {
 	testBanker := std.GetBanker(std.BankerTypeRealmIssue)
 

--- a/position/_TEST_/__TEST_position_increase_burned_position_test.gnoA
+++ b/position/_TEST_/__TEST_position_increase_burned_position_test.gnoA
@@ -1,0 +1,139 @@
+package position
+
+import (
+	"std"
+	"testing"
+
+	"gno.land/r/demo/gnoswap/common"
+	"gno.land/r/demo/gnoswap/consts"
+
+	"gno.land/r/demo/bar"
+	"gno.land/r/demo/foo"
+	"gno.land/r/demo/gns"
+
+	pl "gno.land/r/demo/pool"
+)
+
+// 1. Create Pool
+func TestPoolInitCreatePool(t *testing.T) {
+	std.TestSetRealm(gsaRealm)
+
+	gns.Approve(a2u(consts.POOL_ADDR), consts.POOL_CREATION_FEE)
+	pl.CreatePool(barPath, fooPath, fee500, common.TickMathGetSqrtRatioAtTick(10000).ToString()) // x2.71814592682522526700950038502924144268035888671875
+	// ---       event: {GNOSWAP gno.land/r/demo/pool CreatePool [{m_callType DIRECT} {m_origCaller g13f63ua8uhmuf9mgc0x8zfz04yrsaqh7j78vcgq} {m_prevRealm } {p_poolPath gno.land/r/demo/bar:gno.land/r/demo/foo:500}]}
+}
+
+func TestMintPosition(t *testing.T) {
+	std.TestSetRealm(gsaRealm)
+	bar.Approve(a2u(consts.POOL_ADDR), 18394892)
+	foo.Approve(a2u(consts.POOL_ADDR), 50000000)
+
+	tokenId, liquidity, amount0, amount1 := Mint(
+		barPath,
+		fooPath,
+		fee500,
+		8000,
+		12000,
+		"50000000",
+		"50000000",
+		"0",
+		"0",
+		max_timeout,
+		gsa.String(),
+	)
+	// ---       event: {GNOSWAP gno.land/r/demo/position Mint [{m_callType DIRECT} {m_origCaller g13f63ua8uhmuf9mgc0x8zfz04yrsaqh7j78vcgq} {m_prevRealm } {p_poolPath gno.land/r/demo/bar:gno.land/r/demo/foo:500} {p_tickLower 8000} {p_tickUpper 12000} {tokenId 1} {liquidity 318704392} {amount0 18394892} {amount1 50000000}]}
+	shouldEQ(t, tokenId, 1)
+	shouldEQ(t, getNextId(), 2)
+	shouldEQ(t, amount0, "18394892")
+	shouldEQ(t, amount1, "50000000")
+}
+
+func TestIncreaseLiquidity(t *testing.T) {
+	std.TestSetRealm(gsaRealm)
+	bar.Approve(a2u(consts.POOL_ADDR), 3678979)
+	foo.Approve(a2u(consts.POOL_ADDR), 10000000)
+
+	pool := getPoolFromLpTokenId(uint64(1))
+	oldLiquidity := pool.PoolGetLiquidity()
+
+	_, _, m0, m1, _ := IncreaseLiquidity(
+		uint64(1),   // tokenId
+		"10000000",  // amount0Desired
+		"10000000",  // amount1Desired
+		"0",         // amount0Min
+		"0",         // amount1Min
+		max_timeout, // deadline
+	)
+	// ---       event: {GNOSWAP gno.land/r/demo/position IncreaseLiquidity [{m_callType DIRECT} {m_origCaller g13f63ua8uhmuf9mgc0x8zfz04yrsaqh7j78vcgq} {m_prevRealm } {p_tokenId 1} {poolPath gno.land/r/demo/bar:gno.land/r/demo/foo:500} {liquidity 63740878} {amount0 3678979} {amount1 10000000}]}
+
+	shouldEQ(t, m0, "3678979")
+	shouldEQ(t, m1, "10000000")
+
+	newLiquidity := pool.PoolGetLiquidity()
+
+	shouldEQ(t, newLiquidity.Gt(oldLiquidity), true)
+}
+
+func TestDecreaseLiquidity(t *testing.T) {
+	std.TestSetOrigCaller(gsa)
+
+	oldLiquidity := getPoolFromLpTokenId(uint64(1)).PoolGetLiquidity()
+
+	DecreaseLiquidity(
+		uint64(1),   // tokenId
+		50,          // liquidityRatio
+		"0",         // amount0Min
+		"0",         // amount1Min
+		max_timeout, // deadline
+		false,       // unwrapResult
+	)
+	// ---       event: {GNOSWAP gno.land/r/demo/pool HandleWithdrawalFee [{m_callType INDIRECT} {m_origCaller g13f63ua8uhmuf9mgc0x8zfz04yrsaqh7j78vcgq} {m_prevRealm gno.land/r/demo/position} {p_tokenId 1} {p_token0Path gno.land/r/demo/bar} {p_token1Path gno.land/r/demo/foo} {fee0Amount 0} {fee1Amount 0}]}
+	// ---       event: {GNOSWAP gno.land/r/demo/position CollectFee [{m_callType DIRECT} {m_origCaller g13f63ua8uhmuf9mgc0x8zfz04yrsaqh7j78vcgq} {m_prevRealm } {p_tokenId 1} {fee0 0} {fee1 0} {poolPath gno.land/r/demo/bar:gno.land/r/demo/foo:500}]}
+	// ---       event: {GNOSWAP gno.land/r/demo/position DecreaseLiquidity [{m_callType DIRECT} {m_origCaller g13f63ua8uhmuf9mgc0x8zfz04yrsaqh7j78vcgq} {m_prevRealm } {p_tokenId 1} {p_liquidityRatio 50} {poolPath gno.land/r/demo/bar:gno.land/r/demo/foo:500} {liquidity 191222635} {fee0 0} {fee1 0} {amount0 12153659} {amount1 26993526}]
+
+	newLiquidity := getPoolFromLpTokenId(uint64(1)).PoolGetLiquidity()
+	shouldEQ(t, true, newLiquidity.Lt(oldLiquidity))
+
+	// check fee left
+	tokenId, fee0, fee1, poolPath := CollectFee(1)
+	// ---       event: {GNOSWAP gno.land/r/demo/pool HandleWithdrawalFee [{m_callType INDIRECT} {m_origCaller g13f63ua8uhmuf9mgc0x8zfz04yrsaqh7j78vcgq} {m_prevRealm gno.land/r/demo/position} {p_tokenId 1} {p_token0Path gno.land/r/demo/bar} {p_token1Path gno.land/r/demo/foo} {fee0Amount 0} {fee1Amount 0}]}
+	// ---       event: {GNOSWAP gno.land/r/demo/position CollectFee [{m_callType DIRECT} {m_origCaller g13f63ua8uhmuf9mgc0x8zfz04yrsaqh7j78vcgq} {m_prevRealm } {p_tokenId 1} {fee0 0} {fee1 0} {poolPath gno.land/r/demo/bar:gno.land/r/demo/foo:500}]}
+
+	shouldEQ(t, tokenId, uint64(1))
+	shouldEQ(t, fee0, "0")
+	shouldEQ(t, fee1, "0")
+
+	position := positions[uint64(1)]
+	shouldEQ(t, position.burned, false) // not burned yet
+}
+
+func TestDecreaseLiquidityBurnedPosition(t *testing.T) {
+	std.TestSetOrigCaller(gsa)
+
+	// burn it
+	DecreaseLiquidity(
+		uint64(1),   // tokenId
+		100,         // liquidityRatio
+		"0",         // amount0Min
+		"0",         // amount1Min
+		max_timeout, // deadline
+		true,        // unwrapResult
+	)
+	position := positions[uint64(1)]
+	shouldEQ(t, position.burned, true) // it is burned
+
+	shouldPanicWithMsg(
+		t,
+		func() {
+			IncreaseLiquidity(
+				uint64(1),   // tokenId
+				"10000000",  // amount0Desired
+				"10000000",  // amount1Desired
+				"0",         // amount0Min
+				"0",         // amount1Min
+				max_timeout, // deadline
+			)
+		},
+		"[POSITION] position.gno__increaseLiquidity() || cannot increase liquidity for burned position(1)",
+	)
+}

--- a/position/position.gno
+++ b/position/position.gno
@@ -85,7 +85,6 @@ func Mint(
 			wrap(ugnotSent)
 
 			newUserWugnotBalance := wugnot.BalanceOf(a2u(std.GetOrigCaller()))
-
 			if (newUserWugnotBalance - oldUserWugnotBalance) != ugnotSent {
 				panic(ufmt.Sprintf("[POSITION] position.gno__Mint() || wugnot sent(%d) != wugnot received(%d)", ugnotSent, newUserWugnotBalance-oldUserWugnotBalance))
 			}
@@ -211,6 +210,12 @@ func IncreaseLiquidity(
 
 	// wrap if target pool has wugnot
 	position := positions[tokenId]
+
+	// if position is burned, cannot increase liquidity
+	if position.burned {
+		panic(ufmt.Sprintf("[POSITION] position.gno__increaseLiquidity() || cannot increase liquidity for burned position(%d)", tokenId))
+	}
+
 	pToken0, pToken1, _ := poolKeyDivide(position.poolKey)
 
 	isToken0Wugnot := pToken0 == consts.WRAPPED_WUGNOT


### PR DESCRIPTION
## fix
1. if target position is `burned`, can not increase liquidity