### PR TITLE
hotfix: Temporary pin the gnolang version before interrealm

### DIFF
--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -41,7 +41,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: gnolang/gno
-          ref: master
+          # TODO: change to `master` when the interrealm issue is fixed
+          ref: a3bffb2eb311cc27c419b519146a9906b5a82dba
           path: ./gno
 
       - name: Set up Go


### PR DESCRIPTION
# Description

temporarily pin the repository reference to a before interrealm(https://github.com/gnolang/gno/pull/4060) commit instead of the `master` branch. 

Need to revert this change after the problem has been resolved.