### PR TITLE
GSW-1883 feat: update position operator based on behavior

### DIFF
--- a/position/_GET_no_receiver.gno.gno
+++ b/position/_GET_no_receiver.gno.gno
@@ -6,6 +6,8 @@ import (
 	u256 "gno.land/p/gnoswap/uint256"
 
 	pl "gno.land/r/gnoswap/v2/pool"
+
+	"gno.land/r/gnoswap/v2/gnft"
 )
 
 // type Position
@@ -63,4 +65,8 @@ func PositionIsInRange(tokenId uint64) bool {
 	}
 
 	return false
+}
+
+func PositionGetPositionOwner(tokenId uint64) std.Address {
+	return gnft.OwnerOf(tid(tokenId))
 }

--- a/position/_RPC_api.gno
+++ b/position/_RPC_api.gno
@@ -8,17 +8,19 @@ import (
 	"gno.land/p/demo/ufmt"
 
 	"gno.land/r/gnoswap/v2/common"
-
 	"gno.land/r/gnoswap/v2/consts"
 
 	pl "gno.land/r/gnoswap/v2/pool"
 
 	i256 "gno.land/p/gnoswap/int256"
+
+	"gno.land/r/gnoswap/v2/gnft"
 )
 
 type RpcPosition struct {
 	LpTokenId                uint64 `json:"lpTokenId"`
 	Burned                   bool   `json:"burned"`
+	Owner                    string `json:"owner"`
 	Operator                 string `json:"operator"`
 	PoolKey                  string `json:"poolKey"`
 	TickLower                int32  `json:"tickLower"`
@@ -78,6 +80,7 @@ func ApiGetPositions() string {
 		_positionNode := json.ObjectNode("", map[string]*json.Node{
 			"lpTokenId":                json.NumberNode("lpTokenId", float64(position.LpTokenId)),
 			"burned":                   json.BoolNode("burned", position.Burned),
+			"owner":                    json.StringNode("owner", gnft.OwnerOf(tid(position.LpTokenId)).String()),
 			"operator":                 json.StringNode("operator", position.Operator),
 			"poolKey":                  json.StringNode("poolKey", position.PoolKey),
 			"tickLower":                json.NumberNode("tickLower", float64(position.TickLower)),
@@ -137,6 +140,7 @@ func ApiGetPosition(lpTokenId uint64) string {
 		_positionNode := json.ObjectNode("", map[string]*json.Node{
 			"lpTokenId":                json.NumberNode("lpTokenId", float64(position.LpTokenId)),
 			"burned":                   json.BoolNode("burned", position.Burned),
+			"owner":                    json.StringNode("owner", gnft.OwnerOf(tid(position.LpTokenId)).String()),
 			"operator":                 json.StringNode("operator", position.Operator),
 			"poolKey":                  json.StringNode("poolKey", position.PoolKey),
 			"tickLower":                json.NumberNode("tickLower", float64(position.TickLower)),
@@ -199,6 +203,7 @@ func ApiGetPositionsByPoolPath(poolPath string) string {
 		_positionNode := json.ObjectNode("", map[string]*json.Node{
 			"lpTokenId":                json.NumberNode("lpTokenId", float64(position.LpTokenId)),
 			"burned":                   json.BoolNode("burned", position.Burned),
+			"owner":                    json.StringNode("owner", gnft.OwnerOf(tid(position.LpTokenId)).String()),
 			"operator":                 json.StringNode("operator", position.Operator),
 			"poolKey":                  json.StringNode("poolKey", position.PoolKey),
 			"tickLower":                json.NumberNode("tickLower", float64(position.TickLower)),
@@ -233,7 +238,7 @@ func ApiGetPositionsByAddress(address std.Address) string {
 	rpcPositions := []RpcPosition{}
 	for lpTokenId, position := range positions {
 
-		if position.operator != address {
+		if !(position.operator == address || gnft.OwnerOf(tid(lpTokenId)) == address) {
 			continue
 		}
 
@@ -261,6 +266,7 @@ func ApiGetPositionsByAddress(address std.Address) string {
 		_positionNode := json.ObjectNode("", map[string]*json.Node{
 			"lpTokenId":                json.NumberNode("lpTokenId", float64(position.LpTokenId)),
 			"burned":                   json.BoolNode("burned", position.Burned),
+			"owner":                    json.StringNode("owner", gnft.OwnerOf(tid(position.LpTokenId)).String()),
 			"operator":                 json.StringNode("operator", position.Operator),
 			"poolKey":                  json.StringNode("poolKey", position.PoolKey),
 			"tickLower":                json.NumberNode("tickLower", float64(position.TickLower)),
@@ -404,6 +410,7 @@ func rpcMakePosition(lpTokenId uint64) RpcPosition {
 	return RpcPosition{
 		LpTokenId:                lpTokenId,
 		Burned:                   burned,
+		Owner:                    gnft.OwnerOf(tid(lpTokenId)).String(),
 		Operator:                 position.operator.String(),
 		PoolKey:                  position.poolKey,
 		TickLower:                position.tickLower,

--- a/position/position.gno
+++ b/position/position.gno
@@ -42,17 +42,24 @@ func Mint(
 	common.IsHalted()
 	en.MintAndDistributeGns()
 
+	prev := std.PrevRealm()
+	isUserCalled := prev.PkgPath() == ""
+	isStakerCalled := prev.Addr() == consts.STAKER_ADDR
+
 	if common.GetLimitCaller() {
 		// only user or staker can call
-		prev := std.PrevRealm()
-		isUserCalled := prev.PkgPath() == ""
-		isStakerCalled := prev.Addr() == consts.STAKER_ADDR
 		if !(isUserCalled || isStakerCalled) {
 			panic(addDetailToError(
 				errNoPermission,
 				ufmt.Sprintf("position.gno__Mint() || only user or staker can call isUserCalled(%t) || isStakerCalled(%t), but called from %s", isUserCalled, isStakerCalled, prev.Addr().String()),
 			))
 		}
+	}
+
+	// if user called, set caller & mintTo to user address
+	if isUserCalled {
+		caller = prev.Addr()
+		mintTo = prev.Addr()
 	}
 
 	token0, token1, token0IsNative, token1IsNative := processTokens(token0, token1)
@@ -186,7 +193,7 @@ func mint(params MintParams) (uint64, *u256.Uint, *u256.Uint, *u256.Uint) {
 
 	position := Position{
 		nonce:                    u256.Zero(),
-		operator:                 params.caller,
+		operator:                 consts.ZERO_ADDRESS,
 		poolKey:                  pl.GetPoolPath(params.token0, params.token1, params.fee),
 		tickLower:                params.tickLower,
 		tickUpper:                params.tickUpper,
@@ -843,4 +850,24 @@ func handleUnwrap(pToken0, pToken1 string, unwrapResult bool, userOldWugnotBalan
 		leftOver := userNewWugnotBalance - userOldWugnotBalance
 		unwrap(leftOver, to)
 	}
+}
+
+func SetPositionOperator(tokenId uint64, operator std.Address) {
+	caller := std.PrevRealm().PkgPath()
+	if caller != consts.STAKER_PATH {
+		panic(addDetailToError(
+			errNoPermission,
+			ufmt.Sprintf("position.gno__SetPositionOperator() || caller(%s) is not staker", caller),
+		))
+	}
+
+	_, exist := positions[tokenId]
+	if !exist {
+		panic(addDetailToError(
+			errDataNotFound,
+			ufmt.Sprintf("position.gno__SetPositionOperator() || position(%d) doesn't exist", tokenId),
+		))
+	}
+
+	positions[tokenId].operator = operator
 }

--- a/position/tests/__TEST_fee_collect_with_two_user_test.gnoA
+++ b/position/tests/__TEST_fee_collect_with_two_user_test.gnoA
@@ -49,17 +49,19 @@ func TestCollectFeeWithTwoUser(t *testing.T) {
 	pl.CreatePool(barPath, bazPath, 3000, "25054144837504793118641380156") // encodePriceSqrt(1, 10)
 	poolPath := "gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:3000"
 
-	t.Run("mint and swap fee should be distributed pro rata user's liquidity", func(t *testing.T) {
-		std.TestSetRealm(adminRealm)
+	// initial balance for user1 & user2
+	bar.Transfer(a2u(user1Adderss), 100_000_000)
+	baz.Transfer(a2u(user1Adderss), 100_000_000)
+	bar.Transfer(a2u(user2Adderss), 100_000_000)
+	baz.Transfer(a2u(user2Adderss), 100_000_000)
 
+	t.Run("mint and swap fee should be distributed to user's liquidity", func(t *testing.T) {
+		std.TestSetRealm(user1Realm)
 		bar.Approve(a2u(consts.POOL_ADDR), consts.UINT64_MAX)
 		baz.Approve(a2u(consts.POOL_ADDR), consts.UINT64_MAX)
 		bar.Approve(a2u(consts.ROUTER_ADDR), consts.UINT64_MAX)
 		baz.Approve(a2u(consts.ROUTER_ADDR), consts.UINT64_MAX)
 
-		pool := pl.GetPool(barPath, bazPath, 3000)
-
-		std.TestSetRealm(adminRealm)
 		tokenId_res1, liquidity_res1, amount0_res1, amount1_res1 := pn.Mint(
 			barPath,                // token0 string,
 			bazPath,                // token1 string,
@@ -75,7 +77,12 @@ func TestCollectFeeWithTwoUser(t *testing.T) {
 			admin,
 		)
 
-		std.TestSetRealm(adminRealm)
+		std.TestSetRealm(user2Realm)
+		bar.Approve(a2u(consts.POOL_ADDR), consts.UINT64_MAX)
+		baz.Approve(a2u(consts.POOL_ADDR), consts.UINT64_MAX)
+		bar.Approve(a2u(consts.ROUTER_ADDR), consts.UINT64_MAX)
+		baz.Approve(a2u(consts.ROUTER_ADDR), consts.UINT64_MAX)
+
 		tokenId_res2, liquidity_res2, amount0_res2, amount1_res2 := pn.Mint(
 			barPath,                // token0 string,
 			bazPath,                // token1 string,

--- a/position/tests/__TEST_position_api_test.gnoA
+++ b/position/tests/__TEST_position_api_test.gnoA
@@ -50,7 +50,7 @@ func TestMintBazQux(t *testing.T) {
 	baz.Approve(a2u(consts.POOL_ADDR), consts.UINT64_MAX)
 	qux.Approve(a2u(consts.POOL_ADDR), consts.UINT64_MAX)
 
-	// admin mints => will get tid 1 nft
+	// admin mints => will get tid 3 nft
 	Mint(bazPath, quxPath, fee500, int32(9000), int32(11000), "1000000", "1000000", "1", "1", max_timeout, admin, admin)
 }
 

--- a/position/tests/__TEST_position_native_mint_swap_burn_test.gnoA
+++ b/position/tests/__TEST_position_native_mint_swap_burn_test.gnoA
@@ -80,7 +80,7 @@ func testMintPosition(t *testing.T) {
 
 		position := positions[tokenId]
 		uassert.Equal(t, position.nonce.ToString(), "0")
-		uassert.Equal(t, position.operator, admin)
+		uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 		uassert.Equal(t, position.poolKey, "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v2/gns:500")
 		uassert.Equal(t, position.tickLower, int32(-8000))
 		uassert.Equal(t, position.tickUpper, int32(8000))
@@ -135,7 +135,7 @@ func testSwap(t *testing.T) {
 
 		position := positions[uint64(1)]
 		uassert.Equal(t, position.nonce.ToString(), "0")
-		uassert.Equal(t, position.operator, admin)
+		uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 		uassert.Equal(t, position.poolKey, "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v2/gns:500")
 		uassert.Equal(t, position.tickLower, int32(-8000))
 		uassert.Equal(t, position.tickUpper, int32(8000))

--- a/position/tests/__TEST_position_reposition_gnot_pair_test.gnoA
+++ b/position/tests/__TEST_position_reposition_gnot_pair_test.gnoA
@@ -80,7 +80,7 @@ func testMintPosition01InRange(t *testing.T) {
 
 		position := positions[tokenId]
 		uassert.Equal(t, position.nonce.ToString(), "0")
-		uassert.Equal(t, position.operator, admin)
+		uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 		uassert.Equal(t, position.poolKey, "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v2/gns:500")
 		uassert.Equal(t, position.tickLower, int32(8000))
 		uassert.Equal(t, position.tickUpper, int32(12000))
@@ -120,7 +120,7 @@ func testSwap(t *testing.T) {
 
 		position := positions[uint64(1)]
 		uassert.Equal(t, position.nonce.ToString(), "0")
-		uassert.Equal(t, position.operator, admin)
+		uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 		uassert.Equal(t, position.poolKey, "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v2/gns:500")
 		uassert.Equal(t, position.tickLower, int32(8000))
 		uassert.Equal(t, position.tickUpper, int32(12000))
@@ -177,7 +177,7 @@ func testDecreaseLiquidityInPosition(t *testing.T) {
 
 		position := positions[lpTokenId]
 		uassert.Equal(t, position.nonce.ToString(), "0")
-		uassert.Equal(t, position.operator, admin)
+		uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 		uassert.Equal(t, position.poolKey, "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v2/gns:500")
 		uassert.Equal(t, position.tickLower, int32(8000))
 		uassert.Equal(t, position.tickUpper, int32(12000))
@@ -203,7 +203,7 @@ func testReposition(t *testing.T) {
 		// check current state
 		position := positions[lpTokenId]
 		uassert.Equal(t, position.nonce.ToString(), "0")
-		uassert.Equal(t, position.operator, admin)
+		uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 		uassert.Equal(t, position.poolKey, "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v2/gns:500")
 		uassert.Equal(t, position.tickLower, int32(8000))
 		uassert.Equal(t, position.tickUpper, int32(12000))
@@ -239,7 +239,7 @@ func testReposition(t *testing.T) {
 
 		position = positions[lpTokenId]
 		uassert.Equal(t, position.nonce.ToString(), "0")
-		uassert.Equal(t, position.operator, admin)
+		uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 		uassert.Equal(t, position.poolKey, "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v2/gns:500")
 		uassert.Equal(t, position.tickLower, int32(-1000))
 		uassert.Equal(t, position.tickUpper, int32(1000))

--- a/position/tests/__TEST_position_reposition_grc20_pair_test.gnoA
+++ b/position/tests/__TEST_position_reposition_grc20_pair_test.gnoA
@@ -50,7 +50,7 @@ func TestMintPosition01InRange(t *testing.T) {
 
 	position := positions[tokenId]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500")
 	uassert.Equal(t, position.tickLower, int32(8000))
 	uassert.Equal(t, position.tickUpper, int32(12000))
@@ -83,7 +83,7 @@ func TestSwap1(t *testing.T) {
 
 	position := positions[uint64(1)]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500")
 	uassert.Equal(t, position.tickLower, int32(8000))
 	uassert.Equal(t, position.tickUpper, int32(12000))
@@ -122,7 +122,7 @@ func TestMintPosition02InRange(t *testing.T) {
 
 	position := positions[tokenId]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500")
 	uassert.Equal(t, position.tickLower, int32(8000))
 	uassert.Equal(t, position.tickUpper, int32(12000))
@@ -171,7 +171,7 @@ func TestDecreaseLiquidityInPosition(t *testing.T) {
 
 	position := positions[_lpTokenId]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500")
 	uassert.Equal(t, position.tickLower, int32(8000))
 	uassert.Equal(t, position.tickUpper, int32(12000))
@@ -210,7 +210,7 @@ func TestMintPosition03InRange(t *testing.T) {
 
 	position := positions[tokenId]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500")
 	uassert.Equal(t, position.tickLower, int32(8000))
 	uassert.Equal(t, position.tickUpper, int32(12000))
@@ -260,7 +260,7 @@ func TestReposition(t *testing.T) {
 	// check current state
 	position := positions[_lpTokenId]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500")
 	uassert.Equal(t, position.tickLower, int32(8000))
 	uassert.Equal(t, position.tickUpper, int32(12000))
@@ -283,7 +283,7 @@ func TestReposition(t *testing.T) {
 
 	position = positions[_lpTokenId]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500")
 	uassert.Equal(t, position.tickLower, int32(-1000))
 	uassert.Equal(t, position.tickUpper, int32(1000))

--- a/position/tests/__TEST_position_reposition_grc20_pair_with_swap_test.gnoA
+++ b/position/tests/__TEST_position_reposition_grc20_pair_with_swap_test.gnoA
@@ -50,7 +50,7 @@ func TestMintPosition01InRange(t *testing.T) {
 
 	position := positions[tokenId]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500")
 	uassert.Equal(t, position.tickLower, int32(8000))
 	uassert.Equal(t, position.tickUpper, int32(12000))
@@ -89,7 +89,7 @@ func TestMintPosition02InRange(t *testing.T) {
 
 	position := positions[tokenId]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500")
 	uassert.Equal(t, position.tickLower, int32(8000))
 	uassert.Equal(t, position.tickUpper, int32(12000))
@@ -128,7 +128,7 @@ func TestMintPosition03InRange(t *testing.T) {
 
 	position := positions[tokenId]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500")
 	uassert.Equal(t, position.tickLower, int32(6000))
 	uassert.Equal(t, position.tickUpper, int32(14000))
@@ -161,7 +161,7 @@ func TestSwap1(t *testing.T) {
 
 	position := positions[uint64(1)]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500")
 	uassert.Equal(t, position.tickLower, int32(8000))
 	uassert.Equal(t, position.tickUpper, int32(12000))
@@ -220,7 +220,7 @@ func TestDecreaseLiquidity03(t *testing.T) {
 
 	position := positions[_lpTokenId]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500")
 	uassert.Equal(t, position.tickLower, int32(6000))
 	uassert.Equal(t, position.tickUpper, int32(14000))
@@ -240,7 +240,7 @@ func TestReposition(t *testing.T) {
 	// check current state
 	position := positions[_lpTokenId]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500")
 	uassert.Equal(t, position.tickLower, int32(6000))
 	uassert.Equal(t, position.tickUpper, int32(14000))
@@ -263,7 +263,7 @@ func TestReposition(t *testing.T) {
 
 	position = positions[_lpTokenId]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500")
 	uassert.Equal(t, position.tickLower, int32(8000))
 	uassert.Equal(t, position.tickUpper, int32(12000))
@@ -306,7 +306,7 @@ func TestSwap2(t *testing.T) {
 
 	position := positions[uint64(1)]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500")
 	uassert.Equal(t, position.tickLower, int32(8000))
 	uassert.Equal(t, position.tickUpper, int32(12000))

--- a/position/tests/__TEST_position_same_user_same_pool_diff_range_diff_position_swap_fee_test.gnoA
+++ b/position/tests/__TEST_position_same_user_same_pool_diff_range_diff_position_swap_fee_test.gnoA
@@ -49,7 +49,7 @@ func TestMintPosition01InRange(t *testing.T) {
 
 	position := positions[tokenId]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500")
 	uassert.Equal(t, position.tickLower, int32(7000))
 	uassert.Equal(t, position.tickUpper, int32(13000))
@@ -88,7 +88,7 @@ func TestMintPosition02InRange(t *testing.T) {
 
 	position := positions[tokenId]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500")
 	uassert.Equal(t, position.tickLower, int32(8000))
 	uassert.Equal(t, position.tickUpper, int32(12000))

--- a/position/tests/__TEST_position_same_user_same_pool_same_range_diff_position_swap_fee_test.gnoA
+++ b/position/tests/__TEST_position_same_user_same_pool_same_range_diff_position_swap_fee_test.gnoA
@@ -49,7 +49,7 @@ func TestMintPosition01InRange(t *testing.T) {
 
 	position := positions[tokenId]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500")
 	uassert.Equal(t, position.tickLower, int32(8000))
 	uassert.Equal(t, position.tickUpper, int32(12000))
@@ -88,7 +88,7 @@ func TestMintPosition02InRange(t *testing.T) {
 
 	position := positions[tokenId]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500")
 	uassert.Equal(t, position.tickLower, int32(8000))
 	uassert.Equal(t, position.tickUpper, int32(12000))

--- a/position/tests/__TEST_position_tokens_owed_left_grc20_pair_more_action_test.gnoA
+++ b/position/tests/__TEST_position_tokens_owed_left_grc20_pair_more_action_test.gnoA
@@ -52,7 +52,7 @@ func TestMintPosition01InRange(t *testing.T) {
 
 	position := positions[uint64(1)]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500")
 	uassert.Equal(t, position.tickLower, int32(8000))
 	uassert.Equal(t, position.tickUpper, int32(12000))
@@ -87,7 +87,7 @@ func TestSwap1(t *testing.T) {
 	// pool.swap really doesn't update the position
 	position := positions[uint64(1)]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500")
 	uassert.Equal(t, position.tickLower, int32(8000))
 	uassert.Equal(t, position.tickUpper, int32(12000))
@@ -132,7 +132,7 @@ func TestMintPosition02InRange(t *testing.T) {
 
 	position := positions[uint64(2)]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500")
 	uassert.Equal(t, position.tickLower, int32(9000))
 	uassert.Equal(t, position.tickUpper, int32(10000))
@@ -166,7 +166,7 @@ func TestSwap2(t *testing.T) {
 	// pool.swap really doesn't update the position
 	position := positions[uint64(1)]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500")
 	uassert.Equal(t, position.tickLower, int32(8000))
 	uassert.Equal(t, position.tickUpper, int32(12000))
@@ -201,7 +201,7 @@ func TestSwap3(t *testing.T) {
 	{
 		position := positions[uint64(1)]
 		uassert.Equal(t, position.nonce.ToString(), "0")
-		uassert.Equal(t, position.operator, admin)
+		uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 		uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500")
 		uassert.Equal(t, position.tickLower, int32(8000))
 		uassert.Equal(t, position.tickUpper, int32(12000))
@@ -216,7 +216,7 @@ func TestSwap3(t *testing.T) {
 	{
 		position := positions[uint64(2)]
 		uassert.Equal(t, position.nonce.ToString(), "0")
-		uassert.Equal(t, position.operator, admin)
+		uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 		uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500")
 		uassert.Equal(t, position.tickLower, int32(9000))
 		uassert.Equal(t, position.tickUpper, int32(10000))
@@ -292,7 +292,7 @@ func TestDecreaseLiquidityPosition02(t *testing.T) {
 
 	position := positions[_lpTokenId]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500")
 	uassert.Equal(t, position.tickLower, int32(9000))
 	uassert.Equal(t, position.tickUpper, int32(10000))

--- a/position/tests/__TEST_position_tokens_owed_left_pair_more_action_exact_test.gnoA
+++ b/position/tests/__TEST_position_tokens_owed_left_pair_more_action_exact_test.gnoA
@@ -54,7 +54,7 @@ func TestMintPosition01(t *testing.T) {
 
 	position := positions[uint64(1)]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:3000")
 	uassert.Equal(t, position.tickLower, int32(-49980))
 	uassert.Equal(t, position.tickUpper, int32(49980))
@@ -91,7 +91,7 @@ func TestSwap1(t *testing.T) {
 	// swap really doesn't update the position
 	position := positions[uint64(1)]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:3000")
 	uassert.Equal(t, position.tickLower, int32(-49980))
 	uassert.Equal(t, position.tickUpper, int32(49980))
@@ -131,7 +131,7 @@ func TestMintPosition02(t *testing.T) {
 
 	position := positions[tokenId]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:3000")
 	uassert.Equal(t, position.tickLower, int32(-12120))
 	uassert.Equal(t, position.tickUpper, int32(1740))
@@ -171,7 +171,7 @@ func TestMintPosition03(t *testing.T) {
 
 	position := positions[tokenId]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:3000")
 	uassert.Equal(t, position.tickLower, int32(-12120))
 	uassert.Equal(t, position.tickUpper, int32(1740))
@@ -234,7 +234,7 @@ func TestMintPosition04(t *testing.T) {
 
 	position := positions[tokenId]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:3000")
 	uassert.Equal(t, position.tickLower, int32(-12660))
 	uassert.Equal(t, position.tickUpper, int32(1200))
@@ -331,7 +331,7 @@ func TestDecreaseLiquidityPosition02(t *testing.T) {
 
 	position := positions[_lpTokenId]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:3000")
 	uassert.Equal(t, position.tickLower, int32(-12120))
 	uassert.Equal(t, position.tickUpper, int32(1740))
@@ -378,7 +378,7 @@ func TestDecreaseLiquidityPosition02All(t *testing.T) {
 
 	position := positions[_lpTokenId]
 	uassert.Equal(t, position.nonce.ToString(), "0")
-	uassert.Equal(t, position.operator, admin)
+	uassert.Equal(t, position.operator, consts.ZERO_ADDRESS)
 	uassert.Equal(t, position.poolKey, "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:3000")
 	uassert.Equal(t, position.tickLower, int32(-12120))
 	uassert.Equal(t, position.tickUpper, int32(1740))

--- a/staker/staker.gno
+++ b/staker/staker.gno
@@ -124,8 +124,11 @@ func StakeToken(tokenId uint64) (string, string, string) {
 	deposits[tokenId] = deposit
 
 	if callerIsOwner { // if caller is owner, transfer NFT ownership to staker contract
-		transferDeposit(tokenId, GetOrigPkgAddr())
+		transferDeposit(tokenId, consts.STAKER_ADDR)
 	}
+
+	// after transfer, set caller(user) as position operator (to collect fee and reward)
+	pn.SetPositionOperator(tokenId, caller)
 
 	token0Amount, token1Amount := getTokenPairBalanceFromPosition(tokenId)
 
@@ -322,7 +325,8 @@ func UnstakeToken(tokenId uint64, unwrapResult bool) (string, string, string) { 
 	delete(positionsInternalWarmUpAmount, tokenId)
 
 	// transfer NFT ownership to origin owner
-	gnft.TransferFrom(a2u(GetOrigPkgAddr()), a2u(deposit.owner), tid(tokenId))
+	gnft.TransferFrom(a2u(consts.STAKER_ADDR), a2u(deposit.owner), tid(tokenId))
+	pn.SetPositionOperator(tokenId, consts.ZERO_ADDRESS)
 
 	poolPath := pn.PositionGetPositionPoolKey(tokenId)
 	token0Amount, token1Amount := getTokenPairBalanceFromPosition(tokenId)

--- a/staker/tests/__TEST_staker_NFT_transfer_01_test.gnoA
+++ b/staker/tests/__TEST_staker_NFT_transfer_01_test.gnoA
@@ -1,0 +1,149 @@
+// User 'A' mints NFT
+// User 'A' stakes NFT
+// User 'A' can not transfer NFT to 'B'
+// user 'A' can collect reward
+
+package staker
+
+import (
+	"std"
+	"testing"
+	"time"
+
+	"gno.land/p/demo/testutils"
+	"gno.land/p/demo/uassert"
+
+	"gno.land/r/gnoswap/v2/consts"
+
+	pl "gno.land/r/gnoswap/v2/pool"
+	pn "gno.land/r/gnoswap/v2/position"
+
+	"gno.land/r/gnoswap/v2/gnft"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/qux"
+)
+
+func TestNftTransfer01(t *testing.T) {
+	testInit(t)
+	testPoolCreatePool(t)
+	testPositionMint01(t)
+	testStakeToken01(t)
+	testTransferNft(t)
+	testCollectReward01(t)
+}
+
+func testInit(t *testing.T) {
+	t.Run("initial", func(t *testing.T) {
+		// set pool create fee to 0 for testing
+		std.TestSetRealm(adminRealm)
+		pl.SetPoolCreationFeeByAdmin(0)
+
+		// init pool tiers
+		// tier 1
+		poolTiers["gno.land/r/onbloc/bar:gno.land/r/onbloc/qux:500"] = InternalTier{
+			tier:           1,
+			startTimestamp: time.Now().Unix(),
+		}
+	})
+}
+
+func testPoolCreatePool(t *testing.T) {
+	t.Run("create pool", func(t *testing.T) {
+		std.TestSetRealm(adminRealm)
+		pl.CreatePool(barPath, quxPath, 500, "130621891405341611593710811006") // tick 10_000 ≈ x2.7
+		std.TestSkipHeights(1)
+	})
+}
+
+func testPositionMint01(t *testing.T) {
+	t.Run("mint position 01, bar:qux:500", func(t *testing.T) {
+		std.TestSetRealm(adminRealm)
+		bar.Approve(a2u(consts.POOL_ADDR), consts.UINT64_MAX)
+		qux.Approve(a2u(consts.POOL_ADDR), consts.UINT64_MAX)
+		std.TestSkipHeights(2)
+
+		lpTokenId, liquidity, amount0, amount1 := pn.Mint(
+			barPath,      // token0
+			quxPath,      // token1
+			uint32(500),  // fee
+			int32(9000),  // tickLower
+			int32(11000), // tickUpper
+			"1000",       // amount0Desired
+			"1000",       // amount1Desired
+			"1",          // amount0Min
+			"1",          // amount1Min
+			max_timeout,  // deadline
+			admin,
+			admin,
+		)
+
+		std.TestSkipHeights(1)
+
+		uassert.Equal(t, lpTokenId, uint64(1))
+		uassert.Equal(t, gnft.OwnerOf(tid(lpTokenId)), admin)
+		uassert.Equal(t, amount0, "368")
+		uassert.Equal(t, amount1, "1000")
+	})
+}
+
+func testStakeToken01(t *testing.T) {
+	t.Run("stake position 01, bar:qux:500", func(t *testing.T) {
+		std.TestSetRealm(adminRealm)
+
+		// approve nft to staker
+		gnft.Approve(a2u(consts.STAKER_ADDR), tid(uint64(1)))
+		std.TestSkipHeights(1)
+
+		StakeToken(1) // GNFT tokenId
+
+		std.TestSkipHeights(1)
+
+		uassert.Equal(t, gnft.OwnerOf(tid(1)), consts.STAKER_ADDR)
+		uassert.Equal(t, len(deposits), 1)
+	})
+}
+
+func testTransferNft(t *testing.T) {
+	t.Run("transfer nft", func(t *testing.T) {
+		dummyAddr := testutils.TestAddress("dummy")
+
+		t.Run("caller is not a owner (caller is same as spender)", func(t *testing.T) {
+			uassert.PanicsWithMessage(
+				t,
+				`caller is not token owner or approved`,
+				func() {
+					std.TestSetRealm(adminRealm)
+					gnft.TransferFrom(a2u(admin), a2u(dummyAddr), tid(uint64(1)))
+				},
+			)
+		})
+
+		t.Run("caller is not a owner (caller is different from spender)", func(t *testing.T) {
+			uassert.PanicsWithMessage(
+				t,
+				`caller is not token owner or approved`,
+				func() {
+					std.TestSetRealm(adminRealm)
+					gnft.TransferFrom(a2u(consts.STAKER_ADDR), a2u(dummyAddr), tid(uint64(1)))
+				},
+			)
+		})
+
+		gnft.TransferFrom(a2u(consts.STAKER_ADDR), a2u(dummyAddr), tid(uint64(1)))
+	})
+}
+
+func testCollectReward01(t *testing.T) {
+	t.Run("collect reward", func(t *testing.T) {
+		std.TestSetRealm(adminRealm)
+
+		uassert.NotPanics(
+			t,
+			func() {
+				CollectReward(1, false)
+			},
+			`should not panic`,
+		)
+	})
+}

--- a/staker/tests/__TEST_staker_NFT_transfer_02_test.gnoA
+++ b/staker/tests/__TEST_staker_NFT_transfer_02_test.gnoA
@@ -1,0 +1,85 @@
+// User 'A' mints and stake NFT (with one click staking)
+// user 'A' can collect reward
+
+package staker
+
+import (
+	"std"
+	"testing"
+	"time"
+
+	"gno.land/p/demo/uassert"
+
+	"gno.land/r/gnoswap/v2/consts"
+
+	pl "gno.land/r/gnoswap/v2/pool"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/qux"
+)
+
+func TestNftTransfer02(t *testing.T) {
+	testInit(t)
+	testPoolCreatePool(t)
+	testStakerMintAndStake(t)
+	testCollectReward01(t)
+}
+
+func testInit(t *testing.T) {
+	t.Run("initial", func(t *testing.T) {
+		// set pool create fee to 0 for testing
+		std.TestSetRealm(adminRealm)
+		pl.SetPoolCreationFeeByAdmin(0)
+
+		// init pool tiers
+		// tier 1
+		poolTiers["gno.land/r/onbloc/bar:gno.land/r/onbloc/qux:500"] = InternalTier{
+			tier:           1,
+			startTimestamp: time.Now().Unix(),
+		}
+	})
+}
+
+func testPoolCreatePool(t *testing.T) {
+	t.Run("create pool", func(t *testing.T) {
+		std.TestSetRealm(adminRealm)
+		pl.CreatePool(barPath, quxPath, 500, "130621891405341611593710811006") // tick 10_000 ≈ x2.7
+		std.TestSkipHeights(1)
+	})
+}
+
+func testStakerMintAndStake(t *testing.T) {
+	t.Run("mint and stake", func(t *testing.T) {
+		std.TestSetRealm(adminRealm)
+		bar.Approve(a2u(consts.POOL_ADDR), consts.UINT64_MAX)
+		qux.Approve(a2u(consts.POOL_ADDR), consts.UINT64_MAX)
+		std.TestSkipHeights(2)
+
+		MintAndStake(
+			barPath, // token0
+			quxPath, // token1
+			500,     // fee
+			9000,    // tickLower
+			11000,   // tickUpper
+			"1000",  // amount0Desired
+			"1000",  // amount1Desired
+			"1",     // amount0Min
+			"1",     // amount1Min
+			max_timeout,
+		)
+	})
+}
+
+func testCollectReward01(t *testing.T) {
+	t.Run("collect reward", func(t *testing.T) {
+		std.TestSetRealm(adminRealm)
+
+		uassert.NotPanics(
+			t,
+			func() {
+				CollectReward(1, false)
+			},
+			`should not panic`,
+		)
+	})
+}

--- a/staker/tests/__TEST_staker_NFT_transfer_03_test.gnoA
+++ b/staker/tests/__TEST_staker_NFT_transfer_03_test.gnoA
@@ -1,0 +1,161 @@
+// User 'A' mints NFT
+// User 'A' transfers NFT to 'B'
+// User 'B' stakes NFT
+// User 'A' can not collect reward
+// User 'B' can collect reward
+
+package staker
+
+import (
+	"std"
+	"testing"
+	"time"
+
+	"gno.land/p/demo/testutils"
+	"gno.land/p/demo/uassert"
+
+	"gno.land/r/gnoswap/v2/consts"
+
+	pl "gno.land/r/gnoswap/v2/pool"
+	pn "gno.land/r/gnoswap/v2/position"
+
+	"gno.land/r/gnoswap/v2/gnft"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/qux"
+)
+
+var (
+	dummyAddr  = testutils.TestAddress("dummy")
+	dummyRealm = std.NewUserRealm(dummyAddr)
+)
+
+func TestNftTransfer01(t *testing.T) {
+	testInit(t)
+	testPoolCreatePool(t)
+	testPositionMint01(t)
+	testTransferNft(t)
+	testStakeToken01(t)
+	testCollectReward01(t)
+}
+
+func testInit(t *testing.T) {
+	t.Run("initial", func(t *testing.T) {
+		// set pool create fee to 0 for testing
+		std.TestSetRealm(adminRealm)
+		pl.SetPoolCreationFeeByAdmin(0)
+
+		// init pool tiers
+		// tier 1
+		poolTiers["gno.land/r/onbloc/bar:gno.land/r/onbloc/qux:500"] = InternalTier{
+			tier:           1,
+			startTimestamp: time.Now().Unix(),
+		}
+	})
+}
+
+func testPoolCreatePool(t *testing.T) {
+	t.Run("create pool", func(t *testing.T) {
+		std.TestSetRealm(adminRealm)
+		pl.CreatePool(barPath, quxPath, 500, "130621891405341611593710811006") // tick 10_000 ≈ x2.7
+		std.TestSkipHeights(1)
+	})
+}
+
+func testPositionMint01(t *testing.T) {
+	t.Run("mint position 01, bar:qux:500", func(t *testing.T) {
+		std.TestSetRealm(adminRealm)
+		bar.Approve(a2u(consts.POOL_ADDR), consts.UINT64_MAX)
+		qux.Approve(a2u(consts.POOL_ADDR), consts.UINT64_MAX)
+		std.TestSkipHeights(2)
+
+		lpTokenId, liquidity, amount0, amount1 := pn.Mint(
+			barPath,      // token0
+			quxPath,      // token1
+			uint32(500),  // fee
+			int32(9000),  // tickLower
+			int32(11000), // tickUpper
+			"1000",       // amount0Desired
+			"1000",       // amount1Desired
+			"1",          // amount0Min
+			"1",          // amount1Min
+			max_timeout,  // deadline
+			admin,
+			admin,
+		)
+
+		std.TestSkipHeights(1)
+
+		uassert.Equal(t, lpTokenId, uint64(1))
+		uassert.Equal(t, gnft.OwnerOf(tid(lpTokenId)), admin)
+		uassert.Equal(t, amount0, "368")
+		uassert.Equal(t, amount1, "1000")
+	})
+}
+
+func testTransferNft(t *testing.T) {
+	t.Run("transfer nft", func(t *testing.T) {
+
+		t.Run("transfer nft to another address", func(t *testing.T) {
+			uassert.NotPanics(
+				t,
+				func() {
+					std.TestSetRealm(adminRealm)
+					gnft.TransferFrom(a2u(admin), a2u(dummyAddr), tid(uint64(1)))
+				},
+				`should not panic`,
+			)
+
+			uassert.Equal(t, gnft.OwnerOf(tid(uint64(1))).String(), dummyAddr.String())
+		})
+	})
+}
+
+func testStakeToken01(t *testing.T) {
+	t.Run("admin can not stake(not a owner)", func(t *testing.T) {
+
+		uassert.PanicsWithMessage(
+			t,
+			`[GNOSWAP-STAKER-001] caller has no permission || staker.gno__StakeToken() || caller(g1lmvrrrr4er2us84h2732sru76c9zl2nvknha8c) or staker(g14fclvfqynndp0l6kpyxkpgn4sljw9rr96hz46l) is not owner(g1v36k6mteta047h6lta047h6lta047h6lz7gmv8) of tokenId(1)`,
+			func() {
+				std.TestSetRealm(adminRealm)
+				StakeToken(1)
+			})
+	})
+
+	t.Run("dummyAddr(new owner) can stake", func(t *testing.T) {
+		std.TestSetRealm(dummyRealm)
+		gnft.Approve(a2u(consts.STAKER_ADDR), tid(uint64(1)))
+
+		uassert.NotPanics(
+			t,
+			func() {
+				StakeToken(1)
+			},
+			`should not panic`,
+		)
+	})
+}
+
+func testCollectReward01(t *testing.T) {
+	t.Run("admin can not collect reward(not a owner)", func(t *testing.T) {
+		uassert.PanicsWithMessage(
+			t,
+			`[GNOSWAP-STAKER-001] caller has no permission || staker.gno__CollectReward() || only owner(g1v36k6mteta047h6lta047h6lta047h6lz7gmv8) can collect reward from tokenId(1), called from g1lmvrrrr4er2us84h2732sru76c9zl2nvknha8c`,
+			func() {
+				std.TestSetRealm(adminRealm)
+				CollectReward(1, false)
+			})
+	})
+
+	t.Run("dummyAddr(new owner) can collect reward", func(t *testing.T) {
+		uassert.NotPanics(
+			t,
+			func() {
+				std.TestSetRealm(dummyRealm)
+				CollectReward(1, false)
+			},
+			`should not panic`,
+		)
+	})
+}


### PR DESCRIPTION
## feat
1. by default, position's operator will be ZERO_ADDRESS
2. when position is staked, update operator to caller
3. when position is unstaked, update(reset) operator to ZERO_ADDRESS

## test
1. add three test cases with nft being transfered