### PR TITLE
chore: Remove String Concat With `+` Operator

### DIFF
--- a/_deploy/r/gnoswap/common/strings.gno
+++ b/_deploy/r/gnoswap/common/strings.gno
@@ -1,0 +1,16 @@
+package common
+
+import (
+	"strings"
+
+	"gno.land/p/demo/ufmt"
+)
+
+func Split(tierId string, sep string, length int) ([]string, error) {
+	result := strings.Split(tierId, sep)
+	if len(result) != length {
+		return nil, ufmt.Errorf("invalid length: %d", len(result))
+	}
+
+	return result, nil
+}

--- a/_deploy/r/gnoswap/common/strings.gno
+++ b/_deploy/r/gnoswap/common/strings.gno
@@ -6,8 +6,8 @@ import (
 	"gno.land/p/demo/ufmt"
 )
 
-func Split(tierId string, sep string, length int) ([]string, error) {
-	result := strings.Split(tierId, sep)
+func Split(input string, sep string, length int) ([]string, error) {
+	result := strings.Split(input, sep)
 	if len(result) != length {
 		return nil, ufmt.Errorf("invalid length: %d", len(result))
 	}

--- a/gov/governance/_GET_vote.gno
+++ b/gov/governance/_GET_vote.gno
@@ -2,11 +2,11 @@ package governance
 
 import (
 	"std"
+	"strconv"
 
 	"gno.land/p/demo/ufmt"
 
-	"strconv"
-	"strings"
+	"gno.land/r/gnoswap/v1/common"
 )
 
 func GetVoteByVoteKey(voteKey string) bool {
@@ -110,12 +110,9 @@ func GetVotedAtByVoteKey(voteKey string) uint64 {
 }
 
 func divideVoteKeyToProposalIdAndUser(voteKey string) (uint64, std.Address) {
-	parts := strings.Split(voteKey, ":")
-	if len(parts) != 2 {
-		panic(addDetailToError(
-			errInvalidInput,
-			ufmt.Sprintf("_GET_vote.gno__divideVoteKeyToProposalIdAndUser() || voteKey(%s) is invalid", voteKey),
-		))
+	parts, err := common.Split(voteKey, ":", 2)
+	if err != nil {
+		panic(errInvalidInput)
 	}
 
 	proposalId, err := strconv.ParseUint(parts[0], 10, 64)

--- a/gov/governance/_GET_vote.gno
+++ b/gov/governance/_GET_vote.gno
@@ -112,7 +112,10 @@ func GetVotedAtByVoteKey(voteKey string) uint64 {
 func divideVoteKeyToProposalIdAndUser(voteKey string) (uint64, std.Address) {
 	parts, err := common.Split(voteKey, ":", 2)
 	if err != nil {
-		panic(errInvalidInput)
+		panic(addDetailToError(
+			errInvalidInput,
+			ufmt.Sprintf("_GET_vote.gno__divideVoteKeyToProposalIdAndUser() || voteKey(%s) is invalid", voteKey),
+		))
 	}
 
 	proposalId, err := strconv.ParseUint(parts[0], 10, 64)

--- a/gov/governance/vote.gno
+++ b/gov/governance/vote.gno
@@ -71,7 +71,7 @@ func Vote(proposalId uint64, yes bool) string {
 		))
 	}
 
-	voteKey := ufmt.Sprintf("%d", proposalId) + ":" + voter.String()
+	voteKey := ufmt.Sprintf("%d:%s", proposalId, voter.String())
 	_, voted := votes[voteKey]
 	if voted {
 		panic(addDetailToError(

--- a/launchpad/launchpad_deposit.gno
+++ b/launchpad/launchpad_deposit.gno
@@ -96,7 +96,7 @@ func DepositGns(
 	// deposit History
 	depositor := std.PrevRealm().Addr()
 	depositorStr := depositor.String()
-	depositId := projectId + ":" + tierStr + ":" + depositorStr + ":" + ufmt.Sprintf("%d", std.GetHeight())
+	depositId := ufmt.Sprintf("%s:%s:%s:%d", projectId, tierStr, depositorStr, std.GetHeight())
 
 	// calculate claimable height & time base on deposit height & time
 	calcClaimableHeight := uint64(std.GetHeight()) + tier.collectWaitDuration
@@ -451,27 +451,21 @@ func getProjectIdFromTierId(tierId string) string {
 	// input: gno.land/r/gnoswap/gns:123:30
 	// output: gno.land/r/gnoswap/gns:123
 
-	result := strings.Split(tierId, ":")
-	if len(result) == 3 {
-		return result[0] + ":" + result[1]
+	res, err := common.Split(tierId, ":", 3)
+	if err != nil {
+		panic(err)
 	}
 
-	panic(addDetailToError(
-		errInvalidTier,
-		ufmt.Sprintf("launchpad_deposit.gno__getProjectIdFromTierId() || invalid tierId: %s", tierId),
-	))
+	return ufmt.Sprintf("%s:%s", res[0], res[1])
 }
 
 func getProjectIdAndTierFromTierId(tierId string) (string, string) {
-	result := strings.Split(tierId, ":")
-	if len(result) == 3 {
-		return result[0] + ":" + result[1], result[2]
+	res, err := common.Split(tierId, ":", 3)
+	if err != nil {
+		panic(err)
 	}
 
-	panic(addDetailToError(
-		errInvalidTier,
-		ufmt.Sprintf("launchpad_deposit.gno__getProjectIdAndTierFromTierId() || invalid tierId: %s", tierId),
-	))
+	return ufmt.Sprintf("%s:%s", res[0], res[1]), res[2]
 }
 
 func checkDepositConditions(project Project) {

--- a/launchpad/launchpad_deposit.gno
+++ b/launchpad/launchpad_deposit.gno
@@ -453,7 +453,10 @@ func getProjectIdFromTierId(tierId string) string {
 
 	res, err := common.Split(tierId, ":", 3)
 	if err != nil {
-		panic(err)
+		panic(addDetailToError(
+			errInvalidTier,
+			ufmt.Sprintf("launchpad_deposit.gno__getProjectIdFromTierId() || invalid tierId: %s", tierId),
+		))
 	}
 
 	return ufmt.Sprintf("%s:%s", res[0], res[1])
@@ -462,7 +465,10 @@ func getProjectIdFromTierId(tierId string) string {
 func getProjectIdAndTierFromTierId(tierId string) (string, string) {
 	res, err := common.Split(tierId, ":", 3)
 	if err != nil {
-		panic(err)
+		panic(addDetailToError(
+			errInvalidTier,
+			ufmt.Sprintf("launchpad_deposit.gno__getProjectIdAndTierFromTierId() || invalid tierId: %s", tierId),
+		))
 	}
 
 	return ufmt.Sprintf("%s:%s", res[0], res[1]), res[2]

--- a/position/utils.gno
+++ b/position/utils.gno
@@ -27,7 +27,10 @@ func a2u(addr std.Address) pusers.AddressOrName {
 func poolKeyDivide(poolKey string) (string, string, uint32) {
 	res, err := common.Split(poolKey, ":", 3)
 	if err != nil {
-		panic(errInvalidInput)
+		panic(addDetailToError(
+			errInvalidInput,
+			ufmt.Sprintf("utils.gno__poolKeyDivide() || invalid poolKey(%s)", poolKey),
+		))
 	}
 
 	pToken0, pToken1, pFeeStr := res[0], res[1], res[2]

--- a/position/utils.gno
+++ b/position/utils.gno
@@ -3,11 +3,11 @@ package position
 import (
 	"std"
 	"strconv"
-	"strings"
 	"time"
 
 	"gno.land/p/demo/ufmt"
 	pusers "gno.land/p/demo/users"
+	"gno.land/r/gnoswap/v1/common"
 )
 
 func checkDeadline(deadline int64) {
@@ -25,12 +25,9 @@ func a2u(addr std.Address) pusers.AddressOrName {
 }
 
 func poolKeyDivide(poolKey string) (string, string, uint32) {
-	res := strings.Split(poolKey, ":")
-	if len(res) != 3 {
-		panic(addDetailToError(
-			errInvalidInput,
-			ufmt.Sprintf("utils.gno__poolKeyDivide() || invalid poolKey(%s)", poolKey),
-		))
+	res, err := common.Split(poolKey, ":", 3)
+	if err != nil {
+		panic(errInvalidInput)
 	}
 
 	pToken0, pToken1, pFeeStr := res[0], res[1], res[2]

--- a/router/comptue_routes.gno
+++ b/router/comptue_routes.gno
@@ -4,8 +4,9 @@ import (
 	"sort"
 
 	pl "gno.land/r/gnoswap/v1/pool"
-
 	u256 "gno.land/p/gnoswap/uint256"
+
+	"gno.land/p/demo/ufmt"
 )
 
 // PoolWithMeta is a struct that contains poolPath, token0Path, token1Path, fee, tokenPair, and liquidity
@@ -180,7 +181,7 @@ func findCandidatePools() []PoolWithMeta {
 			token0Path,
 			token1Path,
 			pFee,
-			token0Path + ":" + token1Path,
+			ufmt.Sprintf("%s:%s", token0Path, token1Path),
 			liquidity,
 		})
 	}

--- a/router/utils.gno
+++ b/router/utils.gno
@@ -13,7 +13,10 @@ import (
 func poolPathWithFeeDivide(poolPath string) (string, string, int) {
 	poolPathSplit, err := common.Split(poolPath, ":", 3)
 	if err != nil {
-		panic(errInvalidPoolPath)
+		panic(addDetailToError(
+			errInvalidPoolPath,
+			ufmt.Sprintf("utils.gno__poolPathWithFeeDivide() || invalid poolPath(%s)", poolPath),
+		))
 	}
 
 	feeInt, err := strconv.Atoi(poolPathSplit[2])
@@ -27,7 +30,10 @@ func poolPathWithFeeDivide(poolPath string) (string, string, int) {
 func getDataForSinglePath(poolPath string) (string, string, uint32) {
 	poolPathSplit, err := common.Split(poolPath, ":", 3)
 	if err != nil {
-		panic(errInvalidPoolPath)
+		panic(addDetailToError(
+			errInvalidPoolPath,
+			ufmt.Sprintf("utils.gno__getDataForSinglePath() || len(poolPathSplit) != 3, poolPath: %s", poolPath),
+		))
 	}
 
 	token0 := poolPathSplit[0]

--- a/router/utils.gno
+++ b/router/utils.gno
@@ -7,15 +7,13 @@ import (
 
 	"gno.land/p/demo/ufmt"
 	pusers "gno.land/p/demo/users"
+	"gno.land/r/gnoswap/v1/common"
 )
 
 func poolPathWithFeeDivide(poolPath string) (string, string, int) {
-	poolPathSplit := strings.Split(poolPath, ":")
-	if len(poolPathSplit) != 3 {
-		panic(addDetailToError(
-			errInvalidPoolPath,
-			ufmt.Sprintf("utils.gno__poolPathWithFeeDivide() || len(poolPathSplit) != 3, poolPath: %s", poolPath),
-		))
+	poolPathSplit, err := common.Split(poolPath, ":", 3)
+	if err != nil {
+		panic(errInvalidPoolPath)
 	}
 
 	feeInt, err := strconv.Atoi(poolPathSplit[2])
@@ -27,12 +25,9 @@ func poolPathWithFeeDivide(poolPath string) (string, string, int) {
 }
 
 func getDataForSinglePath(poolPath string) (string, string, uint32) {
-	poolPathSplit := strings.Split(poolPath, ":")
-	if len(poolPathSplit) != 3 {
-		panic(addDetailToError(
-			errInvalidPoolPath,
-			ufmt.Sprintf("utils.gno__getDataForSinglePath() || len(poolPathSplit) != 3, poolPath: %s", poolPath),
-		))
+	poolPathSplit, err := common.Split(poolPath, ":", 3)
+	if err != nil {
+		panic(errInvalidPoolPath)
 	}
 
 	token0 := poolPathSplit[0]

--- a/staker/utils.gno
+++ b/staker/utils.gno
@@ -8,15 +8,13 @@ import (
 	"gno.land/p/demo/grc/grc721"
 	"gno.land/p/demo/ufmt"
 	pusers "gno.land/p/demo/users"
+	"gno.land/r/gnoswap/v1/common"
 )
 
 func poolPathAlign(poolPath string) string {
-	res := strings.Split(poolPath, ":")
-	if len(res) != 3 {
-		panic(addDetailToError(
-			errInvalidPoolPath,
-			ufmt.Sprintf("utils.gno__poolPathAlign() || invalid poolPath(%s)", poolPath),
-		))
+	res, err := common.Split(poolPath, ":", 3)
+	if err != nil {
+		panic(errInvalidPoolPath)
 	}
 
 	pToken0, pToken1, fee := res[0], res[1], res[2]
@@ -29,12 +27,9 @@ func poolPathAlign(poolPath string) string {
 }
 
 func poolPathDivide(poolPath string) (string, string, string) {
-	res := strings.Split(poolPath, ":")
-	if len(res) != 3 {
-		panic(addDetailToError(
-			errInvalidPoolPath,
-			ufmt.Sprintf("utils.gno__poolPathDivide() || invalid poolPath(%s)", poolPath),
-		))
+	res, err := common.Split(poolPath, ":", 3)
+	if err != nil {
+		panic(errInvalidPoolPath)
 	}
 
 	pToken0, pToken1, fee := res[0], res[1], res[2]

--- a/staker/utils.gno
+++ b/staker/utils.gno
@@ -14,7 +14,10 @@ import (
 func poolPathAlign(poolPath string) string {
 	res, err := common.Split(poolPath, ":", 3)
 	if err != nil {
-		panic(errInvalidPoolPath)
+		panic(addDetailToError(
+			errInvalidPoolPath,
+			ufmt.Sprintf("utils.gno__poolPathAlign() || invalid poolPath(%s)", poolPath),
+		))
 	}
 
 	pToken0, pToken1, fee := res[0], res[1], res[2]


### PR DESCRIPTION
# Description

* modified the part where strings were concatenated using the `+` operator to use a formatting function instead.
    - This change was made for readability rather than performance concerns (generally, using the `+` operator for string concatenation can result in minor performance degradation). 

* extracted the logic for splitting strings with a specific separator into a common utility.