### PR TITLE
GSW-2213 fix: Slippage error in ExactOut

### DIFF
--- a/contract/r/gnoswap/router/router.gno
+++ b/contract/r/gnoswap/router/router.gno
@@ -96,7 +96,9 @@ func finalizeSwap(
 	if swapType == ExactOut {
 		// If the pool's raw output is less than user wants, fail fast.
 		// (Optional: some designs skip this, and only check resultAmountOutWithoutFee.)
-		if resultAmountOut.Lt(amountSpecified) {
+		// Allow a tolerance of 1 unit to handle precision issues
+		diff := u256.Zero().Sub(amountSpecified, resultAmountOut)
+		if diff.Gt(u256.NewUint(1)) {
 			panic(addDetailToError(
 				errSlippage,
 				ufmt.Sprintf("Received more than requested in [EXACT_OUT] requested=%s, actual=%s", amountSpecified.ToString(), resultAmountOut.ToString()),

--- a/contract/r/gnoswap/router/router.gno
+++ b/contract/r/gnoswap/router/router.gno
@@ -95,14 +95,19 @@ func finalizeSwap(
 ) (string, string) {
 	if swapType == ExactOut {
 		// If the pool's raw output is less than user wants, fail fast.
-		// (Optional: some designs skip this, and only check resultAmountOutWithoutFee.)
-		// Allow a tolerance of 1 unit to handle precision issues
-		diff := u256.Zero().Sub(amountSpecified, resultAmountOut)
-		if diff.Gt(u256.NewUint(1)) {
-			panic(addDetailToError(
-				errSlippage,
-				ufmt.Sprintf("Received more than requested in [EXACT_OUT] requested=%s, actual=%s", amountSpecified.ToString(), resultAmountOut.ToString()),
-			))
+		//
+		// Allow a tolerance to handle precision issues.
+		//
+		// For ExactOut, we only need to check if the output is less than requested
+		// If it's more, that's actually better for the user
+		if resultAmountOut.Lt(amountSpecified) {
+			diff := u256.Zero().Sub(amountSpecified, resultAmountOut)
+			if diff.Gt(u256.NewUint(1)) {
+				panic(addDetailToError(
+					errSlippage,
+					ufmt.Sprintf("Received more than requested in [EXACT_OUT] requested=%s, actual=%s", amountSpecified.ToString(), resultAmountOut.ToString()),
+				))
+			}
 		}
 	}
 

--- a/contract/r/gnoswap/router/router.gno
+++ b/contract/r/gnoswap/router/router.gno
@@ -17,6 +17,8 @@ import (
 	"gno.land/r/gnoswap/v1/halt"
 )
 
+var errExactOutAmountExceeded = "Received more than requested in [EXACT_OUT] requested=%s, actual=%s"
+
 // commonSwapSetup Common validation and setup logic extracted from SwapRoute
 func commonSwapSetup() {
 	currentLevel := halt.GetCurrentHaltLevel()
@@ -93,71 +95,94 @@ func finalizeSwap(
 	userBeforeWugnotBalance, userWrappedWugnot uint64,
 	amountSpecified *u256.Uint,
 ) (string, string) {
+	// Validate exact out amount if applicable
 	if swapType == ExactOut {
-		// If the pool's raw output is less than user wants, fail fast.
-		//
-		// Allow a tolerance to handle precision issues.
-		//
-		// For ExactOut, we only need to check if the output is less than requested
-		// If it's more, that's actually better for the user
-		if resultAmountOut.Lt(amountSpecified) {
-			diff := u256.Zero().Sub(amountSpecified, resultAmountOut)
-			if diff.Gt(u256.NewUint(1)) {
-				panic(addDetailToError(
-					errSlippage,
-					ufmt.Sprintf("Received more than requested in [EXACT_OUT] requested=%s, actual=%s", amountSpecified.ToString(), resultAmountOut.ToString()),
-				))
-			}
+		if err := validateExactOutAmount(resultAmountOut, amountSpecified); err != nil {
+			panic(addDetailToError(errSlippage, err.Error()))
 		}
 	}
 
+	// Handle swap fee
 	resultAmountOutWithoutFee := handleSwapFee(outputToken, resultAmountOut)
 
+	// Get current wugnot balance
 	userNewWugnotBalance := wugnot.BalanceOf(std.PreviousRealm().Address())
+
+	// Handle GNOT token unwrapping
 	if inputToken == consts.GNOT {
-		totalBefore := userBeforeWugnotBalance + userWrappedWugnot
-		spend := totalBefore - userNewWugnotBalance
-
-		if spend > userWrappedWugnot {
-			// used existing wugnot
-			panic(addDetailToError(
-				errSlippage,
-				ufmt.Sprintf("too much wugnot spent (wrapped: %d, spend: %d)", userWrappedWugnot, spend),
-			))
-		}
-
-		// unwrap left amount
-		toUnwrap := userWrappedWugnot - spend
-		unwrap(toUnwrap)
+		handleGnotInputSwap(userBeforeWugnotBalance, userWrappedWugnot, userNewWugnotBalance)
 	} else if outputToken == consts.GNOT {
-		userRecvWugnot := uint64(userNewWugnotBalance - userBeforeWugnotBalance - userWrappedWugnot)
-		unwrap(userRecvWugnot)
+		handleGnotOutputSwap(userBeforeWugnotBalance, userWrappedWugnot, userNewWugnotBalance)
 	}
 
-	if swapType == ExactIn {
-		// The user gave a fixed input => we must ensure final out >= tokenAmountLimit
-		// resultAmountOutWithoutFee is the actual tokens user receives
-		if resultAmountOutWithoutFee.Lt(tokenAmountLimit) {
-			panic(addDetailToError(
-				errSlippage,
-				ufmt.Sprintf("ExactIn: too few received (min:%s, got:%s)", tokenAmountLimit.ToString(), resultAmountOutWithoutFee.ToString()),
-			))
-		}
-	} else {
-		// swapType == ExactOut
-		// The user wants to get at least "amountSpecified" final tokens,
-		if resultAmountIn.Gt(tokenAmountLimit) {
-			panic(addDetailToError(
-				errSlippage,
-				ufmt.Sprintf("ExactOut: too much spent (max:%s, used:%s)", tokenAmountLimit.ToString(), resultAmountIn.ToString()),
-			))
-		}
-	}
+	// Validate slippage
+	validateSlippage(swapType, resultAmountIn, resultAmountOutWithoutFee, tokenAmountLimit)
 
-	intAmountOut := i256.FromUint256(resultAmountOutWithoutFee) // final user out
+	// Calculate final amounts
+	intAmountOut := i256.FromUint256(resultAmountOutWithoutFee)
 	negativeOut := i256.Zero().Neg(intAmountOut).ToString()
 
 	return resultAmountIn.ToString(), negativeOut
+}
+
+// validateExactOutAmount validates if the output amount meets the specified requirements
+func validateExactOutAmount(resultAmountOut, amountSpecified *u256.Uint) error {
+	if resultAmountOut.Gte(amountSpecified) {
+		return nil
+	}
+
+	diff := u256.Zero().Sub(amountSpecified, resultAmountOut)
+	if diff.Gt(u256.NewUint(1)) {
+		return ufmt.Errorf(errExactOutAmountExceeded, amountSpecified.ToString(), resultAmountOut.ToString())
+	}
+	return nil
+}
+
+// handleGnotInputSwap handles the unwrapping logic for GNOT input tokens
+func handleGnotInputSwap(userBeforeWugnotBalance, userWrappedWugnot, userNewWugnotBalance uint64) {
+	totalBefore := userBeforeWugnotBalance + userWrappedWugnot
+	spend := totalBefore - userNewWugnotBalance
+
+	if spend > userWrappedWugnot {
+		panic(addDetailToError(
+			errSlippage,
+			ufmt.Sprintf("too much wugnot spent (wrapped: %d, spend: %d)",
+				userWrappedWugnot, spend),
+		))
+	}
+
+	toUnwrap := userWrappedWugnot - spend
+	unwrap(toUnwrap)
+}
+
+// handleGnotOutputSwap handles the unwrapping logic for GNOT output tokens
+func handleGnotOutputSwap(userBeforeWugnotBalance, userWrappedWugnot, userNewWugnotBalance uint64) {
+	userRecvWugnot := uint64(userNewWugnotBalance - userBeforeWugnotBalance - userWrappedWugnot)
+	unwrap(userRecvWugnot)
+}
+
+// validateSlippage checks if the swap amounts meet the slippage requirements
+func validateSlippage(swapType SwapType, resultAmountIn, resultAmountOutWithoutFee, tokenAmountLimit *u256.Uint) {
+	switch swapType {
+	case ExactIn:
+		if resultAmountOutWithoutFee.Lt(tokenAmountLimit) {
+			panic(addDetailToError(
+				errSlippage,
+				ufmt.Sprintf("ExactIn: too few received (min:%s, got:%s)",
+					tokenAmountLimit.ToString(), resultAmountOutWithoutFee.ToString()),
+			))
+		}
+	case ExactOut:
+		if resultAmountIn.Gt(tokenAmountLimit) {
+			panic(addDetailToError(
+				errSlippage,
+				ufmt.Sprintf("ExactOut: too much spent (max:%s, used:%s)",
+					tokenAmountLimit.ToString(), resultAmountIn.ToString()),
+			))
+		}
+	default:
+		panic("should not happen")
+	}
 }
 
 // validateRoutesAndQuotes validates the routes and quotes slices based on specific criteria.

--- a/contract/r/gnoswap/router/router_test.gno
+++ b/contract/r/gnoswap/router/router_test.gno
@@ -94,6 +94,20 @@ func TestFinalizeSwap(t *testing.T) {
 			expectError:             true,
 			errorMessage:            "too much wugnot spent",
 		},
+		{
+			name:                    "ExactOut: issue #2213",
+			inputToken:              "gno.land/r/gnoswap/v1/gns",
+			outputToken:             "gno.land/r/gnoswap/v1/test_token/usdc",
+			resultAmountIn:          newUint256("843455035"),
+			resultAmountOut:         newUint256("600901351"),
+			swapType:                ExactOut,
+			tokenAmountLimit:        newUint256("843455036"),
+			userBeforeWugnotBalance: 0,
+			userWrappedWugnot:       0,
+			amountSpecified:         newUint256("600901352"),
+			expectError:             true,
+			errorMessage:            "[GNOSWAP-ROUTER-002] slippage check failed || Received more than requested in [EXACT_OUT] requested=600901352, actual=600901351",
+		},
 	}
 
 	for _, tt := range tests {

--- a/contract/r/gnoswap/router/router_test.gno
+++ b/contract/r/gnoswap/router/router_test.gno
@@ -95,9 +95,9 @@ func TestFinalizeSwap(t *testing.T) {
 			errorMessage:            "too much wugnot spent",
 		},
 		{
-			name:                    "ExactOut: issue #2213",
-			inputToken:              "gno.land/r/gnoswap/v1/gns",
-			outputToken:             "gno.land/r/gnoswap/v1/test_token/usdc",
+			name:                    "ExactOut: Real world slippage error",
+			inputToken:              barPath,
+			outputToken:             bazPath,
 			resultAmountIn:          newUint256("843455035"),
 			resultAmountOut:         newUint256("600901351"),
 			swapType:                ExactOut,
@@ -105,8 +105,7 @@ func TestFinalizeSwap(t *testing.T) {
 			userBeforeWugnotBalance: 0,
 			userWrappedWugnot:       0,
 			amountSpecified:         newUint256("600901352"),
-			expectError:             true,
-			errorMessage:            "[GNOSWAP-ROUTER-002] slippage check failed || Received more than requested in [EXACT_OUT] requested=600901352, actual=600901351",
+			expectError:             false,
 		},
 	}
 

--- a/contract/r/gnoswap/router/tests/router_all_2_route_2_hop_test.gnoA
+++ b/contract/r/gnoswap/router/tests/router_all_2_route_2_hop_test.gnoA
@@ -18,29 +18,29 @@ import (
 	"gno.land/r/onbloc/qux"
 )
 
-func TestCreatePool(t *testing.T) {
+func TestRunAll2Route2Hop(t *testing.T) {
 	testing.SetRealm(adminRealm)
 
+	// create pool
 	gns.Approve(poolAddr, pl.GetPoolCreationFee()*2)
 
 	pl.CreatePool(barPath, bazPath, uint32(500), "130621891405341611593710811006") // tick =  10_000, ratio = 2.71814592682522526700950038502924144268035888671875
 	pl.CreatePool(bazPath, quxPath, uint32(500), "130621891405341611593710811006") // tick =  10_000, ratio = 2.71814592682522526700950038502924144268035888671875
-}
-
-func TestPositionMint(t *testing.T) {
-	// bar_baz_500 by admin
-	testing.SetRealm(adminRealm)
 
 	bar.Approve(poolAddr, consts.UINT64_MAX)
 	baz.Approve(poolAddr, consts.UINT64_MAX)
 	qux.Approve(poolAddr, consts.UINT64_MAX)
 
-	// Mint
 	positionId, liquidity, amount0, amount1 := pn.Mint(barPath, bazPath, uint32(500), int32(9000), int32(11000), "100000", "100000", "0", "0", max_timeout, adminAddr, adminAddr, "")
 	positionId, liquidity, amount0, amount1 = pn.Mint(bazPath, quxPath, uint32(500), int32(9000), int32(11000), "100000", "100000", "0", "0", max_timeout, adminAddr, adminAddr, "")
+
+	testDrySwapRouteBarQuxExactIn(t)
+	testSwapRouteBarQuxExactIn(t)
+	testDrySwapRouteBarQuxExactOut(t)
+	testSwapRouteBarQuxExactOut(t)
 }
 
-func TestDrySwapRouteBarQuxExactIn(t *testing.T) {
+func testDrySwapRouteBarQuxExactIn(t *testing.T) {
 	testing.SetRealm(adminRealm)
 
 	_, dryResult, _ := DrySwapRoute(
@@ -56,7 +56,7 @@ func TestDrySwapRouteBarQuxExactIn(t *testing.T) {
 	uassert.Equal(t, dryResult, "7337")
 }
 
-func TestSwapRouteBarQuxExactIn(t *testing.T) {
+func testSwapRouteBarQuxExactIn(t *testing.T) {
 	testing.SetRealm(adminRealm)
 
 	bar.Approve(poolAddr, 10000)
@@ -77,7 +77,7 @@ func TestSwapRouteBarQuxExactIn(t *testing.T) {
 	uassert.Equal(t, amountOut, "-7318")
 }
 
-func TestDrySwapRouteBarQuxExactOut(t *testing.T) {
+func testDrySwapRouteBarQuxExactOut(t *testing.T) {
 	testing.SetRealm(adminRealm)
 
 	dryResult, _, _ := DrySwapRoute(
@@ -93,7 +93,7 @@ func TestDrySwapRouteBarQuxExactOut(t *testing.T) {
 	uassert.Equal(t, dryResult, "140")
 }
 
-func TestSwapRouteBarQuxExactOut(t *testing.T) {
+func testSwapRouteBarQuxExactOut(t *testing.T) {
 	testing.SetRealm(adminRealm)
 
 	amountIn, amountOut := ExactOutSwapRoute(

--- a/contract/r/gnoswap/router/tests/router_spec_#1_ExactIn_test.gnoA
+++ b/contract/r/gnoswap/router/tests/router_spec_#1_ExactIn_test.gnoA
@@ -18,7 +18,13 @@ import (
 	"gno.land/r/gnoswap/v1/gns"
 )
 
-func TestcreatePool(t *testing.T) {
+func TestRunExactInSwapRoute_1(t *testing.T) {
+	testcreatePool(t)
+	testPositionMint(t)
+	testExactInputSinglePool(t)
+}
+
+func testcreatePool(t *testing.T) {
 	testing.SetRealm(adminRealm)
 
 	gns.Approve(poolAddr, pl.GetPoolCreationFee())
@@ -27,7 +33,7 @@ func TestcreatePool(t *testing.T) {
 	bar.Transfer(user1Addr, 10000)
 }
 
-func TestPositionMint(t *testing.T) {
+func testPositionMint(t *testing.T) {
 	// bar_baz_3000 by admin
 	testing.SetRealm(adminRealm)
 	bar.Approve(poolAddr, 100000000)
@@ -49,7 +55,7 @@ func TestPositionMint(t *testing.T) {
 	// uassert.Equal(t, poolTick, int32(0)) // got -1, expected 0
 }
 
-func TestExactInputSinglePool(t *testing.T) {
+func testExactInputSinglePool(t *testing.T) {
 	// 0 -> 1
 	pool := pl.GetPool(barPath, bazPath, FEE_MEDIUM)
 	poolPath := "gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:3000"

--- a/contract/r/gnoswap/router/tests/router_spec_#2_ExactIn_test.gnoA
+++ b/contract/r/gnoswap/router/tests/router_spec_#2_ExactIn_test.gnoA
@@ -19,7 +19,6 @@ import (
 )
 
 func TestExactInputSinglePool1_to_0(t *testing.T) {
-	// ================================ Pool Setup & Add Liquidity================================================
 	testing.SetRealm(adminRealm)
 
 	gns.Approve(poolAddr, pl.GetPoolCreationFee())

--- a/contract/r/gnoswap/router/tests/router_spec_#3_ExactIn_test.gnoA
+++ b/contract/r/gnoswap/router/tests/router_spec_#3_ExactIn_test.gnoA
@@ -18,36 +18,25 @@ import (
 	"gno.land/r/onbloc/foo"
 )
 
-//=================================Test for SwapRouter exactInput 2 ->1 -> 0 in multi pool=================================
-
-func TestCreatePool(t *testing.T) {
+func TestRunExactInSwapRoute_3(t *testing.T) {
+	// create pool
 	testing.SetRealm(adminRealm)
 	gns.Approve(poolAddr, pl.GetPoolCreationFee()*2)
 
 	pl.CreatePool(barPath, bazPath, 3000, "79228162514264337593543950336")
-
 	pl.CreatePool(bazPath, fooPath, 3000, "79228162514264337593543950336")
 
-	// jsonOutput := pl.ApiGetPools()
-	// jsonStr := gjson.Parse(jsonOutput)
-	// uassert.Equal(t, len(jsonStr.Get("response").Array()), 2)
-}
-
-func TestPositionMint(t *testing.T) {
-	// bar_baz_3000 by admin
+	// position mint
 	testing.SetRealm(adminRealm)
 
 	bar.Approve(poolAddr, consts.UINT64_MAX)
 	baz.Approve(poolAddr, consts.UINT64_MAX)
 	foo.Approve(poolAddr, consts.UINT64_MAX)
 
-	// Mint
 	pn.Mint(barPath, bazPath, uint32(3000), int32(-887220), int32(887220), "1000000", "1000000", "0", "0", max_timeout, adminAddr, adminAddr, "")
 	pn.Mint(bazPath, fooPath, uint32(3000), int32(-887220), int32(887220), "1000000", "1000000", "0", "0", max_timeout, adminAddr, adminAddr, "")
-}
 
-func TestSwapRouteFooBarExactIn(t *testing.T) {
-	testing.SetRealm(adminRealm)
+	// exact in swap foo -> bar
 
 	bar.Approve(routerAddr, 1000000)
 	foo.Approve(routerAddr, 1000000)


### PR DESCRIPTION
# Description

The `ExactOutSwap` operation is failing with a slippage check error. The error occurs when there is a difference of just `1` unit between the requested output amount and the actual output amount.

```plain
[GNOSWAP-ROUTER-002] slippage check failed || Received more than requested in [EXACT_OUT] requested=600901352, actual=600901351
```

## Root Cause

The issue occurs from the precision handling in the `finalizeSwap` function. In the `ExactOut` swap type, the function checks if `resultAmountOut` is less than `amountSpecified`:

```go
if resultAmountOut.Lt(amountSpecified) {
    panic(addDetailToError(
        errSlippage,
        ufmt.Sprintf("Received more than requested in [EXACT_OUT] requested=%s, actual=%s", amountSpecified.ToString(), resultAmountOut.ToString()),
    ))
}
```

This check fails when there is even a 1-unit difference between the requested and actual amounts. Normally, in big number arithmetic, can lead to small differences due to rounding or truncation during calculations.