### PR TITLE
GSW-1967 fix: ugnot protocol_fee wasn't being distributed

### DIFF
--- a/gov/staker/staker.gno
+++ b/gov/staker/staker.gno
@@ -7,6 +7,8 @@ import (
 	"gno.land/p/demo/ufmt"
 	pusers "gno.land/p/demo/users"
 
+	"gno.land/r/demo/wugnot"
+
 	"gno.land/r/gnoswap/v1/common"
 	"gno.land/r/gnoswap/v1/consts"
 
@@ -278,7 +280,16 @@ func CollectReward() {
 
 		// transfer token to caller
 		// token.Transfer(a2u(caller), amount)
-		transferByRegisterCall(tokenPath, caller, amount)
+
+		if tokenPath == consts.WUGNOT_PATH {
+			if amount > 0 {
+				wugnot.Withdraw(amount)
+				banker := std.GetBanker(std.BankerTypeRealmSend)
+				banker.SendCoins(consts.GOV_STAKER_ADDR, caller, std.Coins{{"ugnot", int64(amount)}})
+			}
+		} else {
+			transferByRegisterCall(tokenPath, caller, amount)
+		}
 		userProtocolFeeReward[caller][tokenPath] = 0
 
 		std.Emit(

--- a/gov/staker/tests/__TEST_0_INIT_VARIABLE_AND_HELPER_test.gno
+++ b/gov/staker/tests/__TEST_0_INIT_VARIABLE_AND_HELPER_test.gno
@@ -33,15 +33,3 @@ var (
 	rouRealm = std.NewCodeRealm(consts.ROUTER_PATH)
 	stkRealm = std.NewCodeRealm(consts.STAKER_PATH)
 )
-
-/* HELPER */
-func ugnotBalanceOf(addr std.Address) uint64 {
-	testBanker := std.GetBanker(std.BankerTypeRealmIssue)
-
-	coins := testBanker.GetCoins(addr)
-	if len(coins) == 0 {
-		return 0
-	}
-
-	return uint64(coins.AmountOf("ugnot"))
-}

--- a/gov/staker/tests/__TEST_governance_reward_protocol_fee_test.gnoA
+++ b/gov/staker/tests/__TEST_governance_reward_protocol_fee_test.gnoA
@@ -7,6 +7,8 @@ import (
 	"gno.land/p/demo/testutils"
 	"gno.land/p/demo/uassert"
 
+	"gno.land/r/demo/wugnot"
+
 	"gno.land/r/gnoswap/v1/gns"
 	"gno.land/r/gnoswap/v1/gov/xgns"
 
@@ -30,6 +32,7 @@ var (
 )
 
 func TestGovernanceRewardProtocolFee(t *testing.T) {
+	initData(t)
 	delegateFromAdminToDummy(t)
 	delegetFromDummyToDummy(t)
 	mockProtocolFee(t)
@@ -38,6 +41,11 @@ func TestGovernanceRewardProtocolFee(t *testing.T) {
 	mockProtocolFee2(t)
 	moreReward(t)
 	undelegateAdmin(t)
+}
+
+func initData(t *testing.T) {
+	// prevent `panic: source address g1pf6dv9fjk3rn0m4jjcne306ga4he3mzmupfjl6 does not exist`
+	std.TestIssueCoins(consts.WUGNOT_ADDR, std.Coins{{"ugnot", 1}})
 }
 
 func delegateFromAdminToDummy(t *testing.T) {
@@ -89,6 +97,13 @@ func mockProtocolFee(t *testing.T) {
 	bar.Transfer(a2u(consts.PROTOCOL_FEE_ADDR), 1000)
 	qux.Transfer(a2u(consts.PROTOCOL_FEE_ADDR), 2500)
 
+	// wugnot
+	std.TestSetOrigSend(std.Coins{{"ugnot", 10000}}, nil)
+	std.TestIssueCoins(consts.WUGNOT_ADDR, std.Coins{{"ugnot", 10000}})
+	wugnot.Deposit()
+
+	wugnot.Transfer(a2u(consts.PROTOCOL_FEE_ADDR), 10000)
+
 	uassert.Equal(t, bar.BalanceOf(a2u(consts.PROTOCOL_FEE_ADDR)), uint64(1000))
 	uassert.Equal(t, bar.BalanceOf(a2u(consts.DEV_OPS)), uint64(0))
 	uassert.Equal(t, bar.BalanceOf(a2u(consts.GOV_STAKER_ADDR)), uint64(0))
@@ -96,6 +111,10 @@ func mockProtocolFee(t *testing.T) {
 	uassert.Equal(t, qux.BalanceOf(a2u(consts.PROTOCOL_FEE_ADDR)), uint64(2500))
 	uassert.Equal(t, qux.BalanceOf(a2u(consts.DEV_OPS)), uint64(0))
 	uassert.Equal(t, qux.BalanceOf(a2u(consts.GOV_STAKER_ADDR)), uint64(0))
+
+	uassert.Equal(t, wugnot.BalanceOf(a2u(consts.PROTOCOL_FEE_ADDR)), uint64(10000))
+	uassert.Equal(t, wugnot.BalanceOf(a2u(consts.DEV_OPS)), uint64(0))
+	uassert.Equal(t, wugnot.BalanceOf(a2u(consts.GOV_STAKER_ADDR)), uint64(0))
 }
 
 func skipDummyBlocks(t *testing.T) {
@@ -116,17 +135,19 @@ func skipDummyBlocks(t *testing.T) {
 func reward(t *testing.T) {
 	t.Run("check reward", func(t *testing.T) {
 		gcr := GetClaimableRewardByAddress(dummyAddr)
-		uassert.Equal(t, gcr, `{"height":"136","now":"1234567916","emissionReward":"0","protocolFees":[{"tokenPath":"gno.land/r/onbloc/bar","amount":"833"},{"tokenPath":"gno.land/r/onbloc/qux","amount":"2083"}]}`)
+		uassert.Equal(t, gcr, `{"height":"136","now":"1234567916","emissionReward":"0","protocolFees":[{"tokenPath":"gno.land/r/onbloc/bar","amount":"833"},{"tokenPath":"gno.land/r/onbloc/qux","amount":"2083"},{"tokenPath":"gno.land/r/demo/wugnot","amount":"8333"}]}`)
 	})
 
 	t.Run("collect reward", func(t *testing.T) {
 		uassert.Equal(t, bar.BalanceOf(a2u(dummyAddr)), uint64(0))
 		uassert.Equal(t, qux.BalanceOf(a2u(dummyAddr)), uint64(0))
+		uassert.Equal(t, ugnotBalanceOf(dummyAddr), uint64(0))
 
 		std.TestSetRealm(dummyRealm)
 		CollectReward()
 		uassert.Equal(t, bar.BalanceOf(a2u(dummyAddr)), uint64(833))
 		uassert.Equal(t, qux.BalanceOf(a2u(dummyAddr)), uint64(2083))
+		uassert.Equal(t, ugnotBalanceOf(dummyAddr), uint64(8333))
 	})
 
 	t.Run("same block", func(t *testing.T) {
@@ -135,6 +156,7 @@ func reward(t *testing.T) {
 
 		uassert.Equal(t, bar.BalanceOf(a2u(dummyAddr)), uint64(833))
 		uassert.Equal(t, qux.BalanceOf(a2u(dummyAddr)), uint64(2083))
+		uassert.Equal(t, ugnotBalanceOf(dummyAddr), uint64(8333))
 	})
 
 	t.Run("more block", func(t *testing.T) {
@@ -143,6 +165,7 @@ func reward(t *testing.T) {
 
 		uassert.Equal(t, bar.BalanceOf(a2u(dummyAddr)), uint64(833))
 		uassert.Equal(t, qux.BalanceOf(a2u(dummyAddr)), uint64(2083))
+		uassert.Equal(t, ugnotBalanceOf(dummyAddr), uint64(8333))
 	})
 }
 

--- a/gov/staker/util.gno
+++ b/gov/staker/util.gno
@@ -49,3 +49,14 @@ func getPrev() (string, string) {
 	prev := std.PrevRealm()
 	return prev.Addr().String(), prev.PkgPath()
 }
+
+func ugnotBalanceOf(addr std.Address) uint64 {
+	testBanker := std.GetBanker(std.BankerTypeRealmIssue)
+
+	coins := testBanker.GetCoins(addr)
+	if len(coins) == 0 {
+		return 0
+	}
+
+	return uint64(coins.AmountOf("ugnot"))
+}

--- a/router/protocol_fee_swap.gno
+++ b/router/protocol_fee_swap.gno
@@ -9,8 +9,6 @@ import (
 	"gno.land/p/demo/ufmt"
 
 	u256 "gno.land/p/gnoswap/uint256"
-
-	"gno.land/r/demo/wugnot"
 )
 
 var (
@@ -31,19 +29,7 @@ func handleSwapFee(
 	feeAmountUint64 := feeAmount.Uint64()
 
 	if !isDry {
-		if outputToken == consts.GNOT { // unwrap if coin
-			// wugnot: buyer > router
-			transferFromByRegisterCall(outputToken, std.PrevRealm().Addr(), consts.ROUTER_ADDR, feeAmountUint64)
-
-			// ugnot: wugnot > router
-			wugnot.Withdraw(feeAmountUint64)
-
-			// ugnot: router > feeCollector
-			banker := std.GetBanker(std.BankerTypeRealmSend)
-			banker.SendCoins(consts.ROUTER_ADDR, consts.PROTOCOL_FEE_ADDR, std.Coins{{"ugnot", int64(feeAmountUint64)}})
-		} else { // just transfer if grc20
-			transferFromByRegisterCall(outputToken, std.PrevRealm().Addr(), consts.PROTOCOL_FEE_ADDR, feeAmountUint64)
-		}
+		transferFromByRegisterCall(outputToken, std.PrevRealm().Addr(), consts.PROTOCOL_FEE_ADDR, feeAmountUint64)
 
 		prevAddr, prevRealm := getPrev()
 


### PR DESCRIPTION
## fix
1. collect and distribute protocol_fee in grc20, when unwrap when user requests claiming it.