### PR TITLE
fix(position): `PositionIsInRange` range check

### DIFF
--- a/contract/r/gnoswap/position/getter.gno
+++ b/contract/r/gnoswap/position/getter.gno
@@ -63,10 +63,7 @@ func PositionIsInRange(positionId uint64) bool {
 	poolPath := position.poolKey
 	poolCurrentTick := pl.PoolGetSlot0Tick(poolPath)
 
-	if position.tickLower <= poolCurrentTick && poolCurrentTick <= position.tickUpper {
-		return true
-	}
-	return false
+	return position.tickLower <= poolCurrentTick && poolCurrentTick < position.tickUpper
 }
 
 func PositionGetPositionOwner(positionId uint64) std.Address {


### PR DESCRIPTION
# Description

In Uniswap V3, a position should no longer be considered active when the price moves to or beyond its upper tick boundary. However, the current implementation uses `<= position.tickUpper` for range checking, which incorrectly includes the upper boundary tick in the active range.

- Modified the range check condition from `<= position.tickUpper` to `< position.tickUpper`
- This ensures that positions are correctly marked as inactive once the current tick reaches the upper boundary