### PR TITLE
chore: Copy files to v2 subdirectory and Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ To set up GnoSwap contracts in Gno Core, follow these steps:
    cp -R _deploy/r/gnoswap $WORKDIR/gno/examples/gno.land/r
 
    # copy gnoswap base packages ( includes uint256, int256 and bit of pool calculation )
-   cp -R _deploy/p/gnoswap $WORKDIR/gno/examples/gno.land/p/gnoswap
+   cp -R _deploy/p/gnoswap $WORKDIR/gno/examples/gno.land/p/gnoswap/v2
 
    # copy gnoswap base realms ( includes common logic, variables and consts )
-   cp -R _deploy/r/gnoswap $WORKDIR/gno/examples/gno.land/r/gnoswap
+   cp -R _deploy/r/gnoswap $WORKDIR/gno/examples/gno.land/r/gnoswap/v2
 
    # copy gnoswap realms
-   cp -R pool position router staker $WORKDIR/gno/examples/gno.land/r/gnoswap
+   cp -R pool position router staker $WORKDIR/gno/examples/gno.land/r/gnoswap/v2
    ```
 
 3. Move all test cases into its own directory:

--- a/README.md
+++ b/README.md
@@ -100,14 +100,14 @@ To set up GnoSwap contracts in Gno Core, follow these steps:
 Move the test cases for each contract to their respective directories. It's not necessary to move all tests; you can selectively move only the tests you need. However, files containing `VARS_HELPERS` in their name must be moved.
 
 ```bash
-cd $WORKDIR/gno/examples/gno.land/r/gnoswap/{name}
+cd $WORKDIR/gno/examples/gno.land/r/gnoswap/v2/{name}
 mv _TEST_/* .
 ```
 
 For example, to move all tests for the `pool` realm:
 
 ```bash
-cd $WORKDIR/gno/examples/gno.land/r/pool
+cd $WORKDIR/gno/examples/gno.land/r/gnoswap/v2/pool
 mv _TEST_/* .
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def copy_contracts(workdir):
     # Copy gnoswap realms
     # TODO: Detect realms automatically
     for realm in ["pool", "position", "router", "staker", "emission", "community_pool"]:
-        shutil.copytree(realm, os.path.join(gno_dir, "r", "gnoswap", realm), dirs_exist_ok=True)
+        shutil.copytree(realm, os.path.join(gno_dir, "r", "gnoswap", "v2", realm), dirs_exist_ok=True)
 
 def move_tests(workdir):
     gno_dir = os.path.join(workdir, "gno", "examples", "gno.land", "r")


### PR DESCRIPTION
# Description

Since the contract's paths are updated to `v2`, I modified the previous setup script to move it to copy/move the v2 subdirectory.