### PR TITLE
GSW-1959 fix: get position's liquidity in string, then assign it to uint256

### DIFF
--- a/staker/_RPC_api_calculation_base_data.gno
+++ b/staker/_RPC_api_calculation_base_data.gno
@@ -454,7 +454,7 @@ func GetPositionIsInRange(tokenId uint64) bool {
 func GetPositionLiquidity(tokenId uint64) string {
 	en.MintAndDistributeGns()
 
-	return pn.PositionGetPositionLiquidity(tokenId).ToString()
+	return pn.PositionGetPositionLiquidityStr(tokenId)
 }
 
 func GetMintedGnsAmount() uint64 {

--- a/staker/calculate_pool_position_reward.gno
+++ b/staker/calculate_pool_position_reward.gno
@@ -249,7 +249,8 @@ func CalcPoolPosition() {
 			continue
 		}
 
-		positionLiquidity := pn.PositionGetPositionLiquidity(tokenId)
+		liqStr := pn.PositionGetPositionLiquidityStr(tokenId)
+		positionLiquidity := u256.MustFromDecimal(liqStr)
 		poolTotalStakedLiquidity[poolPath] = poolTotalStakedLiquidity[poolPath].Add(poolTotalStakedLiquidity[poolPath], positionLiquidity)
 	}
 

--- a/staker/reward_recipient_store.gno
+++ b/staker/reward_recipient_store.gno
@@ -141,11 +141,19 @@ func (r *RewardRecipientsMap) GenerateRewardRecipients(depositList map[uint64]De
 			continue
 		}
 		// 3. already exist in the pool, skip
-		if r.GetPoolLiquidity(poolPath) != nil && r.GetPoolLiquidity(poolPath).GetInRangeLiquidity(tokenId) != nil {
+		if r.GetPoolLiquidity(poolPath) != nil &&
+			r.GetPoolLiquidity(poolPath).GetInRangeLiquidity(tokenId) != nil &&
+			!(r.GetPoolLiquidity(poolPath).GetInRangeLiquidity(tokenId).GetLiquidity().IsZero()) {
 			continue
 		}
 		// 4. get position liquidity
-		positionLiquidity := pn.PositionGetPositionLiquidity(tokenId).Clone()
+		liqStr := pn.PositionGetPositionLiquidityStr(tokenId)
+		positionLiquidity := u256.MustFromDecimal(liqStr)
+		if positionLiquidity == nil {
+			positionLiquidity = u256.Zero()
+		} else {
+			positionLiquidity = positionLiquidity.Clone()
+		}
 		// 5. get staked block height of the position
 		positionStakedHeight := deposit.stakeHeight
 		// 6. update liquidity
@@ -288,14 +296,33 @@ func (p *PoolLiquidity) GetStakedHeight(tokenID uint64) int64 {
 }
 
 func (p *PoolLiquidity) RemoveInRangePosition(tokenID uint64) {
-	if _, exist := p.inRangeLiquidityMap[tokenID]; !exist {
+	// nil check for p.inRangeLiquidityMap
+	if p.inRangeLiquidityMap == nil {
 		return
 	}
-	totalLiquidity := p.totalLiquidity
-	tokenLiquidity := p.inRangeLiquidityMap[tokenID].GetLiquidity()
-	totalLiquidity.Sub(totalLiquidity, tokenLiquidity)
-	p.SetTotalLiquidity(totalLiquidity)
-	delete(p.inRangeLiquidityMap, tokenID)
+
+	// nil check for postion
+	position, exist := p.inRangeLiquidityMap[tokenID]
+	if !exist || position == nil {
+		return
+	}
+
+	// nil check for totalLiquidity
+	if p.totalLiquidity == nil {
+		p.totalLiquidity = u256.Zero()
+	}
+
+	// nil check for position liquidity
+	tokenLiquidity := position.GetLiquidity()
+	if tokenLiquidity == nil {
+		return
+	}
+
+	p.totalLiquidity.Sub(p.totalLiquidity, tokenLiquidity)
+	position.SetLiquidity(u256.Zero())
+	position.SetLiquidityRatio(u256.Zero())
+	position.SetStakedHeight(0)
+	p.inRangeLiquidityMap[tokenID] = position
 }
 
 type InRangeLiquidity struct {

--- a/staker/staker.gno
+++ b/staker/staker.gno
@@ -116,7 +116,8 @@ func StakeToken(tokenId uint64) (string, string, string) {
 	}
 
 	// check tokenId has liquidity or not
-	liquidity := pn.PositionGetPositionLiquidity(tokenId) // *u256.Uint
+	liqStr := pn.PositionGetPositionLiquidityStr(tokenId)
+	liquidity := u256.MustFromDecimal(liqStr)
 	if liquidity.Lte(u256.Zero()) {
 		panic(addDetailToError(
 			errZeroLiquidity,


### PR DESCRIPTION
## fix
1. get position's liquidity in string, then assign it to uint256
> logic changed in this pr doesn't change liquidity, therefore need to aviod accessing pointer value directly.