### PR TITLE
feat: `uint256` single value overflow checker

### DIFF
--- a/_deploy/p/gnoswap/uint256/arithmetic.gno
+++ b/_deploy/p/gnoswap/uint256/arithmetic.gno
@@ -416,6 +416,10 @@ func (z *Uint) isBitSet(n uint) bool {
 	return (z.arr[n/64] & (1 << (n % 64))) != 0
 }
 
+func (z *Uint) IsOverflow() bool {
+	return z.isBitSet(255)
+}
+
 // addTo computes x += y.
 // Requires len(x) >= len(y).
 func addTo(x, y []uint64) uint64 {

--- a/_deploy/p/gnoswap/uint256/arithmetic_test.gno
+++ b/_deploy/p/gnoswap/uint256/arithmetic_test.gno
@@ -6,6 +6,49 @@ type binOp2Test struct {
 	x, y, want string
 }
 
+func TestIsOverflow(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *Uint
+		expected bool
+	}{
+		{
+			name: "Number greater than max value",
+			input: &Uint{arr: [4]uint64{
+				^uint64(0), ^uint64(0), ^uint64(0), ^uint64(0),
+			}},
+			expected: true,
+		},
+		{
+			name: "Max value",
+			input: &Uint{arr: [4]uint64{
+				^uint64(0), ^uint64(0), ^uint64(0), ^uint64(0) >> 1,
+			}},
+			expected: false,
+		},
+		{
+			name:     "0",
+			input:    &Uint{arr: [4]uint64{0, 0, 0, 0}},
+			expected: false,
+		},
+		{
+			name: "Only 255th bit set",
+			input: &Uint{arr: [4]uint64{
+				0, 0, 0, uint64(1) << 63,
+			}},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.input.IsOverflow(); got != tt.expected {
+				t.Errorf("IsOverflow() = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestAdd(t *testing.T) {
 	tests := []binOp2Test{
 		{"0", "1", "1"},


### PR DESCRIPTION
# Description

The `IsOverflow()` function checks if a uint256 number has overflowed by examining the 255th bit (the most significant bit). In uint256, the valid range is from 0 to 2^255-1, so any number with the 255th bit set is considered an overflow.