### PR TITLE
GSW-1902 fix: launchpad pool reward calculation

### DIFF
--- a/launchpad/launchpad_reward.gno
+++ b/launchpad/launchpad_reward.gno
@@ -255,10 +255,16 @@ func calculateDepositReward() {
 		sinceLast90 := endHeightFor90 - minU64(endHeightFor90, lastCalculateHeightForProjectTier[project.tier90.id])
 		sinceLast180 := endHeightFor180 - minU64(endHeightFor180, lastCalculateHeightForProjectTier[project.tier180.id])
 
-		// update for next calc
-		lastCalculateHeightForProjectTier[project.tier30.id] = height
-		lastCalculateHeightForProjectTier[project.tier90.id] = height
-		lastCalculateHeightForProjectTier[project.tier180.id] = height
+		// update for next calc ( only when tier is started )
+		if project.tier30.startHeight != 0 {
+			lastCalculateHeightForProjectTier[project.tier30.id] = height
+		}
+		if project.tier90.startHeight != 0 {
+			lastCalculateHeightForProjectTier[project.tier90.id] = height
+		}
+		if project.tier180.startHeight != 0 {
+			lastCalculateHeightForProjectTier[project.tier180.id] = height
+		}
 
 		// reward for each tier
 		rewardX96_30 := new(u256.Uint).Mul(project.tier30.tierAmountPerBlockX96.NilToZero(), u256.NewUint(sinceLast30))

--- a/launchpad/tests/__TEST_launchpad_tier180_single_deposit_reward_by_proejct_test.gnoA
+++ b/launchpad/tests/__TEST_launchpad_tier180_single_deposit_reward_by_proejct_test.gnoA
@@ -1,0 +1,114 @@
+package launchpad
+
+import (
+	"std"
+	"testing"
+	"time"
+
+	"gno.land/p/demo/testutils"
+	"gno.land/p/demo/uassert"
+
+	"gno.land/r/gnoswap/v2/consts"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/foo"
+	"gno.land/r/onbloc/obl"
+
+	"gno.land/r/gnoswap/v2/gns"
+)
+
+var (
+	projectAddr = testutils.TestAddress("projectAddr")
+	user01      = testutils.TestAddress("user01")
+
+	projectRealm = std.NewUserRealm(projectAddr)
+	user01Realm  = std.NewUserRealm(user01)
+)
+
+func TestTier180RewardByTier(t *testing.T) {
+	testCreateProject(t)
+	testDepositGnsTier180(t)
+	testCollectReward(t)
+}
+
+func testCreateProject(t *testing.T) {
+	t.Run("create project", func(t *testing.T) {
+		std.TestSetRealm(adminRealm)
+
+		obl.Approve(a2u(consts.LAUNCHPAD_ADDR), uint64(1_000_000_000))
+		std.TestSkipHeights(1)
+
+		projectId := CreateProject(
+			"Obl Protocol",
+			oblPath,
+			projectAddr,
+			uint64(1_000_000_000), // 1000000000
+			"gno.land/r/onbloc/foo*PAD*gno.land/r/onbloc/bar",
+			"1*PAD*2",
+			uint64(10),                   // 100000000
+			uint64(20),                   // 200000000
+			uint64(70),                   // 700000000
+			uint64(time.Now().Unix()+10), // 10s later
+		)
+		uassert.Equal(t, projectId, `gno.land/r/onbloc/obl:124`)
+		std.TestSkipHeights(1)
+	})
+}
+
+func testDepositGnsTier180(t *testing.T) {
+	t.Run("deposit gns to tier 180", func(t *testing.T) {
+		std.TestSetRealm(adminRealm)
+		gns.Transfer(a2u(user01), uint64(1_000_000)) // to deposit
+		// transfer some grc20 tokens to bypass project condition
+		foo.Transfer(a2u(user01), uint64(10))
+		bar.Transfer(a2u(user01), uint64(10))
+
+		std.TestSetRealm(user01Realm)
+		gns.Approve(a2u(consts.LAUNCHPAD_ADDR), uint64(1_000_000))
+
+		// skip some blocks to make project active
+		std.TestSkipHeights(4)
+		depositId := DepositGns("gno.land/r/onbloc/obl:124:180", uint64(1_000_000))
+		uassert.Equal(t, depositId, `gno.land/r/onbloc/obl:124:180:g1w4ek2u3sx9047h6lta047h6lta047h6lh0ssfv:129`)
+		std.TestSkipHeights(1)
+	})
+}
+
+func testCollectReward(t *testing.T) {
+	std.TestSetRealm(user01Realm)
+
+	t.Run("claim reward before 14 days(for 180day tier's init reward)", func(t *testing.T) {
+		reward := CollectRewardByProjectId(`gno.land/r/onbloc/obl:124`)
+		uassert.Equal(t, reward, uint64(0))
+		std.TestSkipHeights(1)
+	})
+
+	t.Run("claim after 14 days", func(t *testing.T) {
+		std.TestSkipHeights(int64(TIMESTAMP_14DAYS) / 2)
+		reward := CollectRewardByProjectId(`gno.land/r/onbloc/obl:124`)
+		uassert.Equal(t, reward, uint64(54703703))
+	})
+
+	t.Run("no more claim in same block", func(t *testing.T) {
+		reward := CollectRewardByProjectId(`gno.land/r/onbloc/obl:124`)
+		uassert.Equal(t, reward, uint64(0))
+	})
+
+	t.Run("wait 1 more block, then claim", func(t *testing.T) {
+		std.TestSkipHeights(1)
+		reward := CollectRewardByProjectId(`gno.land/r/onbloc/obl:124`)
+		uassert.Equal(t, reward, uint64(129629))
+	})
+
+	t.Run("180day tier is over", func(t *testing.T) {
+		std.TestSkipHeights(int64(TIMESTAMP_180DAYS) / 2)
+		reward := CollectRewardByProjectId(`gno.land/r/onbloc/obl:124`)
+		uassert.Equal(t, reward, uint64(645166666))
+	})
+
+	t.Run("more block after 180 days", func(t *testing.T) {
+		std.TestSkipHeights(int64(TIMESTAMP_180DAYS) / 2)
+		reward := CollectRewardByProjectId(`gno.land/r/onbloc/obl:124`)
+		uassert.Equal(t, reward, uint64(0))
+	})
+}

--- a/launchpad/tests/__TEST_launchpad_tier_all_single_deposit_reward_by_proejct_tier_test.gno
+++ b/launchpad/tests/__TEST_launchpad_tier_all_single_deposit_reward_by_proejct_tier_test.gno
@@ -1,0 +1,143 @@
+package launchpad
+
+import (
+	"std"
+	"testing"
+	"time"
+
+	"gno.land/p/demo/testutils"
+	"gno.land/p/demo/uassert"
+
+	"gno.land/r/gnoswap/v2/consts"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/foo"
+	"gno.land/r/onbloc/obl"
+
+	"gno.land/r/gnoswap/v2/gns"
+)
+
+var (
+	projectAddr = testutils.TestAddress("projectAddr")
+	user01      = testutils.TestAddress("user01")
+
+	projectRealm = std.NewUserRealm(projectAddr)
+	user01Realm  = std.NewUserRealm(user01)
+)
+
+func TestTier180RewardByTier(t *testing.T) {
+	testCreateProject(t)
+	testDepositGnsTier30(t)
+	testCollectRewardTier30(t)
+	testDepositGnsTier180(t)
+	testCollectRewardTier180(t)
+}
+
+func testCreateProject(t *testing.T) {
+	t.Run("create project", func(t *testing.T) {
+		std.TestSetRealm(adminRealm)
+
+		obl.Approve(a2u(consts.LAUNCHPAD_ADDR), uint64(1_000_000_000))
+		std.TestSkipHeights(1)
+
+		projectId := CreateProject(
+			"Obl Protocol",
+			oblPath,
+			projectAddr,
+			uint64(1_000_000_000), // 1000000000
+			"gno.land/r/onbloc/foo*PAD*gno.land/r/onbloc/bar",
+			"1*PAD*2",
+			uint64(10),                   // 100000000
+			uint64(20),                   // 200000000
+			uint64(70),                   // 700000000
+			uint64(time.Now().Unix()+10), // 10s later
+		)
+		uassert.Equal(t, projectId, `gno.land/r/onbloc/obl:124`)
+		std.TestSkipHeights(1)
+	})
+}
+
+func testDepositGnsTier30(t *testing.T) {
+	t.Run("deposit gns to tier 30", func(t *testing.T) {
+		std.TestSetRealm(adminRealm)
+		gns.Transfer(a2u(user01), uint64(1_000_000)) // to deposit
+		// transfer some grc20 tokens to bypass project condition
+		foo.Transfer(a2u(user01), uint64(10))
+		bar.Transfer(a2u(user01), uint64(10))
+
+		std.TestSetRealm(user01Realm)
+		gns.Approve(a2u(consts.LAUNCHPAD_ADDR), uint64(1_000_000))
+
+		// skip some blocks to make project active
+		std.TestSkipHeights(4)
+		depositId := DepositGns("gno.land/r/onbloc/obl:124:30", uint64(1_000_000))
+		uassert.Equal(t, depositId, `gno.land/r/onbloc/obl:124:30:g1w4ek2u3sx9047h6lta047h6lta047h6lh0ssfv:129`)
+		std.TestSkipHeights(1)
+	})
+}
+
+func testCollectRewardTier30(t *testing.T) {
+	std.TestSetRealm(user01Realm)
+
+	t.Run("claim reward before 3 days(for 30day tier's init reward)", func(t *testing.T) {
+		reward := CollectRewardByProjectId(`gno.land/r/onbloc/obl:124`)
+		uassert.Equal(t, reward, uint64(0))
+		std.TestSkipHeights(1)
+	})
+
+	t.Run("30day tier is over", func(t *testing.T) {
+		std.TestSkipHeights(int64(TIMESTAMP_30DAYS) / 2)
+		std.TestSkipHeights(1)
+
+		reward := CollectRewardByProjectId(`gno.land/r/onbloc/obl:124`)
+		uassert.Equal(t, reward, uint64(99999999))
+	})
+
+	t.Run("more block after 30 days", func(t *testing.T) {
+		std.TestSkipHeights(int64(TIMESTAMP_30DAYS) / 2)
+		reward := CollectRewardByProjectId(`gno.land/r/onbloc/obl:124`)
+		uassert.Equal(t, reward, uint64(0))
+	})
+
+	t.Run("collect deposit gns by projectId", func(t *testing.T) {
+		std.TestSkipHeights(1)
+		depositCollected := CollectDepositGnsByProjectId(`gno.land/r/onbloc/obl:124`)
+		uassert.Equal(t, depositCollected, uint64(1_000_000))
+	})
+}
+
+func testDepositGnsTier180(t *testing.T) {
+	t.Run("deposit gns to tier 180", func(t *testing.T) {
+		std.TestSetRealm(adminRealm)
+		gns.Transfer(a2u(user01), uint64(1_000_000)) // to deposit
+		// transfer some grc20 tokens to bypass project condition
+		foo.Transfer(a2u(user01), uint64(10))
+		bar.Transfer(a2u(user01), uint64(10))
+
+		std.TestSetRealm(user01Realm)
+		gns.Approve(a2u(consts.LAUNCHPAD_ADDR), uint64(1_000_000))
+
+		// skip some blocks to make project active
+		std.TestSkipHeights(4)
+		depositId := DepositGns("gno.land/r/onbloc/obl:124:180", uint64(1_000_000))
+		uassert.Equal(t, depositId, `gno.land/r/onbloc/obl:124:180:g1w4ek2u3sx9047h6lta047h6lta047h6lh0ssfv:1937`)
+		std.TestSkipHeights(1)
+	})
+}
+
+func testCollectRewardTier180(t *testing.T) {
+	std.TestSetRealm(user01Realm)
+
+	t.Run("claim reward before 14 days(for 180day tier's init reward)", func(t *testing.T) {
+		reward := CollectRewardByProjectId(`gno.land/r/onbloc/obl:124`)
+		uassert.Equal(t, reward, uint64(0))
+		std.TestSkipHeights(1)
+	})
+
+	t.Run("180day tier is over", func(t *testing.T) {
+		std.TestSkipHeights(int64(TIMESTAMP_180DAYS) / 2)
+		std.TestSkipHeights(1)
+
+		reward := CollectRewardByProjectId(`gno.land/r/onbloc/obl:124`)
+		uassert.Equal(t, reward, uint64(699999999))
+	})


### PR DESCRIPTION
## fix
1. launchpad pool reward calculation
- if pool is inactive, do not update last calculated height