### PR TITLE
GSW-2214 feat: Add Overflow Protection to `DrySwapRoute`

### DIFF
--- a/contract/p/gnoswap/int256/cmp.gno
+++ b/contract/p/gnoswap/int256/cmp.gno
@@ -99,3 +99,7 @@ func (z *Int) Gt(x *Int) bool {
 func (z *Int) Clone() *Int {
 	return &Int{z.abs.Clone(), z.neg}
 }
+
+func (z *Int) IsOverflow() bool {
+	return z.abs.IsOverflow()
+}

--- a/contract/r/gnoswap/router/base.gno
+++ b/contract/r/gnoswap/router/base.gno
@@ -153,3 +153,41 @@ func (op *baseSwapOperation) processRoute(
 
 	return amountIn, amountOut, nil
 }
+
+// handleSingleSwap handles a single swap operation.
+func handleSingleSwap(route string, amountSpecified *i256.Int) (*u256.Uint, *u256.Uint) {
+	input, output, fee := getDataForSinglePath(route)
+	singleParams := SingleSwapParams{
+		tokenIn:         input,
+		tokenOut:        output,
+		fee:             fee,
+		amountSpecified: amountSpecified,
+	}
+
+	return singleSwap(singleParams)
+}
+
+func handleMultiSwap(
+	swapType SwapType,
+	route string,
+	numHops int,
+	amountSpecified *i256.Int,
+) (*u256.Uint, *u256.Uint) {
+	switch swapType {
+	case ExactIn:
+		input, output, fee := getDataForMultiPath(route, 0) // first data
+		sp := newSwapParams(input, output, fee, getPrevAddr(), amountSpecified)
+		return multiSwap(*sp, 0, numHops, route)
+	case ExactOut:
+		input, output, fee := getDataForMultiPath(route, numHops-1) // last data
+		sp := newSwapParams(input, output, fee, getPrevAddr(), amountSpecified)
+		return multiSwapNegative(*sp, numHops-1, route)
+	default:
+		// Any invalid `SwapType` is caught in the `SwapRoute` function,
+		// so no invalid values can get in here.
+		panic(addDetailToError(
+			errInvalidSwapType,
+			ufmt.Sprintf("unknown swapType(%s)", swapType),
+		))
+	}
+}

--- a/contract/r/gnoswap/router/exact_in.gno
+++ b/contract/r/gnoswap/router/exact_in.gno
@@ -105,7 +105,7 @@ func (op *ExactInSwapOperation) Validate() error {
 	// obtained from above.
 	op.amountSpecified = amountIn
 
-	routes, quotes, err := tryParseRoutes(op.params.RouteArr, op.params.QuoteArr)
+	routes, quotes, err := validateRoutesAndQuotes(op.params.RouteArr, op.params.QuoteArr)
 	if err != nil {
 		return err
 	}

--- a/contract/r/gnoswap/router/exact_out.gno
+++ b/contract/r/gnoswap/router/exact_out.gno
@@ -95,7 +95,7 @@ func (op *ExactOutSwapOperation) Validate() error {
 	// when it's an ExactOut
 	op.amountSpecified = i256.Zero().Neg(amountOut)
 
-	routes, quotes, err := tryParseRoutes(op.params.RouteArr, op.params.QuoteArr)
+	routes, quotes, err := validateRoutesAndQuotes(op.params.RouteArr, op.params.QuoteArr)
 	if err != nil {
 		return err
 	}

--- a/contract/r/gnoswap/router/router.gno
+++ b/contract/r/gnoswap/router/router.gno
@@ -123,7 +123,7 @@ func finalizeSwap(
 		toUnwrap := userWrappedWugnot - spend
 		unwrap(toUnwrap)
 	} else if outputToken == consts.GNOT {
-		userRecvWugnot := uint64(userNewWugnotBalance - userBeforeWugnotBalance - userWrappedWugnot)
+		userRecvWugnot := userNewWugnotBalance - userBeforeWugnotBalance - userWrappedWugnot
 		unwrap(userRecvWugnot)
 	}
 

--- a/contract/r/gnoswap/router/router.gno
+++ b/contract/r/gnoswap/router/router.gno
@@ -17,76 +17,181 @@ import (
 	"gno.land/r/gnoswap/v1/halt"
 )
 
-var errExactOutAmountExceeded = "Received more than requested in [EXACT_OUT] requested=%s, actual=%s"
+// ErrorMessages define all error message templates used throughout the router
+const (
+	ErrExactOutAmountExceeded = "Received more than requested in [EXACT_OUT] requested=%s, actual=%s"
+	ErrRouterHalted           = "router contract operations are currently disabled"
+	ErrInvalidRouteLength     = "route length(%d) must be 1~7"
+	ErrRoutesQuotesMismatch   = "mismatch between routes(%d) and quotes(%d) length"
+	ErrInvalidQuote           = "invalid quote(%s) at index(%d)"
+	ErrInvalidQuoteSum        = "quote sum(%d) must be 100"
+)
 
-// commonSwapSetup Common validation and setup logic extracted from SwapRoute
-func commonSwapSetup() {
-	currentLevel := halt.GetCurrentHaltLevel()
-	if currentLevel != halt.LvMainnetSafeMode {
-		// Check if withdrawals are specifically halted, not just if the system is halted
-		if err := halt.IsHalted(phalt.OpTypeWithdraw); err != nil {
-			panic(err.Error())
-		}
-
-		if halt.IsContractHalted(phalt.OpTypeRouter) {
-			panic("router contract operations are currently disabled")
-		}
-	}
-	assertDirectCallOnly()
-
-	en.MintAndDistributeGns()
+// GnotSwapHandler encapsulates methods for handling GNOT token swaps
+type GnotSwapHandler struct {
+	BeforeBalance uint64
+	WrappedAmount uint64
+	NewBalance    uint64
 }
 
-// handleSingleSwap handles a single swap operation.
-func handleSingleSwap(route string, amountSpecified *i256.Int) (*u256.Uint, *u256.Uint) {
-	input, output, fee := getDataForSinglePath(route)
-	singleParams := SingleSwapParams{
-		tokenIn:         input,
-		tokenOut:        output,
-		fee:             fee,
-		amountSpecified: amountSpecified,
+// newGnotSwapHandler creates a new handler for GNOT swaps
+func newGnotSwapHandler(beforeBalance, wrappedAmount uint64) *GnotSwapHandler {
+	return &GnotSwapHandler{
+		BeforeBalance: beforeBalance,
+		WrappedAmount: wrappedAmount,
 	}
-
-	return singleSwap(singleParams)
 }
 
-func handleMultiSwap(
-	swapType SwapType,
-	route string,
-	numHops int,
-	amountSpecified *i256.Int,
-) (*u256.Uint, *u256.Uint) {
+// UpdateNewBalance updates the current balance after swap operations
+func (h *GnotSwapHandler) UpdateNewBalance() {
+	h.NewBalance = wugnot.BalanceOf(std.PreviousRealm().Address())
+}
+
+// HandleInputSwap manages unwrapping logic for GNOT input tokens
+// Returns error if validation fails
+func (h *GnotSwapHandler) HandleInputSwap() error {
+	totalBefore := h.BeforeBalance + h.WrappedAmount
+	spend := totalBefore - h.NewBalance
+
+	if spend > h.WrappedAmount {
+		return ufmt.Errorf("too much wugnot spent (wrapped: %d, spend: %d)",
+			h.WrappedAmount, spend)
+	}
+
+	toUnwrap := h.WrappedAmount - spend
+	unwrap(toUnwrap)
+	return nil
+}
+
+// HandleOutputSwap manages unwrapping logic for GNOT output tokens
+func (h *GnotSwapHandler) HandleOutputSwap() {
+	userRecvWugnot := h.NewBalance - h.BeforeBalance - h.WrappedAmount
+	unwrap(uint64(userRecvWugnot))
+}
+
+// SwapValidator provides validation methods for swap operations
+type SwapValidator struct{}
+
+// ValidateExactOutAmount checks if output amount meets specified requirements
+func (v *SwapValidator) ValidateExactOutAmount(resultAmount, specifiedAmount *u256.Uint) error {
+	if resultAmount.Gte(specifiedAmount) {
+		return nil
+	}
+
+	diff := u256.Zero().Sub(specifiedAmount, resultAmount)
+	if diff.Gt(u256.NewUint(1)) {
+		return ufmt.Errorf(ErrExactOutAmountExceeded, specifiedAmount.ToString(), resultAmount.ToString())
+	}
+	return nil
+}
+
+// ValidateSlippage ensures swap amounts meet slippage requirements
+func (v *SwapValidator) ValidateSlippage(swapType SwapType, amountIn, amountOut, limit *u256.Uint) error {
 	switch swapType {
 	case ExactIn:
-		input, output, fee := getDataForMultiPath(route, 0) // first data
-		swapParams := SwapParams{
-			tokenIn:         input,
-			tokenOut:        output,
-			fee:             fee,
-			recipient:       getPrevAddr(),
-			amountSpecified: amountSpecified,
+		if amountOut.Lt(limit) {
+			return ufmt.Errorf("ExactIn: too few received (min:%s, got:%s)",
+				limit.ToString(), amountOut.ToString())
 		}
-		return multiSwap(swapParams, 0, numHops, route)
 	case ExactOut:
-		input, output, fee := getDataForMultiPath(route, numHops-1) // last data
-		swapParams := SwapParams{
-			tokenIn:         input,
-			tokenOut:        output,
-			fee:             fee,
-			recipient:       getPrevAddr(),
-			amountSpecified: amountSpecified,
+		if amountIn.Gt(limit) {
+			return ufmt.Errorf("ExactOut: too much spent (max:%s, used:%s)",
+				limit.ToString(), amountIn.ToString())
 		}
-		return multiSwapNegative(swapParams, numHops-1, route)
 	default:
-		// Any invalid `SwapType` is caught in the `SwapRoute` function,
-		// so no invalid values can get in here.
-		panic(addDetailToError(
-			errInvalidSwapType,
-			ufmt.Sprintf("unknown swapType(%s)", swapType),
-		))
+		return ufmt.Errorf("invalid swap type")
 	}
+	return nil
 }
 
+// RouteParser handles parsing and validation of routes and quotes
+type RouteParser struct{}
+
+func NewRouteParser() *RouteParser {
+	return &RouteParser{}
+}
+
+// ParseRoutes parses route and quote strings into slices and validates them
+func (p *RouteParser) ParseRoutes(routes, quotes string) ([]string, []string, error) {
+	routesArr := splitSingleChar(routes, ',')
+	quotesArr := splitSingleChar(quotes, ',')
+
+	if err := p.ValidateRoutesAndQuotes(routesArr, quotesArr); err != nil {
+		return nil, nil, err
+	}
+
+	return routesArr, quotesArr, nil
+}
+
+// ValidateRoutesAndQuotes ensures routes and quotes meet required criteria
+func (p *RouteParser) ValidateRoutesAndQuotes(routes, quotes []string) error {
+	rr := len(routes)
+	qq := len(quotes)
+
+	if rr < 1 || rr > 7 {
+		return ufmt.Errorf(ErrInvalidRouteLength, rr)
+	}
+
+	if rr != qq {
+		return ufmt.Errorf(ErrRoutesQuotesMismatch, rr, qq)
+	}
+
+	return p.ValidateQuoteSum(quotes)
+}
+
+// ValidateQuoteSum ensures all quotes add up to 100%
+func (p *RouteParser) ValidateQuoteSum(quotes []string) error {
+	sum := 0
+
+	for i, quote := range quotes {
+		intQuote, err := strconv.Atoi(quote)
+		if err != nil {
+			return ufmt.Errorf(ErrInvalidQuote, quote, i)
+		}
+
+		sum += intQuote
+	}
+
+	if sum != 100 {
+		return ufmt.Errorf(ErrInvalidQuoteSum, sum)
+	}
+
+	return nil
+}
+
+// SecurityCheck performs security validations before any swap operation
+func SecurityCheck() error {
+	currentLevel := halt.GetCurrentHaltLevel()
+
+	// Skip checks in safe mode
+	if currentLevel != halt.LvMainnetSafeMode {
+		// Check for withdraw operation halt
+		if err := halt.IsHalted(phalt.OpTypeWithdraw); err != nil {
+			return err
+		}
+
+		// Check for router contract halt
+		if halt.IsContractHalted(phalt.OpTypeRouter) {
+			return ufmt.Errorf(ErrRouterHalted)
+		}
+	}
+
+	return nil
+}
+
+// SetupSwap performs all necessary validations and setup for a swap operation
+func commonSwapSetup() error {
+	if err := SecurityCheck(); err != nil {
+		return err
+	}
+
+	assertDirectCallOnly()
+	en.MintAndDistributeGns()
+	return nil
+}
+
+// FinalizeSwap handles post-swap operations and validations
+// Returns input and output amount strings after processing
 func finalizeSwap(
 	inputToken, outputToken string,
 	resultAmountIn, resultAmountOut *u256.Uint,
@@ -95,9 +200,11 @@ func finalizeSwap(
 	userBeforeWugnotBalance, userWrappedWugnot uint64,
 	amountSpecified *u256.Uint,
 ) (string, string) {
+	validator := &SwapValidator{}
+
 	// Validate exact out amount if applicable
 	if swapType == ExactOut {
-		if err := validateExactOutAmount(resultAmountOut, amountSpecified); err != nil {
+		if err := validator.ValidateExactOutAmount(resultAmountOut, amountSpecified); err != nil {
 			panic(addDetailToError(errSlippage, err.Error()))
 		}
 	}
@@ -105,18 +212,25 @@ func finalizeSwap(
 	// Handle swap fee
 	resultAmountOutWithoutFee := handleSwapFee(outputToken, resultAmountOut)
 
-	// Get current wugnot balance
-	userNewWugnotBalance := wugnot.BalanceOf(std.PreviousRealm().Address())
+	// Handle GNOT token swaps
+	handler := newGnotSwapHandler(userBeforeWugnotBalance, userWrappedWugnot)
+	handler.UpdateNewBalance()
 
-	// Handle GNOT token unwrapping
+	var err error
 	if inputToken == consts.GNOT {
-		handleGnotInputSwap(userBeforeWugnotBalance, userWrappedWugnot, userNewWugnotBalance)
+		err = handler.HandleInputSwap()
 	} else if outputToken == consts.GNOT {
-		handleGnotOutputSwap(userBeforeWugnotBalance, userWrappedWugnot, userNewWugnotBalance)
+		handler.HandleOutputSwap()
+	}
+
+	if err != nil {
+		panic(addDetailToError(errSlippage, err.Error()))
 	}
 
 	// Validate slippage
-	validateSlippage(swapType, resultAmountIn, resultAmountOutWithoutFee, tokenAmountLimit)
+	if err := validator.ValidateSlippage(swapType, resultAmountIn, resultAmountOutWithoutFee, tokenAmountLimit); err != nil {
+		panic(addDetailToError(errSlippage, err.Error()))
+	}
 
 	// Calculate final amounts
 	intAmountOut := i256.FromUint256(resultAmountOutWithoutFee)
@@ -125,118 +239,7 @@ func finalizeSwap(
 	return resultAmountIn.ToString(), negativeOut
 }
 
-// validateExactOutAmount validates if the output amount meets the specified requirements
-func validateExactOutAmount(resultAmountOut, amountSpecified *u256.Uint) error {
-	if resultAmountOut.Gte(amountSpecified) {
-		return nil
-	}
-
-	diff := u256.Zero().Sub(amountSpecified, resultAmountOut)
-	if diff.Gt(u256.NewUint(1)) {
-		return ufmt.Errorf(errExactOutAmountExceeded, amountSpecified.ToString(), resultAmountOut.ToString())
-	}
-	return nil
-}
-
-// handleGnotInputSwap handles the unwrapping logic for GNOT input tokens
-func handleGnotInputSwap(userBeforeWugnotBalance, userWrappedWugnot, userNewWugnotBalance uint64) {
-	totalBefore := userBeforeWugnotBalance + userWrappedWugnot
-	spend := totalBefore - userNewWugnotBalance
-
-	if spend > userWrappedWugnot {
-		panic(addDetailToError(
-			errSlippage,
-			ufmt.Sprintf("too much wugnot spent (wrapped: %d, spend: %d)",
-				userWrappedWugnot, spend),
-		))
-	}
-
-	toUnwrap := userWrappedWugnot - spend
-	unwrap(toUnwrap)
-}
-
-// handleGnotOutputSwap handles the unwrapping logic for GNOT output tokens
-func handleGnotOutputSwap(userBeforeWugnotBalance, userWrappedWugnot, userNewWugnotBalance uint64) {
-	userRecvWugnot := uint64(userNewWugnotBalance - userBeforeWugnotBalance - userWrappedWugnot)
-	unwrap(userRecvWugnot)
-}
-
-// validateSlippage checks if the swap amounts meet the slippage requirements
-func validateSlippage(swapType SwapType, resultAmountIn, resultAmountOutWithoutFee, tokenAmountLimit *u256.Uint) {
-	switch swapType {
-	case ExactIn:
-		if resultAmountOutWithoutFee.Lt(tokenAmountLimit) {
-			panic(addDetailToError(
-				errSlippage,
-				ufmt.Sprintf("ExactIn: too few received (min:%s, got:%s)",
-					tokenAmountLimit.ToString(), resultAmountOutWithoutFee.ToString()),
-			))
-		}
-	case ExactOut:
-		if resultAmountIn.Gt(tokenAmountLimit) {
-			panic(addDetailToError(
-				errSlippage,
-				ufmt.Sprintf("ExactOut: too much spent (max:%s, used:%s)",
-					tokenAmountLimit.ToString(), resultAmountIn.ToString()),
-			))
-		}
-	default:
-		panic("should not happen")
-	}
-}
-
-// validateRoutesAndQuotes validates the routes and quotes slices based on specific criteria.
-//
-// Parameters:
-// - routes: A slice of strings representing route identifiers.
-// - quotes: A slice of strings representing quote percentages corresponding to each route.
-//
-// Returns:
-// - error: An error if the validation fails; nil if all checks pass.
-func validateRoutesAndQuotes(routes, quotes []string) error {
-	if len(routes) < 1 || len(routes) > 7 {
-		return ufmt.Errorf("route length(%d) must be 1~7", len(routes))
-	}
-
-	if len(routes) != len(quotes) {
-		return ufmt.Errorf("mismatch between routes(%d) and quotes(%d) length", len(routes), len(quotes))
-	}
-
-	var quotesSum int
-
-	for i, quote := range quotes {
-		intQuote, err := strconv.Atoi(quote)
-		if err != nil {
-			return ufmt.Errorf("invalid quote(%s) at index(%d)", quote, i)
-		}
-
-		quotesSum += intQuote
-	}
-
-	if quotesSum != 100 {
-		return ufmt.Errorf("quote sum(%d) must be 100", quotesSum)
-	}
-
-	return nil
-}
-
-// tryParseRoutes parses and validates routes and quotes strings, returning them as slices.
-//
-// Parameters:
-// - routes: A string containing route identifiers separated by commas (e.g., "route1,route2,route3").
-// - quotes: A string containing quote identifiers separated by commas (e.g., "quote1,quote2,quote3").
-//
-// Returns:
-// - []string: A slice of route identifiers parsed from the `routes` string.
-// - []string: A slice of quote identifiers parsed from the `quotes` string.
-// - error: An error if the validation between routes and quotes fails.
-func tryParseRoutes(routes, quotes string) ([]string, []string, error) {
-	routesArr := splitSingleChar(routes, ',')
-	quotesArr := splitSingleChar(quotes, ',')
-
-	if err := validateRoutesAndQuotes(routesArr, quotesArr); err != nil {
-		return nil, nil, err
-	}
-
-	return routesArr, quotesArr, nil
+// validateRoutesAndQuotes is a convenience function that parses and validates routes in one call
+func validateRoutesAndQuotes(routes, quotes string) ([]string, []string, error) {
+	return NewRouteParser().ParseRoutes(routes, quotes)
 }

--- a/contract/r/gnoswap/router/router.gno
+++ b/contract/r/gnoswap/router/router.gno
@@ -17,14 +17,16 @@ import (
 	"gno.land/r/gnoswap/v1/halt"
 )
 
+var one = u256.One()
+
 // ErrorMessages define all error message templates used throughout the router
 const (
-	ErrExactOutAmountExceeded = "Received more than requested in [EXACT_OUT] requested=%s, actual=%s"
-	ErrRouterHalted           = "router contract operations are currently disabled"
-	ErrInvalidRouteLength     = "route length(%d) must be 1~7"
-	ErrRoutesQuotesMismatch   = "mismatch between routes(%d) and quotes(%d) length"
-	ErrInvalidQuote           = "invalid quote(%s) at index(%d)"
-	ErrInvalidQuoteSum        = "quote sum(%d) must be 100"
+	errExactOutAmountExceeded = "Received more than requested in [EXACT_OUT] requested=%s, actual=%s"
+	errRouterHalted           = "router contract operations are currently disabled"
+	errInvalidRouteLength     = "route length(%d) must be 1~7"
+	errRoutesQuotesMismatch   = "mismatch between routes(%d) and quotes(%d) length"
+	errInvalidQuote           = "invalid quote(%s) at index(%d)"
+	errInvalidQuoteSum        = "quote sum(%d) must be 100"
 )
 
 // GnotSwapHandler encapsulates methods for handling GNOT token swaps
@@ -79,8 +81,8 @@ func (v *SwapValidator) ValidateExactOutAmount(resultAmount, specifiedAmount *u2
 	}
 
 	diff := u256.Zero().Sub(specifiedAmount, resultAmount)
-	if diff.Gt(u256.NewUint(1)) {
-		return ufmt.Errorf(ErrExactOutAmountExceeded, specifiedAmount.ToString(), resultAmount.ToString())
+	if diff.Gt(one) {
+		return ufmt.Errorf(errExactOutAmountExceeded, specifiedAmount.ToString(), resultAmount.ToString())
 	}
 	return nil
 }
@@ -129,11 +131,11 @@ func (p *RouteParser) ValidateRoutesAndQuotes(routes, quotes []string) error {
 	qq := len(quotes)
 
 	if rr < 1 || rr > 7 {
-		return ufmt.Errorf(ErrInvalidRouteLength, rr)
+		return ufmt.Errorf(errInvalidRouteLength, rr)
 	}
 
 	if rr != qq {
-		return ufmt.Errorf(ErrRoutesQuotesMismatch, rr, qq)
+		return ufmt.Errorf(errRoutesQuotesMismatch, rr, qq)
 	}
 
 	return p.ValidateQuoteSum(quotes)
@@ -146,42 +148,41 @@ func (p *RouteParser) ValidateQuoteSum(quotes []string) error {
 	for i, quote := range quotes {
 		intQuote, err := strconv.Atoi(quote)
 		if err != nil {
-			return ufmt.Errorf(ErrInvalidQuote, quote, i)
+			return ufmt.Errorf(errInvalidQuote, quote, i)
 		}
 
 		sum += intQuote
 	}
 
 	if sum != 100 {
-		return ufmt.Errorf(ErrInvalidQuoteSum, sum)
+		return ufmt.Errorf(errInvalidQuoteSum, sum)
 	}
 
 	return nil
 }
 
-// SecurityCheck performs security validations before any swap operation
-func SecurityCheck() error {
+// haltCheck performs security validations before any swap operation
+func haltCheck() error {
 	currentLevel := halt.GetCurrentHaltLevel()
 
-	// Skip checks in safe mode
 	if currentLevel != halt.LvMainnetSafeMode {
-		// Check for withdraw operation halt
+		// check for withdraw operation halt
 		if err := halt.IsHalted(phalt.OpTypeWithdraw); err != nil {
 			return err
 		}
 
-		// Check for router contract halt
+		// check for router contract halt
 		if halt.IsContractHalted(phalt.OpTypeRouter) {
-			return ufmt.Errorf(ErrRouterHalted)
+			return ufmt.Errorf(errRouterHalted)
 		}
 	}
 
 	return nil
 }
 
-// SetupSwap performs all necessary validations and setup for a swap operation
+// commonSwapSetup performs all necessary validations and setup for a swap operation
 func commonSwapSetup() error {
-	if err := SecurityCheck(); err != nil {
+	if err := haltCheck(); err != nil {
 		return err
 	}
 
@@ -227,12 +228,11 @@ func finalizeSwap(
 		panic(addDetailToError(errSlippage, err.Error()))
 	}
 
-	// Validate slippage
 	if err := validator.ValidateSlippage(swapType, resultAmountIn, resultAmountOutWithoutFee, tokenAmountLimit); err != nil {
 		panic(addDetailToError(errSlippage, err.Error()))
 	}
 
-	// Calculate final amounts
+	// calculate final amounts
 	intAmountOut := i256.FromUint256(resultAmountOutWithoutFee)
 	negativeOut := i256.Zero().Neg(intAmountOut).ToString()
 

--- a/contract/r/gnoswap/router/router_dry.gno
+++ b/contract/r/gnoswap/router/router_dry.gno
@@ -71,7 +71,20 @@ func DrySwapRoute(
 		}
 
 		resultAmountIn = new(u256.Uint).Add(resultAmountIn, amountIn)
+		if resultAmountIn.IsOverflow() {
+			panic(addDetailToError(
+				errInvalidInput,
+				"overflow in resultAmountIn",
+			))
+		}
+
 		resultAmountOut = new(u256.Uint).Add(resultAmountOut, amountOut)
+		if resultAmountOut.IsOverflow() {
+			panic(addDetailToError(
+				errInvalidInput,
+				"overflow in resultAmountOut",
+			))
+		}
 	}
 
 	return processDryswapResult(
@@ -114,7 +127,7 @@ func parseAmountLimit(amountLimit string) *i256.Int {
 }
 
 func parseRoutes(strRouteArr, quoteArr string) ([]string, []string) {
-	routes, quotes, err := tryParseRoutes(strRouteArr, quoteArr)
+	routes, quotes, err := validateRoutesAndQuotes(strRouteArr, quoteArr)
 	if err != nil {
 		panic(addDetailToError(
 			errInvalidRoutesAndQuotes,
@@ -137,6 +150,12 @@ func parseQuote(quote string) int {
 
 func calculateSwapAmount(amountSpecified *i256.Int, quote int) *i256.Int {
 	toSwap := i256.Zero().Mul(amountSpecified, i256.NewInt(int64(quote)))
+	if toSwap.IsOverflow() {
+		panic(addDetailToError(
+			errInvalidInput,
+			"overflow in calculateSwapAmount",
+		))
+	}
 	return new(i256.Int).Div(toSwap, i256.NewInt(100))
 }
 

--- a/contract/r/gnoswap/router/router_dry.gno
+++ b/contract/r/gnoswap/router/router_dry.gno
@@ -12,6 +12,11 @@ import (
 	"gno.land/r/gnoswap/v1/common"
 )
 
+const (
+	MAX_QUOTE_PERCENTAGE = 100
+	MIN_QUOTE_PERCENTAGE = 0
+)
+
 // DrySwapRoute simulates a token swap route without actually executing the swap.
 // It calculates the expected outcome based on the current state of liquidity pools.
 // Parameters:
@@ -38,6 +43,44 @@ func DrySwapRoute(
 	common.MustRegistered(inputToken)
 	common.MustRegistered(outputToken)
 
+	swapType := parseSwapType(swapTypeStr)
+	amountSpecified := parseAmount(specifiedAmount)
+	amountLimit := parseAmountLimit(tokenAmountLimit)
+	routes, quotes := parseRoutes(strRouteArr, quoteArr)
+
+	if swapType == ExactOut {
+		amountSpecified = i256.Zero().Neg(amountSpecified)
+	}
+
+	zero := u256.Zero()
+
+	amountIn, amountOut := zero, zero
+	resultAmountIn, resultAmountOut := zero, zero
+
+	for i, route := range routes {
+		quote := parseQuote(quotes[i])
+		toSwap := calculateSwapAmount(amountSpecified, quote)
+
+		numHops := strings.Count(route, POOL_SEPARATOR) + 1
+		assertHopsInRange(numHops)
+
+		if numHops == 1 {
+			amountIn, amountOut = handleSingleDrySwap(route, toSwap)
+		} else {
+			amountIn, amountOut = handleMultiDrySwap(swapType, route, numHops, toSwap)
+		}
+
+		resultAmountIn = new(u256.Uint).Add(resultAmountIn, amountIn)
+		resultAmountOut = new(u256.Uint).Add(resultAmountOut, amountOut)
+	}
+
+	return processDryswapResult(
+		swapType, resultAmountIn, resultAmountOut,
+		amountSpecified, amountLimit,
+	)
+}
+
+func parseSwapType(swapTypeStr string) SwapType {
 	swapType, err := trySwapTypeFromStr(swapTypeStr)
 	if err != nil {
 		panic(addDetailToError(
@@ -45,23 +88,32 @@ func DrySwapRoute(
 			ufmt.Sprintf("unknown swapType(%s)", swapTypeStr),
 		))
 	}
+	return swapType
+}
 
-	amountSpecified := i256.MustFromDecimal(specifiedAmount)
-	if amountSpecified.IsZero() || amountSpecified.IsNeg() {
+func parseAmount(amount string) *i256.Int {
+	parsedAmount := i256.MustFromDecimal(amount)
+	if parsedAmount.Lt(i256.Zero()) {
 		panic(addDetailToError(
 			errInvalidInput,
-			ufmt.Sprintf("invalid amountSpecified(%s), must be positive", specifiedAmount),
+			ufmt.Sprintf("invalid amount(%s), must be positive", amount),
 		))
 	}
+	return parsedAmount
+}
 
-	amountLimit := i256.MustFromDecimal(tokenAmountLimit)
-	if amountLimit.IsZero() {
+func parseAmountLimit(amountLimit string) *i256.Int {
+	parsedLimit := i256.MustFromDecimal(amountLimit)
+	if parsedLimit.IsZero() {
 		panic(addDetailToError(
 			errInvalidInput,
-			ufmt.Sprintf("invalid amountLimit(%s), should not be zero", tokenAmountLimit),
+			ufmt.Sprintf("invalid amountLimit(%s), should not be zero", amountLimit),
 		))
 	}
+	return parsedLimit
+}
 
+func parseRoutes(strRouteArr, quoteArr string) ([]string, []string) {
 	routes, quotes, err := tryParseRoutes(strRouteArr, quoteArr)
 	if err != nil {
 		panic(addDetailToError(
@@ -69,41 +121,23 @@ func DrySwapRoute(
 			err.Error()),
 		)
 	}
+	return routes, quotes
+}
 
-	if swapType == ExactOut {
-		amountSpecified = i256.Zero().Neg(amountSpecified)
+func parseQuote(quote string) int {
+	quoteValue, _ := strconv.Atoi(quote)
+	if quoteValue < MIN_QUOTE_PERCENTAGE || quoteValue > MAX_QUOTE_PERCENTAGE {
+		panic(addDetailToError(
+			errInvalidInput,
+			ufmt.Sprintf("quote(%d) must be %d~%d", quoteValue, MIN_QUOTE_PERCENTAGE, MAX_QUOTE_PERCENTAGE),
+		))
 	}
+	return quoteValue
+}
 
-	resultAmountIn := u256.Zero()
-	resultAmountOut := u256.Zero()
-
-	for i, route := range routes {
-		numHops := strings.Count(route, POOL_SEPARATOR) + 1
-		assertHopsInRange(numHops)
-		// don't need to check error here
-		quote, _ := strconv.Atoi(quotes[i])
-		if quote < 0 || quote > 100 {
-			panic(addDetailToError(
-				errInvalidInput,
-				ufmt.Sprintf("quote(%d) must be 0~100", quote),
-			))
-		}
-
-		toSwap := i256.Zero().Mul(amountSpecified, i256.NewInt(int64(quote)))
-		toSwap = new(i256.Int).Div(toSwap, i256.NewInt(100))
-
-		if numHops == 1 {
-			amountIn, amountOut := handleSingleDrySwap(route, toSwap)
-			resultAmountIn = new(u256.Uint).Add(resultAmountIn, amountIn)
-			resultAmountOut = new(u256.Uint).Add(resultAmountOut, amountOut)
-		} else {
-			amountIn, amountOut := handleMultiDrySwap(swapType, route, numHops, toSwap)
-			resultAmountIn = new(u256.Uint).Add(resultAmountIn, amountIn)
-			resultAmountOut = new(u256.Uint).Add(resultAmountOut, amountOut)
-		}
-	}
-
-	return processResult(swapType, resultAmountIn, resultAmountOut, amountSpecified, amountLimit)
+func calculateSwapAmount(amountSpecified *i256.Int, quote int) *i256.Int {
+	toSwap := i256.Zero().Mul(amountSpecified, i256.NewInt(int64(quote)))
+	return new(i256.Int).Div(toSwap, i256.NewInt(100))
 }
 
 func handleSingleDrySwap(route string, amountSpecified *i256.Int) (*u256.Uint, *u256.Uint) {
@@ -124,27 +158,27 @@ func handleMultiDrySwap(
 	numHops int,
 	amountSpecified *i256.Int,
 ) (*u256.Uint, *u256.Uint) {
+	recipient := std.PreviousRealm().Address()
+	pathIndex := getPathIndex(swapType, numHops)
+
+	input, output, fee := getDataForMultiPath(route, pathIndex)
+	swapParams := newSwapParams(input, output, fee, recipient, amountSpecified)
+
+	return executeMultiSwap(swapType, swapParams, pathIndex, numHops, route)
+}
+
+func executeMultiSwap(
+	swapType SwapType,
+	params *SwapParams,
+	pathIndex int,
+	numHops int,
+	route string,
+) (*u256.Uint, *u256.Uint) {
 	switch swapType {
 	case ExactIn:
-		input, output, fee := getDataForMultiPath(route, 0) // first data
-		swapParams := SwapParams{
-			tokenIn:         input,
-			tokenOut:        output,
-			fee:             fee,
-			recipient:       std.PreviousRealm().Address(),
-			amountSpecified: amountSpecified,
-		}
-		return multiDrySwap(swapParams, 0, numHops, route)
+		return multiDrySwap(*params, pathIndex, numHops, route)
 	case ExactOut:
-		input, output, fee := getDataForMultiPath(route, numHops-1) // last data
-		swapParams := SwapParams{
-			tokenIn:         input,
-			tokenOut:        output,
-			fee:             fee,
-			recipient:       std.PreviousRealm().Address(),
-			amountSpecified: amountSpecified,
-		}
-		return multiDrySwapNegative(swapParams, numHops-1, route)
+		return multiDrySwapNegative(*params, pathIndex, route)
 	default:
 		panic(addDetailToError(
 			errInvalidSwapType,
@@ -153,7 +187,7 @@ func handleMultiDrySwap(
 	}
 }
 
-func processResult(swapType SwapType, resultAmountIn, resultAmountOut *u256.Uint, amountSpecified, amountLimit *i256.Int) (string, string, bool) {
+func processDryswapResult(swapType SwapType, resultAmountIn, resultAmountOut *u256.Uint, amountSpecified, amountLimit *i256.Int) (string, string, bool) {
 	switch swapType {
 	case ExactIn:
 		if i256.FromUint256(resultAmountIn).Gt(amountSpecified) {
@@ -172,10 +206,18 @@ func processResult(swapType SwapType, resultAmountIn, resultAmountOut *u256.Uint
 			return resultAmountIn.ToString(), resultAmountOut.ToString(), false
 		}
 		return resultAmountIn.ToString(), resultAmountOut.ToString(), true
+
 	default:
 		panic(addDetailToError(
 			errInvalidSwapType,
 			ufmt.Sprintf("unknown swapType(%s)", swapType),
 		))
 	}
+}
+
+func getPathIndex(swapType SwapType, numHops int) int {
+	if swapType == ExactIn {
+		return 0 // first data
+	}
+	return numHops - 1 // last data
 }

--- a/contract/r/gnoswap/router/router_dry_test.gno
+++ b/contract/r/gnoswap/router/router_dry_test.gno
@@ -91,23 +91,26 @@ func TestProcessResult(t *testing.T) {
 	}
 }
 
+type testDrySwapRouteCases struct {
+	name              string
+	inputToken        string
+	outputToken       string
+	specifiedAmount   string
+	swapTypeStr       string
+	strRouteArr       string
+	quoteArr          string
+	tokenAmountLimit  string
+	expectedAmountIn  string
+	expectedAmountOut string
+	expectedSuccess   bool
+	expectPanic       bool
+}
+
 func TestDrySwapRoute(t *testing.T) {
 	t.Skip("run this test separately with `gno test -v -run TestDrySwapRoute`")
 	createBasicPool(t)
 
-	tests := []struct {
-		name              string
-		inputToken        string
-		outputToken       string
-		specifiedAmount   string
-		swapTypeStr       string
-		strRouteArr       string
-		quoteArr          string
-		tokenAmountLimit  string
-		expectedAmountIn  string
-		expectedAmountOut string
-		expectedSuccess   bool
-	}{
+	tests := []testDrySwapRouteCases{
 		{
 			name:              "ExactIn - Single Route",
 			inputToken:        "gno.land/r/onbloc/bar",
@@ -182,20 +185,8 @@ func TestDrySwapRoute(t *testing.T) {
 }
 
 func TestDrySwapRouteOverflow(t *testing.T) {
-	tests := []struct {
-		name              string
-		inputToken        string
-		outputToken       string
-		specifiedAmount   string
-		swapTypeStr       string
-		strRouteArr       string
-		quoteArr          string
-		tokenAmountLimit  string
-		expectedAmountIn  string
-		expectedAmountOut string
-		expectedSuccess   bool
-		expectPanic       bool
-	}{
+	t.Skip("run this test separately with `gno test -v -run TestDrySwapRouteOverflow`")
+	tests := []testDrySwapRouteCases{
 		{
 			name:              "ExactIn - Overflow in calculateSwapAmount",
 			inputToken:        "gno.land/r/onbloc/bar",

--- a/contract/r/gnoswap/router/router_dry_test.gno
+++ b/contract/r/gnoswap/router/router_dry_test.gno
@@ -181,6 +181,110 @@ func TestDrySwapRoute(t *testing.T) {
 	}
 }
 
+func TestDrySwapRouteOverflow(t *testing.T) {
+	tests := []struct {
+		name              string
+		inputToken        string
+		outputToken       string
+		specifiedAmount   string
+		swapTypeStr       string
+		strRouteArr       string
+		quoteArr          string
+		tokenAmountLimit  string
+		expectedAmountIn  string
+		expectedAmountOut string
+		expectedSuccess   bool
+		expectPanic       bool
+	}{
+		{
+			name:              "ExactIn - Overflow in calculateSwapAmount",
+			inputToken:        "gno.land/r/onbloc/bar",
+			outputToken:       "gno.land/r/onbloc/baz",
+			specifiedAmount:   "115792089237316195423570985008687907853269984665640564039457584007913129639935", // max uint256
+			swapTypeStr:       "EXACT_IN",
+			strRouteArr:       "gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:500",
+			quoteArr:          "100",
+			tokenAmountLimit:  "1",
+			expectedAmountIn:  "0",
+			expectedAmountOut: "0",
+			expectedSuccess:   false,
+			expectPanic:       true,
+		},
+		{
+			name:              "ExactOut - Overflow in calculateSwapAmount",
+			inputToken:        "gno.land/r/onbloc/baz",
+			outputToken:       "gno.land/r/onbloc/bar",
+			specifiedAmount:   "115792089237316195423570985008687907853269984665640564039457584007913129639935", // max uint256
+			swapTypeStr:       "EXACT_OUT",
+			strRouteArr:       "gno.land/r/onbloc/baz:gno.land/r/onbloc/bar:500",
+			quoteArr:          "100",
+			tokenAmountLimit:  "100000",
+			expectedAmountIn:  "0",
+			expectedAmountOut: "0",
+			expectedSuccess:   false,
+			expectPanic:       true,
+		},
+		{
+			name:              "ExactIn - Overflow in resultAmountIn",
+			inputToken:        "gno.land/r/onbloc/bar",
+			outputToken:       "gno.land/r/onbloc/baz",
+			specifiedAmount:   "1000",
+			swapTypeStr:       "EXACT_IN",
+			strRouteArr:       "gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:500,gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:500",
+			quoteArr:          "50,50",
+			tokenAmountLimit:  "1",
+			expectedAmountIn:  "0",
+			expectedAmountOut: "0",
+			expectedSuccess:   false,
+			expectPanic:       true,
+		},
+		{
+			name:              "ExactOut - Overflow in resultAmountOut",
+			inputToken:        "gno.land/r/onbloc/baz",
+			outputToken:       "gno.land/r/onbloc/bar",
+			specifiedAmount:   "1000",
+			swapTypeStr:       "EXACT_OUT",
+			strRouteArr:       "gno.land/r/onbloc/baz:gno.land/r/onbloc/bar:500,gno.land/r/onbloc/baz:gno.land/r/onbloc/bar:500",
+			quoteArr:          "50,50",
+			tokenAmountLimit:  "100000",
+			expectedAmountIn:  "0",
+			expectedAmountOut: "0",
+			expectedSuccess:   false,
+			expectPanic:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					if !tt.expectPanic {
+						t.Errorf("unexpected panic: %v", r)
+					}
+				} else if tt.expectPanic {
+					t.Error("expected panic but got none")
+				}
+			}()
+
+			amountIn, amountOut, success := DrySwapRoute(
+				tt.inputToken,
+				tt.outputToken,
+				tt.specifiedAmount,
+				tt.swapTypeStr,
+				tt.strRouteArr,
+				tt.quoteArr,
+				tt.tokenAmountLimit,
+			)
+
+			if !tt.expectPanic {
+				uassert.Equal(t, tt.expectedAmountIn, amountIn)
+				uassert.Equal(t, tt.expectedAmountOut, amountOut)
+				uassert.Equal(t, tt.expectedSuccess, success)
+			}
+		})
+	}
+}
+
 func createBasicPool(t *testing.T) {
 	t.Helper()
 	testing.SetRealm(adminRealm)

--- a/contract/r/gnoswap/router/router_dry_test.gno
+++ b/contract/r/gnoswap/router/router_dry_test.gno
@@ -7,6 +7,16 @@ import (
 
 	i256 "gno.land/p/gnoswap/int256"
 	u256 "gno.land/p/gnoswap/uint256"
+
+	"gno.land/p/gnoswap/consts"
+	"gno.land/r/gnoswap/v1/gns"
+
+	pl "gno.land/r/gnoswap/v1/pool"
+	pn "gno.land/r/gnoswap/v1/position"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/baz"
+	"gno.land/r/onbloc/qux"
 )
 
 func TestProcessResult(t *testing.T) {
@@ -69,14 +79,121 @@ func TestProcessResult(t *testing.T) {
 
 			switch tt.swapType {
 			case ExactIn:
-				_, result, swapAvailable := processResult(tt.swapType, resultAmountIn, resultAmountOut, amountSpecified, amountLimit)
+				_, result, swapAvailable := processDryswapResult(tt.swapType, resultAmountIn, resultAmountOut, amountSpecified, amountLimit)
 				uassert.Equal(t, tt.expected, result)
 				uassert.Equal(t, tt.expectedSwap, swapAvailable)
 			case ExactOut:
-				result, _, swapAvailable := processResult(tt.swapType, resultAmountIn, resultAmountOut, amountSpecified, amountLimit)
+				result, _, swapAvailable := processDryswapResult(tt.swapType, resultAmountIn, resultAmountOut, amountSpecified, amountLimit)
 				uassert.Equal(t, tt.expected, result)
 				uassert.Equal(t, tt.expectedSwap, swapAvailable)
 			}
 		})
 	}
+}
+
+func TestDrySwapRoute(t *testing.T) {
+	t.Skip("run this test separately with `gno test -v -run TestDrySwapRoute`")
+	createBasicPool(t)
+
+	tests := []struct {
+		name              string
+		inputToken        string
+		outputToken       string
+		specifiedAmount   string
+		swapTypeStr       string
+		strRouteArr       string
+		quoteArr          string
+		tokenAmountLimit  string
+		expectedAmountIn  string
+		expectedAmountOut string
+		expectedSuccess   bool
+	}{
+		{
+			name:              "ExactIn - Single Route",
+			inputToken:        "gno.land/r/onbloc/bar",
+			outputToken:       "gno.land/r/onbloc/baz",
+			specifiedAmount:   "1000",
+			swapTypeStr:       "EXACT_IN",
+			strRouteArr:       "gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:500",
+			quoteArr:          "100",
+			tokenAmountLimit:  "1",
+			expectedAmountIn:  "1000",
+			expectedAmountOut: "2711",
+			expectedSuccess:   true,
+		},
+		{
+			name:              "ExactOut - Single Route",
+			inputToken:        "gno.land/r/onbloc/baz",
+			outputToken:       "gno.land/r/onbloc/bar",
+			specifiedAmount:   "1000",
+			swapTypeStr:       "EXACT_OUT",
+			strRouteArr:       "gno.land/r/onbloc/baz:gno.land/r/onbloc/bar:500",
+			quoteArr:          "100",
+			tokenAmountLimit:  "100000",
+			expectedAmountIn:  "2724",
+			expectedAmountOut: "1000",
+			expectedSuccess:   true,
+		},
+		{
+			name:              "ExactIn - Multi Route",
+			inputToken:        "gno.land/r/onbloc/bar",
+			outputToken:       "gno.land/r/onbloc/qux",
+			specifiedAmount:   "1000",
+			swapTypeStr:       "EXACT_IN",
+			strRouteArr:       "gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:500*POOL*gno.land/r/onbloc/baz:gno.land/r/onbloc/qux:500",
+			quoteArr:          "100",
+			tokenAmountLimit:  "1",
+			expectedAmountIn:  "1000",
+			expectedAmountOut: "7337",
+			expectedSuccess:   true,
+		},
+		{
+			name:              "ExactOut - Multi Route",
+			inputToken:        "gno.land/r/onbloc/bar",
+			outputToken:       "gno.land/r/onbloc/qux",
+			specifiedAmount:   "1000",
+			swapTypeStr:       "EXACT_OUT",
+			strRouteArr:       "gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:500*POOL*gno.land/r/onbloc/baz:gno.land/r/onbloc/qux:500",
+			quoteArr:          "100",
+			tokenAmountLimit:  "10000",
+			expectedAmountIn:  "138",
+			expectedAmountOut: "370",
+			expectedSuccess:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			amountIn, amountOut, success := DrySwapRoute(
+				tt.inputToken,
+				tt.outputToken,
+				tt.specifiedAmount,
+				tt.swapTypeStr,
+				tt.strRouteArr,
+				tt.quoteArr,
+				tt.tokenAmountLimit,
+			)
+
+			uassert.Equal(t, tt.expectedAmountIn, amountIn)
+			uassert.Equal(t, tt.expectedAmountOut, amountOut)
+			uassert.Equal(t, tt.expectedSuccess, success)
+		})
+	}
+}
+
+func createBasicPool(t *testing.T) {
+	t.Helper()
+	testing.SetRealm(adminRealm)
+
+	gns.Approve(poolAddr, pl.GetPoolCreationFee()*2)
+
+	pl.CreatePool(barPath, bazPath, uint32(500), "130621891405341611593710811006") // tick = 10_000
+	pl.CreatePool(bazPath, quxPath, uint32(500), "130621891405341611593710811006") // tick = 10_000
+
+	bar.Approve(poolAddr, consts.UINT64_MAX)
+	baz.Approve(poolAddr, consts.UINT64_MAX)
+	qux.Approve(poolAddr, consts.UINT64_MAX)
+
+	pn.Mint(barPath, bazPath, uint32(500), int32(9000), int32(11000), "100000", "100000", "0", "0", 9999999999, adminAddr, adminAddr, "")
+	pn.Mint(bazPath, quxPath, uint32(500), int32(9000), int32(11000), "100000", "100000", "0", "0", 9999999999, adminAddr, adminAddr, "")
 }

--- a/contract/r/gnoswap/router/tests/router_spec_#4_ExactIn_test.gnoA
+++ b/contract/r/gnoswap/router/tests/router_spec_#4_ExactIn_test.gnoA
@@ -18,24 +18,12 @@ import (
 	"gno.land/r/onbloc/foo"
 )
 
-//=================================Test for SwapRouter exactInput 0 ->1 -> 2 in multi pool=================================
-
-func TestCreatePool(t *testing.T) {
+func TestExactInSwapRoute_4(t *testing.T) {
 	testing.SetRealm(adminRealm)
 	gns.Approve(poolAddr, pl.GetPoolCreationFee()*2)
 
 	pl.CreatePool(barPath, bazPath, 3000, "79228162514264337593543950336")
-
 	pl.CreatePool(bazPath, fooPath, 3000, "79228162514264337593543950336")
-
-	// jsonOutput := pl.ApiGetPools()
-	// jsonStr := gjson.Parse(jsonOutput)
-	// uassert.Equal(t, len(jsonStr.Get("response").Array()), 2)
-}
-
-func TestPositionMint(t *testing.T) {
-	// bar_baz_3000 by admin
-	testing.SetRealm(adminRealm)
 
 	bar.Approve(poolAddr, consts.UINT64_MAX)
 	baz.Approve(poolAddr, consts.UINT64_MAX)
@@ -44,10 +32,6 @@ func TestPositionMint(t *testing.T) {
 	// Mint
 	pn.Mint(barPath, bazPath, uint32(3000), int32(-887220), int32(887220), "1000000", "1000000", "0", "0", max_timeout, adminAddr, adminAddr, "")
 	pn.Mint(bazPath, fooPath, uint32(3000), int32(-887220), int32(887220), "1000000", "1000000", "0", "0", max_timeout, adminAddr, adminAddr, "")
-}
-
-func TestSwapRouteBarfooExactIn(t *testing.T) {
-	testing.SetRealm(adminRealm)
 
 	bar.Approve(routerAddr, 1000000)
 	foo.Approve(routerAddr, 1000000)

--- a/contract/r/gnoswap/router/tests/router_spec_#5_ExactOut_test.gnoA
+++ b/contract/r/gnoswap/router/tests/router_spec_#5_ExactOut_test.gnoA
@@ -19,28 +19,16 @@ import (
 	"gno.land/r/onbloc/qux"
 )
 
-//=================================Test for SwapRouter exactOut 0 ->1 in single pool=================================
-
-func TestCreatePool(t *testing.T) {
+func TestExactOutSwapRoute_5(t *testing.T) {
 	testing.SetRealm(adminRealm)
 	gns.Approve(poolAddr, pl.GetPoolCreationFee()*2)
 
 	pl.CreatePool(barPath, bazPath, 3000, "79228162514264337593543950336")
-}
-
-func TestPositionMint(t *testing.T) {
-	// bar_baz_3000 by admin
-	testing.SetRealm(adminRealm)
 
 	bar.Approve(poolAddr, consts.UINT64_MAX)
 	baz.Approve(poolAddr, consts.UINT64_MAX)
 
-	// Mint
 	pn.Mint(barPath, bazPath, uint32(3000), int32(-887220), int32(887220), "1000000", "1000000", "0", "0", max_timeout, adminAddr, adminAddr, "")
-}
-
-func TestSwapRouteBarBazExactOut(t *testing.T) {
-	testing.SetRealm(adminRealm)
 
 	bar.Approve(routerAddr, 1000000)
 	baz.Approve(routerAddr, 1000000)

--- a/contract/r/gnoswap/router/tests/router_spec_#6_ExactOut_test.gnoA
+++ b/contract/r/gnoswap/router/tests/router_spec_#6_ExactOut_test.gnoA
@@ -17,28 +17,16 @@ import (
 	"gno.land/r/onbloc/baz"
 )
 
-//=================================Test for SwapRouter exactOut 1 -> 0 in single pool=================================
-
-func TestCreatePool(t *testing.T) {
+func TestExactOutSwapRoute_6(t *testing.T) {
 	testing.SetRealm(adminRealm)
 	gns.Approve(poolAddr, pl.GetPoolCreationFee()*2)
 
 	pl.CreatePool(barPath, bazPath, 3000, "79228162514264337593543950336")
-}
-
-func TestPositionMint(t *testing.T) {
-	// bar_baz_3000 by admin
-	testing.SetRealm(adminRealm)
 
 	bar.Approve(poolAddr, consts.UINT64_MAX)
 	baz.Approve(poolAddr, consts.UINT64_MAX)
 
-	// Mint
 	pn.Mint(barPath, bazPath, uint32(3000), int32(-887220), int32(887220), "1000000", "1000000", "0", "0", max_timeout, adminAddr, adminAddr, "")
-}
-
-func TestSwapRouteBazBarExactOut(t *testing.T) {
-	testing.SetRealm(adminRealm)
 
 	bar.Approve(routerAddr, 1000000)
 	baz.Approve(routerAddr, 1000000)

--- a/contract/r/gnoswap/router/tests/router_spec_#7_ExactOut_test.gnoA
+++ b/contract/r/gnoswap/router/tests/router_spec_#7_ExactOut_test.gnoA
@@ -18,36 +18,19 @@ import (
 	"gno.land/r/onbloc/foo"
 )
 
-//=================================Test for SwapRouter exactOut 0 -> 1 -> 2 in Multiple pool=================================
-
-func TestCreatePool(t *testing.T) {
+func TestExactOutSwapRoute_7(t *testing.T) {
 	testing.SetRealm(adminRealm)
 	gns.Approve(poolAddr, pl.GetPoolCreationFee()*2)
 
 	pl.CreatePool(barPath, bazPath, 3000, "79228162514264337593543950336")
-
 	pl.CreatePool(bazPath, fooPath, 3000, "79228162514264337593543950336")
-
-	// jsonOutput := pl.ApiGetPools()
-	// jsonStr := gjson.Parse(jsonOutput)
-	// uassert.Equal(t, len(jsonStr.Get("response").Array()), 2)
-}
-
-func TestPositionMint(t *testing.T) {
-	// bar_baz_3000 by admin
-	testing.SetRealm(adminRealm)
 
 	bar.Approve(poolAddr, consts.UINT64_MAX)
 	baz.Approve(poolAddr, consts.UINT64_MAX)
 	foo.Approve(poolAddr, consts.UINT64_MAX)
 
-	// Mint
 	pn.Mint(barPath, bazPath, uint32(3000), int32(-887220), int32(887220), "1000000", "1000000", "0", "0", max_timeout, adminAddr, adminAddr, "")
 	pn.Mint(bazPath, fooPath, uint32(3000), int32(-887220), int32(887220), "1000000", "1000000", "0", "0", max_timeout, adminAddr, adminAddr, "")
-}
-
-func TestSwapRouteBarfooExactOut(t *testing.T) {
-	testing.SetRealm(adminRealm)
 
 	bar.Approve(routerAddr, 1000000)
 	foo.Approve(routerAddr, 1000000)

--- a/contract/r/gnoswap/router/tests/router_spec_#8_ExactOut_test.gnoA
+++ b/contract/r/gnoswap/router/tests/router_spec_#8_ExactOut_test.gnoA
@@ -18,24 +18,12 @@ import (
 	"gno.land/r/onbloc/foo"
 )
 
-//=================================Test for SwapRouter exactOut 2 -> 1 -> 0 in Multiple pool=================================
-
-func TestCreatePool(t *testing.T) {
+func TestExactOutSwapRoute_8(t *testing.T) {
 	testing.SetRealm(adminRealm)
 	gns.Approve(poolAddr, pl.GetPoolCreationFee()*2)
 
 	pl.CreatePool(barPath, bazPath, 3000, "79228162514264337593543950336")
-
 	pl.CreatePool(bazPath, fooPath, 3000, "79228162514264337593543950336")
-
-	// jsonOutput := pl.ApiGetPools()
-	// jsonStr := gjson.Parse(jsonOutput)
-	// uassert.Equal(t, len(jsonStr.Get("response").Array()), 2)
-}
-
-func TestPositionMint(t *testing.T) {
-	// bar_baz_3000 by admin
-	testing.SetRealm(adminRealm)
 
 	bar.Approve(poolAddr, consts.UINT64_MAX)
 	baz.Approve(poolAddr, consts.UINT64_MAX)
@@ -44,10 +32,6 @@ func TestPositionMint(t *testing.T) {
 	// Mint
 	pn.Mint(barPath, bazPath, uint32(3000), int32(-887220), int32(887220), "1000000", "1000000", "0", "0", max_timeout, adminAddr, adminAddr, "")
 	pn.Mint(bazPath, fooPath, uint32(3000), int32(-887220), int32(887220), "1000000", "1000000", "0", "0", max_timeout, adminAddr, adminAddr, "")
-}
-
-func TestSwapRouteFooBarExactOut(t *testing.T) {
-	testing.SetRealm(adminRealm)
 
 	bar.Approve(routerAddr, 1000000)
 	foo.Approve(routerAddr, 1000000)

--- a/contract/r/gnoswap/router/tests/router_swap_route_1route_1hop_all_liquidity_exact_in_test.gnoA
+++ b/contract/r/gnoswap/router/tests/router_swap_route_1route_1hop_all_liquidity_exact_in_test.gnoA
@@ -19,20 +19,15 @@ import (
 	"gno.land/r/gnoswap/v1/gns"
 )
 
-func TestCreatePool(t *testing.T) {
+func TestAllLiquidityExactIn_1route_1hop(t *testing.T) {
 	testing.SetRealm(adminRealm)
 
 	gns.Approve(poolAddr, pl.GetPoolCreationFee())
 	pl.CreatePool(barPath, bazPath, fee500, common.TickMathGetSqrtRatioAtTick(1).ToString())
-}
 
-func TestPositionMint(t *testing.T) {
-	// bar_baz_500 by admin
-	testing.SetRealm(adminRealm)
 	bar.Approve(poolAddr, 100000)
 	baz.Approve(poolAddr, 100000)
 
-	// Mint
 	positionId, liquidity, amount0, amount1 := pn.Mint(barPath, bazPath, fee500, int32(-6000), int32(6000), "100000", "100000", "0", "0", max_timeout, adminAddr, adminAddr, "")
 
 	uassert.Equal(t, positionId, uint64(1))
@@ -46,10 +41,6 @@ func TestPositionMint(t *testing.T) {
 	poolPath := "gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:500"
 	poolTick := pl.PoolGetSlot0Tick(poolPath)
 	uassert.Equal(t, poolTick, int32(1))
-}
-
-func TestSwapRouteBarBazExactIn(t *testing.T) {
-	poolPath := "gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:500"
 
 	CreatePoolWithoutFee(t)
 	MakeForthMintPositionWithoutFee(t)
@@ -74,10 +65,10 @@ func TestSwapRouteBarBazExactIn(t *testing.T) {
 	uassert.Equal(t, amountIn, "140000")
 	uassert.Equal(t, amountOut, "-105765")
 
-	pool := pl.GetPool(barPath, bazPath, fee500)
-	poolLiq := pool.Liquidity()
+	pool = pl.GetPool(barPath, bazPath, fee500)
+	poolLiq = pool.Liquidity()
 	uassert.Equal(t, poolLiq.ToString(), "435768")
 
-	poolTick := pl.PoolGetSlot0Tick(poolPath)
+	poolTick = pl.PoolGetSlot0Tick(poolPath)
 	uassert.Equal(t, poolTick, int32(-5569))
 }

--- a/contract/r/gnoswap/router/tests/router_swap_route_1route_1hop_all_liquidity_exact_out_test.gnoA
+++ b/contract/r/gnoswap/router/tests/router_swap_route_1route_1hop_all_liquidity_exact_out_test.gnoA
@@ -19,16 +19,12 @@ import (
 	"gno.land/r/gnoswap/v1/gns"
 )
 
-func TestCreatePool(t *testing.T) {
+func TestAllLiquidityExactOut_1route_1hop(t *testing.T) {
 	testing.SetRealm(adminRealm)
 
 	gns.Approve(poolAddr, pl.GetPoolCreationFee())
 	pl.CreatePool(barPath, bazPath, fee500, common.TickMathGetSqrtRatioAtTick(1).ToString())
-}
 
-func TestPositionMint(t *testing.T) {
-	// bar_baz_500 by admin
-	testing.SetRealm(adminRealm)
 	bar.Approve(poolAddr, 100000)
 	baz.Approve(poolAddr, 100000)
 
@@ -46,10 +42,6 @@ func TestPositionMint(t *testing.T) {
 	poolPath := "gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:500"
 	poolTick := pl.PoolGetSlot0Tick(poolPath)
 	uassert.Equal(t, poolTick, int32(1))
-}
-
-func TestSwapRouteBarBazExactOut(t *testing.T) {
-	poolPath := "gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:500"
 
 	CreatePoolWithoutFee(t)
 	MakeForthMintPositionWithoutFee(t)
@@ -75,5 +67,4 @@ func TestSwapRouteBarBazExactOut(t *testing.T) {
 			)
 		},
 	)
-
 }

--- a/contract/r/gnoswap/router/tests/router_swap_route_1route_1hop_out_range_test.gnoA
+++ b/contract/r/gnoswap/router/tests/router_swap_route_1route_1hop_out_range_test.gnoA
@@ -19,7 +19,7 @@ import (
 	"gno.land/r/onbloc/baz"
 )
 
-func TestCreatePool(t *testing.T) {
+func TestSwapRouteOutRange_1route_1hop(t *testing.T) {
 	testing.SetRealm(adminRealm)
 
 	gns.Approve(poolAddr, pl.GetPoolCreationFee())
@@ -37,11 +37,7 @@ func TestCreatePool(t *testing.T) {
 	}
 
 	uassert.Equal(t, response.Size(), 1)
-}
 
-func TestPositionMint(t *testing.T) {
-	// bar_baz_500 by admin
-	testing.SetRealm(adminRealm)
 	bar.Approve(poolAddr, consts.UINT64_MAX)
 	baz.Approve(poolAddr, consts.UINT64_MAX)
 
@@ -55,10 +51,6 @@ func TestPositionMint(t *testing.T) {
 
 	// check pool liquidity
 	uassert.Equal(t, pl.PoolGetLiquidity("gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:500"), "637408")
-}
-
-func TestDrySwapRouteBazBarExactIn(t *testing.T) {
-	testing.SetRealm(adminRealm)
 
 	_, dryResult, _ := DrySwapRoute(
 		bazPath,    // inputToken
@@ -71,10 +63,6 @@ func TestDrySwapRouteBazBarExactIn(t *testing.T) {
 	)
 
 	uassert.Equal(t, dryResult, "367")
-}
-
-func TestSwapRouteBazBarExactIn(t *testing.T) {
-	testing.SetRealm(adminRealm)
 
 	uassert.PanicsWithMessage(
 		t,

--- a/contract/r/gnoswap/router/tests/router_swap_route_1route_1hop_test.gnoA
+++ b/contract/r/gnoswap/router/tests/router_swap_route_1route_1hop_test.gnoA
@@ -18,20 +18,17 @@ import (
 	"gno.land/r/gnoswap/v1/gns"
 )
 
-func TestCreatePool(t *testing.T) {
+const (
+	barbaz500 = "gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:500"
+	bazbar500 = "gno.land/r/onbloc/baz:gno.land/r/onbloc/bar:500"
+)
+
+func TestSwapRoute_1route_1hop(t *testing.T) {
 	testing.SetRealm(adminRealm)
 
 	gns.Approve(poolAddr, pl.GetPoolCreationFee())
 	pl.CreatePool(barPath, bazPath, fee500, "130621891405341611593710811006") // tick =  10_000, ratio = 2.71814592682522526700950038502924144268035888671875
 
-	// jsonOutput := pl.ApiGetPools()
-	// jsonStr := gjson.Parse(jsonOutput)
-	// uassert.Equal(t, len(jsonStr.Get("response").Array()), 1)
-}
-
-func TestPositionMint(t *testing.T) {
-	// bar_baz_500 by admin
-	testing.SetRealm(adminRealm)
 	bar.Approve(poolAddr, 36790)
 	baz.Approve(poolAddr, 100000)
 
@@ -41,98 +38,79 @@ func TestPositionMint(t *testing.T) {
 	uassert.Equal(t, positionId, uint64(1))
 	uassert.Equal(t, amount0, "36790")
 	uassert.Equal(t, amount1, "100000")
-}
-
-func TestDrySwapRouteBarBazExactIn(t *testing.T) {
-	testing.SetRealm(adminRealm)
 
 	_, dryResult, _ := DrySwapRoute(
-		barPath,    // inputToken
-		bazPath,    // outputToken
-		"1000",     // amountSpecified
-		"EXACT_IN", // swapType
-		"gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:500", // strRouteArr
-		"100", // quoteArr
+		barPath,
+		bazPath,
+		"1000",
+		"EXACT_IN",
+		barbaz500,
+		"100",
 		"1",
 	)
 
 	uassert.Equal(t, dryResult, "2711")
-}
-
-func TestSwapRouteBarBazExactIn(t *testing.T) {
-	testing.SetRealm(adminRealm)
 
 	bar.Approve(poolAddr, uint64(1000))
 	baz.Approve(routerAddr, consts.UINT64_MAX) // ITS FOR 0.15% fee
 
 	amountIn, amountOut := ExactInSwapRoute(
-		barPath, // inputToken
-		bazPath, // outputToken
-		"1000",  // amountSpecified
-		"gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:500", // strRouteArr
-		"100",  // quoteArr
-		"2700", // tokenAmountLimit
+		barPath,
+		bazPath,
+		"1000",
+		barbaz500,
+		"100",
+		"2700",
 		time.Now().Add(time.Hour).Unix(),
 		"", // referrer
 	)
 
 	uassert.Equal(t, amountIn, "1000")
 	uassert.Equal(t, amountOut, "-2707")
-}
-
-func TestSwapRouteBarBazExactOut(t *testing.T) {
-	testing.SetRealm(adminRealm)
 
 	bar.Approve(poolAddr, uint64(1000))
 	baz.Approve(routerAddr, consts.UINT64_MAX) // ITS FOR 0.15% fee
 
-	amountIn, amountOut := ExactOutSwapRoute(
-		barPath, // inputToken
-		bazPath, // outputToken
-		"1000",  // amountSpecified
-		"gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:500", // strRouteArr
-		"100", // quoteArr
-		"371", // tokenAmountLimit
+	amountIn, amountOut = ExactOutSwapRoute(
+		barPath,
+		bazPath,
+		"1000",
+		barbaz500,
+		"100",
+		"371",
 		time.Now().Add(time.Hour).Unix(),
 		"", // referrer
 	)
 
 	uassert.Equal(t, amountIn, "371")
 	uassert.Equal(t, amountOut, "-999")
-}
-
-func TestSwapRouteBazBarExactIn(t *testing.T) {
-	testing.SetRealm(adminRealm)
 
 	baz.Approve(poolAddr, consts.UINT64_MAX)
 	bar.Approve(routerAddr, consts.UINT64_MAX) // ITS FOR 0.15% fee
 
-	amountIn, amountOut := ExactInSwapRoute(
-		bazPath, // inputToken
-		barPath, // outputToken
-		"1000",  // amountSpecified
-		"gno.land/r/onbloc/baz:gno.land/r/onbloc/bar:500", // strRouteArr
-		"100", // quoteArr
-		"360", // tokenAmountLimit
+	amountIn, amountOut = ExactInSwapRoute(
+		bazPath,
+		barPath,
+		"1000",
+		bazbar500,
+		"100",
+		"360",
 		time.Now().Add(time.Hour).Unix(),
 		"", // referrer
 	)
 
 	uassert.Equal(t, amountIn, "1000")
 	uassert.Equal(t, amountOut, "-368")
-}
 
-func TestSwapRouteBazBarExactOut(t *testing.T) {
-	testing.SetRealm(adminRealm)
 	bar.Approve(routerAddr, consts.UINT64_MAX)
 
-	amountIn, amountOut := ExactOutSwapRoute(
-		bazPath, // inputToken
-		barPath, // outputToken
-		"3000",  // amountSpecified
-		"gno.land/r/onbloc/baz:gno.land/r/onbloc/bar:500", // strRouteArr
-		"100",  // quoteArr
-		"8200", // tokenAmountLimit
+	amountIn, amountOut = ExactOutSwapRoute(
+		bazPath,
+		barPath,
+		"3000",
+		bazbar500,
+		"100",
+		"8200",
 		time.Now().Add(time.Hour).Unix(),
 		"", // referrer
 	)


### PR DESCRIPTION
## Description

In the dry swap, may overflow in the following two cases:

1. During quote calculation in `calculateSwapAmount`
2. When accumulating results in `resultAmountIn` and `resultAmountOut`

## Changes

- Added `IsOverflow` function to `int256` package
- Added overflow check in `calculateSwapAmount` and `DrySwapRoute` functions in the `router_dry.gno` file
- Added related tests
    - Need to run separately because it creates the pool within the test
- Refactored `router.gno` file