### PR TITLE
feat: Emit ticks information from Swap events

### DIFF
--- a/contract/r/gnoswap/pool/pool_type.gno
+++ b/contract/r/gnoswap/pool/pool_type.gno
@@ -1,7 +1,11 @@
 package pool
 
 import (
+	"strconv"
+	"strings"
+
 	"gno.land/p/demo/avl"
+	"gno.land/p/demo/ufmt"
 	u256 "gno.land/p/gnoswap/uint256"
 )
 
@@ -70,6 +74,30 @@ type Pool struct {
 	ticks                *avl.Tree  // tick(int32) -> TickInfo
 	tickBitmaps          *avl.Tree  // tick(wordPos)(int16) -> bitMap(tickWord ^ mask)(*u256.Uint)
 	positions            *avl.Tree  // maps the key (caller, lower tick, upper tick) to a unique position
+}
+
+func (p *Pool) Ticks() string {
+	if p.ticks == nil {
+		return "[]"
+	}
+
+	var result []string
+	p.ticks.Iterate("", "", func(key string, value interface{}) bool {
+		tick, err := strconv.ParseInt(key, 10, 32)
+		if err != nil {
+			return true
+		}
+		tickInfo := value.(TickInfo)
+		result = append(result, ufmt.Sprintf(
+			`{"tick":%d,"feeGrowthOutside0X128":"%s","feeGrowthOutside1X128":"%s"}`,
+			tick,
+			tickInfo.feeGrowthOutside0X128.ToString(),
+			tickInfo.feeGrowthOutside1X128.ToString(),
+		))
+		return true
+	})
+
+	return "[" + strings.Join(result, ",") + "]"
 }
 
 func (p *Pool) PoolPath() string {

--- a/contract/r/gnoswap/pool/swap.gno
+++ b/contract/r/gnoswap/pool/swap.gno
@@ -130,6 +130,7 @@ func Swap(
 		"feeGrowthGlobal1X128", pool.FeeGrowthGlobal1X128().ToString(),
 		"balanceToken0", pool.BalanceToken0().ToString(),
 		"balanceToken1", pool.BalanceToken1().ToString(),
+		"ticks", pool.Ticks(),
 	)
 
 	return result.Amount0.ToString(), result.Amount1.ToString()


### PR DESCRIPTION
### Enhancements to tick data handling:

* **Added `Ticks` method to `Pool` struct**: This method iterates over the `ticks` AVL tree, converts each tick's data into a JSON-like string format, and returns a concatenated string representation of all ticks. (`contract/r/gnoswap/pool/pool_type.gno`, [contract/r/gnoswap/pool/pool_type.gnoR79-R102](diffhunk://#diff-aff118d48fc271a85312e9706162cf06f2b8fd3a4e2b687f2a8286700c078b4bR79-R102))

* **Updated `Swap` function to include tick data**: The `Swap` function now calls the new `Ticks` method and includes the resulting tick data in its output. (`contract/r/gnoswap/pool/swap.gno`, [contract/r/gnoswap/pool/swap.gnoR133](diffhunk://#diff-2e80ee12d605a9afabc1424c74775545c4dfa7e0c7b7999a368069aa65b6a771R133))