### PR TITLE
fix: Complete Stake Wipeout on Partial Undelegation

### DIFF
--- a/contract/r/gnoswap/gov/staker/reward.gno
+++ b/contract/r/gnoswap/gov/staker/reward.gno
@@ -340,12 +340,31 @@ func (self *RewardState) claim(staker std.Address, currentBalance uint64, curren
 	return reward, protocolFeeRewards
 }
 
-func (self *RewardState) removeStake(staker std.Address, amount uint64, currentBalance uint64, currentProtocolFeeBalances map[string]uint64) (uint64, map[string]uint64) {
+func (self *RewardState) removeStake(
+	staker std.Address,
+	amount uint64,
+	currentBalance uint64,
+	currentProtocolFeeBalances map[string]uint64,
+) (uint64, map[string]uint64) {
 	self.finalize(currentBalance, currentProtocolFeeBalances)
 
 	reward, protocolFeeRewards := self.deductReward(staker)
 
-	self.stakerInfos.Remove(staker.String())
+	stakerStr := staker.String()
+	stakerInfoValue, exists := self.stakerInfos.Get(stakerStr)
+	if !exists {
+		panic("staker info not found")
+	}
+	stakerInfo := stakerInfoValue.(StakerRewardInfo)
+
+	// remove completely only if the total stake amount is equal to the undelegate amount
+	if stakerInfo.StakedAmount == amount {
+		self.stakerInfos.Remove(stakerStr)
+	} else {
+		// reduce the partial amount
+		stakerInfo.StakedAmount -= amount
+		self.stakerInfos.Set(stakerStr, stakerInfo)
+	}
 
 	self.totalXGNSStake -= amount
 

--- a/contract/r/gnoswap/gov/staker/reward_test.gno
+++ b/contract/r/gnoswap/gov/staker/reward_test.gno
@@ -104,3 +104,72 @@ func TestRewardCalculation_1_4(t *testing.T) {
 		t.Errorf("expected reward %d, got %d", 75+60+75, reward)
 	}
 }
+
+func TestRemoveStake(t *testing.T) {
+	state := NewRewardState()
+	staker := testutils.TestAddress("staker")
+
+	// set initial stake
+	initialStake := uint64(10000000) // 10 GNS
+	currentBalance := uint64(1000000000)
+	currentProtocolFeeBalances := make(map[string]uint64)
+
+	// add initial stake
+	state.addStake(1, staker, initialStake, currentBalance, currentProtocolFeeBalances)
+
+	t.Run("partial unstake test", func(t *testing.T) {
+		// unstake half of the initial stake
+		partialAmount := uint64(5000000) // 5 GNS
+
+		reward, protocolFeeRewards := state.removeStake(
+			staker,
+			partialAmount,
+			currentBalance,
+			currentProtocolFeeBalances,
+		)
+
+		// check if the staker info still exists
+		stakerInfoValue, exists := state.stakerInfos.Get(staker.String())
+		if !exists {
+			t.Error("staker info is completely deleted")
+		}
+
+		// check the remaining stake amount
+		stakerInfo := stakerInfoValue.(StakerRewardInfo)
+		expectedRemainingStake := initialStake - partialAmount
+		if stakerInfo.StakedAmount != expectedRemainingStake {
+			t.Errorf("wrong remaining stake amount: expected %d, got %d",
+				expectedRemainingStake, stakerInfo.StakedAmount)
+		}
+
+		// check the total stake amount
+		if state.totalXGNSStake != expectedRemainingStake {
+			t.Errorf("wrong total stake amount: expected %d, got %d",
+				expectedRemainingStake, state.totalXGNSStake)
+		}
+	})
+
+	t.Run("full unstake test", func(t *testing.T) {
+		// unstake the remaining amount
+		remainingAmount := uint64(5000000) // 5 GNS
+
+		reward, protocolFeeRewards := state.removeStake(
+			staker,
+			remainingAmount,
+			currentBalance,
+			currentProtocolFeeBalances,
+		)
+
+		// check if the staker info is deleted
+		_, exists := state.stakerInfos.Get(staker.String())
+		if exists {
+			t.Error("staker info is not deleted after full unstake")
+		}
+
+		// check if the total stake amount is 0
+		if state.totalXGNSStake != 0 {
+			t.Errorf("wrong total stake amount: expected 0, got %d",
+				state.totalXGNSStake)
+		}
+	})
+}


### PR DESCRIPTION
# Description

When a user attempts to partially undelegate their staked `GNS` tokens, the current `removeStake` completely removes the staker's information from the state, regardless of the undelegation amount.

This lead to:
- Loss of remaining delegation information
- Loss of rewards for the delegation information
- Incorrect total stake calculation

## Changes

Modified the `removeStake` function to:
1. Preserve staker information for partial undelegations
2. Only remove staker information when the entire amount is undelegated
3. Correctly update stake amount for partial undelegations

## Implementation Details

- Added checker that checks if undelegation amount equals total staked amount
- For partial undelegations:
    - Maintain staker info in state
    - Subtract only the desire amount from stake
- For complete undelegations:
    - Remove staker info (original behavior)
    - Update total stake to zero

## Testing

Added test cases to verify:

1. Partial undelegation maintains correct state
2. Complete undelegation removes state propoerly

```bash
$ gno test examples/gno.land/r/gnoswap/v1/gov/staker/reward_test.gno -run TestRemoveStake
```

### Before  

```plain
panic: nil is not of type gno.land/r/gnoswap/v1/gov/staker.StakerRewardInfo
Stacktrace:
fn<VPBlock(1,1)>(t<VPBlock(1,0)>)
    gno.land/r/gnoswap/v1/gov/staker/:138
tRunner<VPBlock(3,45)>(subT<VPBlock(1,5)>,f<VPBlock(1,2)>,t<VPBlock(1,0)>.verbose)
    testing/testing.gno:383
t<VPBlock(1,0)>.Run(partial unstake test,(const-type testing.testingFunc)(func(t *(testing<VPBlock(2,0)>.T)){ ... }))
    testing/testing.gno:175
fn<VPBlock(1,1)>(t<VPBlock(1,0)>)
    gno.land/r/gnoswap/v1/gov/staker/reward_test.gno:120
tRunner<VPBlock(3,45)>(t<VPBlock(1,5)>,test<VPBlock(1,3)>.F,verbose<VPBlock(1,1)>)
    testing/testing.gno:383
package{}.RunTest(TestRemoveStake,false,false,package{}.InternalTest<len=2>)
    testing/testing.gno:315

--- FAIL: TestRemoveStake (0.00s)
--- FAIL: TestRemoveStake/partial_unstake_test (0.00s)
staker info is completely deleted
examples/gno.land/r/gnoswap/v1/gov/staker: test pkg: failed: "TestRemoveStake"
FAIL    examples/gno.land/r/gnoswap/v1/gov/staker     2.28s
```

### After

```plain
ok      examples/gno.land/r/gnoswap/v1/gov/staker     2.31s
```