### PR TITLE
GSW-1838 chore: remove prefix from pool's receiver getter

### DIFF
--- a/pool/getter.gno
+++ b/pool/getter.gno
@@ -11,119 +11,119 @@ func PoolGetPoolList() []string {
 }
 
 func PoolGetToken0Path(poolPath string) string {
-	return mustGetPool(poolPath).PoolGetToken0Path()
+	return mustGetPool(poolPath).GetToken0Path()
 }
 
 func PoolGetToken1Path(poolPath string) string {
-	return mustGetPool(poolPath).PoolGetToken1Path()
+	return mustGetPool(poolPath).GetToken1Path()
 }
 
 func PoolGetFee(poolPath string) uint32 {
-	return mustGetPool(poolPath).PoolGetFee()
+	return mustGetPool(poolPath).GetFee()
 }
 
 func PoolGetBalanceToken0(poolPath string) string {
-	return mustGetPool(poolPath).PoolGetBalanceToken0().ToString()
+	return mustGetPool(poolPath).GetBalanceToken0().ToString()
 }
 
 func PoolGetBalanceToken1(poolPath string) string {
-	return mustGetPool(poolPath).PoolGetBalanceToken1().ToString()
+	return mustGetPool(poolPath).GetBalanceToken1().ToString()
 }
 
 func PoolGetTickSpacing(poolPath string) int32 {
-	return mustGetPool(poolPath).PoolGetTickSpacing()
+	return mustGetPool(poolPath).GetTickSpacing()
 }
 
 func PoolGetMaxLiquidityPerTick(poolPath string) string {
-	return mustGetPool(poolPath).PoolGetMaxLiquidityPerTick().ToString()
+	return mustGetPool(poolPath).GetMaxLiquidityPerTick().ToString()
 }
 
 func PoolGetSlot0SqrtPriceX96(poolPath string) string {
-	return mustGetPool(poolPath).PoolGetSlot0SqrtPriceX96().ToString()
+	return mustGetPool(poolPath).GetSlot0SqrtPriceX96().ToString()
 }
 
 func PoolGetSlot0Tick(poolPath string) int32 {
-	return mustGetPool(poolPath).PoolGetSlot0Tick()
+	return mustGetPool(poolPath).GetSlot0Tick()
 }
 
 func PoolGetSlot0FeeProtocol(poolPath string) uint8 {
-	return mustGetPool(poolPath).PoolGetSlot0FeeProtocol()
+	return mustGetPool(poolPath).GetSlot0FeeProtocol()
 }
 
 func PoolGetSlot0Unlocked(poolPath string) bool {
-	return mustGetPool(poolPath).PoolGetSlot0Unlocked()
+	return mustGetPool(poolPath).GetSlot0Unlocked()
 }
 
 func PoolGetFeeGrowthGlobal0X128(poolPath string) string {
-	return mustGetPool(poolPath).PoolGetFeeGrowthGlobal0X128().ToString()
+	return mustGetPool(poolPath).GetFeeGrowthGlobal0X128().ToString()
 }
 
 func PoolGetFeeGrowthGlobal1X128(poolPath string) string {
-	return mustGetPool(poolPath).PoolGetFeeGrowthGlobal1X128().ToString()
+	return mustGetPool(poolPath).GetFeeGrowthGlobal1X128().ToString()
 }
 
 func PoolGetProtocolFeesToken0(poolPath string) string {
-	return mustGetPool(poolPath).PoolGetProtocolFeesToken0().ToString()
+	return mustGetPool(poolPath).GetProtocolFeesToken0().ToString()
 }
 
 func PoolGetProtocolFeesToken1(poolPath string) string {
-	return mustGetPool(poolPath).PoolGetProtocolFeesToken1().ToString()
+	return mustGetPool(poolPath).GetProtocolFeesToken1().ToString()
 }
 
 func PoolGetLiquidity(poolPath string) string {
-	return mustGetPool(poolPath).PoolGetLiquidity().ToString()
+	return mustGetPool(poolPath).GetLiquidity().ToString()
 }
 
 // position
 func PoolGetPositionLiquidity(poolPath, key string) string {
-	return mustGetPool(poolPath).PoolGetPositionLiquidity(key).ToString()
+	return mustGetPool(poolPath).GetPositionLiquidity(key).ToString()
 }
 
 func PoolGetPositionFeeGrowthInside0LastX128(poolPath, key string) string {
-	return mustGetPool(poolPath).PoolGetPositionFeeGrowthInside0LastX128(key).ToString()
+	return mustGetPool(poolPath).GetPositionFeeGrowthInside0LastX128(key).ToString()
 }
 
 func PoolGetPositionFeeGrowthInside1LastX128(poolPath, key string) string {
-	return mustGetPool(poolPath).PoolGetPositionFeeGrowthInside1LastX128(key).ToString()
+	return mustGetPool(poolPath).GetPositionFeeGrowthInside1LastX128(key).ToString()
 }
 
 func PoolGetPositionTokensOwed0(poolPath, key string) string {
-	return mustGetPool(poolPath).PoolGetPositionTokensOwed0(key).ToString()
+	return mustGetPool(poolPath).GetPositionTokensOwed0(key).ToString()
 }
 
 func PoolGetPositionTokensOwed1(poolPath, key string) string {
-	return mustGetPool(poolPath).PoolGetPositionTokensOwed1(key).ToString()
+	return mustGetPool(poolPath).GetPositionTokensOwed1(key).ToString()
 }
 
 // tick
 func PoolGetTickLiquidityGross(poolPath string, tick int32) string {
-	return mustGetPool(poolPath).PoolGetTickLiquidityGross(tick).ToString()
+	return mustGetPool(poolPath).GetTickLiquidityGross(tick).ToString()
 }
 
 func PoolGetTickLiquidityNet(poolPath string, tick int32) string {
-	return mustGetPool(poolPath).PoolGetTickLiquidityNet(tick).ToString()
+	return mustGetPool(poolPath).GetTickLiquidityNet(tick).ToString()
 }
 
 func PoolGetTickFeeGrowthOutside0X128(poolPath string, tick int32) string {
-	return mustGetPool(poolPath).PoolGetTickFeeGrowthOutside0X128(tick).ToString()
+	return mustGetPool(poolPath).GetTickFeeGrowthOutside0X128(tick).ToString()
 }
 
 func PoolGetTickFeeGrowthOutside1X128(poolPath string, tick int32) string {
-	return mustGetPool(poolPath).PoolGetTickFeeGrowthOutside1X128(tick).ToString()
+	return mustGetPool(poolPath).GetTickFeeGrowthOutside1X128(tick).ToString()
 }
 
 func PoolGetTickCumulativeOutside(poolPath string, tick int32) int64 {
-	return mustGetPool(poolPath).PoolGetTickCumulativeOutside(tick)
+	return mustGetPool(poolPath).GetTickCumulativeOutside(tick)
 }
 
 func PoolGetTickSecondsPerLiquidityOutsideX128(poolPath string, tick int32) string {
-	return mustGetPool(poolPath).PoolGetTickSecondsPerLiquidityOutsideX128(tick).ToString()
+	return mustGetPool(poolPath).GetTickSecondsPerLiquidityOutsideX128(tick).ToString()
 }
 
 func PoolGetTickSecondsOutside(poolPath string, tick int32) uint32 {
-	return mustGetPool(poolPath).PoolGetTickSecondsOutside(tick)
+	return mustGetPool(poolPath).GetTickSecondsOutside(tick)
 }
 
 func PoolGetTickInitialized(poolPath string, tick int32) bool {
-	return mustGetPool(poolPath).PoolGetTickInitialized(tick)
+	return mustGetPool(poolPath).GetTickInitialized(tick)
 }

--- a/pool/pool.gno
+++ b/pool/pool.gno
@@ -971,71 +971,71 @@ func checkAmountRange(amount *u256.Uint) (uint64, error) {
 }
 
 // receiver getters
-func (p *Pool) PoolGetToken0Path() string {
+func (p *Pool) GetToken0Path() string {
 	return p.token0Path
 }
 
-func (p *Pool) PoolGetToken1Path() string {
+func (p *Pool) GetToken1Path() string {
 	return p.token1Path
 }
 
-func (p *Pool) PoolGetFee() uint32 {
+func (p *Pool) GetFee() uint32 {
 	return p.fee
 }
 
-func (p *Pool) PoolGetBalanceToken0() *u256.Uint {
+func (p *Pool) GetBalanceToken0() *u256.Uint {
 	return p.balances.token0
 }
 
-func (p *Pool) PoolGetBalanceToken1() *u256.Uint {
+func (p *Pool) GetBalanceToken1() *u256.Uint {
 	return p.balances.token1
 }
 
-func (p *Pool) PoolGetTickSpacing() int32 {
+func (p *Pool) GetTickSpacing() int32 {
 	return p.tickSpacing
 }
 
-func (p *Pool) PoolGetMaxLiquidityPerTick() *u256.Uint {
+func (p *Pool) GetMaxLiquidityPerTick() *u256.Uint {
 	return p.maxLiquidityPerTick
 }
 
-func (p *Pool) PoolGetSlot0() Slot0 {
+func (p *Pool) GetSlot0() Slot0 {
 	return p.slot0
 }
 
-func (p *Pool) PoolGetSlot0SqrtPriceX96() *u256.Uint {
+func (p *Pool) GetSlot0SqrtPriceX96() *u256.Uint {
 	return p.slot0.sqrtPriceX96
 }
 
-func (p *Pool) PoolGetSlot0Tick() int32 {
+func (p *Pool) GetSlot0Tick() int32 {
 	return p.slot0.tick
 }
 
-func (p *Pool) PoolGetSlot0FeeProtocol() uint8 {
+func (p *Pool) GetSlot0FeeProtocol() uint8 {
 	return p.slot0.feeProtocol
 }
 
-func (p *Pool) PoolGetSlot0Unlocked() bool {
+func (p *Pool) GetSlot0Unlocked() bool {
 	return p.slot0.unlocked
 }
 
-func (p *Pool) PoolGetFeeGrowthGlobal0X128() *u256.Uint {
+func (p *Pool) GetFeeGrowthGlobal0X128() *u256.Uint {
 	return p.feeGrowthGlobal0X128
 }
 
-func (p *Pool) PoolGetFeeGrowthGlobal1X128() *u256.Uint {
+func (p *Pool) GetFeeGrowthGlobal1X128() *u256.Uint {
 	return p.feeGrowthGlobal1X128
 }
 
-func (p *Pool) PoolGetProtocolFeesToken0() *u256.Uint {
+func (p *Pool) GetProtocolFeesToken0() *u256.Uint {
 	return p.protocolFees.token0
 }
 
-func (p *Pool) PoolGetProtocolFeesToken1() *u256.Uint {
+func (p *Pool) GetProtocolFeesToken1() *u256.Uint {
 	return p.protocolFees.token1
 }
 
-func (p *Pool) PoolGetLiquidity() *u256.Uint {
+func (p *Pool) GetLiquidity() *u256.Uint {
 	return p.liquidity
 }
 

--- a/pool/position.gno
+++ b/pool/position.gno
@@ -107,23 +107,23 @@ func positionUpdate(
 
 // receiver getters
 
-func (p *Pool) PoolGetPositionLiquidity(key string) *u256.Uint {
+func (p *Pool) GetPositionLiquidity(key string) *u256.Uint {
 	return p.mustGetPosition(key).liquidity
 }
 
-func (p *Pool) PoolGetPositionFeeGrowthInside0LastX128(key string) *u256.Uint {
+func (p *Pool) GetPositionFeeGrowthInside0LastX128(key string) *u256.Uint {
 	return p.mustGetPosition(key).feeGrowthInside0LastX128
 }
 
-func (p *Pool) PoolGetPositionFeeGrowthInside1LastX128(key string) *u256.Uint {
+func (p *Pool) GetPositionFeeGrowthInside1LastX128(key string) *u256.Uint {
 	return p.mustGetPosition(key).feeGrowthInside1LastX128
 }
 
-func (p *Pool) PoolGetPositionTokensOwed0(key string) *u256.Uint {
+func (p *Pool) GetPositionTokensOwed0(key string) *u256.Uint {
 	return p.mustGetPosition(key).tokensOwed0
 }
 
-func (p *Pool) PoolGetPositionTokensOwed1(key string) *u256.Uint {
+func (p *Pool) GetPositionTokensOwed1(key string) *u256.Uint {
 	return p.mustGetPosition(key).tokensOwed1
 }
 

--- a/pool/tick.gno
+++ b/pool/tick.gno
@@ -144,35 +144,35 @@ func getFeeGrowthAboveX128(
 }
 
 // receiver getters
-func (p *Pool) PoolGetTickLiquidityGross(tick int32) *u256.Uint {
+func (p *Pool) GetTickLiquidityGross(tick int32) *u256.Uint {
 	return p.mustGetTick(tick).liquidityGross
 }
 
-func (p *Pool) PoolGetTickLiquidityNet(tick int32) *i256.Int {
+func (p *Pool) GetTickLiquidityNet(tick int32) *i256.Int {
 	return p.mustGetTick(tick).liquidityNet
 }
 
-func (p *Pool) PoolGetTickFeeGrowthOutside0X128(tick int32) *u256.Uint {
+func (p *Pool) GetTickFeeGrowthOutside0X128(tick int32) *u256.Uint {
 	return p.mustGetTick(tick).feeGrowthOutside0X128
 }
 
-func (p *Pool) PoolGetTickFeeGrowthOutside1X128(tick int32) *u256.Uint {
+func (p *Pool) GetTickFeeGrowthOutside1X128(tick int32) *u256.Uint {
 	return p.mustGetTick(tick).feeGrowthOutside1X128
 }
 
-func (p *Pool) PoolGetTickCumulativeOutside(tick int32) int64 {
+func (p *Pool) GetTickCumulativeOutside(tick int32) int64 {
 	return p.mustGetTick(tick).tickCumulativeOutside
 }
 
-func (p *Pool) PoolGetTickSecondsPerLiquidityOutsideX128(tick int32) *u256.Uint {
+func (p *Pool) GetTickSecondsPerLiquidityOutsideX128(tick int32) *u256.Uint {
 	return p.mustGetTick(tick).secondsPerLiquidityOutsideX128
 }
 
-func (p *Pool) PoolGetTickSecondsOutside(tick int32) uint32 {
+func (p *Pool) GetTickSecondsOutside(tick int32) uint32 {
 	return p.mustGetTick(tick).secondsOutside
 }
 
-func (p *Pool) PoolGetTickInitialized(tick int32) bool {
+func (p *Pool) GetTickInitialized(tick int32) bool {
 	return p.mustGetTick(tick).initialized
 }
 

--- a/position/_RPC_api.gno
+++ b/position/_RPC_api.gno
@@ -390,7 +390,7 @@ func rpcMakePosition(lpTokenId uint64) RpcPosition {
 	burned := isBurned(lpTokenId)
 
 	pool := pl.GetPoolFromPoolPath(position.poolKey)
-	currentX96 := pool.PoolGetSlot0SqrtPriceX96()
+	currentX96 := pool.GetSlot0SqrtPriceX96()
 	lowerX96 := common.TickMathGetSqrtRatioAtTick(position.tickLower)
 	upperX96 := common.TickMathGetSqrtRatioAtTick(position.tickUpper)
 
@@ -439,24 +439,24 @@ func unclaimedFee(tokenId uint64) (*i256.Int, *i256.Int) {
 	poolKey := positions[tokenId].poolKey
 	pool := pl.GetPoolFromPoolPath(poolKey)
 
-	currentTick := pool.PoolGetSlot0Tick()
+	currentTick := pool.GetSlot0Tick()
 
-	_feeGrowthGlobal0X128 := pool.PoolGetFeeGrowthGlobal0X128()     // u256
+	_feeGrowthGlobal0X128 := pool.GetFeeGrowthGlobal0X128()         // u256
 	feeGrowthGlobal0X128 := i256.FromUint256(_feeGrowthGlobal0X128) // i256
 
-	_feeGrowthGlobal1X128 := pool.PoolGetFeeGrowthGlobal1X128()     // u256
+	_feeGrowthGlobal1X128 := pool.GetFeeGrowthGlobal1X128()         // u256
 	feeGrowthGlobal1X128 := i256.FromUint256(_feeGrowthGlobal1X128) // i256
 
-	_tickUpperFeeGrowthOutside0X128 := pool.PoolGetTickFeeGrowthOutside0X128(tickUpper) // u256
+	_tickUpperFeeGrowthOutside0X128 := pool.GetTickFeeGrowthOutside0X128(tickUpper)     // u256
 	tickUpperFeeGrowthOutside0X128 := i256.FromUint256(_tickUpperFeeGrowthOutside0X128) // i256
 
-	_tickUpperFeeGrowthOutside1X128 := pool.PoolGetTickFeeGrowthOutside1X128(tickUpper) // u256
+	_tickUpperFeeGrowthOutside1X128 := pool.GetTickFeeGrowthOutside1X128(tickUpper)     // u256
 	tickUpperFeeGrowthOutside1X128 := i256.FromUint256(_tickUpperFeeGrowthOutside1X128) // i256
 
-	_tickLowerFeeGrowthOutside0X128 := pool.PoolGetTickFeeGrowthOutside0X128(tickLower) // u256
+	_tickLowerFeeGrowthOutside0X128 := pool.GetTickFeeGrowthOutside0X128(tickLower)     // u256
 	tickLowerFeeGrowthOutside0X128 := i256.FromUint256(_tickLowerFeeGrowthOutside0X128) // i256
 
-	_tickLowerFeeGrowthOutside1X128 := pool.PoolGetTickFeeGrowthOutside1X128(tickLower) // u256
+	_tickLowerFeeGrowthOutside1X128 := pool.GetTickFeeGrowthOutside1X128(tickLower)     // u256
 	tickLowerFeeGrowthOutside1X128 := i256.FromUint256(_tickLowerFeeGrowthOutside1X128) // i256
 
 	_feeGrowthInside0LastX128 := positions[tokenId].feeGrowthInside0LastX128 // u256

--- a/position/liquidity_management.gno
+++ b/position/liquidity_management.gno
@@ -16,7 +16,7 @@ import (
 func addLiquidity(params AddLiquidityParams) (*u256.Uint, *u256.Uint, *u256.Uint) {
 	pool := pl.GetPoolFromPoolPath(params.poolKey)
 
-	sqrtPriceX96 := pool.PoolGetSlot0SqrtPriceX96()
+	sqrtPriceX96 := pool.GetSlot0SqrtPriceX96()
 	sqrtRatioAX96 := common.TickMathGetSqrtRatioAtTick(params.tickLower)
 	sqrtRatioBX96 := common.TickMathGetSqrtRatioAtTick(params.tickUpper)
 

--- a/position/position.gno
+++ b/position/position.gno
@@ -189,7 +189,7 @@ func mint(params MintParams) (uint64, *u256.Uint, *u256.Uint, *u256.Uint) {
 	nextId++
 
 	positionKey := positionKeyCompute(GetOrigPkgAddr(), params.tickLower, params.tickUpper)
-	_feeGrowthInside0LastX128, _feeGrowthInside1LastX128 := pool.PoolGetPositionFeeGrowthInside0LastX128(positionKey), pool.PoolGetPositionFeeGrowthInside1LastX128(positionKey)
+	_feeGrowthInside0LastX128, _feeGrowthInside1LastX128 := pool.GetPositionFeeGrowthInside0LastX128(positionKey), pool.GetPositionFeeGrowthInside1LastX128(positionKey)
 	feeGrowthInside0LastX128 := u256.MustFromDecimal(_feeGrowthInside0LastX128.ToString())
 	feeGrowthInside1LastX128 := u256.MustFromDecimal(_feeGrowthInside1LastX128.ToString())
 
@@ -320,7 +320,7 @@ func increaseLiquidity(params IncreaseLiquidityParams) (uint64, *u256.Uint, *u25
 
 	pool := pl.GetPoolFromPoolPath(position.poolKey)
 	positionKey := positionKeyCompute(GetOrigPkgAddr(), position.tickLower, position.tickUpper)
-	_feeGrowthInside0LastX128, _feeGrowthInside1LastX128 := pool.PoolGetPositionFeeGrowthInside0LastX128(positionKey), pool.PoolGetPositionFeeGrowthInside1LastX128(positionKey)
+	_feeGrowthInside0LastX128, _feeGrowthInside1LastX128 := pool.GetPositionFeeGrowthInside0LastX128(positionKey), pool.GetPositionFeeGrowthInside1LastX128(positionKey)
 	feeGrowthInside0LastX128 := u256.MustFromDecimal(_feeGrowthInside0LastX128.ToString())
 	feeGrowthInside1LastX128 := u256.MustFromDecimal(_feeGrowthInside1LastX128.ToString())
 
@@ -446,7 +446,7 @@ func decreaseLiquidity(params DecreaseLiquidityParams) (uint64, *u256.Uint, *u25
 	verifyBurnedAmounts(burnedAmount0, burnedAmount1, params.amount0Min, params.amount1Min)
 
 	positionKey := positionKeyCompute(GetOrigPkgAddr(), position.tickLower, position.tickUpper)
-	_feeGrowthInside0LastX128, _feeGrowthInside1LastX128 := pool.PoolGetPositionFeeGrowthInside0LastX128(positionKey), pool.PoolGetPositionFeeGrowthInside1LastX128(positionKey)
+	_feeGrowthInside0LastX128, _feeGrowthInside1LastX128 := pool.GetPositionFeeGrowthInside0LastX128(positionKey), pool.GetPositionFeeGrowthInside1LastX128(positionKey)
 	feeGrowthInside0LastX128 := u256.MustFromDecimal(_feeGrowthInside0LastX128.ToString())
 	feeGrowthInside1LastX128 := u256.MustFromDecimal(_feeGrowthInside1LastX128.ToString())
 
@@ -592,7 +592,7 @@ func Reposition(
 
 	pool := pl.GetPoolFromPoolPath(position.poolKey)
 	positionKey := positionKeyCompute(GetOrigPkgAddr(), tickLower, tickUpper)
-	_feeGrowthInside0LastX128, _feeGrowthInside1LastX128 := pool.PoolGetPositionFeeGrowthInside0LastX128(positionKey), pool.PoolGetPositionFeeGrowthInside1LastX128(positionKey)
+	_feeGrowthInside0LastX128, _feeGrowthInside1LastX128 := pool.GetPositionFeeGrowthInside0LastX128(positionKey), pool.GetPositionFeeGrowthInside1LastX128(positionKey)
 	feeGrowthInside0LastX128 := u256.MustFromDecimal(_feeGrowthInside0LastX128.ToString())
 	feeGrowthInside1LastX128 := u256.MustFromDecimal(_feeGrowthInside1LastX128.ToString())
 
@@ -676,7 +676,7 @@ func CollectFee(tokenId uint64, unwrapResult bool) (uint64, string, string, stri
 
 	positionKey := positionKeyCompute(GetOrigPkgAddr(), position.tickLower, position.tickUpper)
 	pool := pl.GetPoolFromPoolPath(position.poolKey)
-	_feeGrowthInside0LastX128, _feeGrowthInside1LastX128 := pool.PoolGetPositionFeeGrowthInside0LastX128(positionKey), pool.PoolGetPositionFeeGrowthInside1LastX128(positionKey)
+	_feeGrowthInside0LastX128, _feeGrowthInside1LastX128 := pool.GetPositionFeeGrowthInside0LastX128(positionKey), pool.GetPositionFeeGrowthInside1LastX128(positionKey)
 	feeGrowthInside0LastX128 := u256.MustFromDecimal(_feeGrowthInside0LastX128.ToString())
 	feeGrowthInside1LastX128 := u256.MustFromDecimal(_feeGrowthInside1LastX128.ToString())
 


### PR DESCRIPTION
## chore
1. remove `Pool` prefix from pool's receiver getter funcs

