### PR TITLE
fix: Early withdrawals in `CollectDepositGnsByDepositId`

### DIFF
--- a/contract/r/gnoswap/launchpad/launchpad_deposit.gno
+++ b/contract/r/gnoswap/launchpad/launchpad_deposit.gno
@@ -18,6 +18,12 @@ import (
 	"gno.land/r/gnoswap/v1/referral"
 )
 
+const (
+	// BLOCKS_PER_DAY = SECONDS_PER_DAY * (MILLISECONDS_PER_SECOND / BLOCK_GENERATION_INTERVAL)
+	// = 86400 * (1000 / 2000) = 43200
+	BLOCKS_PER_DAY uint64 = uint64(consts.SECONDS_PER_DAY * consts.MILLISECONDS_PER_SECOND / consts.BLOCK_GENERATION_INTERVAL)
+)
+
 var launchpadAddr, _ = access.GetAddress(access.ROLE_LAUNCHPAD)
 
 var (
@@ -47,8 +53,6 @@ type DepositState struct {
 	DepositsByUserProject map[std.Address]map[string][]string
 }
 
-// TODO:
-// 1. 주석 추가
 // ProjectTierInfo contains information about a project tier
 type ProjectTierInfo struct {
 	Project       Project
@@ -883,6 +887,20 @@ func validateDepositCollection(depositId string, caller std.Address) (Deposit, P
 	}
 
 	currentHeight := uint64(std.ChainHeight())
+
+	tierDuration, err := strconv.ParseUint(deposit.tier, 10, 64)
+	if err != nil {
+		return Deposit{}, Project{}, errors.New("invalid tier duration")
+	}
+
+	// calculate tier end height (deposit height + tier duration in blocks)
+	tierEndHeight := deposit.depositHeight + (tierDuration * BLOCKS_PER_DAY)
+
+	// to prevent the withdrawal of deposits before the actual tier period ends,
+	// we need to verify that deposits can only be withdrawn after the tier period has completely ended.
+	if currentHeight < tierEndHeight {
+		return Deposit{}, Project{}, errors.New("tier lock period has not ended yet")
+	}
 
 	if !isPassedClaimableHeight(deposit, currentHeight) {
 		return Deposit{}, Project{}, errors.New("not passed claimable block height yet")

--- a/contract/r/gnoswap/launchpad/launchpad_deposit_test.gno
+++ b/contract/r/gnoswap/launchpad/launchpad_deposit_test.gno
@@ -2,6 +2,7 @@ package launchpad
 
 import (
 	"std"
+	"strings"
 	"testing"
 	"time"
 
@@ -765,12 +766,65 @@ func TestCollectDepositGnsByDepositId_ExactClaimable(t *testing.T) {
 		1000,
 	)
 
+	// Skip to the end of tier period (30 days)
+	tierDuration := uint64(30)
+	blocksToSkip := (tierDuration * BLOCKS_PER_DAY) + 1 // +1 to ensure we're past the tier period
+	testing.SkipHeights(int64(blocksToSkip))
+
+	testing.SetRealm(std.NewUserRealm(userA))
+	collected := CollectDepositGnsByDepositId(deposit.id)
+	uassert.Equal(t, uint64(200), collected, "should collect the deposit fully after tier period ends")
+}
+
+func TestCollectDepositGnsByDepositId_BeforeTierEnds(t *testing.T) {
+	_, userA := setupTestDeposit(t)
+	project := createTestProject(t)
+	projects[project.id] = project
+
+	now := uint64(time.Now().Unix())
+	initialHeight := uint64(std.ChainHeight())
+
+	info := ProjectTierInfo{
+		Project:       project,
+		Tier:          project.tiers[30],
+		TierType:      "30",
+		CurrentHeight: initialHeight,
+		CurrentTime:   now,
+	}
+
+	testing.SetRealm(std.NewUserRealm(userA))
+	deposit, err := createDeposit(info, 200)
+	if err != nil {
+		t.Fatalf("failed create deposit: %v", err)
+	}
+	deposit.claimableHeight = initialHeight + 10
+	deposit.claimableTime = now + 60
+
+	updateDepositIndices(deposit, &DepositState{
+		Deposits:              deposits,
+		DepositsByProject:     depositsByProject,
+		DepositsByUser:        depositsByUser,
+		DepositsByUserProject: depositsByUserByProject,
+	})
+
+	// Skip only to claimable height (but before tier ends)
 	skipCount := deposit.claimableHeight - uint64(std.ChainHeight())
 	if skipCount > 0 {
 		testing.SkipHeights(int64(skipCount))
 	}
 
 	testing.SetRealm(std.NewUserRealm(userA))
-	collected := CollectDepositGnsByDepositId(deposit.id)
-	uassert.Equal(t, uint64(200), collected, "should collect the deposit fully after claimableHeight/time")
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Errorf("Expected panic but got none")
+		}
+		errMsg, ok := r.(string)
+		if !ok || !strings.Contains(errMsg, "tier lock period has not ended yet") {
+			t.Errorf("unexpected error: %v", r)
+		}
+	}()
+
+	CollectDepositGnsByDepositId(deposit.id)
 }


### PR DESCRIPTION
# Description

The `CollectDepositGnsByDepositId` function was allowing users to withdraw their deposits prematurely by only checking `claimableHeight`. This was problematic because claimable duration (for collecting rewards) is much shorter than the fixed tier duration.

Changes:
- Added validation in `validateDepositCollection` to ensure deposits can only be withdrawn after the full tier period (30/90/180 days) has ended
- Added `BLOCKS_PER_DAY` constant based on block generation interval
- Added test cases to verify both successful withdrawal after tier period and failed withdrawal before tier period ends

This ensures deposits remain locked for the entire tier duration as intended, preventing early withdrawals.