### PR TITLE
chore: Remove Unused Consts

### DIFF
--- a/_deploy/p/gnoswap/uint256/uint256.gno
+++ b/_deploy/p/gnoswap/uint256/uint256.gno
@@ -10,7 +10,6 @@ import (
 
 const (
 	MaxUint64 = 1<<64 - 1
-	uintSize  = 32 << (^uint(0) >> 63)
 )
 
 // Uint is represented as an array of 4 uint64, in little-endian order,

--- a/gov/governance/util.gno
+++ b/gov/governance/util.gno
@@ -12,11 +12,6 @@ import (
 	u256 "gno.land/p/gnoswap/uint256"
 )
 
-const (
-	MaxUint64 = 1<<64 - 1
-	uintSize  = 32 << (^uint(0) >> 63)
-)
-
 func strToInt(str string) int {
 	res, err := strconv.Atoi(str)
 	if err != nil {

--- a/launchpad/util.gno
+++ b/launchpad/util.gno
@@ -12,11 +12,6 @@ import (
 	u256 "gno.land/p/gnoswap/uint256"
 )
 
-const (
-	MaxUint64 = 1<<64 - 1
-	uintSize  = 32 << (^uint(0) >> 63)
-)
-
 func strToInt(str string) int {
 	res, err := strconv.Atoi(str)
 	if err != nil {


### PR DESCRIPTION
# Description

Remove all the unused `uintSize` and some `MaxUint64` const values