### PR TITLE
refactor: remove unnecessary functions from the gns realm

### DIFF
--- a/contract/r/gnoswap/gns/gns.gno
+++ b/contract/r/gnoswap/gns/gns.gno
@@ -85,7 +85,6 @@ func MintGns(address std.Address) uint64 {
 
 	// mint calculated amount to address
 	err := privateLedger.Mint(address, amountToMint)
-	err := privateLedger.Mint(address, amountToMint)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -107,7 +106,6 @@ func MintGns(address std.Address) uint64 {
 func Burn(from std.Address, amount uint64) {
 	owner.AssertCallerIsOwner()
 	checkErr(privateLedger.Burn(from, amount))
-	checkErr(privateLedger.Burn(from, amount))
 
 	burnAmount += amount
 
@@ -117,7 +115,6 @@ func Burn(from std.Address, amount uint64) {
 		"prevAddr", prevAddr,
 		"prevRealm", prevPkgPath,
 		"burnedBlockHeight", formatInt(std.GetHeight()),
-		"burnFrom", from.String(),
 		"burnFrom", from.String(),
 		"burnedGNSAmount", formatUint(amount),
 		"accumBurnedGNSAmount", formatUint(GetBurnAmount()),
@@ -144,8 +141,6 @@ func Render(path string) string {
 	case path == "":
 		return Token.RenderHome()
 	case c == 2 && parts[0] == "balance":
-		owner := std.Address(parts[1])
-		balance := UserTeller.BalanceOf(owner)
 		owner := std.Address(parts[1])
 		balance := UserTeller.BalanceOf(owner)
 		return ufmt.Sprintf("%d\n", balance)

--- a/contract/r/gnoswap/gns/gns.gno
+++ b/contract/r/gnoswap/gns/gns.gno
@@ -49,35 +49,8 @@ func init() {
 	burnAmount = uint64(0)
 }
 
-func GetName() string {
-	return Token.GetName()
-}
-
-func GetSymbol() string {
-	return Token.GetSymbol()
-}
-
-func GetDecimals() uint {
-	return Token.GetDecimals()
-}
-
 func TotalSupply() uint64 {
 	return Token.TotalSupply()
-}
-
-func KnownAccounts() int {
-	return Token.KnownAccounts()
-}
-
-func BalanceOfAddress(owner std.Address) uint64 {
-	common.AssertValidAddr(owner)
-	return Token.BalanceOf(owner)
-}
-
-func AllowanceOfAddress(owner, spender std.Address) uint64 {
-	common.AssertValidAddr(owner)
-	common.AssertValidAddr(spender)
-	return Token.Allowance(owner, spender)
 }
 
 func BalanceOf(owner std.Address) uint64 {
@@ -88,10 +61,7 @@ func Allowance(owner, spender std.Address) uint64 {
 	return UserTeller.Allowance(owner, spender)
 }
 
-func SpendAllowance(owner, spender std.Address, amount uint64) {
-	checkErr(privateLedger.SpendAllowance(owner, spender, amount))
-}
-
+func MintGns(address std.Address) uint64 {
 func MintGns(address std.Address) uint64 {
 	lastGNSMintedHeight := GetLastMintedHeight()
 	currentHeight := std.GetHeight()
@@ -116,6 +86,7 @@ func MintGns(address std.Address) uint64 {
 
 	// mint calculated amount to address
 	err := privateLedger.Mint(address, amountToMint)
+	err := privateLedger.Mint(address, amountToMint)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -135,7 +106,9 @@ func MintGns(address std.Address) uint64 {
 }
 
 func Burn(from std.Address, amount uint64) {
+func Burn(from std.Address, amount uint64) {
 	owner.AssertCallerIsOwner()
+	checkErr(privateLedger.Burn(from, amount))
 	checkErr(privateLedger.Burn(from, amount))
 
 	burnAmount += amount
@@ -147,6 +120,7 @@ func Burn(from std.Address, amount uint64) {
 		"prevRealm", prevPkgPath,
 		"burnedBlockHeight", formatInt(std.GetHeight()),
 		"burnFrom", from.String(),
+		"burnFrom", from.String(),
 		"burnedGNSAmount", formatUint(amount),
 		"accumBurnedGNSAmount", formatUint(GetBurnAmount()),
 	)
@@ -154,12 +128,18 @@ func Burn(from std.Address, amount uint64) {
 
 func Transfer(to std.Address, amount uint64) {
 	checkErr(UserTeller.Transfer(to, amount))
+func Transfer(to std.Address, amount uint64) {
+	checkErr(UserTeller.Transfer(to, amount))
 }
 
 func Approve(spender std.Address, amount uint64) {
 	checkErr(UserTeller.Approve(spender, amount))
+func Approve(spender std.Address, amount uint64) {
+	checkErr(UserTeller.Approve(spender, amount))
 }
 
+func TransferFrom(from, to std.Address, amount uint64) {
+	checkErr(UserTeller.TransferFrom(from, to, amount))
 func TransferFrom(from, to std.Address, amount uint64) {
 	checkErr(UserTeller.TransferFrom(from, to, amount))
 }
@@ -172,6 +152,8 @@ func Render(path string) string {
 	case path == "":
 		return Token.RenderHome()
 	case c == 2 && parts[0] == "balance":
+		owner := std.Address(parts[1])
+		balance := UserTeller.BalanceOf(owner)
 		owner := std.Address(parts[1])
 		balance := UserTeller.BalanceOf(owner)
 		return ufmt.Sprintf("%d\n", balance)

--- a/contract/r/gnoswap/gns/gns.gno
+++ b/contract/r/gnoswap/gns/gns.gno
@@ -53,12 +53,28 @@ func TotalSupply() uint64 {
 	return Token.TotalSupply()
 }
 
+func GetName() string {
+	return Token.GetName()
+}
+
+func GetSymbol() string {
+	return Token.GetSymbol()
+}
+
+func GetDecimals() uint {
+	return Token.GetDecimals()
+}
+
+func KnownAccounts() int {
+	return Token.KnownAccounts()
+}
+
 func BalanceOf(owner std.Address) uint64 {
-	return UserTeller.BalanceOf(owner)
+	return Token.BalanceOf(owner)
 }
 
 func Allowance(owner, spender std.Address) uint64 {
-	return UserTeller.Allowance(owner, spender)
+	return Token.Allowance(owner, spender)
 }
 
 func MintGns(address std.Address) uint64 {
@@ -142,7 +158,7 @@ func Render(path string) string {
 		return Token.RenderHome()
 	case c == 2 && parts[0] == "balance":
 		owner := std.Address(parts[1])
-		balance := UserTeller.BalanceOf(owner)
+		balance := Token.BalanceOf(owner)
 		return ufmt.Sprintf("%d\n", balance)
 	default:
 		return "404\n"

--- a/contract/r/gnoswap/gns/gns.gno
+++ b/contract/r/gnoswap/gns/gns.gno
@@ -62,7 +62,6 @@ func Allowance(owner, spender std.Address) uint64 {
 }
 
 func MintGns(address std.Address) uint64 {
-func MintGns(address std.Address) uint64 {
 	lastGNSMintedHeight := GetLastMintedHeight()
 	currentHeight := std.GetHeight()
 
@@ -106,7 +105,6 @@ func MintGns(address std.Address) uint64 {
 }
 
 func Burn(from std.Address, amount uint64) {
-func Burn(from std.Address, amount uint64) {
 	owner.AssertCallerIsOwner()
 	checkErr(privateLedger.Burn(from, amount))
 	checkErr(privateLedger.Burn(from, amount))
@@ -128,18 +126,12 @@ func Burn(from std.Address, amount uint64) {
 
 func Transfer(to std.Address, amount uint64) {
 	checkErr(UserTeller.Transfer(to, amount))
-func Transfer(to std.Address, amount uint64) {
-	checkErr(UserTeller.Transfer(to, amount))
 }
 
 func Approve(spender std.Address, amount uint64) {
 	checkErr(UserTeller.Approve(spender, amount))
-func Approve(spender std.Address, amount uint64) {
-	checkErr(UserTeller.Approve(spender, amount))
 }
 
-func TransferFrom(from, to std.Address, amount uint64) {
-	checkErr(UserTeller.TransferFrom(from, to, amount))
 func TransferFrom(from, to std.Address, amount uint64) {
 	checkErr(UserTeller.TransferFrom(from, to, amount))
 }

--- a/contract/r/gnoswap/gns/gns_test.gno
+++ b/contract/r/gnoswap/gns/gns_test.gno
@@ -27,8 +27,23 @@ var (
 	bob   = testutils.TestAddress("bob")
 )
 
-func TestTotalSupply(t *testing.T) {
+func TestGetName(t *testing.T) {
+	uassert.Equal(t, "Gnoswap", GetName())
+}
 
+func TestGetSymbol(t *testing.T) {
+	uassert.Equal(t, "GNS", GetSymbol())
+}
+
+func TestGetDecimals(t *testing.T) {
+	uassert.Equal(t, uint(6), GetDecimals())
+}
+
+func TestKnownAccounts(t *testing.T) {
+	uassert.Equal(t, int(1), KnownAccounts())
+}
+
+func TestTotalSupply(t *testing.T) {
 	uassert.Equal(t, INITIAL_MINT_AMOUNT, TotalSupply())
 }
 

--- a/contract/r/gnoswap/gns/gns_test.gno
+++ b/contract/r/gnoswap/gns/gns_test.gno
@@ -27,112 +27,13 @@ var (
 	bob   = testutils.TestAddress("bob")
 )
 
-func TestGetName(t *testing.T) {
-	uassert.Equal(t, "Gnoswap", GetName())
-}
-
-func TestGetSymbol(t *testing.T) {
-	uassert.Equal(t, "GNS", GetSymbol())
-}
-
-func TestGetDecimals(t *testing.T) {
-	uassert.Equal(t, uint(6), GetDecimals())
-}
-
 func TestTotalSupply(t *testing.T) {
 
 	uassert.Equal(t, INITIAL_MINT_AMOUNT, TotalSupply())
 }
 
-func TestKnownAccounts(t *testing.T) {
-	uassert.Equal(t, int(1), KnownAccounts())
-}
-
-func TestBalanceOfAddress(t *testing.T) {
-	t.Run(
-		"should return balance of address",
-		func(t *testing.T) {
-			uassert.Equal(t, INITIAL_MINT_AMOUNT, BalanceOfAddress(consts.ADMIN))
-		},
-	)
-	t.Run(
-		"should panic if address is not valid",
-		func(t *testing.T) {
-			uassert.PanicsWithMessage(t, "[GNOSWAP-COMMON-005] invalid address || 0xabcdefg", func() {
-				BalanceOfAddress("0xabcdefg")
-			})
-		},
-	)
-}
-
-func TestAllowanceOfAddress(t *testing.T) {
-	t.Run(
-		"should return allowance of address",
-		func(t *testing.T) {
-			uassert.Equal(t, uint64(0), AllowanceOfAddress(consts.ADMIN, alice))
-
-			std.TestSetOrigCaller(consts.ADMIN)
-			Approve(alice, uint64(123))
-			uassert.Equal(t, uint64(123), AllowanceOfAddress(consts.ADMIN, alice))
-		},
-	)
-	t.Run(
-		"should panic if address is not valid",
-		func(t *testing.T) {
-			uassert.PanicsWithMessage(t, "[GNOSWAP-COMMON-005] invalid address || 0xabcdefg", func() {
-				AllowanceOfAddress("0xabcdefg", alice)
-			})
-		},
-	)
-	t.Run(
-		"should panic if spender is not valid",
-		func(t *testing.T) {
-			uassert.PanicsWithMessage(t, "[GNOSWAP-COMMON-005] invalid address || 0xabcdefg", func() {
-				AllowanceOfAddress(consts.ADMIN, "0xabcdefg")
-			})
-		},
-	)
-}
-
 func TestBalanceOf(t *testing.T) {
 	uassert.Equal(t, INITIAL_MINT_AMOUNT, BalanceOf(consts.ADMIN))
-}
-
-func TestSpendAllowance(t *testing.T) {
-	t.Run(
-		"should spend allowance",
-		func(t *testing.T) {
-			std.TestSetOrigCaller(consts.ADMIN)
-			Approve(alice, uint64(123))
-
-			SpendAllowance(consts.ADMIN, alice, uint64(23))
-			uassert.Equal(t, uint64(100), Allowance(consts.ADMIN, alice))
-		},
-	)
-	t.Run(
-		"should panic if address is not valid",
-		func(t *testing.T) {
-			uassert.PanicsWithMessage(t, "invalid address", func() {
-				SpendAllowance("0xabcdefg", alice, uint64(123))
-			})
-		},
-	)
-	t.Run(
-		"should panic if spender is not valid",
-		func(t *testing.T) {
-			uassert.PanicsWithMessage(t, "invalid address", func() {
-				SpendAllowance(consts.ADMIN, "0xabcdefg", uint64(123))
-			})
-		},
-	)
-	t.Run(
-		"should panic if allowance is not enough",
-		func(t *testing.T) {
-			uassert.PanicsWithMessage(t, "insufficient allowance", func() {
-				SpendAllowance(consts.ADMIN, alice, uint64(123))
-			})
-		},
-	)
 }
 
 func TestAssertTooManyEmission(t *testing.T) {
@@ -289,17 +190,20 @@ func TestGrc20Methods(t *testing.T) {
 			name: "BalanceOf(admin)",
 			fn: func() {
 				uassert.Equal(t, INITIAL_MINT_AMOUNT, BalanceOf(consts.ADMIN))
+				uassert.Equal(t, INITIAL_MINT_AMOUNT, BalanceOf(consts.ADMIN))
 			},
 		},
 		{
 			name: "BalanceOf(alice)",
 			fn: func() {
 				uassert.Equal(t, uint64(0), BalanceOf(alice))
+				uassert.Equal(t, uint64(0), BalanceOf(alice))
 			},
 		},
 		{
 			name: "Allowance(admin, alice)",
 			fn: func() {
+				uassert.Equal(t, uint64(0), Allowance(consts.ADMIN, alice))
 				uassert.Equal(t, uint64(0), Allowance(consts.ADMIN, alice))
 			},
 		},
@@ -308,12 +212,14 @@ func TestGrc20Methods(t *testing.T) {
 			fn: func() {
 				std.TestSetRealm(emissionRealm)
 				MintGns(consts.ADMIN)
+				MintGns(consts.ADMIN)
 			},
 		},
 		{
 			name: "MintGns without permission should panic",
 			fn: func() {
 				std.TestSkipHeights(1)
+				MintGns(consts.ADMIN)
 				MintGns(consts.ADMIN)
 			},
 			shouldPanic: true,
@@ -324,11 +230,13 @@ func TestGrc20Methods(t *testing.T) {
 			fn: func() {
 				std.TestSetRealm(adminRealm)
 				Burn(consts.ADMIN, uint64(1))
+				Burn(consts.ADMIN, uint64(1))
 			},
 		},
 		{
 			name: "Burn without permission should panic",
 			fn: func() {
+				Burn(consts.ADMIN, uint64(1))
 				Burn(consts.ADMIN, uint64(1))
 			},
 			shouldPanic: true,
@@ -339,12 +247,14 @@ func TestGrc20Methods(t *testing.T) {
 			fn: func() {
 				std.TestSetRealm(adminRealm)
 				Transfer(alice, uint64(1))
+				Transfer(alice, uint64(1))
 			},
 		},
 		{
 			name: "Transfer without enough balance should panic",
 			fn: func() {
 				std.TestSetRealm(std.NewUserRealm(alice))
+				Transfer(bob, uint64(1))
 				Transfer(bob, uint64(1))
 			},
 			shouldPanic: true,
@@ -354,6 +264,7 @@ func TestGrc20Methods(t *testing.T) {
 			name: "Transfer to self should panic",
 			fn: func() {
 				std.TestSetRealm(adminRealm)
+				Transfer(consts.ADMIN, uint64(1))
 				Transfer(consts.ADMIN, uint64(1))
 			},
 			shouldPanic: true,
@@ -365,9 +276,11 @@ func TestGrc20Methods(t *testing.T) {
 				// approve first
 				std.TestSetRealm(adminRealm)
 				Approve(alice, uint64(1))
+				Approve(alice, uint64(1))
 
 				// alice transfer admin's balance to bob
 				std.TestSetRealm(std.NewUserRealm(alice))
+				TransferFrom(consts.ADMIN, bob, uint64(1))
 				TransferFrom(consts.ADMIN, bob, uint64(1))
 			},
 		},
@@ -376,8 +289,10 @@ func TestGrc20Methods(t *testing.T) {
 			fn: func() {
 				std.TestSetRealm(adminRealm)
 				Approve(alice, uint64(1))
+				Approve(alice, uint64(1))
 
 				std.TestSetRealm(std.NewUserRealm(alice))
+				TransferFrom(consts.ADMIN, bob, uint64(2))
 				TransferFrom(consts.ADMIN, bob, uint64(2))
 			},
 			shouldPanic: true,

--- a/contract/r/gnoswap/gns/gns_test.gno
+++ b/contract/r/gnoswap/gns/gns_test.gno
@@ -190,20 +190,17 @@ func TestGrc20Methods(t *testing.T) {
 			name: "BalanceOf(admin)",
 			fn: func() {
 				uassert.Equal(t, INITIAL_MINT_AMOUNT, BalanceOf(consts.ADMIN))
-				uassert.Equal(t, INITIAL_MINT_AMOUNT, BalanceOf(consts.ADMIN))
 			},
 		},
 		{
 			name: "BalanceOf(alice)",
 			fn: func() {
 				uassert.Equal(t, uint64(0), BalanceOf(alice))
-				uassert.Equal(t, uint64(0), BalanceOf(alice))
 			},
 		},
 		{
 			name: "Allowance(admin, alice)",
 			fn: func() {
-				uassert.Equal(t, uint64(0), Allowance(consts.ADMIN, alice))
 				uassert.Equal(t, uint64(0), Allowance(consts.ADMIN, alice))
 			},
 		},
@@ -212,14 +209,12 @@ func TestGrc20Methods(t *testing.T) {
 			fn: func() {
 				std.TestSetRealm(emissionRealm)
 				MintGns(consts.ADMIN)
-				MintGns(consts.ADMIN)
 			},
 		},
 		{
 			name: "MintGns without permission should panic",
 			fn: func() {
 				std.TestSkipHeights(1)
-				MintGns(consts.ADMIN)
 				MintGns(consts.ADMIN)
 			},
 			shouldPanic: true,
@@ -230,13 +225,11 @@ func TestGrc20Methods(t *testing.T) {
 			fn: func() {
 				std.TestSetRealm(adminRealm)
 				Burn(consts.ADMIN, uint64(1))
-				Burn(consts.ADMIN, uint64(1))
 			},
 		},
 		{
 			name: "Burn without permission should panic",
 			fn: func() {
-				Burn(consts.ADMIN, uint64(1))
 				Burn(consts.ADMIN, uint64(1))
 			},
 			shouldPanic: true,
@@ -247,14 +240,12 @@ func TestGrc20Methods(t *testing.T) {
 			fn: func() {
 				std.TestSetRealm(adminRealm)
 				Transfer(alice, uint64(1))
-				Transfer(alice, uint64(1))
 			},
 		},
 		{
 			name: "Transfer without enough balance should panic",
 			fn: func() {
 				std.TestSetRealm(std.NewUserRealm(alice))
-				Transfer(bob, uint64(1))
 				Transfer(bob, uint64(1))
 			},
 			shouldPanic: true,
@@ -264,7 +255,6 @@ func TestGrc20Methods(t *testing.T) {
 			name: "Transfer to self should panic",
 			fn: func() {
 				std.TestSetRealm(adminRealm)
-				Transfer(consts.ADMIN, uint64(1))
 				Transfer(consts.ADMIN, uint64(1))
 			},
 			shouldPanic: true,
@@ -276,11 +266,9 @@ func TestGrc20Methods(t *testing.T) {
 				// approve first
 				std.TestSetRealm(adminRealm)
 				Approve(alice, uint64(1))
-				Approve(alice, uint64(1))
 
 				// alice transfer admin's balance to bob
 				std.TestSetRealm(std.NewUserRealm(alice))
-				TransferFrom(consts.ADMIN, bob, uint64(1))
 				TransferFrom(consts.ADMIN, bob, uint64(1))
 			},
 		},
@@ -289,10 +277,8 @@ func TestGrc20Methods(t *testing.T) {
 			fn: func() {
 				std.TestSetRealm(adminRealm)
 				Approve(alice, uint64(1))
-				Approve(alice, uint64(1))
 
 				std.TestSetRealm(std.NewUserRealm(alice))
-				TransferFrom(consts.ADMIN, bob, uint64(2))
 				TransferFrom(consts.ADMIN, bob, uint64(2))
 			},
 			shouldPanic: true,


### PR DESCRIPTION
## Description
1. Remove unnecessary function in gns
> related manfred comment https://github.com/gnoswap-labs/gnoswap/pull/465#discussion_r1923307199 
2. use Token object if possible
> since Token is read-only object, it is safer