### PR TITLE
fix: Update deposit collection logic to prevent delayed withdrawals

### DIFF
--- a/contract/r/gnoswap/launchpad/launchpad_deposit.gno
+++ b/contract/r/gnoswap/launchpad/launchpad_deposit.gno
@@ -791,11 +791,6 @@ func processDepositCollection(
 			panic(err.Error())
 		}
 
-		// skip if deposit is already collected
-		if isAlreadyCollected(deposit) {
-			continue
-		}
-
 		deposit.setDepositCollectHeight(currentHeight)
 		deposit.setDepositCollectTime(now)
 		deposits[deposit.id] = deposit

--- a/contract/r/gnoswap/launchpad/launchpad_deposit.gno
+++ b/contract/r/gnoswap/launchpad/launchpad_deposit.gno
@@ -141,7 +141,9 @@ func DepositGns(targetProjectTierId string, amount uint64, referrer string) stri
 	if err != nil {
 		panic(addDetailToError(errInvalidInput, err.Error()))
 	}
-	updateDeposit(deposit)
+	if err = updateDeposit(deposit); err != nil {
+		panic(err)
+	}
 
 	if tier.isFirstDeposit() {
 		// update StartHeight, StartTime, TierAmountPerBlockX128
@@ -461,11 +463,7 @@ func checkDepositConditions(project Project) {
 // Returns:
 // - bool: True if the tier is active, otherwise false.
 func checkTierActive(project Project, tier Tier) bool {
-	if tier.ended.height < uint64(std.ChainHeight()) {
-		return false
-	}
-
-	return true
+	return tier.ended.height >= uint64(std.ChainHeight())
 }
 
 // convertTierTypeStrToUint64 converts a tier type string to its corresponding uint64 value.
@@ -671,16 +669,13 @@ func calculateClaimableTimes(info ProjectTierInfo) (uint64, uint64) {
 		minU64(calcTime, info.Tier.ended.time)
 }
 
-func updateDeposit(deposit Deposit) {
+func updateDeposit(deposit Deposit) error {
 	// Update deposits
 	_, ok := deposits[deposit.id]
 	if !ok {
 		deposits[deposit.id] = deposit
 	} else {
-		panic(addDetailToError(
-			errDuplicateDeposit,
-			ufmt.Sprintf("deposit(%s) already exists", deposit.id),
-		))
+		return errors.New(ufmt.Sprintf("deposit(%s) already exists", deposit.id))
 	}
 
 	// Update depositsByUser
@@ -712,9 +707,12 @@ func updateDeposit(deposit Deposit) {
 		depositsByUserByProject[deposit.depositor][deposit.projectId],
 		deposit.id,
 	)
+
+	return nil
 }
 
 // updateDepositIndices updates all deposit-related indices
+// testing only
 func updateDepositIndices(deposit Deposit, state *DepositState) {
 	// Update deposits
 	_, ok := state.Deposits[deposit.id]
@@ -783,7 +781,8 @@ func processDepositCollection(
 			continue
 		}
 
-		if currentHeight < project.Ended().height {
+		// determine when each deposit can be claimed
+		if !isPassedClaimableHeight(deposit, currentHeight) || isAlreadyCollected(deposit) {
 			continue
 		}
 
@@ -791,7 +790,9 @@ func processDepositCollection(
 		if err != nil {
 			panic(err.Error())
 		}
-		if !isPassedClaimableHeight(deposit, currentHeight) || isAlreadyCollected(deposit) {
+
+		// skip if deposit is already collected
+		if isAlreadyCollected(deposit) {
 			continue
 		}
 

--- a/contract/r/gnoswap/launchpad/launchpad_deposit_test.gno
+++ b/contract/r/gnoswap/launchpad/launchpad_deposit_test.gno
@@ -774,3 +774,138 @@ func TestCollectDepositGnsByDepositId_ExactClaimable(t *testing.T) {
 	collected := CollectDepositGnsByDepositId(deposit.id)
 	uassert.Equal(t, uint64(200), collected, "should collect the deposit fully after claimableHeight/time")
 }
+
+func TestProcessDepositCollection_ClaimableLogic(t *testing.T) {
+	_, testAddr := setupTestDeposit(t)
+	project := createTestProject(t)
+	projects[project.id] = project
+
+	baseHeight := uint64(std.ChainHeight())
+	baseTime := uint64(time.Now().Unix())
+
+	type testDeposit struct {
+		amount         uint64
+		claimableDelay uint64
+		expectedResult bool
+	}
+
+	tests := []testDeposit{
+		{100, 10, true},  // Claimable deposit (short waiting period)
+		{200, 50, false}, // Not yet claimable deposit (long waiting period)
+		{300, 5, true},   // Claimable deposit (very short waiting period)
+	}
+
+	depositIds := []string{}
+	totalClaimableAmount := uint64(0)
+
+	// create deposits with different heights and times
+	for i, tt := range tests {
+		// avoid creating deposits at the same height
+		// this may cause the test to duplicate the same id error
+		testing.SkipHeights(1)
+		currentHeight := uint64(std.ChainHeight())
+		currentTime := baseTime + uint64(i*100)
+
+		info := ProjectTierInfo{
+			Project:       project,
+			Tier:          project.tiers[30],
+			TierType:      "30",
+			CurrentHeight: currentHeight,
+			CurrentTime:   currentTime,
+		}
+
+		deposit, err := createDeposit(info, tt.amount)
+		if err != nil {
+			t.Fatalf("failed to create deposit: %v", err)
+		}
+
+		// Set claimable height
+		deposit.claimableHeight = currentHeight + tt.claimableDelay
+		deposits[deposit.id] = deposit
+		depositIds = append(depositIds, deposit.id)
+
+		if tt.expectedResult {
+			totalClaimableAmount += tt.amount
+		}
+
+		// Update deposit indices
+		updateDepositIndices(deposit, &DepositState{
+			Deposits:              make(map[string]Deposit),
+			DepositsByProject:     depositsByProject,
+			DepositsByUser:        depositsByUser,
+			DepositsByUserProject: depositsByUserByProject,
+		})
+	}
+
+	// Skip blocks until reaching claimable point
+	testing.SkipHeights(15)
+
+	// Execute processDepositCollection
+	amount, err := processDepositCollection(depositIds, "")
+	if err != nil {
+		t.Fatalf("processDepositCollection failed: %v", err)
+	}
+
+	uassert.Equal(t, totalClaimableAmount, amount, "collected amount should match expected claimable amount")
+
+	for i, tt := range tests {
+		deposit := deposits[depositIds[i]]
+		if tt.expectedResult {
+			// Verify claimable deposits
+			uassert.NotEqual(t, uint64(0), deposit.depositCollectHeight,
+				"claimable deposit should have been collected")
+			uassert.Equal(t, tt.amount, deposit.amount,
+				"collected amount should match deposit amount")
+		} else {
+			// Verify non-claimable deposits
+			uassert.Equal(t, uint64(0), deposit.depositCollectHeight,
+				"non-claimable deposit should not have been collected")
+		}
+	}
+}
+
+func TestProcessDepositCollection_ProjectEndCondition(t *testing.T) {
+	_, testAddr := setupTestDeposit(t)
+	project := createTestProject(t)
+
+	// Set project end height to future
+	currentHeight := uint64(std.ChainHeight())
+	project.ended.height = currentHeight + 100
+	projects[project.id] = project
+
+	// Create deposit
+	info := ProjectTierInfo{
+		Project:       project,
+		Tier:          project.tiers[30],
+		TierType:      "30",
+		CurrentHeight: currentHeight,
+		CurrentTime:   uint64(time.Now().Unix()),
+	}
+
+	deposit, err := createDeposit(info, 100)
+	if err != nil {
+		t.Fatalf("failed to create deposit: %v", err)
+	}
+
+	// Set claimable height to current height
+	deposit.claimableHeight = currentHeight
+	deposits[deposit.id] = deposit
+
+	updateDepositIndices(deposit, &DepositState{
+		Deposits:              make(map[string]Deposit),
+		DepositsByProject:     depositsByProject,
+		DepositsByUser:        depositsByUser,
+		DepositsByUserProject: depositsByUserByProject,
+	})
+
+	// Test if deposit can be claimed before project ends
+	amount, err := processDepositCollection([]string{deposit.id}, "")
+	if err != nil {
+		t.Fatalf("processDepositCollection failed: %v", err)
+	}
+
+	uassert.Equal(t, uint64(100), amount,
+		"should be able to collect deposit even before project end")
+	uassert.NotEqual(t, uint64(0), deposits[deposit.id].depositCollectHeight,
+		"deposit should have been collected")
+}


### PR DESCRIPTION
# Description

The `processDepositCollection` function was incorrectly requiring all depositors to wait until the project ends before withdrawing their GNS tokens. This was due to the condition `currentHeight < project.Ended().height` which prevented withdrawals before project completion.

## Changes

- Removed the project end height check from `processDepositCollection`
- Each deposit can now be collected independently based on its individual claimable height
- Code tidy

## Test Coverage

Added two new test cases:

1. `TestProcessDepositCollection_ClaimableLogic`
   - Tests multiple deposits with different claimable heights
   - Verifies that deposits can be collected independently
   - Validates correct handling of claimable and non-claimable deposits

2. `TestProcessDepositCollection_ProjectEndCondition`
   - Tests deposit collection before project end
   - Confirms deposits can be withdrawn regardless of project status
   - Validates correct amount collection and state updates