### PR TITLE
GSW-1968 refactor: use latest privileges access check logic

### DIFF
--- a/_deploy/r/gnoswap/common/halt.gno
+++ b/_deploy/r/gnoswap/common/halt.gno
@@ -20,7 +20,7 @@ func IsHalted() {
 	if halted {
 		panic(addDetailToError(
 			errHalted,
-			"halt.gno__IsHalted() || gnoswap halted",
+			"gnoswap halted",
 		))
 	}
 }
@@ -28,11 +28,12 @@ func IsHalted() {
 // SetHaltByAdmin sets the halt status.
 func SetHaltByAdmin(halt bool) {
 	caller := std.PrevRealm().Addr()
-	if caller != consts.ADMIN {
+	err := AdminOnly(caller)
+	if err != nil {
 		panic(addDetailToError(
 			errNoPermission,
 			ufmt.Sprintf(
-				"halt.gno__SetHaltByAdmin() || only admin(%s) can set halt, called from %s",
+				"only admin(%s) can set halt, called from %s",
 				consts.ADMIN,
 				caller,
 			),
@@ -63,11 +64,12 @@ func SetHaltByAdmin(halt bool) {
 // Only governance contract can execute this function via proposal
 func SetHalt(halt bool) {
 	caller := std.PrevRealm().Addr()
-	if caller != consts.GOV_GOVERNANCE_ADDR {
+	err := GovernanceOnly(caller)
+	if err != nil {
 		panic(addDetailToError(
 			errNoPermission,
 			ufmt.Sprintf(
-				"halt.gno__SetHalt() || only governance(%s) can set halt, called from %s",
+				"only governance(%s) can set halt, called from %s",
 				consts.GOV_GOVERNANCE_ADDR,
 				caller,
 			),

--- a/_deploy/r/gnoswap/common/halt_test.gno
+++ b/_deploy/r/gnoswap/common/halt_test.gno
@@ -28,7 +28,7 @@ func TestSetHaltByAdmin(t *testing.T) {
 	t.Run("with non-admin privilege, panics", func(t *testing.T) {
 		uassert.PanicsWithMessage(
 			t,
-			`[GNOSWAP-COMMON-001] caller has no permission || halt.gno__SetHaltByAdmin() || only admin(g17290cwvmrapvp869xfnhhawa8sm9edpufzat7d) can set halt, called from g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm`,
+			`[GNOSWAP-COMMON-001] caller has no permission || only admin(g17290cwvmrapvp869xfnhhawa8sm9edpufzat7d) can set halt, called from g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm`,
 			func() { SetHaltByAdmin(false) },
 		)
 	})
@@ -37,7 +37,7 @@ func TestSetHaltByAdmin(t *testing.T) {
 		std.TestSetRealm(govRealm)
 		uassert.PanicsWithMessage(
 			t,
-			`[GNOSWAP-COMMON-001] caller has no permission || halt.gno__SetHaltByAdmin() || only admin(g17290cwvmrapvp869xfnhhawa8sm9edpufzat7d) can set halt, called from g17s8w2ve7k85fwfnrk59lmlhthkjdted8whvqxd`,
+			`[GNOSWAP-COMMON-001] caller has no permission || only admin(g17290cwvmrapvp869xfnhhawa8sm9edpufzat7d) can set halt, called from g17s8w2ve7k85fwfnrk59lmlhthkjdted8whvqxd`,
 			func() { SetHaltByAdmin(false) },
 		)
 	})
@@ -56,7 +56,7 @@ func TestSetHalt(t *testing.T) {
 	t.Run("with non-governance privilege, panics", func(t *testing.T) {
 		uassert.PanicsWithMessage(
 			t,
-			`[GNOSWAP-COMMON-001] caller has no permission || halt.gno__SetHalt() || only governance(g17s8w2ve7k85fwfnrk59lmlhthkjdted8whvqxd) can set halt, called from g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm`,
+			`[GNOSWAP-COMMON-001] caller has no permission || only governance(g17s8w2ve7k85fwfnrk59lmlhthkjdted8whvqxd) can set halt, called from g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm`,
 			func() { SetHalt(false) },
 		)
 	})
@@ -65,7 +65,7 @@ func TestSetHalt(t *testing.T) {
 		std.TestSetRealm(adminRealm)
 		uassert.PanicsWithMessage(
 			t,
-			`[GNOSWAP-COMMON-001] caller has no permission || halt.gno__SetHalt() || only governance(g17s8w2ve7k85fwfnrk59lmlhthkjdted8whvqxd) can set halt, called from g17290cwvmrapvp869xfnhhawa8sm9edpufzat7d`,
+			`[GNOSWAP-COMMON-001] caller has no permission || only governance(g17s8w2ve7k85fwfnrk59lmlhthkjdted8whvqxd) can set halt, called from g17290cwvmrapvp869xfnhhawa8sm9edpufzat7d`,
 			func() { SetHalt(false) },
 		)
 	})


### PR DESCRIPTION
## refactor
1. `common` has new privileges check logic(#390), therefore apply it.