### PR TITLE
fix(test): missing realm arguments in emission tests

### DIFF
--- a/contract/r/gnoswap/emission/distribution_test.gno
+++ b/contract/r/gnoswap/emission/distribution_test.gno
@@ -205,6 +205,7 @@ func TestChangeDistributionPcts(t *testing.T) {
 	callbackStakerEmissionChange = func(amount int64) {}
 
 	changeDistributionPcts(
+		cross,
 		1, 1000,
 		2, 2000,
 		3, 3000,


### PR DESCRIPTION
## Descriptions

This PR fixes missing realm arguments in emission tests by adding the required `cross` parameter to the `changeDistributionPcts` function call in the test suite.

## Key Changes

### Function Call Update

**`TestChangeDistributionPcts` in `distribution_test.gno`:**
```go
// Before
changeDistributionPcts(
    1, 1000,
    2, 2000,
    3, 3000,
    4, 4000,
)

// After
changeDistributionPcts(
    cross,
    1, 1000,
    2, 2000,
    3, 3000,
    4, 4000,
)
```

## Technical Details

### Issue Resolution

The test was failing because the `changeDistributionPcts` function requires a realm parameter (`cross`) as its first argument, but the test was not providing it. This fix ensures that:

1. **Proper Realm Context**: The function now receives the required realm context for cross-realm operations
2. **Test Compatibility**: The test now matches the expected function signature
3. **Consistent Architecture**: Follows the established pattern of passing realm parameters in Gno

### Impact

- **Test Reliability**: Fixes failing tests in the emission module
- **Code Consistency**: Aligns with the realm-based architecture pattern used throughout the codebase
- **Maintainability**: Ensures tests properly validate the function behavior with correct parameters

## Files Changed

- `contract/r/gnoswap/emission/distribution_test.gno`

## Testing

The fix ensures that emission distribution tests run successfully without missing realm argument errors.