### PR TITLE
CI: Use gno before xform2 version

### DIFF
--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -41,7 +41,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: gnolang/gno
-          ref: master
+          # ref: master
+          ref: 47d44988b47f9b7f05c34fe421f6166107487fe1 # before xform2
           path: ./gno
 
       - name: Set up Go


### PR DESCRIPTION
# Description

fixed to use gno before xform2 version on CI