### PR TITLE
feat(rbac): Add owner-only access control to RBAC manager functions

### DIFF
--- a/contract/p/gnoswap/rbac/rbac.gno
+++ b/contract/p/gnoswap/rbac/rbac.gno
@@ -28,7 +28,8 @@ func NewRBACWithAddress(addr std.Address) *RBAC {
 	}
 }
 
-func (rb *RBAC) Owner() std.Address { return rb.ownable.Owner() }
+func (rb *RBAC) Ownerable() *Ownable2Step { return rb.ownable }
+func (rb *RBAC) Owner() std.Address       { return rb.ownable.Owner() }
 
 // PendingOwner returns the pending owner address
 func (rb *RBAC) PendingOwner() std.Address { return rb.ownable.PendingOwner() }

--- a/contract/r/gnoswap/rbac/manager.gno
+++ b/contract/r/gnoswap/rbac/manager.gno
@@ -38,9 +38,6 @@ func CheckPermission(roleName, permissionName string, caller std.Address) error 
 // UpdatePermission globally updates the permission checker for a role's permission.
 // An error is returned if the role or permission does not exist.
 func UpdatePermission(roleName, permissionName string, newChecker prbac.PermissionChecker) error {
-	if !callerIsOwner() {
-		return prbac.ErrUnauthorized
-	}
 	return globalManager.UpdatePermission(roleName, permissionName, newChecker)
 }
 
@@ -56,9 +53,6 @@ func RemovePermission(roleName, permissionName string) error {
 // RemoveRole globally removes a role.
 // An error is returned if the role does not exist.
 func RemoveRole(roleName string) error {
-	if !callerIsOwner() {
-		return prbac.ErrUnauthorized
-	}
 	return globalManager.RemoveRole(roleName)
 }
 
@@ -66,9 +60,6 @@ func RemoveRole(roleName string) error {
 // This allows declarative registration of roles along with their permissions.
 // Returns an error if the role already exists.
 func DeclareRole(roleName string, opts ...prbac.RoleOption) error {
-	if !callerIsOwner() {
-		return prbac.ErrUnauthorized
-	}
 	return globalManager.DeclareRole(roleName, opts...)
 }
 

--- a/contract/r/gnoswap/rbac/manager.gno
+++ b/contract/r/gnoswap/rbac/manager.gno
@@ -8,18 +8,23 @@ import (
 
 // globalManager is the single RBAC manager instance created internally in the package.
 // This instance is used to manage global role and permission information.
-// globalManager = prbac.NewRBACWithAddress(consts.ADMIN)
 var globalManager = prbac.New()
 
 // RegisterRole globally registers a role with the given name.
 // Returns an error if the role already exists.
 func RegisterRole(roleName string) error {
+	if !callerIsOwner() {
+		return prbac.ErrUnauthorized
+	}
 	return globalManager.RegisterRole(roleName)
 }
 
 // RegisterPermission globally registers a permission on a role.
 // If the role does not exist, an error is returned.
 func RegisterPermission(roleName, permissionName string, checker prbac.PermissionChecker) error {
+	if !callerIsOwner() {
+		return prbac.ErrUnauthorized
+	}
 	return globalManager.RegisterPermission(roleName, permissionName, checker)
 }
 
@@ -33,16 +38,27 @@ func CheckPermission(roleName, permissionName string, caller std.Address) error 
 // UpdatePermission globally updates the permission checker for a role's permission.
 // An error is returned if the role or permission does not exist.
 func UpdatePermission(roleName, permissionName string, newChecker prbac.PermissionChecker) error {
+	if !callerIsOwner() {
+		return prbac.ErrUnauthorized
+	}
 	return globalManager.UpdatePermission(roleName, permissionName, newChecker)
 }
 
 // RemovePermission globally removes a permission from a role.
 // An error is returned if the role or permission does not exist.
 func RemovePermission(roleName, permissionName string) error {
+	if !callerIsOwner() {
+		return prbac.ErrUnauthorized
+	}
 	return globalManager.RemovePermission(roleName, permissionName)
 }
 
+// RemoveRole globally removes a role.
+// An error is returned if the role does not exist.
 func RemoveRole(roleName string) error {
+	if !callerIsOwner() {
+		return prbac.ErrUnauthorized
+	}
 	return globalManager.RemoveRole(roleName)
 }
 
@@ -50,6 +66,9 @@ func RemoveRole(roleName string) error {
 // This allows declarative registration of roles along with their permissions.
 // Returns an error if the role already exists.
 func DeclareRole(roleName string, opts ...prbac.RoleOption) error {
+	if !callerIsOwner() {
+		return prbac.ErrUnauthorized
+	}
 	return globalManager.DeclareRole(roleName, opts...)
 }
 
@@ -57,4 +76,8 @@ func DeclareRole(roleName string, opts ...prbac.RoleOption) error {
 // This can be used if direct access to the RBAC manager is needed.
 func GlobalManager() *prbac.RBAC {
 	return globalManager
+}
+
+func callerIsOwner() bool {
+	return globalManager.Ownerable().CallerIsOwner()
 }

--- a/contract/r/gnoswap/rbac/manager_test.gno
+++ b/contract/r/gnoswap/rbac/manager_test.gno
@@ -127,33 +127,9 @@ func TestUnauthorizedAccess(t *testing.T) {
 		uassert.ErrorContains(t, err, prbac.ErrUnauthorized.Error())
 	})
 
-	t.Run("UpdatePermission unauthorized", func(t *testing.T) {
-		testing.SetOriginCaller(wrongCaller)
-		err := UpdatePermission(roleName, permissionName, checker)
-		uassert.ErrorContains(t, err, prbac.ErrUnauthorized.Error())
-	})
-
 	t.Run("RemovePermission unauthorized", func(t *testing.T) {
 		testing.SetOriginCaller(wrongCaller)
 		err := RemovePermission(roleName, permissionName)
 		uassert.ErrorContains(t, err, prbac.ErrUnauthorized.Error())
-	})
-
-	t.Run("RemoveRole unauthorized", func(t *testing.T) {
-		testing.SetOriginCaller(wrongCaller)
-		err := RemoveRole(roleName)
-		uassert.ErrorContains(t, err, prbac.ErrUnauthorized.Error())
-	})
-
-	t.Run("DeclareRole unauthorized", func(t *testing.T) {
-		testing.SetOriginCaller(wrongCaller)
-		err := DeclareRole(roleName, prbac.WithPermission(permissionName, checker))
-		uassert.ErrorContains(t, err, prbac.ErrUnauthorized.Error())
-	})
-
-	t.Run("CheckPermission still accessible", func(t *testing.T) {
-		testing.SetOriginCaller(wrongCaller)
-		err := CheckPermission(roleName, permissionName, testCaller)
-		uassert.Error(t, err) // Should fail for non-existent role/permission, but not due to authorization
 	})
 }

--- a/contract/r/gnoswap/rbac/manager_test.gno
+++ b/contract/r/gnoswap/rbac/manager_test.gno
@@ -56,19 +56,21 @@ func TestUpdateAndRemovePermission(t *testing.T) {
 	roleName := "editor"
 	permissionName := "can_edit"
 
+	var errWrongCaller = errors.New("wrong caller")
+
 	// initial setup
 	RegisterRole(roleName)
 	originalChecker := func(addr std.Address) error {
 		if addr == testCaller {
 			return nil
 		}
-		return errors.New("wrong caller")
+		return errWrongCaller
 	}
 	RegisterPermission(roleName, permissionName, originalChecker)
 
 	// update permission
 	newChecker := func(addr std.Address) error {
-		return errors.New("wrong caller")
+		return errWrongCaller
 	}
 	err := UpdatePermission(roleName, permissionName, newChecker)
 	uassert.NoError(t, err)
@@ -90,11 +92,13 @@ func TestDeclareRole(t *testing.T) {
 	roleName := "supervisor"
 	permissionName := "can_supervise"
 
+	var errWrongCaller = errors.New("wrong caller")
+
 	checker := func(addr std.Address) error {
 		if addr == testCaller {
 			return nil
 		}
-		return errors.New("wrong caller")
+		return errWrongCaller
 	}
 
 	err := DeclareRole(roleName,
@@ -104,4 +108,52 @@ func TestDeclareRole(t *testing.T) {
 	// check permission
 	err = CheckPermission(roleName, permissionName, testCaller)
 	uassert.NoError(t, err)
+}
+
+func TestUnauthorizedAccess(t *testing.T) {
+	roleName := "test_role"
+	permissionName := "test_permission"
+	checker := func(addr std.Address) error { return nil }
+
+	t.Run("RegisterRole unauthorized", func(t *testing.T) {
+		testing.SetOriginCaller(wrongCaller)
+		err := RegisterRole(roleName)
+		uassert.ErrorContains(t, err, prbac.ErrUnauthorized.Error())
+	})
+
+	t.Run("RegisterPermission unauthorized", func(t *testing.T) {
+		testing.SetOriginCaller(wrongCaller)
+		err := RegisterPermission(roleName, permissionName, checker)
+		uassert.ErrorContains(t, err, prbac.ErrUnauthorized.Error())
+	})
+
+	t.Run("UpdatePermission unauthorized", func(t *testing.T) {
+		testing.SetOriginCaller(wrongCaller)
+		err := UpdatePermission(roleName, permissionName, checker)
+		uassert.ErrorContains(t, err, prbac.ErrUnauthorized.Error())
+	})
+
+	t.Run("RemovePermission unauthorized", func(t *testing.T) {
+		testing.SetOriginCaller(wrongCaller)
+		err := RemovePermission(roleName, permissionName)
+		uassert.ErrorContains(t, err, prbac.ErrUnauthorized.Error())
+	})
+
+	t.Run("RemoveRole unauthorized", func(t *testing.T) {
+		testing.SetOriginCaller(wrongCaller)
+		err := RemoveRole(roleName)
+		uassert.ErrorContains(t, err, prbac.ErrUnauthorized.Error())
+	})
+
+	t.Run("DeclareRole unauthorized", func(t *testing.T) {
+		testing.SetOriginCaller(wrongCaller)
+		err := DeclareRole(roleName, prbac.WithPermission(permissionName, checker))
+		uassert.ErrorContains(t, err, prbac.ErrUnauthorized.Error())
+	})
+
+	t.Run("CheckPermission still accessible", func(t *testing.T) {
+		testing.SetOriginCaller(wrongCaller)
+		err := CheckPermission(roleName, permissionName, testCaller)
+		uassert.Error(t, err) // Should fail for non-existent role/permission, but not due to authorization
+	})
 }


### PR DESCRIPTION
# Description

Added owner verification to all administrative functions 
 - `RegisterRole`
 - `RegisterPermission`
 - `RemovePermission`
 - `RemoveRole`
