### PR TITLE
fix(gov/governance): Improve voting weight calculation to ensure fair participation for all delegators

### DIFF
--- a/contract/r/gnoswap/gov/governance/tests/governance_vote_gov_delegated_test.gnoA
+++ b/contract/r/gnoswap/gov/governance/tests/governance_vote_gov_delegated_test.gnoA
@@ -85,14 +85,14 @@ func proposeText(t *testing.T) {
 			proposal := pp.(ProposalInfo)
 
 			// 50% of voting xGNS supply
-			if proposal.QuorumAmount != 500000 {
-				t.Fatalf("proposal.QuorumAmount is not 500000")
+			if proposal.QuorumAmount != 1500000 {
+				t.Fatalf("proposal.QuorumAmount is not 1500000, got %d", proposal.QuorumAmount)
 			}
 
 			maxVotingWeight, _ := gs.GetPossibleVotingAddressWithWeight(proposal.State.CreatedAt - config.VotingWeightSmoothingDuration)
 			// config.VotingWeightSmoothingDuration = 10s = 5 block
 
-			uassert.Equal(t, maxVotingWeight, uint64(1000000))
+			uassert.Equal(t, maxVotingWeight, uint64(3000000))
 			// createdAt > 125 // 1234567894
 			// (createdAt - VotingWeightSmoothingDuration) > 120 // 1234567884
 			// no delegation happend until block 120

--- a/contract/r/gnoswap/gov/governance/tests/governance_vote_gov_delegated_undelegated_after_propose_before_vote_test.gnoA
+++ b/contract/r/gnoswap/gov/governance/tests/governance_vote_gov_delegated_undelegated_after_propose_before_vote_test.gnoA
@@ -100,12 +100,12 @@ func testProposeText(t *testing.T) {
 			pp, ok := proposals.Get(strconv.FormatUint(proposalID, 10))
 			uassert.True(t, ok)
 			proposal := pp.(ProposalInfo)
-			uassert.Equal(t, proposal.QuorumAmount, uint64(500000)) // 50% of voting xGNS supply
+			uassert.Equal(t, proposal.QuorumAmount, uint64(1500000)) // 50% of voting xGNS supply
 
 			maxVotingWeight, _ := gs.GetPossibleVotingAddressWithWeight(proposal.State.CreatedAt - config.VotingWeightSmoothingDuration)
 			// config.VotingWeightSmoothingDuration = 10s = 5 block
 
-			uassert.Equal(t, maxVotingWeight, uint64(1000000))
+			uassert.Equal(t, maxVotingWeight, uint64(3000000))
 			// createdAt > 125 // 1234567894
 			// (createdAt - VotingWeightSmoothingDuration) > 120 // 1234567884
 			// no delegation happend until block 120

--- a/contract/r/gnoswap/gov/governance/tests/governance_vote_gov_delegated_undelegated_before_propose_test.gnoA
+++ b/contract/r/gnoswap/gov/governance/tests/governance_vote_gov_delegated_undelegated_before_propose_test.gnoA
@@ -111,12 +111,13 @@ func testProposeText(t *testing.T) {
 			pp, ok := proposals.Get(strconv.FormatUint(proposalID, 10))
 			uassert.True(t, ok)
 			proposal := pp.(ProposalInfo)
-			uassert.Equal(t, proposal.QuorumAmount, uint64(500000))
+			// 50% of voting xGNS supply
+			uassert.Equal(t, proposal.QuorumAmount, uint64(1000000))
 
 			maxVotingWeight, _ := gs.GetPossibleVotingAddressWithWeight(proposal.State.CreatedAt - config.VotingWeightSmoothingDuration)
 			// config.VotingWeightSmoothingDuration = 10s = 5 block
 
-			uassert.Equal(t, maxVotingWeight, uint64(1000000))
+			uassert.Equal(t, maxVotingWeight, uint64(2000000))
 			// createdAt > 127 // 1234567898
 			// (createdAt - VotingWeightSmoothingDuration) > 122 // 1234567888
 			// no delegation happend until block 122

--- a/contract/r/gnoswap/gov/staker/api_history.gno
+++ b/contract/r/gnoswap/gov/staker/api_history.gno
@@ -9,6 +9,10 @@ import (
 )
 
 // GetPossibleVotingAddressWithWeight returns the max voting weight + and possible voting address with weight
+//
+// This function calculates voting weights for all delegators by using their latest delegation amounts
+// regardless of the endTimestamp. This ensures that all delegators can participate in voting
+// with their current delegation amounts, even if their records were updated after the endTimestamp.
 func GetPossibleVotingAddressWithWeight(endTimestamp uint64) (uint64, map[std.Address]uint64) {
 	if endTimestamp > uint64(time.Now().Unix()) {
 		panic(addDetailToError(
@@ -24,18 +28,18 @@ func GetPossibleVotingAddressWithWeight(endTimestamp uint64) (uint64, map[std.Ad
 		history := value.([]DelegationSnapShotHistory)
 		toAddr := std.Address(key)
 
-		for i := len(history) - 1; i >= 0; i-- {
-			record := history[i]
-
-			if record.updatedAt > endTimestamp {
-				continue
-			}
-
-			addressWithWeight[toAddr] = record.amount
-			totalWeight += record.amount
-
-			break
+		// skip when there is no delegation history
+		if len(history) == 0 {
+			return false
 		}
+
+		// find the latest delegation record
+		latestRecord := history[len(history)-1]
+
+		// use the latest delegation amount even if the record is updated after endTimestamp
+		// this ensures all delegators can participate in voting with their current delegation amounts
+		addressWithWeight[toAddr] = latestRecord.amount
+		totalWeight += latestRecord.amount
 
 		return false
 	})


### PR DESCRIPTION
## Description

Modifies the `GetPossibleVotingAddressWithWeight` function to ensure all delegators can participate in voting with their current delegation amounts, regardless of when their delegation records were last updated.

Previously, delegation records updated after the `endTimestamp` were ignored. This prevented some delegators from participating in voting even though they had valid delegation amounts. So, The time-based filtering created an unfair voting environment.

### Changes
- Removed the time-based filtering logic that ignored records after `endTimestamp`
    - Now using the latest delegation amount for each delegator