### PR TITLE
refactor: change dryswap return value

### DIFF
--- a/contract/r/gnoswap/router/router_dry.gno
+++ b/contract/r/gnoswap/router/router_dry.gno
@@ -14,24 +14,35 @@ import (
 
 // DrySwapRoute simulates a token swap route without actually executing the swap.
 // It calculates the expected outcome based on the current state of liquidity pools.
-// Returns the expected amount in or out
+// Parameters:
+// - inputToken: the symbol of the input token
+// - outputToken: the symbol of the output token
+// - specifiedAmount: the amount specified by the user (input or output, depending on swapKind)
+// - swapTypeStr: the type of swap ("exactIn" or "exactOut")
+// - strRouteArr: comma-separated swap route strings
+// - quoteArr: comma-separated quote percentages for each route
+// - tokenAmountLimit: a limit for token amount depending on swapKind
+// Returns:
+// - amountInStr: the calculated input amount as a string
+// - amountOutStr: the calculated output amount as a string
+// - success: true if the simulated swap meets all constraints
 func DrySwapRoute(
 	inputToken string,
 	outputToken string,
 	specifiedAmount string,
-	swapKind string,
+	swapTypeStr string,
 	strRouteArr string,
 	quoteArr string,
 	tokenAmountLimit string,
-) string {
+) (string, string, bool) {
 	common.MustRegistered(inputToken)
 	common.MustRegistered(outputToken)
 
-	swapType, err := trySwapTypeFromStr(swapKind)
+	swapType, err := trySwapTypeFromStr(swapTypeStr)
 	if err != nil {
 		panic(addDetailToError(
 			errInvalidSwapType,
-			ufmt.Sprintf("unknown swapType(%s)", swapKind),
+			ufmt.Sprintf("unknown swapType(%s)", swapTypeStr),
 		))
 	}
 
@@ -142,24 +153,25 @@ func handleMultiDrySwap(
 	}
 }
 
-func processResult(swapType SwapType, resultAmountIn, resultAmountOut *u256.Uint, amountSpecified, amountLimit *i256.Int) string {
+func processResult(swapType SwapType, resultAmountIn, resultAmountOut *u256.Uint, amountSpecified, amountLimit *i256.Int) (string, string, bool) {
 	switch swapType {
 	case ExactIn:
 		if i256.FromUint256(resultAmountIn).Gt(amountSpecified) {
-			return "-1"
+			return resultAmountIn.ToString(), resultAmountOut.ToString(), false
 		}
 		if i256.FromUint256(resultAmountOut).Lt(amountLimit) {
-			return "-1"
+			return resultAmountIn.ToString(), resultAmountOut.ToString(), false
 		}
-		return resultAmountOut.ToString()
+		return resultAmountIn.ToString(), resultAmountOut.ToString(), true
+
 	case ExactOut:
 		if i256.FromUint256(resultAmountOut).Lt(amountSpecified) {
-			return "-1"
+			return resultAmountIn.ToString(), resultAmountOut.ToString(), false
 		}
 		if i256.FromUint256(resultAmountIn).Gt(amountLimit) {
-			return "-1"
+			return resultAmountIn.ToString(), resultAmountOut.ToString(), false
 		}
-		return resultAmountIn.ToString()
+		return resultAmountIn.ToString(), resultAmountOut.ToString(), true
 	default:
 		panic(addDetailToError(
 			errInvalidSwapType,

--- a/contract/r/gnoswap/router/router_dry_test.gno
+++ b/contract/r/gnoswap/router/router_dry_test.gno
@@ -17,6 +17,7 @@ func TestProcessResult(t *testing.T) {
 		resultAmountOut string
 		amountSpecified string
 		expected        string
+		expectedSwap    bool
 	}{
 		{
 			name:            "ExactIn - Normal",
@@ -25,6 +26,7 @@ func TestProcessResult(t *testing.T) {
 			resultAmountOut: "95",
 			amountSpecified: "100",
 			expected:        "95",
+			expectedSwap:    true,
 		},
 		{
 			name:            "ExactIn - Input Mismatch",
@@ -32,7 +34,8 @@ func TestProcessResult(t *testing.T) {
 			resultAmountIn:  "99",
 			resultAmountOut: "5",
 			amountSpecified: "100",
-			expected:        "-1",
+			expected:        "5",
+			expectedSwap:    false,
 		},
 		{
 			name:            "ExactOut - Normal",
@@ -41,6 +44,7 @@ func TestProcessResult(t *testing.T) {
 			resultAmountOut: "100",
 			amountSpecified: "100",
 			expected:        "105",
+			expectedSwap:    true,
 		},
 		{
 			name:            "ExactOut - Output Mismatch",
@@ -48,7 +52,8 @@ func TestProcessResult(t *testing.T) {
 			resultAmountIn:  "105",
 			resultAmountOut: "95",
 			amountSpecified: "100",
-			expected:        "-1",
+			expected:        "105",
+			expectedSwap:    false,
 		},
 	}
 
@@ -62,8 +67,16 @@ func TestProcessResult(t *testing.T) {
 				amountLimit, _ = i256.FromDecimal("500")
 			}
 
-			result := processResult(tt.swapType, resultAmountIn, resultAmountOut, amountSpecified, amountLimit)
-			uassert.Equal(t, result, tt.expected)
+			switch tt.swapType {
+			case ExactIn:
+				_, result, swapAvailable := processResult(tt.swapType, resultAmountIn, resultAmountOut, amountSpecified, amountLimit)
+				uassert.Equal(t, tt.expected, result)
+				uassert.Equal(t, tt.expectedSwap, swapAvailable)
+			case ExactOut:
+				result, _, swapAvailable := processResult(tt.swapType, resultAmountIn, resultAmountOut, amountSpecified, amountLimit)
+				uassert.Equal(t, tt.expected, result)
+				uassert.Equal(t, tt.expectedSwap, swapAvailable)
+			}
 		})
 	}
 }

--- a/contract/r/gnoswap/router/router_test.gno
+++ b/contract/r/gnoswap/router/router_test.gno
@@ -264,7 +264,7 @@ func TestCompareExactInAndDrySwapWithNoLiquidityChanged(t *testing.T) {
 			testing.SetRealm(std.NewCodeRealm(routerPath))
 			wugnot.Approve(poolContract, maxApprove)
 
-			drySwapAmountOut := DrySwapRoute(
+			drySwapAmountIn, drySwapAmountOut, swapAvaialbe := DrySwapRoute(
 				tt.inputToken,
 				tt.outputToken,
 				tt.amountIn,
@@ -453,7 +453,7 @@ func TestCompareExactInAndDrySwapWithWhenLiquidityAdded(t *testing.T) {
 			testing.SetRealm(std.NewCodeRealm(routerPath))
 			wugnot.Approve(poolContract, maxApprove)
 
-			drySwapAmountOut := DrySwapRoute(
+			drySwapAmountIn, drySwapAmountOut, swapAvailable := DrySwapRoute(
 				tt.inputToken,
 				tt.outputToken,
 				tt.amountIn,
@@ -635,7 +635,7 @@ func TestCompareExactInAndDrySwapWithWhenLiquidityPartiallyRemoved(t *testing.T)
 			testing.SetRealm(std.NewCodeRealm(routerPath))
 			wugnot.Approve(poolContract, maxApprove)
 
-			drySwapAmountOut := DrySwapRoute(
+			drySwapAmountIn, drySwapAmountOut, swapAvailable := DrySwapRoute(
 				tt.inputToken,
 				tt.outputToken,
 				tt.amountIn,
@@ -800,7 +800,7 @@ func TestCompareExactInAndDrySwapWithWhenZeroForOneIsFalse(t *testing.T) {
 			testing.SetRealm(std.NewCodeRealm(routerPath))
 			wugnot.Approve(poolContract, maxApprove)
 
-			drySwapAmountOut := DrySwapRoute(
+			drySwapAmountIn, drySwapAmountOut, swapAvailable := DrySwapRoute(
 				tt.inputToken,
 				tt.outputToken,
 				tt.amountIn,

--- a/contract/r/gnoswap/router/tests/router_all_2_route_2_hop_test.gnoA
+++ b/contract/r/gnoswap/router/tests/router_all_2_route_2_hop_test.gnoA
@@ -43,7 +43,7 @@ func TestPositionMint(t *testing.T) {
 func TestDrySwapRouteBarQuxExactIn(t *testing.T) {
 	testing.SetRealm(adminRealm)
 
-	dryResult := DrySwapRoute(
+	_, dryResult, _ := DrySwapRoute(
 		barPath,    // inputToken
 		quxPath,    // outputToken
 		"1000",     // amountSpecified
@@ -80,7 +80,7 @@ func TestSwapRouteBarQuxExactIn(t *testing.T) {
 func TestDrySwapRouteBarQuxExactOut(t *testing.T) {
 	testing.SetRealm(adminRealm)
 
-	dryResult := DrySwapRoute(
+	dryResult, _, _ := DrySwapRoute(
 		barPath,     // inputToken
 		quxPath,     // outputToken
 		"1000",      // amountSpecified
@@ -114,7 +114,7 @@ func TestSwapRouteBarQuxExactOut(t *testing.T) {
 func TestDrySwapRouteQuxBarExactIn(t *testing.T) {
 	testing.SetRealm(adminRealm)
 
-	dryResult := DrySwapRoute(
+	_, dryResult, _ := DrySwapRoute(
 		quxPath,    // inputToken
 		barPath,    // outputToken
 		"1000",     // amountSpecified
@@ -148,7 +148,7 @@ func TestSwapRouteQuxBarExactIn(t *testing.T) {
 func TestDrySwapRouteQuxBarExactOut(t *testing.T) {
 	testing.SetRealm(adminRealm)
 
-	dryResult := DrySwapRoute(
+	dryResult, _, _ := DrySwapRoute(
 		quxPath,     // inputToken
 		barPath,     // outputToken
 		"1000",      // amountSpecified

--- a/contract/r/gnoswap/router/tests/router_swap_route_1route_1hop_out_range_test.gnoA
+++ b/contract/r/gnoswap/router/tests/router_swap_route_1route_1hop_out_range_test.gnoA
@@ -60,7 +60,7 @@ func TestPositionMint(t *testing.T) {
 func TestDrySwapRouteBazBarExactIn(t *testing.T) {
 	testing.SetRealm(adminRealm)
 
-	dryResult := DrySwapRoute(
+	_, dryResult, _ := DrySwapRoute(
 		bazPath,    // inputToken
 		barPath,    // outputToken
 		"1000",     // amountSpecified

--- a/contract/r/gnoswap/router/tests/router_swap_route_1route_1hop_test.gnoA
+++ b/contract/r/gnoswap/router/tests/router_swap_route_1route_1hop_test.gnoA
@@ -46,7 +46,7 @@ func TestPositionMint(t *testing.T) {
 func TestDrySwapRouteBarBazExactIn(t *testing.T) {
 	testing.SetRealm(adminRealm)
 
-	dryResult := DrySwapRoute(
+	_, dryResult, _ := DrySwapRoute(
 		barPath,    // inputToken
 		bazPath,    // outputToken
 		"1000",     // amountSpecified

--- a/contract/r/gnoswap/router/tests/router_swap_route_1route_1hop_wrapped_native_in_out_test.gnoA
+++ b/contract/r/gnoswap/router/tests/router_swap_route_1route_1hop_wrapped_native_in_out_test.gnoA
@@ -48,7 +48,7 @@ func TestPositionMintQuxGnot(t *testing.T) {
 func TestDrySwapRouteQuxGnotExactIn(t *testing.T) {
 	testing.SetRealm(adminRealm)
 
-	dryResult := DrySwapRoute(
+	_, dryResult, _ := DrySwapRoute(
 		quxPath,               // inputToken
 		consts.WRAPPED_WUGNOT, // outputToken
 		"1000",                // amountSpecified
@@ -63,7 +63,7 @@ func TestDrySwapRouteQuxGnotExactIn(t *testing.T) {
 func TestDrySwapRouteQuxGnotExactOut(t *testing.T) {
 	testing.SetRealm(adminRealm)
 
-	dryResult := DrySwapRoute(
+	dryResult, _, _ := DrySwapRoute(
 		quxPath,               // inputToken
 		consts.WRAPPED_WUGNOT, // outputToken
 		"1000",                // amountSpecified

--- a/contract/r/gnoswap/router/tests/router_swap_route_1route_2hop_wrapped_native_in_out_test.gnoA
+++ b/contract/r/gnoswap/router/tests/router_swap_route_1route_2hop_wrapped_native_in_out_test.gnoA
@@ -84,7 +84,7 @@ func TestPositionMintQuxGnot(t *testing.T) {
 func TestDrySwapRouteBarGnotExactIn(t *testing.T) {
 	testing.SetRealm(adminRealm)
 
-	dryResult := DrySwapRoute(
+	_, dryResult, _ := DrySwapRoute(
 		barPath,               // inputToken
 		consts.WRAPPED_WUGNOT, // outputToken
 		"1000",                // amountSpecified
@@ -99,7 +99,7 @@ func TestDrySwapRouteBarGnotExactIn(t *testing.T) {
 func TestDrySwapRouteBarGnotExactOut(t *testing.T) {
 	testing.SetRealm(adminRealm)
 
-	dryResult := DrySwapRoute(
+	dryResult, _, _ := DrySwapRoute(
 		barPath,               // inputToken
 		consts.WRAPPED_WUGNOT, // outputToken
 		"20000",               // amountSpecified
@@ -114,7 +114,7 @@ func TestDrySwapRouteBarGnotExactOut(t *testing.T) {
 func TestDrySwapRouteGnotBarExactIn(t *testing.T) {
 	testing.SetRealm(adminRealm)
 
-	dryResult := DrySwapRoute(
+	_, dryResult, _ := DrySwapRoute(
 		consts.WRAPPED_WUGNOT, // intputToken
 		barPath,               // outputToken
 		"5000",                // amountSpecified
@@ -129,7 +129,7 @@ func TestDrySwapRouteGnotBarExactIn(t *testing.T) {
 func TestDrySwapRouteGnotBarExactOut(t *testing.T) {
 	testing.SetRealm(adminRealm)
 
-	dryResult := DrySwapRoute(
+	dryResult, _, _ := DrySwapRoute(
 		consts.WRAPPED_WUGNOT, // intputToken
 		barPath,               // outputToken
 		"100",                 // amountSpecified

--- a/contract/r/gnoswap/router/tests/router_swap_route_1route_3hop_wrapped_native_middle_test.gnoA
+++ b/contract/r/gnoswap/router/tests/router_swap_route_1route_3hop_wrapped_native_middle_test.gnoA
@@ -80,7 +80,7 @@ func TestPositionMintGnotBar(t *testing.T) {
 func TestDrySwapRouteGnsBarExactIn(t *testing.T) {
 	testing.SetRealm(adminRealm)
 
-	dryResult := DrySwapRoute(
+	_, dryResult, _ := DrySwapRoute(
 		consts.GNS_PATH, // inputToken
 		barPath,         // outputToken
 		"1000",          // amountSpecified

--- a/contract/r/gnoswap/router/tests/router_swap_route_2route_2hop_test.gnoA
+++ b/contract/r/gnoswap/router/tests/router_swap_route_2route_2hop_test.gnoA
@@ -47,7 +47,7 @@ func TestPositionMint(t *testing.T) {
 func TestDrySwapRouteBarQuxExactIn(t *testing.T) {
 	testing.SetRealm(adminRealm)
 
-	dryResult := DrySwapRoute(
+	_, dryResult, _ := DrySwapRoute(
 		barPath,    // inputToken
 		quxPath,    // outputToken
 		"1000",     // amountSpecified


### PR DESCRIPTION
Change the return value of dryswap.

The return value is the result of the swap simulation and is expressed as follows.
amount0, amount1, swapability (bool)