### PR TITLE
fix(staker): Add owner verification in `UnStakeToken`

### DIFF
--- a/contract/r/gnoswap/staker/errors.gno
+++ b/contract/r/gnoswap/staker/errors.gno
@@ -39,6 +39,7 @@ var (
 	errIncentiveNotFound           = errors.New("[GNOSWAP-STAKER-030] incentive not found")
 	errWarmUpAmountNotFound        = errors.New("[GNOSWAP-STAKER-031] warm-up amount not found")
 	errOverflow                    = errors.New("[GNOSWAP-STAKER-032] overflow")
+	errUnauthorized                = errors.New("[GNOSWAP-STAKER-033] unauthorized access")
 )
 
 func addDetailToError(err error, detail string) string {

--- a/contract/r/gnoswap/staker/staker.gno
+++ b/contract/r/gnoswap/staker/staker.gno
@@ -1,7 +1,6 @@
 package staker
 
 import (
-	"errors"
 	"std"
 	"time"
 

--- a/contract/r/gnoswap/staker/staker.gno
+++ b/contract/r/gnoswap/staker/staker.gno
@@ -1,6 +1,7 @@
 package staker
 
 import (
+	"errors"
 	"std"
 	"time"
 
@@ -225,7 +226,7 @@ func StakeToken(positionId uint64, referrer string) (string, string, string) {
 	assertOnlyNotHalted()
 	assertOnlyNotStaked(positionId)
 
-	en.MintAndDistributeGns() // en으로 묶이지 않게 callback으로 호출 => 등록된 function이 call 되야 함.
+	en.MintAndDistributeGns()
 
 	owner := gnft.MustOwnerOf(positionIdFrom(positionId))
 	caller := getPrevAddr()
@@ -552,8 +553,19 @@ func CollectReward(positionId uint64, unwrapResult bool) (string, string, map[st
 func UnStakeToken(positionId uint64, unwrapResult bool) (string, string, string) { // poolPath, token0Amount, token1Amount
 	assertOnlyNotHalted()
 
-	// unStaked status
+	// onwer check
 	deposit := deposits.Get(positionId)
+	caller := getPrevAddr()
+	if deposit.owner != caller {
+		panic(addDetailToError(
+			errUnauthorized,
+			ufmt.Sprintf("caller(%s) is not the owner(%s)", 
+				caller.String(), 
+				deposit.owner.String()),
+		))
+	}
+
+	// unStaked status
 	poolPath := deposit.targetPoolPath
 
 	// claim All Rewards

--- a/contract/r/gnoswap/staker/staker.gno
+++ b/contract/r/gnoswap/staker/staker.gno
@@ -552,7 +552,7 @@ func CollectReward(positionId uint64, unwrapResult bool) (string, string, map[st
 func UnStakeToken(positionId uint64, unwrapResult bool) (string, string, string) { // poolPath, token0Amount, token1Amount
 	assertOnlyNotHalted()
 
-	// onwer check
+	// Verify that the caller is the actual owner of the deposit to prevent unauthorized unstaking
 	deposit := deposits.Get(positionId)
 	caller := getPrevAddr()
 	if deposit.owner != caller {


### PR DESCRIPTION
# Description

The `UnStakerToken` allowed any caller to unstake tokens without verifying if they are the actual owner of the deposit. This could potentially lead to unauthorized withdrawal of staked tokens.

Thus, Added explicit owner verification in the `UnStakeToken` function.