### PR TITLE
GSW-2258 fix: referral time checks

### DIFF
--- a/contract/r/gnoswap/referral/global_keeper.gno
+++ b/contract/r/gnoswap/referral/global_keeper.gno
@@ -58,6 +58,7 @@ func TryRegister(addr std.Address, referral string) bool {
 		std.Emit(
 			EventRegisterFailed,
 			"address", addr.String(),
+			"error", err.Error(),
 		)
 		return false
 	}

--- a/contract/r/gnoswap/referral/keeper.gno
+++ b/contract/r/gnoswap/referral/keeper.gno
@@ -63,17 +63,27 @@ func (k *keeper) setReferral(addr, refAddr std.Address, eventType string) error 
 			return k.remove(addr)
 		}
 		refAddr = std.Address("")
-	} else {
-		if err := k.checkRateLimit(addr.String()); err != nil {
-			return err
-		}
 	}
 
-	k.store.Set(addr.String(), refAddr.String())
+	addrStr := addr.String()
+	refAddrStr := refAddr.String()
+	prevVal, prevExists := k.store.Get(addrStr)
+
+	k.store.Set(addrStr, refAddrStr)
+	if err := k.checkRateLimit(addrStr); err != nil {
+		// rollback: if there is a previous value, restore it, otherwise delete it
+		if prevExists {
+			k.store.Set(addrStr, prevVal)
+		} else {
+			k.store.Remove(addrStr)
+		}
+		return err
+	}
+
 	std.Emit(
 		eventType,
-		"myAddress", addr.String(),
-		"refAddress", refAddr.String(),
+		"myAddress", addrStr,
+		"refAddress", refAddrStr,
 	)
 
 	return nil

--- a/contract/r/gnoswap/referral/keeper.gno
+++ b/contract/r/gnoswap/referral/keeper.gno
@@ -14,8 +14,9 @@ const (
 
 // keeper implements the `ReferralKeeper` interface using an AVL tree for storage.
 type keeper struct {
-	store   *avl.Tree
-	lastOps map[string]int64
+	store      *avl.Tree
+	lastOps    map[string]int64
+	lastSuccess map[string]bool
 }
 
 // check interface implementation at compile time
@@ -25,8 +26,9 @@ var _ ReferralKeeper = &keeper{}
 // The keeper is initialized with an empty AVL tree for storing referral relationships.
 func NewKeeper() ReferralKeeper {
 	return &keeper{
-		store:   avl.NewTree(),
-		lastOps: make(map[string]int64),
+		store:      avl.NewTree(),
+		lastOps:    make(map[string]int64),
+		lastSuccess: make(map[string]bool),
 	}
 }
 
@@ -58,27 +60,26 @@ func (k *keeper) setReferral(addr, refAddr std.Address, eventType string) error 
 		return err
 	}
 
+	addrStr := addr.String()
+	refAddrStr := refAddr.String()
+
 	if refAddr == zeroAddress {
 		if k.has(addr) {
 			return k.remove(addr)
 		}
-		refAddr = std.Address("")
+		refAddr = zeroAddress
 	}
 
-	addrStr := addr.String()
-	refAddrStr := refAddr.String()
-	prevVal, prevExists := k.store.Get(addrStr)
+	// check rate limit if the previous operation was successful
+	if k.lastSuccess[addrStr] {
+		if err := k.checkRateLimit(addrStr); err != nil {
+			return err
+		}
+	}
 
 	k.store.Set(addrStr, refAddrStr)
-	if err := k.checkRateLimit(addrStr); err != nil {
-		// rollback: if there is a previous value, restore it, otherwise delete it
-		if prevExists {
-			k.store.Set(addrStr, prevVal)
-		} else {
-			k.store.Remove(addrStr)
-		}
-		return err
-	}
+	k.lastSuccess[addrStr] = true
+	k.lastOps[addrStr] = time.Now().Unix()
 
 	std.Emit(
 		eventType,
@@ -178,6 +179,5 @@ func (k *keeper) checkRateLimit(addr string) error {
 		}
 	}
 
-	k.lastOps[addr] = now
 	return nil
 }

--- a/contract/r/gnoswap/referral/keeper.gno
+++ b/contract/r/gnoswap/referral/keeper.gno
@@ -14,9 +14,8 @@ const (
 
 // keeper implements the `ReferralKeeper` interface using an AVL tree for storage.
 type keeper struct {
-	store      *avl.Tree
-	lastOps    map[string]int64
-	lastSuccess map[string]bool
+	store   *avl.Tree
+	lastOps map[string]int64
 }
 
 // check interface implementation at compile time
@@ -26,9 +25,8 @@ var _ ReferralKeeper = &keeper{}
 // The keeper is initialized with an empty AVL tree for storing referral relationships.
 func NewKeeper() ReferralKeeper {
 	return &keeper{
-		store:      avl.NewTree(),
-		lastOps:    make(map[string]int64),
-		lastSuccess: make(map[string]bool),
+		store:   avl.NewTree(),
+		lastOps: make(map[string]int64),
 	}
 }
 
@@ -68,17 +66,13 @@ func (k *keeper) setReferral(addr, refAddr std.Address, eventType string) error 
 			return k.remove(addr)
 		}
 		refAddr = zeroAddress
-	}
-
-	// check rate limit if the previous operation was successful
-	if k.lastSuccess[addrStr] {
+	} else {
 		if err := k.checkRateLimit(addrStr); err != nil {
 			return err
 		}
 	}
 
 	k.store.Set(addrStr, refAddrStr)
-	k.lastSuccess[addrStr] = true
 	k.lastOps[addrStr] = time.Now().Unix()
 
 	std.Emit(

--- a/contract/r/gnoswap/referral/keeper_test.gno
+++ b/contract/r/gnoswap/referral/keeper_test.gno
@@ -799,3 +799,37 @@ func TestGlobalIsEmpty(t *testing.T) {
 		})
 	}
 }
+
+func TestRetryAfterFailure(t *testing.T) {
+	k := setupKeeper()
+	cleanup := mockValidCaller()
+	defer cleanup()
+
+	invalidRef := std.Address("000000000001")
+	err := k.register(validAddr1, invalidRef)
+	if err == nil {
+		t.Error("should fail")
+	}
+
+	// trying to register with valid address
+	// should not check rate limit
+	err = k.register(validAddr1, validAddr2)
+	if err != nil {
+		t.Errorf("re-register failed: %v", err)
+	}
+
+	// check if registration is successful
+	refAddr, err := k.get(validAddr1)
+	if err != nil {
+		t.Errorf("check registration failed: %v", err)
+	}
+	if refAddr != validAddr2 {
+		t.Errorf("registered address is not correct: got %v, want %v", refAddr, validAddr2)
+	}
+
+	// check rate limit is applied
+	err = k.register(validAddr1, validAddr2)
+	if err == nil {
+		t.Error("should fail")
+	}
+}

--- a/contract/r/gnoswap/referral/keeper_test.gno
+++ b/contract/r/gnoswap/referral/keeper_test.gno
@@ -16,6 +16,8 @@ const STRESS_TEST_NUM = 10000 // arbitrary number
 var (
 	validAddr1  = testutils.TestAddress("valid1")
 	validAddr2  = testutils.TestAddress("valid2")
+	validAddr3  = testutils.TestAddress("valid3")
+	validAddr4  = testutils.TestAddress("valid4")
 	invalidAddr = testutils.TestAddress("invalid")
 )
 
@@ -805,31 +807,31 @@ func TestTryRegisterRetryAfterFailure(t *testing.T) {
 	defer cleanup()
 
 	invalidRef := "000000000001"
-	success := TryRegister(validAddr1, invalidRef)
+	success := TryRegister(validAddr3, invalidRef)
 	if success {
 		t.Error("should fail with invalid referral address")
 	}
 
-	validAddr2Str := validAddr2.String()
+	validAddrStr := validAddr4.String()
 
 	// trying to register with valid address
 	// should not check rate limit
-	success = TryRegister(validAddr1, validAddr2Str)
+	success = TryRegister(validAddr3, validAddrStr)
 	if !success {
 		t.Error("re-register should succeed with valid address")
 	}
 
 	// check if registration is successful
-	refAddr := GetReferral(validAddr1.String())
+	refAddr := GetReferral(validAddr3.String())
 	if refAddr == "" {
 		t.Error("should not be empty")
 	}
-	if refAddr != validAddr2Str {
-		t.Errorf("registered address is not correct: got %v, want %v", refAddr, validAddr2Str)
+	if refAddr != validAddrStr {
+		t.Errorf("registered address is not correct: got %v, want %v", refAddr, validAddrStr)
 	}
 
 	// check rate limit is applied
-	success = TryRegister(validAddr1, validAddr2Str)
+	success = TryRegister(validAddr3, validAddrStr)
 	if success {
 		t.Error("should fail due to rate limit")
 	}

--- a/contract/r/gnoswap/referral/keeper_test.gno
+++ b/contract/r/gnoswap/referral/keeper_test.gno
@@ -800,36 +800,37 @@ func TestGlobalIsEmpty(t *testing.T) {
 	}
 }
 
-func TestRetryAfterFailure(t *testing.T) {
-	k := setupKeeper()
+func TestTryRegisterRetryAfterFailure(t *testing.T) {
 	cleanup := mockValidCaller()
 	defer cleanup()
 
-	invalidRef := std.Address("000000000001")
-	err := k.register(validAddr1, invalidRef)
-	if err == nil {
-		t.Error("should fail")
+	invalidRef := "000000000001"
+	success := TryRegister(validAddr1, invalidRef)
+	if success {
+		t.Error("should fail with invalid referral address")
 	}
+
+	validAddr2Str := validAddr2.String()
 
 	// trying to register with valid address
 	// should not check rate limit
-	err = k.register(validAddr1, validAddr2)
-	if err != nil {
-		t.Errorf("re-register failed: %v", err)
+	success = TryRegister(validAddr1, validAddr2Str)
+	if !success {
+		t.Error("re-register should succeed with valid address")
 	}
 
 	// check if registration is successful
-	refAddr, err := k.get(validAddr1)
-	if err != nil {
-		t.Errorf("check registration failed: %v", err)
+	refAddr := GetReferral(validAddr1.String())
+	if refAddr == "" {
+		t.Error("should not be empty")
 	}
-	if refAddr != validAddr2 {
-		t.Errorf("registered address is not correct: got %v, want %v", refAddr, validAddr2)
+	if refAddr != validAddr2Str {
+		t.Errorf("registered address is not correct: got %v, want %v", refAddr, validAddr2Str)
 	}
 
 	// check rate limit is applied
-	err = k.register(validAddr1, validAddr2)
-	if err == nil {
-		t.Error("should fail")
+	success = TryRegister(validAddr1, validAddr2Str)
+	if success {
+		t.Error("should fail due to rate limit")
 	}
 }


### PR DESCRIPTION
# Description

The existing implementation had a condition that required waiting for 24 hours before attempting to register a referral again, even when the previous attempt had failed.

So, modified the code to store the success status along with the referral information for each address. Now, the time check is only performed when the previous referral registration was successful; otherwise, the check is skipped.

Additionally, I added an error field to the events emitted when the `TryRegister` function fails, so that the specific reason for failure is also output.

For example:

```json
[
  {
    "type": "ReferralRegistrationFailed",
    "attrs": [
      {
        "key": "address",
        "value": "g1weskc6tyx9047h6lta047h6lta047h6lwtjkk9"
      },
      {
        "key": "error",
        "value": "invalid address format"
      }
    ],
    "pkg_path": "gno.land/r/gnoswap/v1/referral",
    "func": "TryRegister"
  },
  {
    "type": "RegisterReferral",
    "attrs": [
      {
        "key": "myAddress",
        "value": "g1weskc6tyx9047h6lta047h6lta047h6lwtjkk9"
      },
      {
        "key": "refAddress",
        "value": "g1weskc6tyxf047h6lta047h6lta047h6lxjwum9"
      }
    ],
    "pkg_path": "gno.land/r/gnoswap/v1/referral",
    "func": "setReferral"
  },
  {
    "type": "ReferralRegistrationSuccess",
    "attrs": [
      {
        "key": "address",
        "value": "g1weskc6tyx9047h6lta047h6lta047h6lwtjkk9"
      },
      {
        "key": "referral",
        "value": "g1weskc6tyxf047h6lta047h6lta047h6lxjwum9"
      }
    ],
    "pkg_path": "gno.land/r/gnoswap/v1/referral",
    "func": "TryRegister"
  }
]
```