### PR TITLE
GSW-1399 fix do not use existing wugnot balance when swapping ugnot

### DIFF
--- a/__local/test/all_test_data.mk
+++ b/__local/test/all_test_data.mk
@@ -32,11 +32,11 @@ INCENTIVE_END := $(shell expr $(TOMORROW_MIDNIGHT) + 7776000) # 7776000 SECONDS 
 
 MAKEFILE := $(shell realpath $(firstword $(MAKEFILE_LIST)))
 
-# GNOLAND_RPC_URL ?= http://localhost:26657
-# CHAINID ?= dev
+GNOLAND_RPC_URL ?= http://localhost:26657
+CHAINID ?= dev
 
-GNOLAND_RPC_URL ?= https://dev.rpc.gnoswap.io:443
-CHAINID ?= dev.gnoswap
+# GNOLAND_RPC_URL ?= https://dev.rpc.gnoswap.io:443
+# CHAINID ?= dev.gnoswap
 
 ROOT_DIR:=$(shell dirname $(MAKEFILE))/../../
 

--- a/__local/test/emission_test.mk
+++ b/__local/test/emission_test.mk
@@ -21,11 +21,11 @@ TX_EXPIRE := 9999999999
 
 MAKEFILE := $(shell realpath $(firstword $(MAKEFILE_LIST)))
 
-# GNOLAND_RPC_URL ?= http://localhost:26657
-# CHAINID ?= dev
+GNOLAND_RPC_URL ?= http://localhost:26657
+CHAINID ?= dev
 
-GNOLAND_RPC_URL ?= https://dev.rpc.gnoswap.io:443
-CHAINID ?= dev.gnoswap
+# GNOLAND_RPC_URL ?= https://dev.rpc.gnoswap.io:443
+# CHAINID ?= dev.gnoswap
 
 ROOT_DIR:=$(shell dirname $(MAKEFILE))/../../
 

--- a/router/router.gno
+++ b/router/router.gno
@@ -48,7 +48,6 @@ func SwapRoute(
 	}
 
 	en.MintAndDistributeGns()
-	// sr.CalcPoolPosition()
 
 	amountSpecified := i256.MustFromDecimal(_amountSpecified)
 	tokenAmountLimit := u256.MustFromDecimal(_tokenAmountLimit)
@@ -62,11 +61,32 @@ func SwapRoute(
 		amountSpecified = i256.Zero().Neg(amountSpecified)
 	}
 
-	userOldWugnotBalance, _ := handleGNOT(inputToken, outputToken)
+	var userBeforeWugnotBalance uint64
+	var userWrappedWugnot uint64
+	if inputToken == consts.GNOT || outputToken == consts.GNOT {
+		userBeforeWugnotBalance = wugnot.BalanceOf(a2u(std.GetOrigCaller()))
+
+		sent := std.GetOrigSend()
+		ugnotSentByUser := uint64(sent.AmountOf("ugnot"))
+		if ugnotSentByUser > 0 {
+			wrap(ugnotSentByUser)
+		}
+
+		userWrappedWugnot = ugnotSentByUser
+	}
 
 	resultAmountIn, resultAmountOut := processRoutes(routes, quotes, amountSpecified, swapType)
 
-	amountIn, amountOut := finalizeSwap(inputToken, outputToken, resultAmountIn, resultAmountOut, swapType, tokenAmountLimit, userOldWugnotBalance)
+	amountIn, amountOut := finalizeSwap(
+		inputToken,
+		outputToken,
+		resultAmountIn,
+		resultAmountOut,
+		swapType,
+		tokenAmountLimit,
+		userBeforeWugnotBalance,
+		userWrappedWugnot,
+	)
 
 	std.Emit(
 		"GNOSWAP",
@@ -109,19 +129,6 @@ func validateInput(amountSpecified *i256.Int, swapType string, routes, quotes []
 	if quotesSum != 100 {
 		panic("[ROUTER] Quote sum is not 100")
 	}
-}
-
-func handleGNOT(inputToken, outputToken string) (uint64, uint64) {
-	userOldWugnotBalance := uint64(0)
-	if inputToken == consts.GNOT {
-		sent := std.GetOrigSend()
-		ugnotSentByUser := uint64(sent.AmountOf("ugnot"))
-		wrap(ugnotSentByUser)
-		userOldWugnotBalance = wugnot.BalanceOf(a2u(std.GetOrigCaller()))
-	} else if outputToken == consts.GNOT {
-		userOldWugnotBalance = wugnot.BalanceOf(a2u(std.GetOrigCaller()))
-	}
-	return userOldWugnotBalance, 0
 }
 
 func processRoutes(routes, quotes []string, amountSpecified *i256.Int, swapType string) (*u256.Uint, *u256.Uint) {
@@ -168,14 +175,25 @@ func handleSingleSwap(route string, amountSpecified *i256.Int, isDry bool) (*u25
 	return singleSwap(singleParams)
 }
 
-func finalizeSwap(inputToken, outputToken string, resultAmountIn, resultAmountOut *u256.Uint, swapType string, tokenAmountLimit *u256.Uint, userOldWugnotBalance uint64) (string, string) {
+func finalizeSwap(inputToken, outputToken string, resultAmountIn, resultAmountOut *u256.Uint, swapType string, tokenAmountLimit *u256.Uint, userBeforeWugnotBalance, userWrappedWugnot uint64) (string, string) {
 	afterFee := handleSwapFee(outputToken, resultAmountOut, false)
 
 	userNewWugnotBalance := wugnot.BalanceOf(a2u(std.GetOrigCaller()))
 	if inputToken == consts.GNOT {
-		unwrap(userNewWugnotBalance)
+		totalBefore := userBeforeWugnotBalance + userWrappedWugnot
+		spend := totalBefore - userNewWugnotBalance
+
+		if spend > userWrappedWugnot {
+			// used existing wugnot
+			panic(ufmt.Sprintf("[ROUTER] Too much wugnot spent (wrapped: %d, spend: %d)", userWrappedWugnot, spend))
+		}
+
+		// unwrap left amount
+		toUnwrap := userWrappedWugnot - spend
+		unwrap(toUnwrap)
+
 	} else if outputToken == consts.GNOT {
-		userRecvWugnot := uint64(userNewWugnotBalance - userOldWugnotBalance)
+		userRecvWugnot := uint64(userNewWugnotBalance - userBeforeWugnotBalance - userWrappedWugnot)
 		unwrap(userRecvWugnot)
 	}
 

--- a/router/tests/__TEST_router_all_2_route_2_hop_with_emission_test.gnoA
+++ b/router/tests/__TEST_router_all_2_route_2_hop_with_emission_test.gnoA
@@ -93,7 +93,7 @@ func TestSwapRouteBarQuxExactIn(t *testing.T) {
 
 	shouldEQ(t, gns.TotalSupply(), 100001455479412)
 	shouldEQ(t, gnsBalance(consts.EMISSION_ADDR), 1)
-	shouldEQ(t, gnsBalance(consts.STAKER_ADDR), 0) // SwapRoute calls CalcPoolPosition, so nothing will be left
+	shouldEQ(t, gnsBalance(consts.STAKER_ADDR), 1091609559)
 	shouldEQ(t, gnsBalance(consts.DEV_OPS), 291095882)
 
 	shouldEQ(t, amountIn, "1000")
@@ -141,7 +141,7 @@ func TestSwapRouteBarQuxExactOut(t *testing.T) {
 
 	shouldEQ(t, gns.TotalSupply(), 100001469748818)
 	shouldEQ(t, gnsBalance(consts.EMISSION_ADDR), 1)
-	shouldEQ(t, gnsBalance(consts.STAKER_ADDR), 0) // SwapRoute calls CalcPoolPosition, so nothing will be left
+	shouldEQ(t, gnsBalance(consts.STAKER_ADDR), 1102311614)
 	shouldEQ(t, gnsBalance(consts.DEV_OPS), 293949763)
 
 	shouldEQ(t, amountIn, "140")
@@ -230,7 +230,7 @@ func TestSwapRouteQuxBarExactOut(t *testing.T) {
 
 	shouldEQ(t, gns.TotalSupply(), 100001498287630)
 	shouldEQ(t, gnsBalance(consts.EMISSION_ADDR), 1)
-	shouldEQ(t, gnsBalance(consts.STAKER_ADDR), 0) // SwapRoute calls CalcPoolPosition, so nothing will be left
+	shouldEQ(t, gnsBalance(consts.STAKER_ADDR), 1123715724)
 	shouldEQ(t, gnsBalance(consts.DEV_OPS), 299657525)
 
 	shouldEQ(t, amountIn, "7365")

--- a/router/tests/__TEST_router_swap_route_1route_1hop_native_in_out_test.gnoA
+++ b/router/tests/__TEST_router_swap_route_1route_1hop_native_in_out_test.gnoA
@@ -24,15 +24,9 @@ func TestCreatePool(t *testing.T) {
 
 	gns.Approve(a2u(consts.POOL_ADDR), pl.GetPoolCreationFee()*3)
 
-	pl.CreatePool(barPath, bazPath, fee500, "130621891405341611593710811006") // tick =  10_000, ratio = 2.71814592682522526700950038502924144268035888671875
-	// ---       event: {GNOSWAP gno.land/r/gnoswap/v2/pool CreatePool [{m_callType DIRECT} {m_origCaller g1lmvrrrr4er2us84h2732sru76c9zl2nvknha8c} {m_prevRealm } {p_poolPath gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:500}]}
-
-	pl.CreatePool(bazPath, quxPath, fee500, "130621891405341611593710811006") // tick =  10_000, ratio = 2.71814592682522526700950038502924144268035888671875
-	// ---       event: {GNOSWAP gno.land/r/gnoswap/v2/pool CreatePool [{m_callType DIRECT} {m_origCaller g1lmvrrrr4er2us84h2732sru76c9zl2nvknha8c} {m_prevRealm } {p_poolPath gno.land/r/onbloc/baz:gno.land/r/onbloc/qux:500}]}
-
+	pl.CreatePool(barPath, bazPath, fee500, "130621891405341611593710811006")     // tick =  10_000, ratio = 2.71814592682522526700950038502924144268035888671875
+	pl.CreatePool(bazPath, quxPath, fee500, "130621891405341611593710811006")     // tick =  10_000, ratio = 2.71814592682522526700950038502924144268035888671875
 	pl.CreatePool(quxPath, consts.GNOT, fee500, "130621891405341611593710811006") // tick =  10_000, ratio = 2.71814592682522526700950038502924144268035888671875
-	// ---       event: {GNOSWAP gno.land/r/gnoswap/v2/pool CreatePool [{m_callType DIRECT} {m_origCaller g1lmvrrrr4er2us84h2732sru76c9zl2nvknha8c} {m_prevRealm } {p_poolPath gno.land/r/onbloc/qux:gno.land/r/demo/wugnot:500}]}
-
 	// 1 bar ≈ 19.683 gnot
 
 	jsonStr := pl.ApiGetPools()
@@ -54,7 +48,6 @@ func TestPositionMintBarBaz(t *testing.T) {
 	bar.Approve(a2u(consts.POOL_ADDR), consts.UINT64_MAX)
 	baz.Approve(a2u(consts.POOL_ADDR), consts.UINT64_MAX)
 	tokenId, liquidity, amount0, amount1 := pn.Mint(barPath, bazPath, fee500, int32(9000), int32(11000), "100000", "100000", "0", "0", max_timeout, gsa.String())
-	// ---       event: {GNOSWAP gno.land/r/gnoswap/v2/position Mint [{m_callType DIRECT} {m_origCaller g1lmvrrrr4er2us84h2732sru76c9zl2nvknha8c} {m_prevRealm } {p_poolPath gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:500} {p_tickLower 9000} {p_tickUpper 11000} {tokenId 1} {liquidity 1243732} {amount0 36790} {amount1 100000}]}
 
 	shouldEQ(t, tokenId, uint64(1))
 	shouldEQ(t, amount0, "36790")  // bar
@@ -67,7 +60,6 @@ func TestPositionMintBazQux(t *testing.T) {
 	qux.Approve(a2u(consts.POOL_ADDR), consts.UINT64_MAX)
 
 	tokenId, liquidity, amount0, amount1 := pn.Mint(bazPath, quxPath, fee500, int32(9000), int32(11000), "100000", "100000", "0", "0", max_timeout, gsa.String())
-	// ---       event: {GNOSWAP gno.land/r/gnoswap/v2/position Mint [{m_callType DIRECT} {m_origCaller g1lmvrrrr4er2us84h2732sru76c9zl2nvknha8c} {m_prevRealm } {p_poolPath gno.land/r/onbloc/baz:gno.land/r/onbloc/qux:500} {p_tickLower 9000} {p_tickUpper 11000} {tokenId 2} {liquidity 1243732} {amount0 36790} {amount1 100000}]}
 
 	shouldEQ(t, tokenId, uint64(2))
 	shouldEQ(t, amount0, "36790")
@@ -86,7 +78,6 @@ func TestPositionMintQuxGnot(t *testing.T) {
 	wugnot.Approve(a2u(consts.POSITION_ADDR), consts.UINT64_MAX) // wrap unwrap
 
 	tokenId, liquidity, amount0, amount1 := pn.Mint(quxPath, consts.GNOT, fee500, int32(9000), int32(11000), "100000", "100000", "0", "0", max_timeout, gsa.String())
-	// ---       event: {GNOSWAP gno.land/r/gnoswap/v2/position Mint [{m_callType DIRECT} {m_origCaller g1lmvrrrr4er2us84h2732sru76c9zl2nvknha8c} {m_prevRealm } {p_poolPath gno.land/r/onbloc/qux:gno.land/r/demo/wugnot:500} {p_tickLower 9000} {p_tickUpper 11000} {tokenId 3} {liquidity 1243732} {amount0 36790} {amount1 100000}]}
 
 	shouldEQ(t, tokenId, uint64(3))
 	shouldEQ(t, amount0, "100000")
@@ -117,8 +108,14 @@ func TestSwapRouteBarGnotExactIn(t *testing.T) {
 	wugnot.Approve(a2u(consts.ROUTER_ADDR), consts.UINT64_MAX) // for output
 	wugnot.Approve(a2u(consts.ROUTER_ADDR), consts.UINT64_MAX) // for unwrap
 
+	// wrap some ugnot
+	std.TestSetOrigSend(std.Coins{{"ugnot", 5000}}, nil)
+	wugnot.Deposit()
+
+	std.TestSetOrigSend(std.Coins{{}}, nil)
+
 	oldWugnot := wugnot.BalanceOf(a2u(gsa))
-	shouldEQ(t, oldWugnot, 0)
+	shouldEQ(t, oldWugnot, 5000)
 
 	oldUgnot := ugnotBalanceOf(gsa)
 	shouldEQ(t, oldUgnot, 900009)
@@ -139,15 +136,11 @@ func TestSwapRouteBarGnotExactIn(t *testing.T) {
 		"100", // quoteArr
 		"0",   // tokenAmountLimit
 	)
-	// ---       event: {GNOSWAP gno.land/r/gnoswap/v2/pool Swap [{m_callType INDIRECT} {m_origCaller g1lmvrrrr4er2us84h2732sru76c9zl2nvknha8c} {m_prevRealm gno.land/r/gnoswap/v2/router} {p_poolPath gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:500} {p_zeroForOne true} {p_amountSpecified 1000} {p_sqrtPriceLimitX96 4295128740} {p_payer g1lmvrrrr4er2us84h2732sru76c9zl2nvknha8c} {p_recipient g1pjtpgjpsn4hjfv2n4mpz8cczdn32jkpsqwxuav} {amount0 1000} {amount1 -2711} {protocol_fee0 0} {protocol_fee1 0} {swap_fee 1}]}
-	// ---       event: {GNOSWAP gno.land/r/gnoswap/v2/pool Swap [{m_callType INDIRECT} {m_origCaller g1lmvrrrr4er2us84h2732sru76c9zl2nvknha8c} {m_prevRealm gno.land/r/gnoswap/v2/router} {p_poolPath gno.land/r/onbloc/baz:gno.land/r/onbloc/qux:500} {p_zeroForOne true} {p_amountSpecified 2711} {p_sqrtPriceLimitX96 4295128740} {p_payer g1pjtpgjpsn4hjfv2n4mpz8cczdn32jkpsqwxuav} {p_recipient g1pjtpgjpsn4hjfv2n4mpz8cczdn32jkpsqwxuav} {amount0 2711} {amount1 -7337} {protocol_fee0 0} {protocol_fee1 0} {swap_fee 2}]}
-	// ---       event: {GNOSWAP gno.land/r/gnoswap/v2/pool Swap [{m_callType INDIRECT} {m_origCaller g1lmvrrrr4er2us84h2732sru76c9zl2nvknha8c} {m_prevRealm gno.land/r/gnoswap/v2/router} {p_poolPath gno.land/r/onbloc/qux:gno.land/r/demo/wugnot:500} {p_zeroForOne true} {p_amountSpecified 7337} {p_sqrtPriceLimitX96 4295128740} {p_payer g1pjtpgjpsn4hjfv2n4mpz8cczdn32jkpsqwxuav} {p_recipient g1lmvrrrr4er2us84h2732sru76c9zl2nvknha8c} {amount0 7337} {amount1 -19740} {protocol_fee0 0} {protocol_fee1 0} {swap_fee 4}]}
-	// ---       event: {GNOSWAP gno.land/r/gnoswap/v2/router SwapRoute [{m_callType DIRECT} {m_origCaller g1lmvrrrr4er2us84h2732sru76c9zl2nvknha8c} {m_prevRealm } {p_input gno.land/r/onbloc/bar} {p_output gnot} {p_swapType EXACT_IN} {p_amountSpecified 1000} {p_route gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:500*POOL*gno.land/r/onbloc/baz:gno.land/r/onbloc/qux:500*POOL*gno.land/r/onbloc/qux:gno.land/r/demo/wugnot:500} {p_quote 100} {amountIn 1000} {amountOut -19711}]}
 	shouldEQ(t, amountIn, "1000")
 	shouldEQ(t, amountOut, "-19711")
 
 	newWugnot := wugnot.BalanceOf(a2u(gsa))
-	shouldEQ(t, newWugnot, 0)
+	shouldEQ(t, newWugnot, 5000) // IT SHOULD STAY SAME SINCE SWAP USED uGNOT, not WUGNOT
 
 	newUgnot := ugnotBalanceOf(gsa)
 	shouldEQ(t, newUgnot, 919720) // 900009 + 19711
@@ -182,19 +175,18 @@ func TestSwapRouteGnotBarExactIn(t *testing.T) {
 	bar.Approve(a2u(consts.ROUTER_ADDR), consts.UINT64_MAX)  // for output
 
 	oldWugnot := wugnot.BalanceOf(a2u(gsa))
-	shouldEQ(t, oldWugnot, 0)
+	shouldEQ(t, oldWugnot, 5000)
 
 	oldUgnot := ugnotBalanceOf(gsa)
 	shouldEQ(t, oldUgnot, 919720)
-
-	// send
-	std.TestSetOrigSend(std.Coins{{"ugnot", 5000}}, nil)
 
 	feeColUgnot := ugnotBalanceOf(consts.PROTOCOL_FEE_ADDR)
 	feeColWugnot := wugnotBalanceOf(consts.PROTOCOL_FEE_ADDR)
 	shouldEQ(t, feeColUgnot, 29)
 	shouldEQ(t, feeColWugnot, 0)
 
+	// send
+	std.TestSetOrigSend(std.Coins{{"ugnot", 5000}}, nil)
 	amountIn, amountOut := SwapRoute(
 		consts.GNOT, // intputToken
 		barPath,     // outputToken
@@ -204,18 +196,15 @@ func TestSwapRouteGnotBarExactIn(t *testing.T) {
 		"100", // quoteArr
 		"0",
 	)
-	// ---       event: {GNOSWAP gno.land/r/gnoswap/v2/pool Swap [{m_callType INDIRECT} {m_origCaller g1lmvrrrr4er2us84h2732sru76c9zl2nvknha8c} {m_prevRealm gno.land/r/gnoswap/v2/router} {p_poolPath gno.land/r/onbloc/qux:gno.land/r/demo/wugnot:500} {p_zeroForOne false} {p_amountSpecified 5000} {p_sqrtPriceLimitX96 1461446703485210103287273052203988822378723970341} {p_payer g1lmvrrrr4er2us84h2732sru76c9zl2nvknha8c} {p_recipient g1pjtpgjpsn4hjfv2n4mpz8cczdn32jkpsqwxuav} {amount0 -1869} {amount1 5000} {protocol_fee0 0} {protocol_fee1 0} {swap_fee 3}]}
-	// ---       event: {GNOSWAP gno.land/r/gnoswap/v2/pool Swap [{m_callType INDIRECT} {m_origCaller g1lmvrrrr4er2us84h2732sru76c9zl2nvknha8c} {m_prevRealm gno.land/r/gnoswap/v2/router} {p_poolPath gno.land/r/onbloc/baz:gno.land/r/onbloc/qux:500} {p_zeroForOne false} {p_amountSpecified 1869} {p_sqrtPriceLimitX96 1461446703485210103287273052203988822378723970341} {p_payer g1pjtpgjpsn4hjfv2n4mpz8cczdn32jkpsqwxuav} {p_recipient g1pjtpgjpsn4hjfv2n4mpz8cczdn32jkpsqwxuav} {amount0 -691} {amount1 1869} {protocol_fee0 0} {protocol_fee1 0} {swap_fee 1}]}
-	// ---       event: {GNOSWAP gno.land/r/gnoswap/v2/pool Swap [{m_callType INDIRECT} {m_origCaller g1lmvrrrr4er2us84h2732sru76c9zl2nvknha8c} {m_prevRealm gno.land/r/gnoswap/v2/router} {p_poolPath gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:500} {p_zeroForOne false} {p_amountSpecified 691} {p_sqrtPriceLimitX96 1461446703485210103287273052203988822378723970341} {p_payer g1pjtpgjpsn4hjfv2n4mpz8cczdn32jkpsqwxuav} {p_recipient g1lmvrrrr4er2us84h2732sru76c9zl2nvknha8c} {amount0 -254} {amount1 691} {protocol_fee0 0} {protocol_fee1 0} {swap_fee 1}]}
-	// ---       event: {GNOSWAP gno.land/r/gnoswap/v2/router SwapRoute [{m_callType DIRECT} {m_origCaller g1lmvrrrr4er2us84h2732sru76c9zl2nvknha8c} {m_prevRealm } {p_input gnot} {p_output gno.land/r/onbloc/bar} {p_swapType EXACT_IN} {p_amountSpecified 5000} {p_route gno.land/r/demo/wugnot:gno.land/r/onbloc/qux:500*POOL*gno.land/r/onbloc/qux:gno.land/r/onbloc/baz:500*POOL*gno.land/r/onbloc/baz:gno.land/r/onbloc/bar:500} {p_quote 100} {amountIn 5000} {amountOut -254}]}
+	std.TestSetOrigSend(std.Coins{{}}, nil)
 	shouldEQ(t, amountIn, "5000")
 	shouldEQ(t, amountOut, "-254")
 
 	newWugnot := wugnot.BalanceOf(a2u(gsa))
-	shouldEQ(t, newWugnot, 0)
+	shouldEQ(t, newWugnot, 5000)
 
 	newUgnot := ugnotBalanceOf(gsa)
-	shouldEQ(t, newUgnot, 919720)
+	shouldEQ(t, newUgnot, 919720) // GNO VM BUG, ugnot amount should be decreased but `std.TestSetOrigSend` doesn't really decrease caller's ugnot balance
 
 	feeColUgnot = ugnotBalanceOf(consts.PROTOCOL_FEE_ADDR)
 	feeColWugnot = wugnotBalanceOf(consts.PROTOCOL_FEE_ADDR)


### PR DESCRIPTION
## fix
1. do not use pre-exising wugnot balance when swapping ugnot
- selecting ugnot => use only ugnot coin
- selecting wugnot => use only wugnot token