### PR TITLE
GSW-1968 feat: check emission is caller or not

### DIFF
--- a/_deploy/r/gnoswap/common/access.gno
+++ b/_deploy/r/gnoswap/common/access.gno
@@ -7,9 +7,13 @@ import (
 	"gno.land/r/gnoswap/v1/consts"
 )
 
+const (
+	ErrNoPermission = "caller(%s) has no permission"
+)
+
 func AssertCaller(caller, addr std.Address) error {
 	if caller != addr {
-		return ufmt.Errorf("caller(%s) has no permission", caller.String())
+		return ufmt.Errorf(ErrNoPermission, caller.String())
 	}
 	return nil
 }
@@ -23,56 +27,65 @@ func SatisfyCond(cond bool) error {
 
 func AdminOnly(caller std.Address) error {
 	if caller != consts.ADMIN {
-		return ufmt.Errorf("caller(%s) has no permission", caller.String())
+		return ufmt.Errorf(ErrNoPermission, caller.String())
 	}
 	return nil
 }
 
 func GovernanceOnly(caller std.Address) error {
 	if caller != consts.GOV_GOVERNANCE_ADDR {
-		return ufmt.Errorf("caller(%s) has no permission", caller.String())
+		return ufmt.Errorf(ErrNoPermission, caller.String())
 	}
 	return nil
 }
 
 func GovStakerOnly(caller std.Address) error {
 	if caller != consts.GOV_STAKER_ADDR {
-		return ufmt.Errorf("caller(%s) has no permission", caller.String())
+		return ufmt.Errorf(ErrNoPermission, caller.String())
 	}
 	return nil
 }
 
 func RouterOnly(caller std.Address) error {
 	if caller != consts.ROUTER_ADDR {
-		return ufmt.Errorf("caller(%s) has no permission", caller.String())
+		return ufmt.Errorf(ErrNoPermission, caller.String())
 	}
 	return nil
 }
 
 func PositionOnly(caller std.Address) error {
 	if caller != consts.POSITION_ADDR {
-		return ufmt.Errorf("caller(%s) has no permission", caller.String())
+		return ufmt.Errorf(ErrNoPermission, caller.String())
 	}
 	return nil
 }
 
 func StakerOnly(caller std.Address) error {
 	if caller != consts.STAKER_ADDR {
-		return ufmt.Errorf("caller(%s) has no permission", caller.String())
-	}
-	return nil
-}
-
-func TokenRegisterOnly(caller std.Address) error {
-	if caller != consts.TOKEN_REGISTER {
-		return ufmt.Errorf("caller(%s) has no permission", caller.String())
+		return ufmt.Errorf(ErrNoPermission, caller.String())
 	}
 	return nil
 }
 
 func LaunchpadOnly(caller std.Address) error {
 	if caller != consts.LAUNCHPAD_ADDR {
-		return ufmt.Errorf("caller(%s) has no permission", caller.String())
+		return ufmt.Errorf(ErrNoPermission, caller.String())
+	}
+	return nil
+}
+
+func EmissionOnly(caller std.Address) error {
+	if caller != consts.EMISSION_ADDR {
+		return ufmt.Errorf(ErrNoPermission, caller.String())
+	}
+	return nil
+}
+
+// DEPRECATED
+// TODO: remove after r/grc20reg is applied for all contracts
+func TokenRegisterOnly(caller std.Address) error {
+	if caller != consts.TOKEN_REGISTER {
+		return ufmt.Errorf(ErrNoPermission, caller.String())
 	}
 	return nil
 }

--- a/_deploy/r/gnoswap/common/access_test.gno
+++ b/_deploy/r/gnoswap/common/access_test.gno
@@ -1,0 +1,136 @@
+package common
+
+import (
+	"std"
+	"testing"
+
+	"gno.land/p/demo/testutils"
+	"gno.land/p/demo/uassert"
+
+	"gno.land/r/gnoswap/v1/consts"
+)
+
+var (
+	addr01 = testutils.TestAddress("addr01")
+	addr02 = testutils.TestAddress("addr02")
+)
+
+func TestAssertCaller(t *testing.T) {
+	t.Run("same caller", func(t *testing.T) {
+		uassert.NoError(t, AssertCaller(addr01, addr01))
+	})
+
+	t.Run("different caller", func(t *testing.T) {
+		uassert.Error(t, AssertCaller(addr01, addr02))
+	})
+}
+
+func TestSatisfyCond(t *testing.T) {
+	t.Run("true", func(t *testing.T) {
+		uassert.NoError(t, SatisfyCond(true))
+	})
+
+	t.Run("false", func(t *testing.T) {
+		uassert.Error(t, SatisfyCond(false))
+	})
+}
+
+func TestAdminOnly(t *testing.T) {
+	t.Run("caller is admin", func(t *testing.T) {
+		uassert.NoError(t, AdminOnly(consts.ADMIN))
+	})
+
+	t.Run("caller is not admin", func(t *testing.T) {
+		uassert.Error(t, AdminOnly(addr01))
+	})
+}
+
+func TestGovernanceOnly(t *testing.T) {
+	t.Run("caller is governance", func(t *testing.T) {
+		uassert.NoError(t, GovernanceOnly(consts.GOV_GOVERNANCE_ADDR))
+	})
+
+	t.Run("caller is not governance", func(t *testing.T) {
+		uassert.Error(t, GovernanceOnly(addr01))
+	})
+}
+
+func TestGovStakerOnly(t *testing.T) {
+	t.Run("caller is gov staker", func(t *testing.T) {
+		uassert.NoError(t, GovStakerOnly(consts.GOV_STAKER_ADDR))
+	})
+
+	t.Run("caller is not gov staker", func(t *testing.T) {
+		uassert.Error(t, GovStakerOnly(addr01))
+	})
+}
+
+func TestRouterOnly(t *testing.T) {
+	t.Run("caller is router", func(t *testing.T) {
+		uassert.NoError(t, RouterOnly(consts.ROUTER_ADDR))
+	})
+
+	t.Run("caller is not router", func(t *testing.T) {
+		uassert.Error(t, RouterOnly(addr01))
+	})
+}
+
+func TestPositionOnly(t *testing.T) {
+	t.Run("caller is position", func(t *testing.T) {
+		uassert.NoError(t, PositionOnly(consts.POSITION_ADDR))
+	})
+
+	t.Run("caller is not position", func(t *testing.T) {
+		uassert.Error(t, PositionOnly(addr01))
+	})
+}
+
+func TestStakerOnly(t *testing.T) {
+	t.Run("caller is staker", func(t *testing.T) {
+		uassert.NoError(t, StakerOnly(consts.STAKER_ADDR))
+	})
+
+	t.Run("caller is not staker", func(t *testing.T) {
+		uassert.Error(t, StakerOnly(addr01))
+	})
+}
+
+func TestLaunchpadOnly(t *testing.T) {
+	t.Run("caller is launchpad", func(t *testing.T) {
+		uassert.NoError(t, LaunchpadOnly(consts.LAUNCHPAD_ADDR))
+	})
+
+	t.Run("caller is not launchpad", func(t *testing.T) {
+		uassert.Error(t, LaunchpadOnly(addr01))
+	})
+}
+
+func TestEmissionOnly(t *testing.T) {
+	t.Run("caller is emission", func(t *testing.T) {
+		uassert.NoError(t, EmissionOnly(consts.EMISSION_ADDR))
+	})
+
+	t.Run("caller is not emission", func(t *testing.T) {
+		uassert.Error(t, EmissionOnly(addr01))
+	})
+}
+
+func TestTokenRegisterOnly(t *testing.T) {
+	t.Run("caller is token register", func(t *testing.T) {
+		uassert.NoError(t, TokenRegisterOnly(consts.TOKEN_REGISTER))
+	})
+
+	t.Run("caller is not token register", func(t *testing.T) {
+		uassert.Error(t, TokenRegisterOnly(addr01))
+	})
+}
+
+func TestUserOnly(t *testing.T) {
+	t.Run("caller is user", func(t *testing.T) {
+		uassert.NoError(t, UserOnly(std.NewUserRealm(addr01)))
+	})
+
+	t.Run("caller is not user", func(t *testing.T) {
+		uassert.Error(t, UserOnly(std.NewCodeRealm("gno.land/r/realm")))
+	})
+}

--- a/_deploy/r/gnoswap/common/gno.mod
+++ b/_deploy/r/gnoswap/common/gno.mod
@@ -1,9 +1,1 @@
 module gno.land/r/gnoswap/v1/common
-
-require (
-	gno.land/p/demo/ufmt v0.0.0-latest
-	gno.land/p/gnoswap/int256 v0.0.0-latest
-	gno.land/p/gnoswap/pool v0.0.0-latest
-	gno.land/p/gnoswap/uint256 v0.0.0-latest
-	gno.land/r/gnoswap/v1/consts v0.0.0-latest
-)


### PR DESCRIPTION
## feat
1. `EmissionOnly` checks whether caller is emisson contract or not
2. add unittest

## fix
3. remove deprecated `require` from gno.mod
