### PR TITLE
GSW-2216 fix: Unable to create Full Range position in 0.01% fee pool

### DIFF
--- a/contract/r/gnoswap/pool/position_test.gno
+++ b/contract/r/gnoswap/pool/position_test.gno
@@ -408,58 +408,6 @@ func TestAssertValidTickLower(t *testing.T) {
 	}
 }
 
-func TestAssertValidTickUpper(t *testing.T) {
-	tests := []struct {
-		name        string
-		tickLower   int32
-		tickUpper   int32
-		shouldPanic bool
-		expected    string
-	}{
-		{
-			name:        "tickUpper equals MAX_TICK",
-			tickLower:   consts.MIN_TICK,
-			tickUpper:   consts.MAX_TICK,
-			shouldPanic: true,
-			expected:    "[GNOSWAP-POOL-014] tickUpper is invalid || tickUpper(887272) > MAX_TICK(887272)",
-		},
-		{
-			name:        "tickUpper less than MAX_TICK",
-			tickLower:   consts.MIN_TICK + 1,
-			tickUpper:   consts.MAX_TICK - 1,
-			shouldPanic: false,
-			expected:    "",
-		},
-		{
-			name:        "tickUpper greater than MAX_TICK (panic)",
-			tickLower:   consts.MIN_TICK - 1,
-			tickUpper:   consts.MAX_TICK + 1,
-			shouldPanic: true,
-			expected:    "[GNOSWAP-POOL-014] tickUpper is invalid || tickUpper(887273) > MAX_TICK(887272)",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			defer func() {
-				if r := recover(); r == nil {
-					if tt.shouldPanic {
-						t.Errorf("unexpected panic: %v", r)
-					}
-					return
-				} else {
-					if tt.shouldPanic {
-						uassert.Equal(t, tt.expected, r.(string))
-					} else {
-						t.Errorf("expected no panic, but got: %v", r)
-					}
-				}
-			}()
-			assertValidTickUpper(tt.tickUpper)
-		})
-	}
-}
-
 func TestUpdatePosition(t *testing.T) {
 	poolParams := &createPoolParams{
 		token0Path:   "token0",

--- a/contract/r/gnoswap/pool/tick.gno
+++ b/contract/r/gnoswap/pool/tick.gno
@@ -451,7 +451,7 @@ func assertValidTickLower(tickLower int32) {
 }
 
 func assertValidTickUpper(tickUpper int32) {
-	if tickUpper >= consts.MAX_TICK {
+	if tickUpper > consts.MAX_TICK {
 		panic(newErrorWithDetail(
 			errTickUpperInvalid,
 			ufmt.Sprintf("tickUpper(%d) > MAX_TICK(%d)", tickUpper, consts.MAX_TICK),

--- a/contract/r/gnoswap/pool/tick_test.gno
+++ b/contract/r/gnoswap/pool/tick_test.gno
@@ -6,6 +6,7 @@ import (
 	"gno.land/p/demo/avl"
 	"gno.land/p/demo/uassert"
 
+	"gno.land/p/gnoswap/consts"
 	i256 "gno.land/p/gnoswap/int256"
 	u256 "gno.land/p/gnoswap/uint256"
 )

--- a/contract/r/gnoswap/pool/tick_test.gno
+++ b/contract/r/gnoswap/pool/tick_test.gno
@@ -726,3 +726,91 @@ func deleteTick(t *testing.T, pool *Pool, tick int32) {
 	t.Helper()
 	pool.deleteTick(tick)
 }
+
+func TestAssertValidTickUpper(t *testing.T) {
+	tests := []struct {
+		name        string
+		tickUpper   int32
+		shouldPanic bool
+	}{
+		{
+			name:        "valid tick upper (MAX_TICK)",
+			tickUpper:   consts.MAX_TICK,
+			shouldPanic: false,
+		},
+		{
+			name:        "valid tick upper (MAX_TICK - 1)",
+			tickUpper:   consts.MAX_TICK - 1,
+			shouldPanic: false,
+		},
+		{
+			name:        "invalid tick upper (MAX_TICK + 1)",
+			tickUpper:   consts.MAX_TICK + 1,
+			shouldPanic: true,
+		},
+		// Issue: GSW-2216
+		{
+			name:        "full range position tick upper",
+			tickUpper:   887272,
+			shouldPanic: false,
+		},
+		{
+			name:        "valid tick upper (MAX_TICK - 10)",
+			tickUpper:   consts.MAX_TICK - 10,
+			shouldPanic: false,
+		},
+		{
+			name:        "valid tick upper (MAX_TICK - 100)",
+			tickUpper:   consts.MAX_TICK - 100,
+			shouldPanic: false,
+		},
+		{
+			name:        "valid tick upper (MAX_TICK - 1000)",
+			tickUpper:   consts.MAX_TICK - 1000,
+			shouldPanic: false,
+		},
+		{
+			name:        "invalid tick upper (MAX_TICK + 10)",
+			tickUpper:   consts.MAX_TICK + 10,
+			shouldPanic: true,
+		},
+		{
+			name:        "invalid tick upper (MAX_TICK + 100)",
+			tickUpper:   consts.MAX_TICK + 100,
+			shouldPanic: true,
+		},
+		{
+			name:        "invalid tick upper (MAX_TICK + 1000)",
+			tickUpper:   consts.MAX_TICK + 1000,
+			shouldPanic: true,
+		},
+		{
+			name:        "valid tick upper (MAX_TICK - tickSpacing)",
+			tickUpper:   consts.MAX_TICK - 100,
+			shouldPanic: false,
+		},
+		{
+			name:        "valid tick upper (MAX_TICK - 2*tickSpacing)",
+			tickUpper:   consts.MAX_TICK - 200,
+			shouldPanic: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.shouldPanic {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("expected panic, but got nil")
+					}
+				}()
+			}
+
+			assertValidTickUpper(tt.tickUpper)
+
+			if tt.shouldPanic {
+				t.Errorf("expected panic, but got none")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Fixes an issue where users cannot create Full Range positions in pools with 0.01% fee tier. The problem was in the `assertValidTickUpper` function in `tick.gno`, which incorrectly rejected valid tick upper values equal to `MAX_TICK`.

## Changes

- `tickUpper >= consts.MAX_TICK` -> `tickUpper > consts.MAX_TICK`
