### PR TITLE
fix:  Delegation Snapshot History in `unDelegate`

### DIFF
--- a/contract/r/gnoswap/gov/staker/staker_delegate.gno
+++ b/contract/r/gnoswap/gov/staker/staker_delegate.gno
@@ -141,12 +141,15 @@ func unDelegate(to std.Address, amount uint64) {
 	}
 	delegatedTo.Set(toStr, currentToAmount-amount)
 
+	currentTime := uint64(time.Now().Unix())
+	currentHeight := uint64(std.ChainHeight())
+
 	// update delegation history
 	delegation := DelegationHistory{
 		to:        to,
 		amount:    amount,
-		timestamp: uint64(time.Now().Unix()),
-		height:    uint64(std.ChainHeight()),
+		timestamp: currentTime,
+		height:    currentHeight,
 		add:       false,
 	}
 	var history []DelegationHistory
@@ -165,18 +168,19 @@ func unDelegate(to std.Address, amount uint64) {
 		))
 	}
 	stat := statValue.([]DelegationSnapShotHistory)
-	remainingAmount := amount
-	for i := 0; i < len(stat); i++ {
-		if stat[i].amount > 0 {
-			if stat[i].amount < remainingAmount {
-				remainingAmount -= stat[i].amount
-				stat = append(stat[:i], stat[i+1:]...)
-			} else {
-				stat[i].amount -= remainingAmount
-				stat[i].updatedAt = uint64(time.Now().Unix())
-				break
-			}
-		}
+	lastAmount := stat[len(stat)-1].amount
+
+	// append new snapshot (set amount to current amount - amount)
+	newSnapshot := DelegationSnapShotHistory{
+		to:           to,
+		amount:       lastAmount - amount,
+		updatedBlock: currentHeight,
+		updatedAt:    currentTime,
 	}
+
+	if len(stat) > 0 && newSnapshot.updatedAt <= stat[len(stat)-1].updatedAt {
+		newSnapshot.updatedAt = stat[len(stat)-1].updatedAt + 1
+	}
+	stat = append(stat, newSnapshot)
 	delegationSnapShotHistory.Set(to.String(), stat)
 }


### PR DESCRIPTION
## Issue

The previous implementation of `unDelegate` had an issue with the `DelegationSnapShotHistory` update logic. When processing undelegations, it attempted to modify historical snapshots directly, which:
1. Disrupted the chronological order of snapshots
2. Incorrectly represented the delegation power at specific points in time
3. Could lead to incorrect voting power calculations when using `GetPossibleVotingAddressWithWeight`

For example, with snapshots `[2, 4, 6]` representing the total delegation power at different timestamps, an undelegation of `2` would incorrectly modify historical records instead of adding a new snapshot with the current total.

## Changes
Modified the `unDelegate` function to:
1. Preserve all historical snapshots
2. Add a new snapshot entry with the current total delegation power after undelegation
3. Ensure proper timestamp ordering by adding a safeguard that prevents new snapshots from having timestamps equal to or earlier than previous snapshots

## Testing

Added tests that verify:

1. Correct snapshot creation after multiple delegations and undelegations
2. Proper chronological ordering of snapshots
3. Accurate total delegation power at each snapshot
4. Preservation of historical records

Test scenario:

- Initial delegation of 100 -> [100]
- Additional delegation of 50 -> [100, 150]
- Undelegation of 30 -> [100, 150, 120]
- Verification that each snapshot maintains correct timestamp ordering
- Confirmation that the final snapshot accurately reflects current delegation power

The test ensures that the snapshot history maintains both historical accuracy and proper time ordering, which is crucial for correct voting power calculations.
