### PR TITLE
fix: allow zero address registration without rate limit check

### DIFF
--- a/contract/r/gnoswap/referral/keeper.gno
+++ b/contract/r/gnoswap/referral/keeper.gno
@@ -70,10 +70,10 @@ func (k *keeper) setReferral(addr, refAddr std.Address, eventType string) error 
 			}
 		}
 		return nil
-	} else {
-		if err := k.checkRateLimit(addrStr); err != nil {
-			return err
-		}
+	}
+
+	if err := k.checkRateLimit(addrStr); err != nil {
+		return err
 	}
 
 	k.store.Set(addrStr, refAddrStr)

--- a/contract/r/gnoswap/referral/keeper.gno
+++ b/contract/r/gnoswap/referral/keeper.gno
@@ -63,9 +63,13 @@ func (k *keeper) setReferral(addr, refAddr std.Address, eventType string) error 
 
 	if refAddr == zeroAddress {
 		if k.has(addr) {
-			return k.remove(addr)
+			// remove only if the address is already registered
+			_, ok := k.store.Remove(addrStr)
+			if !ok {
+				return ErrNotFound
+			}
 		}
-		refAddr = zeroAddress
+		return nil
 	} else {
 		if err := k.checkRateLimit(addrStr); err != nil {
 			return err
@@ -108,8 +112,11 @@ func (k *keeper) remove(target std.Address) error {
 
 	tgt := target.String()
 
-	if err := k.checkRateLimit(tgt); err != nil {
-		return err
+	// do not check rate limit when removing with zeroAddress
+	if target != zeroAddress {
+		if err := k.checkRateLimit(tgt); err != nil {
+			return err
+		}
 	}
 
 	_, ok := k.store.Remove(tgt)

--- a/contract/r/gnoswap/referral/keeper.gno
+++ b/contract/r/gnoswap/referral/keeper.gno
@@ -112,11 +112,8 @@ func (k *keeper) remove(target std.Address) error {
 
 	tgt := target.String()
 
-	// do not check rate limit when removing with zeroAddress
-	if target != zeroAddress {
-		if err := k.checkRateLimit(tgt); err != nil {
-			return err
-		}
+	if err := k.checkRateLimit(tgt); err != nil {
+		return err
 	}
 
 	_, ok := k.store.Remove(tgt)

--- a/contract/r/gnoswap/referral/keeper_test.gno
+++ b/contract/r/gnoswap/referral/keeper_test.gno
@@ -848,7 +848,7 @@ func TestRegisterWithEmptyRefAddrAndThenValidRefAddr(t *testing.T) {
 	// try to register with empty refAddr
 	success := TryRegister(validAddr5, "")
 	if !success {
-		t.Error("empty refAddr registration should succeed")
+		t.Error("empty refAddr registration should be bypassed")
 	}
 
 	// try to register with valid address

--- a/contract/r/gnoswap/referral/keeper_test.gno
+++ b/contract/r/gnoswap/referral/keeper_test.gno
@@ -18,6 +18,10 @@ var (
 	validAddr2  = testutils.TestAddress("valid2")
 	validAddr3  = testutils.TestAddress("valid3")
 	validAddr4  = testutils.TestAddress("valid4")
+	validAddr5  = testutils.TestAddress("valid5")
+	validAddr6  = testutils.TestAddress("valid6")
+	validAddr7  = testutils.TestAddress("valid7")
+	validAddr8  = testutils.TestAddress("valid8")
 	invalidAddr = testutils.TestAddress("invalid")
 )
 
@@ -834,5 +838,59 @@ func TestTryRegisterRetryAfterFailure(t *testing.T) {
 	success = TryRegister(validAddr3, validAddrStr)
 	if success {
 		t.Error("should fail due to rate limit")
+	}
+}
+
+func TestRegisterWithEmptyRefAddrAndThenValidRefAddr(t *testing.T) {
+	cleanup := mockValidCaller()
+	defer cleanup()
+
+	// try to register with empty refAddr
+	success := TryRegister(validAddr5, "")
+	if !success {
+		t.Error("empty refAddr registration should succeed")
+	}
+
+	// try to register with valid address
+	validAddr6Str := validAddr6.String()
+	success = TryRegister(validAddr5, validAddr6Str)
+	if !success {
+		t.Error("should succeed with valid address after empty refAddr")
+	}
+
+	// check registered address
+	refAddr := GetReferral(validAddr5.String())
+	if refAddr != validAddr6Str {
+		t.Errorf("registered address is not correct: got %v, want %v", refAddr, validAddr6Str)
+	}
+}
+
+func TestRegisterWithValidRefAddrAndThenRemoveWithEmptyRefAddr(t *testing.T) {
+	cleanup := mockValidCaller()
+	defer cleanup()
+
+	// register with valid address
+	validAddrStr := validAddr7.String()
+	success := TryRegister(validAddr8, validAddrStr)
+	if !success {
+		t.Error("should succeed with valid address")
+	}
+
+	// check registered address
+	refAddr := GetReferral(validAddr8.String())
+	if refAddr != validAddrStr {
+		t.Errorf("registered address is not correct: got %v, want %v", refAddr, validAddrStr)
+	}
+
+	// remove with empty refAddr
+	success = TryRegister(validAddr8, "")
+	if !success {
+		t.Error("should succeed with empty refAddr to remove")
+	}
+
+	// check removed
+	refAddr = GetReferral(validAddr8.String())
+	if refAddr != "" {
+		t.Error("referral should be removed")
 	}
 }


### PR DESCRIPTION
# Description

When registering with zero address (`""`), the referral system was incorrectly applying rate limits.

Especially, after that case, subsequent registrations with valid addresses were rate limited.

This fix involves:
- Modifying the `setReferral` function to skip rate limit checks when the referral address is zero
- Ensuring that zero address registratins don't affect the rate limit state.