### PR TITLE
fix: Prevent Fee Calculation Underflow

### DIFF
--- a/contract/p/gnoswap/gnsmath/swap_math.gno
+++ b/contract/p/gnoswap/gnsmath/swap_math.gno
@@ -33,6 +33,15 @@ func SwapMathComputeSwapStepStr(
 		panic("SwapMathComputeSwapStepStr: invalid input")
 	}
 
+	// This function is publicly accessible and can be called by external users or contracts.
+	// While the pool realm only uses predefined fee values (100, 500, 3000, 10000) which are safely within range,
+	// external callers could potentially pass any feePips value. The fee calculation involves subtracting feePips
+	// from 1000000 (representing 100%), and if feePips exceeds 1000000, it would cause an underflow,
+	// leading to incorrect fee calculations.
+	if feePips > 1000000 {
+		panic("SwapMathComputeSwapStepStr: feePips must be less than or equal to 1000000")
+	}
+
 	// zeroForOne determines swap direction based on the relationship of current vs. target
 	zeroForOne := sqrtRatioCurrentX96.Gte(sqrtRatioTargetX96)
 

--- a/contract/p/gnoswap/gnsmath/swap_math_test.gno
+++ b/contract/p/gnoswap/gnsmath/swap_math_test.gno
@@ -198,6 +198,23 @@ func TestSwapMathComputeSwapStepStrFail(t *testing.T) {
 			shouldPanic:     true,
 			expectedMessage: "SwapMathComputeSwapStepStr: invalid input",
 		},
+		{
+			name:            "feePips exceeds maximum allowed value",
+			currentX96:      encodePriceSqrtTest(t, "1", "1"),
+			targetX96:       encodePriceSqrtTest(t, "101", "100"),
+			liquidity:       u256.MustFromDecimal("2000000000000000000"),
+			amountRemaining: i256.MustFromDecimal("1000000000000000000"),
+			feePips:         1000001,
+			sqrtNextX96:     encodePriceSqrtTest(t, "101", "100"),
+			chkSqrtNextX96: func(sqrtRatioNextX96, priceTarget *u256.Uint) {
+				uassert.True(t, sqrtRatioNextX96.Eq(priceTarget))
+			},
+			amountIn:        "9975124224178055",
+			amountOut:       "9925619580021728",
+			feeAmount:       "5988667735148",
+			shouldPanic:     true,
+			expectedMessage: "SwapMathComputeSwapStepStr: feePips must be less than or equal to 1000000",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
# Description

Added a check to ensure that `feePips` does not exceed 1,000,000. If this limit is violated, the function will panic with an appropriate error message. This prevents underflow during fee calculations when subtracting `feePips` from 1,000,000.