### PR TITLE
chore: Remove boolean conversion

### DIFF
--- a/staker/tests/__TEST_staker_short_warmup_period_external_12_test.gnoA
+++ b/staker/tests/__TEST_staker_short_warmup_period_external_12_test.gnoA
@@ -157,6 +157,6 @@ func TestCollectReward(t *testing.T) {
 	newBar := bar.BalanceOf(a2u(gsa))
 	newQux := qux.BalanceOf(a2u(gsa))
 
-	shouldEQ(t, bool(newBar > oldBar), true)
-	shouldEQ(t, bool(newQux > oldQux), true)
+	shouldEQ(t, newBar > oldBar, true)
+	shouldEQ(t, newQux > oldQux, true)
 }

--- a/staker/tests/__TEST_staker_short_warmup_period_external_13_gns_external_test.gnoA
+++ b/staker/tests/__TEST_staker_short_warmup_period_external_13_gns_external_test.gnoA
@@ -162,6 +162,6 @@ func TestCollectReward(t *testing.T) {
 	shouldEQ(t, newBar-oldBar, uint64(485))
 	shouldEQ(t, newGns-oldGns, uint64(485))
 
-	shouldEQ(t, bool(bool(newBar > oldBar)), true)
-	shouldEQ(t, bool(newGns > oldGns), true)
+	shouldEQ(t, newBar > oldBar, true)
+	shouldEQ(t, newGns > oldGns, true)
 }


### PR DESCRIPTION
# Description

Since the gno's boolean value comparison has been fixed, removed the boolean conversions.

note: this must be merge after merged [#2725](https://github.com/gnolang/gno/pull/2725). So, until then this PR will drafted. So, I'll leave it in draft until then.