### PR TITLE
style: interface -> any

### DIFF
--- a/contract/p/gnoswap/uint256/_helper_test.gno
+++ b/contract/p/gnoswap/uint256/_helper_test.gno
@@ -4,13 +4,13 @@ import (
 	"testing"
 )
 
-func shouldEQ(t *testing.T, got, expected interface{}) {
+func shouldEQ(t *testing.T, got, expected any) {
 	if got != expected {
 		t.Errorf("got %v, expected %v", got, expected)
 	}
 }
 
-func shouldNEQ(t *testing.T, got, expected interface{}) {
+func shouldNEQ(t *testing.T, got, expected any) {
 	if got == expected {
 		t.Errorf("got %v, didn't expected %v", got, expected)
 	}

--- a/contract/p/gnoswap/uint256/conversion.gno
+++ b/contract/p/gnoswap/uint256/conversion.gno
@@ -83,7 +83,7 @@ func (z *Uint) Dec() string {
 	return string(out[pos-len(buf):])
 }
 
-func (z *Uint) Scan(src interface{}) error {
+func (z *Uint) Scan(src any) error {
 	if src == nil {
 		z.Clear()
 		return nil

--- a/contract/r/gnoswap/common/grc721_position_id.gno
+++ b/contract/r/gnoswap/common/grc721_position_id.gno
@@ -12,9 +12,9 @@ import (
 // NOTE: input parameter positionId can be string, int, uint64, or grc721.TokenID
 // if positionId is nil or not supported, it will panic
 // if input type is not supported, it will panic
-// input: positionId interface{}
+// input: positionId any
 // output: grc721.TokenID
-func PositionIdFrom(positionId interface{}) grc721.TokenID {
+func PositionIdFrom(positionId any) grc721.TokenID {
 	if positionId == nil {
 		panic(newErrorWithDetail(
 			errInvalidPositionId,

--- a/contract/r/gnoswap/common/grc721_position_id_test.gno
+++ b/contract/r/gnoswap/common/grc721_position_id_test.gno
@@ -9,7 +9,7 @@ import (
 func TestPositionIdFrom(t *testing.T) {
 	tests := []struct {
 		name      string
-		input     interface{}
+		input     any
 		want      grc721.TokenID
 		wantPanic bool
 	}{

--- a/contract/r/gnoswap/emission/distribution.gno
+++ b/contract/r/gnoswap/emission/distribution.gno
@@ -139,7 +139,7 @@ func changeDistributionPcts(
 func distributeToTarget(amount uint64) uint64 {
 	totalSent := uint64(0)
 
-	distributionBpsPct.Iterate("", "", func(targetStr string, iPct interface{}) bool {
+	distributionBpsPct.Iterate("", "", func(targetStr string, iPct any) bool {
 		targetInt, err := strconv.Atoi(targetStr)
 		if err != nil {
 			panic(addDetailToError(

--- a/contract/r/gnoswap/emission/utils.gno
+++ b/contract/r/gnoswap/emission/utils.gno
@@ -98,7 +98,7 @@ func assertSumDistributionPct(pct01, pct02, pct03, pct04 uint64) {
 	}
 }
 
-func formatUint(v interface{}) string {
+func formatUint(v any) string {
 	switch v := v.(type) {
 	case uint8:
 		return strconv.FormatUint(uint64(v), 10)
@@ -111,7 +111,7 @@ func formatUint(v interface{}) string {
 	}
 }
 
-func formatInt(v interface{}) string {
+func formatInt(v any) string {
 	switch v := v.(type) {
 	case int32:
 		return strconv.FormatInt(int64(v), 10)

--- a/contract/r/gnoswap/gns/utils.gno
+++ b/contract/r/gnoswap/gns/utils.gno
@@ -68,7 +68,7 @@ func milliToSec(ms int64) int64 {
 	return ms / consts.MILLISECONDS_PER_SECOND
 }
 
-func formatUint(v interface{}) string {
+func formatUint(v any) string {
 	switch v := v.(type) {
 	case uint8:
 		return strconv.FormatUint(uint64(v), 10)
@@ -81,7 +81,7 @@ func formatUint(v interface{}) string {
 	}
 }
 
-func formatInt(v interface{}) string {
+func formatInt(v any) string {
 	switch v := v.(type) {
 	case int32:
 		return strconv.FormatInt(int64(v), 10)

--- a/contract/r/gnoswap/gov/governance/api.gno
+++ b/contract/r/gnoswap/gov/governance/api.gno
@@ -34,7 +34,7 @@ func GetProposals() string {
 	proposalsObj := metaNode()
 	proposalArr := json.ArrayNode("", nil)
 
-	proposals.Iterate("", "", func(key string, value interface{}) bool {
+	proposals.Iterate("", "", func(key string, value any) bool {
 		proposalObj := getProposalById(proposalId)
 		proposalArr.AppendArray(proposalObj)
 		return false
@@ -94,7 +94,7 @@ func GetVotesByAddress(addr std.Address) string {
 
 	// sertUesrVote does add data to `userVotes` with key (voter_pid) as key
 	// therefore this function can not search for 'specific_address'
-	userVotes.Iterate("", "", func(key string, value interface{}) bool {
+	userVotes.Iterate("", "", func(key string, value any) bool {
 		if strings.HasPrefix(key, addr.String()) {
 			voteObj := createVoteJsonNode(addr, proposalId, value.(voteWithWeight))
 			votesArr.AppendArray(voteObj)

--- a/contract/r/gnoswap/gov/governance/config.gno
+++ b/contract/r/gnoswap/gov/governance/config.gno
@@ -48,7 +48,7 @@ func getConfigByVersion(v uint64) (Config, bool) {
 
 func getLatestVersion() uint64 {
 	var maxVersion uint64
-	configVersions.ReverseIterate("", "", func(key string, value interface{}) bool {
+	configVersions.ReverseIterate("", "", func(key string, value any) bool {
 		maxVersion = parseUint64(key)
 		return true
 	})

--- a/contract/r/gnoswap/gov/governance/proposal.gno
+++ b/contract/r/gnoswap/gov/governance/proposal.gno
@@ -317,7 +317,7 @@ type proposalStateUpdater struct {
 func updateProposalsState() {
 	now := uint64(time.Now().Unix())
 
-	proposals.Iterate("", "", func(key string, value interface{}) bool {
+	proposals.Iterate("", "", func(key string, value any) bool {
 		proposal := value.(ProposalInfo)
 		if proposal.State.Canceled || proposal.State.Expired || proposal.State.Executed {
 			return false

--- a/contract/r/gnoswap/gov/governance/utils.gno
+++ b/contract/r/gnoswap/gov/governance/utils.gno
@@ -62,7 +62,7 @@ func mustGetVoteInfo(voteKey string) voteWithWeight {
 }
 
 // Iterates over an AVL tree and applies a callback function to each element
-func iterTree(tree *avl.Tree, cb func(key string, value interface{}) bool) {
+func iterTree(tree *avl.Tree, cb func(key string, value any) bool) {
 	tree.Iterate("", "", cb)
 }
 
@@ -120,7 +120,7 @@ func getPrev() (string, string) {
 }
 
 // Formats an unsigned integer to a string
-func formatUint(v interface{}) string {
+func formatUint(v any) string {
 	switch v := v.(type) {
 	case uint8:
 		return strconv.FormatUint(uint64(v), 10)

--- a/contract/r/gnoswap/gov/staker/api_history.gno
+++ b/contract/r/gnoswap/gov/staker/api_history.gno
@@ -20,7 +20,7 @@ func GetPossibleVotingAddressWithWeight(endTimestamp uint64) (uint64, map[std.Ad
 	totalWeight := uint64(0)
 	addressWithWeight := make(map[std.Address]uint64)
 
-	delegationSnapShotHistory.Iterate("", "", func(key string, value interface{}) bool {
+	delegationSnapShotHistory.Iterate("", "", func(key string, value any) bool {
 		history := value.([]DelegationSnapShotHistory)
 		toAddr := std.Address(key)
 

--- a/contract/r/gnoswap/gov/staker/clean_delegation_stat_history.gno
+++ b/contract/r/gnoswap/gov/staker/clean_delegation_stat_history.gno
@@ -57,7 +57,7 @@ func cleanDelegationStatHistory() {
 	// delete history older than 1 day, but keep the latest one
 	keepFrom := height - uint64(thresholdVotingWeightBlockHeight)
 
-	delegationSnapShotHistory.Iterate("", "", func(key string, value interface{}) bool {
+	delegationSnapShotHistory.Iterate("", "", func(key string, value any) bool {
 		history := value.([]DelegationSnapShotHistory)
 
 		// reverse history

--- a/contract/r/gnoswap/gov/staker/reward.gno
+++ b/contract/r/gnoswap/gov/staker/reward.gno
@@ -43,7 +43,7 @@ func updateAndGetProtocolFeeBalance() map[string]uint64 {
 	pf.DistributeProtocolFee()
 	gotAccuProtocolFee := pf.GetAccuTransferToGovStaker()
 
-	gotAccuProtocolFee.Iterate("", "", func(key string, value interface{}) bool {
+	gotAccuProtocolFee.Iterate("", "", func(key string, value any) bool {
 		amount := value.(uint64)
 		currentProtocolFeeBalance[key] += amount
 		return false

--- a/contract/r/gnoswap/launchpad/reward_calculation.gno
+++ b/contract/r/gnoswap/launchpad/reward_calculation.gno
@@ -83,7 +83,7 @@ func (states RewardStates) set(projectId string, tierStr string, state *RewardSt
 func (states RewardStates) deleteProject(projectId string) uint64 {
 	totalLeftover := uint64(0)
 	keys := []string{}
-	states.states.Iterate(projectId+":", projectId+";", func(key string, value interface{}) bool {
+	states.states.Iterate(projectId+":", projectId+";", func(key string, value any) bool {
 		state := value.(*RewardState)
 		totalEmptyBlock := state.TotalEmptyBlock
 		if state.TotalStake == 0 {

--- a/contract/r/gnoswap/launchpad/util.gno
+++ b/contract/r/gnoswap/launchpad/util.gno
@@ -101,7 +101,7 @@ func getPrevPkgPath() string {
 }
 
 // formatUint returns the string representation of the uint64 value.
-func formatUint(v interface{}) string {
+func formatUint(v any) string {
 	switch v := v.(type) {
 	case uint8:
 		return strconv.FormatUint(uint64(v), 10)

--- a/contract/r/gnoswap/pool/api.gno
+++ b/contract/r/gnoswap/pool/api.gno
@@ -12,7 +12,7 @@ import (
 
 func ApiGetPools() string {
 	rpcPools := []RpcPool{}
-	pools.Iterate("", "", func(poolPath string, value interface{}) bool {
+	pools.Iterate("", "", func(poolPath string, value any) bool {
 		rpcPool := newRpcPool(poolPath)
 		rpcPools = append(rpcPools, rpcPool)
 

--- a/contract/r/gnoswap/pool/getter.gno
+++ b/contract/r/gnoswap/pool/getter.gno
@@ -2,7 +2,7 @@ package pool
 
 func PoolGetPoolList() []string {
 	poolPaths := []string{}
-	pools.Iterate("", "", func(poolPath string, _ interface{}) bool {
+	pools.Iterate("", "", func(poolPath string, _ any) bool {
 		poolPaths = append(poolPaths, poolPath)
 
 		return false

--- a/contract/r/gnoswap/pool/json.gno
+++ b/contract/r/gnoswap/pool/json.gno
@@ -82,7 +82,7 @@ func newRpcPool(poolPath string) RpcPool {
 	rpcPool.Liquidity = pool.liquidity.ToString()
 
 	rpcPool.Ticks = RpcTicks{}
-	pool.ticks.Iterate("", "", func(tickStr string, iTickInfo interface{}) bool {
+	pool.ticks.Iterate("", "", func(tickStr string, iTickInfo any) bool {
 		tick, _ := strconv.Atoi(tickStr)
 		tickInfo := iTickInfo.(TickInfo)
 
@@ -101,7 +101,7 @@ func newRpcPool(poolPath string) RpcPool {
 	})
 
 	rpcPool.TickBitmaps = RpcTickBitmaps{}
-	pool.tickBitmaps.Iterate("", "", func(tickStr string, iTickBitmap interface{}) bool {
+	pool.tickBitmaps.Iterate("", "", func(tickStr string, iTickBitmap any) bool {
 		tick, _ := strconv.Atoi(tickStr)
 		pool.setTickBitmap(int16(tick), iTickBitmap.(*u256.Uint))
 
@@ -109,7 +109,7 @@ func newRpcPool(poolPath string) RpcPool {
 	})
 
 	rpcPositions := []RpcPosition{}
-	pool.positions.Iterate("", "", func(posKey string, iPositionInfo interface{}) bool {
+	pool.positions.Iterate("", "", func(posKey string, iPositionInfo any) bool {
 		owner, tickLower, tickUpper := posKeyDivide(posKey)
 		posInfo := iPositionInfo.(PositionInfo)
 

--- a/contract/r/gnoswap/pool/pool_manager.gno
+++ b/contract/r/gnoswap/pool/pool_manager.gno
@@ -348,7 +348,7 @@ func setFeeProtocol(feeProtocol0, feeProtocol1 uint8) uint8 {
 	newFee := feeProtocol0 + (feeProtocol1 << 4) // ( << 4 ) = ( * 16 )
 
 	// Update slot0 for each pool
-	pools.Iterate("", "", func(poolPath string, iPool interface{}) bool {
+	pools.Iterate("", "", func(poolPath string, iPool any) bool {
 		pool := iPool.(*Pool)
 		pool.slot0.feeProtocol = newFee
 

--- a/contract/r/gnoswap/pool/tests/pool_single_lp_test.gnoA
+++ b/contract/r/gnoswap/pool/tests/pool_single_lp_test.gnoA
@@ -321,7 +321,7 @@ func TestSetFeeProtocolByAdmin(t *testing.T) {
 	testing.SetRealm(adminRealm)
 	SetFeeProtocolByAdmin(6, 8)
 
-	pools.Iterate("", "", func(poolPath string, iPool interface{}) bool {
+	pools.Iterate("", "", func(poolPath string, iPool any) bool {
 		pool := iPool.(*Pool)
 		uassert.Equal(t, pool.Slot0FeeProtocol(), uint8(134))
 		return false

--- a/contract/r/gnoswap/pool/utils.gno
+++ b/contract/r/gnoswap/pool/utils.gno
@@ -256,7 +256,7 @@ func assertOnlyRegistered(tokenPath string) {
 	common.MustRegistered(tokenPath)
 }
 
-func formatUint(v interface{}) string {
+func formatUint(v any) string {
 	switch v := v.(type) {
 	case uint8:
 		return strconv.FormatUint(uint64(v), 10)
@@ -269,7 +269,7 @@ func formatUint(v interface{}) string {
 	}
 }
 
-func formatInt(v interface{}) string {
+func formatInt(v any) string {
 	switch v := v.(type) {
 	case int32:
 		return strconv.FormatInt(int64(v), 10)

--- a/contract/r/gnoswap/position/utils.gno
+++ b/contract/r/gnoswap/position/utils.gno
@@ -219,9 +219,9 @@ func checkDeadline(deadline int64) {
 // NOTE: input parameter positionId can be string, int, uint64, or grc721.TokenID
 // if positionId is nil or not supported, it will panic
 // if positionId is not found, it will panic
-// input: positionId interface{}
+// input: positionId any
 // output: grc721.TokenID
-func positionIdFrom(positionId interface{}) grc721.TokenID {
+func positionIdFrom(positionId any) grc721.TokenID {
 	if positionId == nil {
 		panic(newErrorWithDetail(errInvalidInput, "positionId is nil"))
 	}
@@ -358,7 +358,7 @@ func verifySlippageAmounts(amount0, amount1, amount0Min, amount1Min *u256.Uint) 
 	}
 }
 
-func formatUint(v interface{}) string {
+func formatUint(v any) string {
 	switch v := v.(type) {
 	case uint8:
 		return strconv.FormatUint(uint64(v), 10)
@@ -371,7 +371,7 @@ func formatUint(v interface{}) string {
 	}
 }
 
-func formatInt(v interface{}) string {
+func formatInt(v any) string {
 	switch v := v.(type) {
 	case int32:
 		return strconv.FormatInt(int64(v), 10)

--- a/contract/r/gnoswap/position/utils_test.gno
+++ b/contract/r/gnoswap/position/utils_test.gno
@@ -493,7 +493,7 @@ func TestCheckDeadline(t *testing.T) {
 func TestPositionIdFrom(t *testing.T) {
 	tests := []struct {
 		name        string
-		input       interface{}
+		input       any
 		expected    string
 		shouldPanic bool
 	}{

--- a/contract/r/gnoswap/protocol_fee/api.gno
+++ b/contract/r/gnoswap/protocol_fee/api.gno
@@ -69,7 +69,7 @@ func buildByAvlTree(tree *avl.Tree) *json.Node {
 		WriteString("height", formatInt(std.ChainHeight())).
 		WriteString("now", formatInt(time.Now().Unix()))
 
-	tree.Iterate("", "", func(key string, value interface{}) bool {
+	tree.Iterate("", "", func(key string, value any) bool {
 		data.WriteString(key, formatUint(value.(uint64)))
 		return false
 	})

--- a/contract/r/gnoswap/referral/keeper.gno
+++ b/contract/r/gnoswap/referral/keeper.gno
@@ -153,7 +153,7 @@ func (k *keeper) get(addr std.Address) (std.Address, error) {
 
 func (k *keeper) isEmpty() bool {
 	empty := true
-	k.store.Iterate("", "", func(key string, value interface{}) bool {
+	k.store.Iterate("", "", func(key string, value any) bool {
 		empty = false
 		return true // stop iteration on first item
 	})

--- a/contract/r/gnoswap/router/utils.gno
+++ b/contract/r/gnoswap/router/utils.gno
@@ -206,7 +206,7 @@ func splitSingleChar(s string, sep byte) []string {
 	return result
 }
 
-func formatUint(v interface{}) string {
+func formatUint(v any) string {
 	switch v := v.(type) {
 	case uint8:
 		return strconv.FormatUint(uint64(v), 10)

--- a/contract/r/gnoswap/staker/_helper_test.gno
+++ b/contract/r/gnoswap/staker/_helper_test.gno
@@ -551,7 +551,7 @@ func getPrintInfo(t *testing.T) string {
 	emissionDebug.GnsADMIN = gns.BalanceOf(consts.ADMIN)
 
 	poolTiers := make(map[string]uint64)
-	pools.tree.Iterate("", "", func(poolPath string, iPool interface{}) bool {
+	pools.tree.Iterate("", "", func(poolPath string, iPool any) bool {
 		poolTier := poolTier.CurrentTier(poolPath)
 		poolTiers[poolPath] = poolTier
 		return false
@@ -571,7 +571,7 @@ func getPrintInfo(t *testing.T) string {
 			pool.NumPoolInSameTier = numTier3
 		}
 
-		deposits.tree.Iterate("", "", func(positionIdStr string, value interface{}) bool {
+		deposits.tree.Iterate("", "", func(positionIdStr string, value any) bool {
 			positionId := DecodeUint(positionIdStr)
 			deposit := value.(*Deposit)
 
@@ -660,7 +660,7 @@ func makePoolsNode(t *testing.T, emissionPool []ApiEmissionDebugPool) []*json.No
 	poolNodes := make([]*json.Node, 0)
 
 	poolTiers := make(map[string]uint64)
-	pools.tree.Iterate("", "", func(poolPath string, iPool interface{}) bool {
+	pools.tree.Iterate("", "", func(poolPath string, iPool any) bool {
 		poolTier := poolTier.CurrentTier(poolPath)
 		poolTiers[poolPath] = poolTier
 		return false
@@ -692,7 +692,7 @@ func makePoolsNode(t *testing.T, emissionPool []ApiEmissionDebugPool) []*json.No
 func makePositionsNode(t *testing.T, poolPath string) []*json.Node {
 	positions := make([]*json.Node, 0)
 
-	deposits.tree.Iterate("", "", func(positionIdStr string, value interface{}) bool {
+	deposits.tree.Iterate("", "", func(positionIdStr string, value any) bool {
 		positionId := DecodeUint(positionIdStr)
 		deposit := value.(*Deposit)
 

--- a/contract/r/gnoswap/staker/api.gno
+++ b/contract/r/gnoswap/staker/api.gno
@@ -23,7 +23,7 @@ func ApiGetRewardTokens() string {
 
 		// HANDLE EXTERNAL
 		if pool.IsExternallyIncentivizedPool() {
-			pool.incentives.byTime.Iterate("", "", func(key string, value interface{}) bool {
+			pool.incentives.byTime.Iterate("", "", func(key string, value any) bool {
 				ictv := value.(*ExternalIncentive)
 				if ictv.RewardToken() == "" {
 					return false
@@ -67,7 +67,7 @@ func ApiGetRewardTokensByPoolPath(targetPoolPath string) string {
 
 	// HANDLE EXTERNAL
 	if pool.IsExternallyIncentivizedPool() {
-		pool.incentives.byTime.Iterate("", "", func(key string, value interface{}) bool {
+		pool.incentives.byTime.Iterate("", "", func(key string, value any) bool {
 			ictv := value.(*ExternalIncentive)
 			if ictv.RewardToken() == "" {
 				return false
@@ -91,9 +91,9 @@ func ApiGetRewardTokensByPoolPath(targetPoolPath string) string {
 func ApiGetExternalIncentives() string {
 	apiExternalIncentives := []ApiExternalIncentive{}
 
-	pools.tree.Iterate("", "", func(key string, value interface{}) bool {
+	pools.tree.Iterate("", "", func(key string, value any) bool {
 		pool := value.(*Pool)
-		pool.incentives.byTime.Iterate("", "", func(key string, value interface{}) bool {
+		pool.incentives.byTime.Iterate("", "", func(key string, value any) bool {
 			ictv := value.(*ExternalIncentive)
 			externalIctv := newApiExternalIncentive(ictv)
 			apiExternalIncentives = append(apiExternalIncentives, externalIctv)
@@ -151,7 +151,7 @@ func ApiGetExternalIncentivesByPoolPath(targetPoolPath string) string {
 		))
 	}
 
-	pool.incentives.byTime.Iterate("", "", func(key string, value interface{}) bool {
+	pool.incentives.byTime.Iterate("", "", func(key string, value any) bool {
 		incentive := value.(*ExternalIncentive)
 		if incentive.targetPoolPath != targetPoolPath {
 			return false
@@ -174,9 +174,9 @@ func ApiGetExternalIncentivesByPoolPath(targetPoolPath string) string {
 func ApiGetExternalIncentivesByRewardTokenPath(rewardTokenPath string) string {
 	apiExternalIncentives := []ApiExternalIncentive{}
 
-	pools.tree.Iterate("", "", func(key string, value interface{}) bool {
+	pools.tree.Iterate("", "", func(key string, value any) bool {
 		pool := value.(*Pool)
-		pool.incentives.byTime.Iterate("", "", func(key string, value interface{}) bool {
+		pool.incentives.byTime.Iterate("", "", func(key string, value any) bool {
 			incentive := value.(*ExternalIncentive)
 			if incentive.rewardToken != rewardTokenPath {
 				return false
@@ -201,7 +201,7 @@ func ApiGetExternalIncentivesByRewardTokenPath(rewardTokenPath string) string {
 func ApiGetInternalIncentives() string {
 	apiInternalIncentives := []ApiInternalIncentive{}
 
-	poolTier.membership.Iterate("", "", func(key string, value interface{}) bool {
+	poolTier.membership.Iterate("", "", func(key string, value any) bool {
 		poolPath := key
 		internalTier := value.(uint64)
 		internalIctv := newApiInternalIncentive(poolPath, internalTier)
@@ -239,7 +239,7 @@ func ApiGetInternalIncentivesByPoolPath(targetPoolPath string) string {
 func ApiGetInternalIncentivesByTiers(targetTier uint64) string {
 	apiInternalIncentives := []ApiInternalIncentive{}
 
-	poolTier.membership.Iterate("", "", func(key string, value interface{}) bool {
+	poolTier.membership.Iterate("", "", func(key string, value any) bool {
 		poolPath := key
 		internalTier := value.(uint64)
 		if internalTier != targetTier {

--- a/contract/r/gnoswap/staker/filetests/average_block_time_change_from_gns_filetest.gno
+++ b/contract/r/gnoswap/staker/filetests/average_block_time_change_from_gns_filetest.gno
@@ -183,7 +183,7 @@ func testGnsAvgBlockTime() {
 	}
 }
 
-func positionIdFrom(positionId interface{}) grc721.TokenID {
+func positionIdFrom(positionId any) grc721.TokenID {
 	if positionId == nil {
 		panic("positionId is nil")
 	}

--- a/contract/r/gnoswap/staker/filetests/no_position_to_give_reward_filetest.gno
+++ b/contract/r/gnoswap/staker/filetests/no_position_to_give_reward_filetest.gno
@@ -139,7 +139,7 @@ func testUnstakePos01() {
 	}
 }
 
-func positionIdFrom(positionId interface{}) grc721.TokenID {
+func positionIdFrom(positionId any) grc721.TokenID {
 	if positionId == nil {
 		panic("positionId is nil")
 	}

--- a/contract/r/gnoswap/staker/filetests/pool_add_to_tier2_and_change_to_tier3_internal_filetest.gno
+++ b/contract/r/gnoswap/staker/filetests/pool_add_to_tier2_and_change_to_tier3_internal_filetest.gno
@@ -212,7 +212,7 @@ func testChangePoolTier3() {
 	}
 }
 
-func positionIdFrom(positionId interface{}) grc721.TokenID {
+func positionIdFrom(positionId any) grc721.TokenID {
 	if positionId == nil {
 		panic("positionId is nil")
 	}

--- a/contract/r/gnoswap/staker/filetests/pool_add_to_tier2_and_removed_internal_filetest.gno
+++ b/contract/r/gnoswap/staker/filetests/pool_add_to_tier2_and_removed_internal_filetest.gno
@@ -230,7 +230,7 @@ func testRemovePoolTier() {
 	}
 }
 
-func positionIdFrom(positionId interface{}) grc721.TokenID {
+func positionIdFrom(positionId any) grc721.TokenID {
 	if positionId == nil {
 		panic("positionId is nil")
 	}

--- a/contract/r/gnoswap/staker/filetests/position_inrange_change_by_swap_external_filetest.gno
+++ b/contract/r/gnoswap/staker/filetests/position_inrange_change_by_swap_external_filetest.gno
@@ -273,7 +273,7 @@ func testCheckReward03() {
 	}
 }
 
-func positionIdFrom(positionId interface{}) grc721.TokenID {
+func positionIdFrom(positionId any) grc721.TokenID {
 	if positionId == nil {
 		panic("positionId is nil")
 	}

--- a/contract/r/gnoswap/staker/filetests/position_inrange_change_by_swap_internal_filetest.gno
+++ b/contract/r/gnoswap/staker/filetests/position_inrange_change_by_swap_internal_filetest.gno
@@ -252,7 +252,7 @@ func testCheckReward03() {
 	}
 }
 
-func positionIdFrom(positionId interface{}) grc721.TokenID {
+func positionIdFrom(positionId any) grc721.TokenID {
 	if positionId == nil {
 		panic("positionId is nil")
 	}

--- a/contract/r/gnoswap/staker/filetests/reward_for_user_collect_change_by_collecting_reward_external_filetest.gno
+++ b/contract/r/gnoswap/staker/filetests/reward_for_user_collect_change_by_collecting_reward_external_filetest.gno
@@ -209,7 +209,7 @@ func testCollectRewardPos01() {
 	}
 }
 
-func positionIdFrom(positionId interface{}) grc721.TokenID {
+func positionIdFrom(positionId any) grc721.TokenID {
 	if positionId == nil {
 		panic("positionId is nil")
 	}

--- a/contract/r/gnoswap/staker/filetests/reward_for_user_collect_change_by_collecting_reward_internal_filetest.gno
+++ b/contract/r/gnoswap/staker/filetests/reward_for_user_collect_change_by_collecting_reward_internal_filetest.gno
@@ -162,7 +162,7 @@ func testCollectRewardPos01() {
 	}
 }
 
-func positionIdFrom(positionId interface{}) grc721.TokenID {
+func positionIdFrom(positionId any) grc721.TokenID {
 	if positionId == nil {
 		panic("positionId is nil")
 	}

--- a/contract/r/gnoswap/staker/filetests/single_gns_external_ends_filetest.gno
+++ b/contract/r/gnoswap/staker/filetests/single_gns_external_ends_filetest.gno
@@ -240,7 +240,7 @@ func testCollectRewardPos01AndPos02AfterEnd() {
 	}
 }
 
-func positionIdFrom(positionId interface{}) grc721.TokenID {
+func positionIdFrom(positionId any) grc721.TokenID {
 	if positionId == nil {
 		panic("positionId is nil")
 	}

--- a/contract/r/gnoswap/staker/filetests/single_position_stake_unstake_restake_filetest.gno
+++ b/contract/r/gnoswap/staker/filetests/single_position_stake_unstake_restake_filetest.gno
@@ -179,7 +179,7 @@ func testStakeTokenPos01Again() {
 	}
 }
 
-func positionIdFrom(positionId interface{}) grc721.TokenID {
+func positionIdFrom(positionId any) grc721.TokenID {
 	if positionId == nil {
 		panic("positionId is nil")
 	}

--- a/contract/r/gnoswap/staker/filetests/single_position_stake_unstake_same_block_filetest.gno
+++ b/contract/r/gnoswap/staker/filetests/single_position_stake_unstake_same_block_filetest.gno
@@ -125,7 +125,7 @@ func testStakeAndUnstakeTokenPos01() {
 	}
 }
 
-func positionIdFrom(positionId interface{}) grc721.TokenID {
+func positionIdFrom(positionId any) grc721.TokenID {
 	if positionId == nil {
 		panic("positionId is nil")
 	}

--- a/contract/r/gnoswap/staker/filetests/staked_liquidity_change_by_staking_unstaking_external_filetest.gno
+++ b/contract/r/gnoswap/staker/filetests/staked_liquidity_change_by_staking_unstaking_external_filetest.gno
@@ -220,7 +220,7 @@ func testCollectRewardAfterUnstake() {
 	}
 }
 
-func positionIdFrom(positionId interface{}) grc721.TokenID {
+func positionIdFrom(positionId any) grc721.TokenID {
 	if positionId == nil {
 		panic("positionId is nil")
 	}

--- a/contract/r/gnoswap/staker/filetests/staked_liquidity_change_by_staking_unstaking_internal_filetest.gno
+++ b/contract/r/gnoswap/staker/filetests/staked_liquidity_change_by_staking_unstaking_internal_filetest.gno
@@ -183,7 +183,7 @@ func testCollectRewardAfterUnstake() {
 	}
 }
 
-func positionIdFrom(positionId interface{}) grc721.TokenID {
+func positionIdFrom(positionId any) grc721.TokenID {
 	if positionId == nil {
 		panic("positionId is nil")
 	}

--- a/contract/r/gnoswap/staker/getter.gno
+++ b/contract/r/gnoswap/staker/getter.gno
@@ -49,7 +49,7 @@ func GetPoolIncentiveIdList(poolPath string) []string {
 	pool := GetPoolByPoolPath(poolPath)
 
 	ids := []string{}
-	pool.incentives.byTime.Iterate("", "", func(key string, value interface{}) bool {
+	pool.incentives.byTime.Iterate("", "", func(key string, value any) bool {
 		ids = append(ids, key)
 		return true
 	})
@@ -538,7 +538,7 @@ func GetExternalIncentive(incentiveId string) *ExternalIncentive {
 // - []ExternalIncentive: A slice of `ExternalIncentive` objects associated with the specified pool path.
 func GetExternalIncentiveByPoolPath(poolPath string) []ExternalIncentive {
 	incentives := []ExternalIncentive{}
-	externalIncentives.tree.Iterate("", "", func(key string, value interface{}) bool {
+	externalIncentives.tree.Iterate("", "", func(key string, value any) bool {
 		incentive := value.(*ExternalIncentive)
 		if incentive.targetPoolPath == poolPath {
 			incentives = append(incentives, *incentive)
@@ -564,7 +564,7 @@ func GetPrintExternalInfo() string {
 		}
 
 		externalIncentivesList := []ApiExternalDebugIncentive{}
-		externalIncentives.tree.Iterate("", "", func(key string, value interface{}) bool {
+		externalIncentives.tree.Iterate("", "", func(key string, value any) bool {
 			incentive := value.(*ExternalIncentive)
 			if incentive.targetPoolPath == deposit.targetPoolPath {
 				externalIncentive := ApiExternalDebugIncentive{

--- a/contract/r/gnoswap/staker/query.gno
+++ b/contract/r/gnoswap/staker/query.gno
@@ -58,10 +58,10 @@ func QueryIncentiveData(incentiveId string) (*IncentiveData, error) {
 	var found bool
 	var data IncentiveData
 
-	pools.tree.Iterate("", "", func(key string, value interface{}) bool {
+	pools.tree.Iterate("", "", func(key string, value any) bool {
 		pool := value.(*Pool)
 
-		pool.incentives.byTime.Iterate("", "", func(key string, value interface{}) bool {
+		pool.incentives.byTime.Iterate("", "", func(key string, value any) bool {
 			if key == incentiveId {
 				ictv := value.(*ExternalIncentive)
 				data = IncentiveData{
@@ -108,7 +108,7 @@ func QueryDepositData(lpTokenId uint64) (*DepositData, error) {
 
 func filterActiveIncentives(pool *Pool, currentHeight int64) []string {
 	ictvIds := make([]string, 0)
-	pool.incentives.byHeight.Iterate("", "", func(key string, value interface{}) bool {
+	pool.incentives.byHeight.Iterate("", "", func(key string, value any) bool {
 		ictv := value.(*ExternalIncentive)
 		if ictv.startHeight <= currentHeight && currentHeight < ictv.endHeight {
 			ictvId := incentiveIdByTime(

--- a/contract/r/gnoswap/staker/reward_calculation_canonical_env_test.gno
+++ b/contract/r/gnoswap/staker/reward_calculation_canonical_env_test.gno
@@ -101,7 +101,7 @@ func NewCanonicalRewardState(t *testing.T, pools *Pools, deposits *Deposits, tic
 	result.global.poolTier = NewPoolTier(pools, 123, test_gnousdc, func() uint64 { return result.PerBlockEmission }, func(start, end int64) ([]int64, []uint64) {
 		heights := make([]int64, 0)
 		emissions := make([]uint64, 0)
-		result.emissionUpdates.Iterate(start, end, func(key int64, value interface{}) bool {
+		result.emissionUpdates.Iterate(start, end, func(key int64, value any) bool {
 			heights = append(heights, key)
 			emissions = append(emissions, value.(uint64))
 			return false

--- a/contract/r/gnoswap/staker/reward_calculation_incentives.gno
+++ b/contract/r/gnoswap/staker/reward_calculation_incentives.gno
@@ -69,7 +69,7 @@ func (self *Incentives) GetAllInHeights(startHeight, endHeight int64) map[string
 	self.byHeight.ReverseIterate(
 		"",
 		EncodeUint(uint64(endHeight)),
-		func(key string, value interface{}) bool {
+		func(key string, value any) bool {
 			incentive := value.(*ExternalIncentive)
 			if incentive.endHeight < startHeight {
 				// incentive is already ended
@@ -84,7 +84,7 @@ func (self *Incentives) GetAllInHeights(startHeight, endHeight int64) map[string
 	self.byEndHeight.Iterate(
 		EncodeUint(uint64(startHeight)),
 		"",
-		func(key string, value interface{}) bool {
+		func(key string, value any) bool {
 			incentive := value.(*ExternalIncentive)
 			if incentive.startHeight > endHeight {
 				// incentive is not started yet
@@ -131,7 +131,7 @@ func (self *Incentives) startUnclaimablePeriod(startHeight int64) {
 // ignores if currently not in unclaimable period
 func (self *Incentives) endUnclaimablePeriod(endHeight int64) {
 	startHeight := int64(0)
-	self.unclaimablePeriods.ReverseIterate(0, endHeight, func(key int64, value interface{}) bool {
+	self.unclaimablePeriods.ReverseIterate(0, endHeight, func(key int64, value any) bool {
 		if value.(int64) != 0 {
 			// Already ended, no need to update
 			// keeping startHeight as 0 to indicate this
@@ -162,7 +162,7 @@ func (self *Incentives) calculateUnclaimableReward(incentiveId string) uint64 {
 
 	blocks := int64(0)
 
-	self.unclaimablePeriods.ReverseIterate(0, incentive.startHeight, func(key int64, value interface{}) bool {
+	self.unclaimablePeriods.ReverseIterate(0, incentive.startHeight, func(key int64, value any) bool {
 		endHeight := value.(int64)
 		if endHeight == 0 {
 			endHeight = incentive.endHeight
@@ -174,7 +174,7 @@ func (self *Incentives) calculateUnclaimableReward(incentiveId string) uint64 {
 		return true
 	})
 
-	self.unclaimablePeriods.Iterate(incentive.startHeight, incentive.endHeight, func(key int64, value interface{}) bool {
+	self.unclaimablePeriods.Iterate(incentive.startHeight, incentive.endHeight, func(key int64, value any) bool {
 		startHeight := key
 		endHeight := value.(int64)
 		if endHeight == 0 {

--- a/contract/r/gnoswap/staker/reward_calculation_pool.gno
+++ b/contract/r/gnoswap/staker/reward_calculation_pool.gno
@@ -66,7 +66,7 @@ func (self *Pools) Has(poolPath string) bool {
 }
 
 func (self *Pools) IterateAll(fn func(key string, pool *Pool) bool) {
-	self.tree.Iterate("", "", func(key string, value interface{}) bool {
+	self.tree.Iterate("", "", func(key string, value any) bool {
 		return fn(key, value.(*Pool))
 	})
 }
@@ -156,7 +156,7 @@ func NewPool(poolPath string, currentHeight int64) *Pool {
 func (self *Pool) CurrentGlobalRewardRatioAccumulation(currentHeight int64) (int64, *u256.Uint) {
 	var height int64
 	var acc *u256.Uint
-	self.globalRewardRatioAccumulation.ReverseIterate(0, currentHeight, func(key int64, value interface{}) bool {
+	self.globalRewardRatioAccumulation.ReverseIterate(0, currentHeight, func(key int64, value any) bool {
 		height = key
 		acc = value.(*u256.Uint)
 		return true
@@ -171,7 +171,7 @@ func (self *Pool) CurrentGlobalRewardRatioAccumulation(currentHeight int64) (int
 // Returns the tick.
 func (self *Pool) CurrentTick(currentHeight int64) int32 {
 	var tick int32
-	self.historicalTick.ReverseIterate(0, currentHeight, func(key int64, value interface{}) bool {
+	self.historicalTick.ReverseIterate(0, currentHeight, func(key int64, value any) bool {
 		tick = value.(int32)
 		return true
 	})
@@ -180,7 +180,7 @@ func (self *Pool) CurrentTick(currentHeight int64) int32 {
 
 func (self *Pool) CurrentStakedLiquidity(currentHeight int64) *u256.Uint {
 	var liquidity *u256.Uint
-	self.stakedLiquidity.ReverseIterate(0, currentHeight, func(key int64, value interface{}) bool {
+	self.stakedLiquidity.ReverseIterate(0, currentHeight, func(key int64, value any) bool {
 		liquidity = value.(*u256.Uint)
 		return true
 	})
@@ -196,7 +196,7 @@ func (self *Pool) IsExternallyIncentivizedPool() bool {
 // Returns the reward.
 func (self *Pool) CurrentReward(currentHeight int64) uint64 {
 	var reward uint64
-	self.rewardCache.ReverseIterate(0, currentHeight, func(key int64, value interface{}) bool {
+	self.rewardCache.ReverseIterate(0, currentHeight, func(key int64, value any) bool {
 		reward = value.(uint64)
 		return true
 	})
@@ -289,7 +289,7 @@ func (self *Pool) RewardStateOf(deposit *Deposit) *RewardState {
 // It calls rewardPerWarmup for each rewardCache interval, applies warmup, and returns the rewards and penalties.
 func (self *RewardState) calculateInternalReward(startHeight, endHeight int64) ([]uint64, []uint64) {
 	currentReward := self.pool.CurrentReward(startHeight)
-	self.pool.rewardCache.Iterate(startHeight, endHeight, func(key int64, value interface{}) bool {
+	self.pool.rewardCache.Iterate(startHeight, endHeight, func(key int64, value any) bool {
 		// we calculate per-position reward
 		self.rewardPerWarmup(startHeight, int64(key), currentReward)
 		currentReward = value.(uint64)

--- a/contract/r/gnoswap/staker/reward_calculation_pool_tier.gno
+++ b/contract/r/gnoswap/staker/reward_calculation_pool_tier.gno
@@ -139,7 +139,7 @@ func (self *PoolTier) CurrentReward(tier uint64) uint64 {
 // CurrentCount returns the current count of pools in the given tier.
 func (self *PoolTier) CurrentCount(tier uint64) int {
 	count := 0
-	self.membership.Iterate("", "", func(key string, value interface{}) bool {
+	self.membership.Iterate("", "", func(key string, value any) bool {
 		if value.(uint64) == tier {
 			count++
 		}
@@ -151,7 +151,7 @@ func (self *PoolTier) CurrentCount(tier uint64) int {
 // CurrentAllTierCounts returns the current count of pools in each tier.
 func (self *PoolTier) CurrentAllTierCounts() []uint64 {
 	count := make([]uint64, AllTierCount)
-	self.membership.Iterate("", "", func(key string, value interface{}) bool {
+	self.membership.Iterate("", "", func(key string, value any) bool {
 		count[value.(uint64)]++
 		return false
 	})
@@ -197,7 +197,7 @@ func (self *PoolTier) changeTier(currentHeight int64, pools *Pools, poolPath str
 	currentEmission := self.getEmission()
 
 	// Cache updated reward for each tiered pool
-	self.membership.Iterate("", "", func(key string, value interface{}) bool {
+	self.membership.Iterate("", "", func(key string, value any) bool {
 		pool, ok := pools.Get(key)
 		if !ok {
 			panic("changeTier: pool not found")
@@ -250,7 +250,7 @@ func (self *PoolTier) applyCacheToAllPools(pools *Pools, currentBlock int64, emi
 	counts := self.CurrentAllTierCounts()
 
 	// apply cache to all pools
-	self.membership.Iterate("", "", func(key string, value interface{}) bool {
+	self.membership.Iterate("", "", func(key string, value any) bool {
 		tierNum := value.(uint64)
 		pool, ok := pools.Get(key)
 		if !ok {

--- a/contract/r/gnoswap/staker/reward_calculation_tick.gno
+++ b/contract/r/gnoswap/staker/reward_calculation_tick.gno
@@ -105,7 +105,7 @@ type Tick struct {
 // CurrentOutsideAccumulation returns the latest outside accumulation for the tick
 func (self *Tick) CurrentOutsideAccumulation(blockNumber int64) *u256.Uint {
 	var acc *u256.Uint
-	self.outsideAccumulation.ReverseIterate(0, blockNumber, func(key int64, value interface{}) bool {
+	self.outsideAccumulation.ReverseIterate(0, blockNumber, func(key int64, value any) bool {
 		acc = value.(*u256.Uint)
 		return true
 	})

--- a/contract/r/gnoswap/staker/reward_calculation_types.gno
+++ b/contract/r/gnoswap/staker/reward_calculation_types.gno
@@ -60,7 +60,7 @@ func DecodeUint(s string) uint64 {
 // - Iterate: Iterates over keys and values in a range.
 // - ReverseIterate: Iterates in reverse order over keys and values in a range.
 type UintTree struct {
-	tree *avl.Tree // blockNumber -> interface{}
+	tree *avl.Tree // blockNumber -> any
 }
 
 // NewUintTree creates a new UintTree instance.
@@ -70,7 +70,7 @@ func NewUintTree() *UintTree {
 	}
 }
 
-func (self *UintTree) Get(key int64) (interface{}, bool) {
+func (self *UintTree) Get(key int64) (any, bool) {
 	v, ok := self.tree.Get(EncodeUint(uint64(key)))
 	if !ok {
 		return nil, false
@@ -78,7 +78,7 @@ func (self *UintTree) Get(key int64) (interface{}, bool) {
 	return v, true
 }
 
-func (self *UintTree) set(key int64, value interface{}) {
+func (self *UintTree) set(key int64, value any) {
 	self.tree.Set(EncodeUint(uint64(key)), value)
 }
 
@@ -90,14 +90,14 @@ func (self *UintTree) remove(key int64) {
 	self.tree.Remove(EncodeUint(uint64(key)))
 }
 
-func (self *UintTree) Iterate(start, end int64, fn func(key int64, value interface{}) bool) {
-	self.tree.Iterate(EncodeUint(uint64(start)), EncodeUint(uint64(end)), func(key string, value interface{}) bool {
+func (self *UintTree) Iterate(start, end int64, fn func(key int64, value any) bool) {
+	self.tree.Iterate(EncodeUint(uint64(start)), EncodeUint(uint64(end)), func(key string, value any) bool {
 		return fn(int64(DecodeUint(key)), value)
 	})
 }
 
-func (self *UintTree) ReverseIterate(start, end int64, fn func(key int64, value interface{}) bool) {
-	self.tree.ReverseIterate(EncodeUint(uint64(start)), EncodeUint(uint64(end)), func(key string, value interface{}) bool {
+func (self *UintTree) ReverseIterate(start, end int64, fn func(key int64, value any) bool) {
+	self.tree.ReverseIterate(EncodeUint(uint64(start)), EncodeUint(uint64(end)), func(key string, value any) bool {
 		return fn(int64(DecodeUint(key)), value)
 	})
 }

--- a/contract/r/gnoswap/staker/reward_calculation_types_test.gno
+++ b/contract/r/gnoswap/staker/reward_calculation_types_test.gno
@@ -77,9 +77,9 @@ func TestUintTree(t *testing.T) {
 	tree.set(300, "c")
 
 	var keys []uint64
-	var values []interface{}
+	var values []any
 
-	tree.Iterate(100, 300, func(key int64, value interface{}) bool {
+	tree.Iterate(100, 300, func(key int64, value any) bool {
 		keys = append(keys, uint64(key))
 		values = append(values, value)
 		return false
@@ -87,7 +87,7 @@ func TestUintTree(t *testing.T) {
 
 	// Verify results
 	expectedKeys := []uint64{100, 200}
-	expectedValues := []interface{}{"a", "b"}
+	expectedValues := []any{"a", "b"}
 
 	if !compareUintSlices(t, keys, expectedKeys) || !compareInterfaces(t, values, expectedValues) {
 		t.Errorf("UintTree.Iterate() keys = %v, values = %v; want keys = %v, values = %v", keys, values, expectedKeys, expectedValues)
@@ -109,7 +109,7 @@ func compareUintSlices(t *testing.T, a, b []uint64) bool {
 }
 
 // Helper function to compare slices of interfaces
-func compareInterfaces(t *testing.T, a, b []interface{}) bool {
+func compareInterfaces(t *testing.T, a, b []any) bool {
 	t.Helper()
 	if len(a) != len(b) {
 		return false

--- a/contract/r/gnoswap/staker/staker.gno
+++ b/contract/r/gnoswap/staker/staker.gno
@@ -59,7 +59,7 @@ func (self *Deposits) remove(positionId uint64) {
 }
 
 func (self *Deposits) Iterate(start uint64, end uint64, fn func(positionId uint64, deposit *Deposit) bool) {
-	self.tree.Iterate(EncodeUint(start), EncodeUint(end), func(positionId string, depositI interface{}) bool {
+	self.tree.Iterate(EncodeUint(start), EncodeUint(end), func(positionId string, depositI any) bool {
 		return fn(DecodeUint(positionId), depositI.(*Deposit))
 	})
 }
@@ -123,7 +123,7 @@ func (self *Stakers) IterateAll(address std.Address, fn func(depositId uint64, d
 		return
 	}
 	depositTree := depositTreeI.(*avl.Tree)
-	depositTree.Iterate("", "", func(depositId string, depositI interface{}) bool {
+	depositTree.Iterate("", "", func(depositId string, depositI any) bool {
 		deposit := depositI.(*Deposit)
 		return fn(DecodeUint(depositId), deposit)
 	})

--- a/contract/r/gnoswap/staker/utils.gno
+++ b/contract/r/gnoswap/staker/utils.gno
@@ -89,7 +89,7 @@ func poolPathDivide(poolPath string) (string, string, string) {
 //
 // Output:
 //   - grc721.TokenID: the converted token ID
-func positionIdFrom(positionId interface{}) grc721.TokenID {
+func positionIdFrom(positionId any) grc721.TokenID {
 	if positionId == nil {
 		panic(addDetailToError(
 			errDataNotFound,
@@ -186,7 +186,7 @@ func assertOnlyNotHalted() {
 	}
 }
 
-func formatUint(v interface{}) string {
+func formatUint(v any) string {
 	switch v := v.(type) {
 	case uint8:
 		return strconv.FormatUint(uint64(v), 10)
@@ -199,7 +199,7 @@ func formatUint(v interface{}) string {
 	}
 }
 
-func formatInt(v interface{}) string {
+func formatInt(v any) string {
 	switch v := v.(type) {
 	case int32:
 		return strconv.FormatInt(int64(v), 10)

--- a/contract/r/gnoswap/staker/utils_test.gno
+++ b/contract/r/gnoswap/staker/utils_test.gno
@@ -101,7 +101,7 @@ func TestPoolPathDivide(t *testing.T) {
 func TestTid(t *testing.T) {
 	tests := []struct {
 		name        string
-		input       interface{}
+		input       any
 		expected    string
 		shouldPanic bool
 	}{

--- a/tests/integration/testscript_testing.go
+++ b/tests/integration/testscript_testing.go
@@ -30,7 +30,7 @@ func TSTestingT(ts *testscript.TestScript) TestingTS {
 	return &testingTS{ts}
 }
 
-func (t *testingTS) Errorf(format string, args ...interface{}) {
+func (t *testingTS) Errorf(format string, args ...any) {
 	defer recover() // we can ignore recover result, we just want to catch it up
 	t.Fatalf(format, args...)
 }


### PR DESCRIPTION
# Description

Fixed to use `any` type instead of `interface{}`, which also follows the go's style convention.