### PR TITLE
fix(tokens): Remove gloval vars

### DIFF
--- a/contract/r/gnoswap/gns/gns.gno
+++ b/contract/r/gnoswap/gns/gns.gno
@@ -20,25 +20,19 @@ const (
 )
 
 var (
-	owner         *ownable.Ownable
-	token         *grc20.Token
-	privateLedger *grc20.PrivateLedger
-	UserTeller    grc20.Teller
+	adminAddr, _         = access.GetAddress(access.ROLE_ADMIN)
+	token, privateLedger = grc20.NewToken("Gnoswap", "GNS", 6)
+	UserTeller           = token.CallerTeller()
+	owner                = ownable.NewWithAddress(adminAddr)
 
 	leftEmissionAmount   int64 // amount of GNS can be minted for emission
 	mintedEmissionAmount int64 // amount of GNS that has been minted for emission
 	lastMintedHeight     int64 // last block height that gns was minted for emission
 
 	burnAmount int64 // amount of GNS that has been burned
-
-	adminAddr, _ = access.GetAddress(access.ROLE_ADMIN)
 )
 
 func init() {
-	owner = ownable.NewWithAddress(adminAddr)
-	token, privateLedger = grc20.NewToken("Gnoswap", "GNS", 6)
-	UserTeller = token.CallerTeller()
-
 	privateLedger.Mint(owner.Owner(), INITIAL_MINT_AMOUNT)
 	cross(grc20reg.Register)(token, "")
 

--- a/contract/r/gnoswap/test_token/bar/bar.gno
+++ b/contract/r/gnoswap/test_token/bar/bar.gno
@@ -12,44 +12,49 @@ import (
 )
 
 var (
-	Token, privateLedger = grc20.NewToken("Bar", "BAR", 6)
-	UserTeller           = Token.CallerTeller()
+	token, privateLedger = grc20.NewToken("Bar", "BAR", 6)
 	owner                = ownable.NewWithAddress("g17290cwvmrapvp869xfnhhawa8sm9edpufzat7d") // ADMIN
 )
 
 func init() {
 	privateLedger.Mint(owner.Owner(), 100_000_000_000_000)
-	cross(grc20reg.Register)(Token, "")
+	cross(grc20reg.Register)(token, "")
 }
 
 func TotalSupply() int64 {
 	crossing()
-	return UserTeller.TotalSupply()
+	userTeller := token.CallerTeller()
+	return userTeller.TotalSupply()
 }
 
 func BalanceOf(owner std.Address) int64 {
 	crossing()
-	return UserTeller.BalanceOf(owner)
+	userTeller := token.CallerTeller()
+	return userTeller.BalanceOf(owner)
 }
 
 func Allowance(owner, spender std.Address) int64 {
 	crossing()
-	return UserTeller.Allowance(owner, spender)
+	userTeller := token.CallerTeller()
+	return userTeller.Allowance(owner, spender)
 }
 
 func Transfer(to std.Address, amount int64) {
 	crossing()
-	checkErr(UserTeller.Transfer(to, amount))
+	userTeller := token.CallerTeller()
+	checkErr(userTeller.Transfer(to, amount))
 }
 
 func Approve(spender std.Address, amount int64) {
 	crossing()
-	checkErr(UserTeller.Approve(spender, amount))
+	userTeller := token.CallerTeller()
+	checkErr(userTeller.Approve(spender, amount))
 }
 
 func TransferFrom(from, to std.Address, amount int64) {
 	crossing()
-	checkErr(UserTeller.TransferFrom(from, to, amount))
+	userTeller := token.CallerTeller()
+	checkErr(userTeller.TransferFrom(from, to, amount))
 }
 
 func Burn(from std.Address, amount int64) {
@@ -65,10 +70,11 @@ func Render(path string) string {
 
 	switch {
 	case path == "":
-		return Token.RenderHome()
+		return token.RenderHome()
 	case c == 2 && parts[0] == "balance":
 		owner := std.Address(parts[1])
-		balance := UserTeller.BalanceOf(owner)
+		userTeller := token.CallerTeller()
+		balance := userTeller.BalanceOf(owner)
 		return ufmt.Sprintf("%d\n", balance)
 	default:
 		return "404\n"

--- a/contract/r/gnoswap/test_token/baz/baz.gno
+++ b/contract/r/gnoswap/test_token/baz/baz.gno
@@ -12,44 +12,49 @@ import (
 )
 
 var (
-	Token, privateLedger = grc20.NewToken("Baz", "BAZ", 6)
-	UserTeller           = Token.CallerTeller()
+	token, privateLedger = grc20.NewToken("Baz", "BAZ", 6)
 	owner                = ownable.NewWithAddress("g17290cwvmrapvp869xfnhhawa8sm9edpufzat7d") // ADMIN
 )
 
 func init() {
 	privateLedger.Mint(owner.Owner(), 100_000_000_000_000)
-	cross(grc20reg.Register)(Token, "")
+	cross(grc20reg.Register)(token, "")
 }
 
 func TotalSupply() int64 {
 	crossing()
-	return UserTeller.TotalSupply()
+	userTeller := token.CallerTeller()
+	return userTeller.TotalSupply()
 }
 
 func BalanceOf(owner std.Address) int64 {
 	crossing()
-	return UserTeller.BalanceOf(owner)
+	userTeller := token.CallerTeller()
+	return userTeller.BalanceOf(owner)
 }
 
 func Allowance(owner, spender std.Address) int64 {
 	crossing()
-	return UserTeller.Allowance(owner, spender)
+	userTeller := token.CallerTeller()
+	return userTeller.Allowance(owner, spender)
 }
 
 func Transfer(to std.Address, amount int64) {
 	crossing()
-	checkErr(UserTeller.Transfer(to, amount))
+	userTeller := token.CallerTeller()
+	checkErr(userTeller.Transfer(to, amount))
 }
 
 func Approve(spender std.Address, amount int64) {
 	crossing()
-	checkErr(UserTeller.Approve(spender, amount))
+	userTeller := token.CallerTeller()
+	checkErr(userTeller.Approve(spender, amount))
 }
 
 func TransferFrom(from, to std.Address, amount int64) {
 	crossing()
-	checkErr(UserTeller.TransferFrom(from, to, amount))
+	userTeller := token.CallerTeller()
+	checkErr(userTeller.TransferFrom(from, to, amount))
 }
 
 func Burn(from std.Address, amount int64) {
@@ -65,10 +70,11 @@ func Render(path string) string {
 
 	switch {
 	case path == "":
-		return Token.RenderHome()
+		return token.RenderHome()
 	case c == 2 && parts[0] == "balance":
 		owner := std.Address(parts[1])
-		balance := UserTeller.BalanceOf(owner)
+		userTeller := token.CallerTeller()
+		balance := userTeller.BalanceOf(owner)
 		return ufmt.Sprintf("%d\n", balance)
 	default:
 		return "404\n"

--- a/contract/r/gnoswap/test_token/foo/foo.gno
+++ b/contract/r/gnoswap/test_token/foo/foo.gno
@@ -12,44 +12,49 @@ import (
 )
 
 var (
-	Token, privateLedger = grc20.NewToken("Foo", "FOO", 6)
-	UserTeller           = Token.CallerTeller()
+	token, privateLedger = grc20.NewToken("Foo", "FOO", 6)
 	owner                = ownable.NewWithAddress("g17290cwvmrapvp869xfnhhawa8sm9edpufzat7d") // ADMIN
 )
 
 func init() {
 	privateLedger.Mint(owner.Owner(), 100_000_000_000_000)
-	cross(grc20reg.Register)(Token, "")
+	cross(grc20reg.Register)(token, "")
 }
 
 func TotalSupply() int64 {
 	crossing()
-	return UserTeller.TotalSupply()
+	userTeller := token.CallerTeller()
+	return userTeller.TotalSupply()
 }
 
 func BalanceOf(owner std.Address) int64 {
 	crossing()
-	return UserTeller.BalanceOf(owner)
+	userTeller := token.CallerTeller()
+	return userTeller.BalanceOf(owner)
 }
 
 func Allowance(owner, spender std.Address) int64 {
 	crossing()
-	return UserTeller.Allowance(owner, spender)
+	userTeller := token.CallerTeller()
+	return userTeller.Allowance(owner, spender)
 }
 
 func Transfer(to std.Address, amount int64) {
 	crossing()
-	checkErr(UserTeller.Transfer(to, amount))
+	userTeller := token.CallerTeller()
+	checkErr(userTeller.Transfer(to, amount))
 }
 
 func Approve(spender std.Address, amount int64) {
 	crossing()
-	checkErr(UserTeller.Approve(spender, amount))
+	userTeller := token.CallerTeller()
+	checkErr(userTeller.Approve(spender, amount))
 }
 
 func TransferFrom(from, to std.Address, amount int64) {
 	crossing()
-	checkErr(UserTeller.TransferFrom(from, to, amount))
+	userTeller := token.CallerTeller()
+	checkErr(userTeller.TransferFrom(from, to, amount))
 }
 
 func Burn(from std.Address, amount int64) {
@@ -65,10 +70,11 @@ func Render(path string) string {
 
 	switch {
 	case path == "":
-		return Token.RenderHome()
+		return token.RenderHome()
 	case c == 2 && parts[0] == "balance":
 		owner := std.Address(parts[1])
-		balance := UserTeller.BalanceOf(owner)
+		userTeller := token.CallerTeller()
+		balance := userTeller.BalanceOf(owner)
 		return ufmt.Sprintf("%d\n", balance)
 	default:
 		return "404\n"

--- a/contract/r/gnoswap/test_token/obl/obl.gno
+++ b/contract/r/gnoswap/test_token/obl/obl.gno
@@ -12,44 +12,49 @@ import (
 )
 
 var (
-	Token, privateLedger = grc20.NewToken("Obl", "OBL", 6)
-	UserTeller           = Token.CallerTeller()
+	token, privateLedger = grc20.NewToken("Obl", "OBL", 6)
 	owner                = ownable.NewWithAddress("g17290cwvmrapvp869xfnhhawa8sm9edpufzat7d") // ADMIN
 )
 
 func init() {
 	privateLedger.Mint(owner.Owner(), 100_000_000_000_000)
-	cross(grc20reg.Register)(Token, "")
+	cross(grc20reg.Register)(token, "")
 }
 
 func TotalSupply() int64 {
 	crossing()
-	return UserTeller.TotalSupply()
+	userTeller := token.CallerTeller()
+	return userTeller.TotalSupply()
 }
 
 func BalanceOf(owner std.Address) int64 {
 	crossing()
-	return UserTeller.BalanceOf(owner)
+	userTeller := token.CallerTeller()
+	return userTeller.BalanceOf(owner)
 }
 
 func Allowance(owner, spender std.Address) int64 {
 	crossing()
-	return UserTeller.Allowance(owner, spender)
+	userTeller := token.CallerTeller()
+	return userTeller.Allowance(owner, spender)
 }
 
 func Transfer(to std.Address, amount int64) {
 	crossing()
-	checkErr(UserTeller.Transfer(to, amount))
+	userTeller := token.CallerTeller()
+	checkErr(userTeller.Transfer(to, amount))
 }
 
 func Approve(spender std.Address, amount int64) {
 	crossing()
-	checkErr(UserTeller.Approve(spender, amount))
+	userTeller := token.CallerTeller()
+	checkErr(userTeller.Approve(spender, amount))
 }
 
 func TransferFrom(from, to std.Address, amount int64) {
 	crossing()
-	checkErr(UserTeller.TransferFrom(from, to, amount))
+	userTeller := token.CallerTeller()
+	checkErr(userTeller.TransferFrom(from, to, amount))
 }
 
 func Burn(from std.Address, amount int64) {
@@ -65,10 +70,11 @@ func Render(path string) string {
 
 	switch {
 	case path == "":
-		return Token.RenderHome()
+		return token.RenderHome()
 	case c == 2 && parts[0] == "balance":
 		owner := std.Address(parts[1])
-		balance := UserTeller.BalanceOf(owner)
+		userTeller := token.CallerTeller()
+		balance := userTeller.BalanceOf(owner)
 		return ufmt.Sprintf("%d\n", balance)
 	default:
 		return "404\n"

--- a/contract/r/gnoswap/test_token/qux/qux.gno
+++ b/contract/r/gnoswap/test_token/qux/qux.gno
@@ -12,44 +12,49 @@ import (
 )
 
 var (
-	Token, privateLedger = grc20.NewToken("Qux", "QUX", 6)
-	UserTeller           = Token.CallerTeller()
+	token, privateLedger = grc20.NewToken("Qux", "QUX", 6)
 	owner                = ownable.NewWithAddress("g17290cwvmrapvp869xfnhhawa8sm9edpufzat7d") // ADMIN
 )
 
 func init() {
 	privateLedger.Mint(owner.Owner(), 100_000_000_000_000)
-	cross(grc20reg.Register)(Token, "")
+	cross(grc20reg.Register)(token, "")
 }
 
 func TotalSupply() int64 {
 	crossing()
-	return UserTeller.TotalSupply()
+	userTeller := token.CallerTeller()
+	return userTeller.TotalSupply()
 }
 
 func BalanceOf(owner std.Address) int64 {
 	crossing()
-	return UserTeller.BalanceOf(owner)
+	userTeller := token.CallerTeller()
+	return userTeller.BalanceOf(owner)
 }
 
 func Allowance(owner, spender std.Address) int64 {
 	crossing()
-	return UserTeller.Allowance(owner, spender)
+	userTeller := token.CallerTeller()
+	return userTeller.Allowance(owner, spender)
 }
 
 func Transfer(to std.Address, amount int64) {
 	crossing()
-	checkErr(UserTeller.Transfer(to, amount))
+	userTeller := token.CallerTeller()
+	checkErr(userTeller.Transfer(to, amount))
 }
 
 func Approve(spender std.Address, amount int64) {
 	crossing()
-	checkErr(UserTeller.Approve(spender, amount))
+	userTeller := token.CallerTeller()
+	checkErr(userTeller.Approve(spender, amount))
 }
 
 func TransferFrom(from, to std.Address, amount int64) {
 	crossing()
-	checkErr(UserTeller.TransferFrom(from, to, amount))
+	userTeller := token.CallerTeller()
+	checkErr(userTeller.TransferFrom(from, to, amount))
 }
 
 func Burn(from std.Address, amount int64) {
@@ -65,10 +70,11 @@ func Render(path string) string {
 
 	switch {
 	case path == "":
-		return Token.RenderHome()
+		return token.RenderHome()
 	case c == 2 && parts[0] == "balance":
 		owner := std.Address(parts[1])
-		balance := UserTeller.BalanceOf(owner)
+		userTeller := token.CallerTeller()
+		balance := userTeller.BalanceOf(owner)
 		return ufmt.Sprintf("%d\n", balance)
 	default:
 		return "404\n"

--- a/contract/r/gnoswap/test_token/usdc/usdc.gno
+++ b/contract/r/gnoswap/test_token/usdc/usdc.gno
@@ -12,44 +12,49 @@ import (
 )
 
 var (
-	Token, privateLedger = grc20.NewToken("Usd Coin", "USDC", 6)
-	UserTeller           = Token.CallerTeller()
+	token, privateLedger = grc20.NewToken("Usd Coin", "USDC", 6)
 	owner                = ownable.NewWithAddress("g17290cwvmrapvp869xfnhhawa8sm9edpufzat7d") // ADMIN
 )
 
 func init() {
 	privateLedger.Mint(owner.Owner(), 100_000_000_000_000)
-	cross(grc20reg.Register)(Token, "")
+	cross(grc20reg.Register)(token, "")
 }
 
 func TotalSupply() int64 {
 	crossing()
-	return UserTeller.TotalSupply()
+	userTeller := token.CallerTeller()
+	return userTeller.TotalSupply()
 }
 
 func BalanceOf(owner std.Address) int64 {
 	crossing()
-	return UserTeller.BalanceOf(owner)
+	userTeller := token.CallerTeller()
+	return userTeller.BalanceOf(owner)
 }
 
 func Allowance(owner, spender std.Address) int64 {
 	crossing()
-	return UserTeller.Allowance(owner, spender)
+	userTeller := token.CallerTeller()
+	return userTeller.Allowance(owner, spender)
 }
 
 func Transfer(to std.Address, amount int64) {
 	crossing()
-	checkErr(UserTeller.Transfer(to, amount))
+	userTeller := token.CallerTeller()
+	checkErr(userTeller.Transfer(to, amount))
 }
 
 func Approve(spender std.Address, amount int64) {
 	crossing()
-	checkErr(UserTeller.Approve(spender, amount))
+	userTeller := token.CallerTeller()
+	checkErr(userTeller.Approve(spender, amount))
 }
 
 func TransferFrom(from, to std.Address, amount int64) {
 	crossing()
-	checkErr(UserTeller.TransferFrom(from, to, amount))
+	userTeller := token.CallerTeller()
+	checkErr(userTeller.TransferFrom(from, to, amount))
 }
 
 func Burn(from std.Address, amount int64) {
@@ -65,10 +70,11 @@ func Render(path string) string {
 
 	switch {
 	case path == "":
-		return Token.RenderHome()
+		return token.RenderHome()
 	case c == 2 && parts[0] == "balance":
 		owner := std.Address(parts[1])
-		balance := UserTeller.BalanceOf(owner)
+		userTeller := token.CallerTeller()
+		balance := userTeller.BalanceOf(owner)
 		return ufmt.Sprintf("%d\n", balance)
 	default:
 		return "404\n"


### PR DESCRIPTION
# Description

The existing test token implementation was storing and using `UserTeller` as a global variable, which could lead to unintended behavior, so it was changed to have each function directly retrieve and process the corresponding value.