### PR TITLE
GSW-2260 feat(position): Update `Mint` function's event to include token balances

### DIFF
--- a/contract/r/gnoswap/position/position.gno
+++ b/contract/r/gnoswap/position/position.gno
@@ -155,6 +155,8 @@ func Mint(
 		"amount0", amount0.ToString(),
 		"amount1", amount1.ToString(),
 		"sqrtPriceX96", poolSqrtPriceX96,
+		"token0Balance", pl.PoolGetBalanceToken0(processedInput.poolPath),
+		"token1Balance", pl.PoolGetBalanceToken1(processedInput.poolPath),
 	)
 
 	return id, liquidity.ToString(), amount0.ToString(), amount1.ToString()


### PR DESCRIPTION
# Description

Update `Mint` function's event to emit the `token0Balance` and `token1Balance`. These values were retrieved directly from the pool via the pool path.

**Output**

```diff
{
  "type": "Mint",
  "attrs": [
    {
      "key": "prevAddr",
      "value": "g17290cwvmrapvp869xfnhhawa8sm9edpufzat7d"
    },
    {
      "key": "prevRealm",
      "value": ""
    },
    {
      "key": "tickLower",
      "value": "-887270"
    },
    {
      "key": "tickUpper",
      "value": "887270"
    },
    {
      "key": "poolPath",
      "value": "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500"
    },
    {
      "key": "mintTo",
      "value": "g17290cwvmrapvp869xfnhhawa8sm9edpufzat7d"
    },
    {
      "key": "caller",
      "value": "g17290cwvmrapvp869xfnhhawa8sm9edpufzat7d"
    },
    {
      "key": "lpPositionId",
      "value": "12"
    },
    {
      "key": "liquidity",
      "value": "50000"
    },
    {
      "key": "amount0",
      "value": "50000"
    },
    {
      "key": "amount1",
      "value": "50000"
    },
    {
      "key": "sqrtPriceX96",
      "value": "79228162514264337593543950336"
    },
+   {
+    "key": "token0Balance",
+     "value": "5819884"
+   },
+   {
+     "key": "token1Balance",
+     "value": "5819884"
+   }
  ],
  "pkg_path": "gno.land/r/gnoswap/v1/position",
  "func": "Mint"
}
```