### PR TITLE
fix: add caller parameters in position methods

### DIFF
--- a/contract/r/gnoswap/gnft/testutils.gno
+++ b/contract/r/gnoswap/gnft/testutils.gno
@@ -1,0 +1,17 @@
+package gnft
+
+import (
+	"testing"
+
+	"gno.land/p/demo/avl"
+	"gno.land/p/demo/grc/grc721"
+)
+
+func InitGNFTTest(t *testing.T) {
+	t.Helper()
+
+	func(cur realm) {
+		nft = grc721.NewBasicNFT("GNOSWAP NFT", "GNFT")
+		tokenList = avl.NewTree()
+	}(cross)
+}

--- a/contract/r/gnoswap/pool/_helper_test.gno
+++ b/contract/r/gnoswap/pool/_helper_test.gno
@@ -380,13 +380,13 @@ func MintPositionAll(t *testing.T, caller std.Address) {
 			fee3000,
 			p.tickLower,
 			p.tickUpper,
-			"100000000",  // liquidityAmount
-			"100000000",  // unused
-			"0",          // unused
-			"0",          // unused
-			max_timeout,  // unused
-			caller,       // mintTo (recipient)
-			caller)       // positionCaller
+			"100000000", // liquidityAmount
+			"100000000", // unused
+			"0",         // unused
+			"0",         // unused
+			max_timeout, // unused
+			caller,      // mintTo (recipient)
+			caller)      // positionCaller
 	}
 }
 

--- a/contract/r/gnoswap/pool/getter_test.gno
+++ b/contract/r/gnoswap/pool/getter_test.gno
@@ -299,47 +299,87 @@ func TestPoolGetters(t *testing.T) {
 }
 
 func TestPositionGetters(t *testing.T) {
-	testInitData(t)
+	tests := []struct {
+		name                             string
+		poolPath                         string
+		positionKey                      string
+		expectedLiquidity                string
+		expectedFeeGrowthInside0LastX128 string
+		expectedFeeGrowthInside1LastX128 string
+		expectedTokensOwed0              string
+		expectedTokensOwed1              string
+		expectedHasAbort                 bool
+		expectedAbortMessage             string
+	}{
+		{
+			name:                             "position getters is success by valid position",
+			poolPath:                         "token0:token1:3000",
+			positionKey:                      "test_position",
+			expectedLiquidity:                "1000000",
+			expectedFeeGrowthInside0LastX128: "2000000",
+			expectedFeeGrowthInside1LastX128: "3000000",
+			expectedTokensOwed0:              "4000000",
+			expectedTokensOwed1:              "5000000",
+			expectedHasAbort:                 false,
+		},
+		{
+			name:                             "position getters is failed by invalid position",
+			poolPath:                         "token0:token1:3000",
+			positionKey:                      "invalid_position",
+			expectedLiquidity:                "0",
+			expectedFeeGrowthInside0LastX128: "0",
+			expectedFeeGrowthInside1LastX128: "0",
+			expectedTokensOwed0:              "0",
+			expectedTokensOwed1:              "0",
+			expectedHasAbort:                 true,
+			expectedAbortMessage:             "[GNOSWAP-POSITION-009] position is not clear || position(1) isn't clear(liquidity:3812338, tokensOwed0:0, tokensOwed1:0)",
+		},
+	}
 
-	t.Run("valid position", func(t *testing.T) {
-		validPoolPath := "token0:token1:3000"
-		validPositionKey := "test_position"
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initPositionTest(t)
+			testInitData(t)
 
-		t.Run("get position liquidity", func(t *testing.T) {
-			liquidity := PoolGetPositionLiquidity(validPoolPath, validPositionKey)
-			if liquidity != "1000000" {
-				t.Errorf("Expected liquidity [%s], got %s", "1000000", liquidity)
+			var liquidity u256.Uint
+			var feeGrowthInside0LastX128 u256.Uint
+			var feeGrowthInside1LastX128 u256.Uint
+			var tokensOwed0 u256.Uint
+			var tokensOwed1 u256.Uint
+
+			if tt.expectedHasAbort {
+				uassert.AbortsWithMessage(t, tt.expectedAbortMessage, func() {
+					PoolGetPositionLiquidity(tt.poolPath, tt.positionKey)
+				})
+				uassert.AbortsWithMessage(t, tt.expectedAbortMessage, func() {
+					PoolGetPositionFeeGrowthInside0LastX128(tt.poolPath, tt.positionKey)
+				})
+				uassert.AbortsWithMessage(t, tt.expectedAbortMessage, func() {
+					PoolGetPositionFeeGrowthInside1LastX128(tt.poolPath, tt.positionKey)
+				})
+				uassert.AbortsWithMessage(t, tt.expectedAbortMessage, func() {
+					PoolGetPositionTokensOwed0(tt.poolPath, tt.positionKey)
+				})
+				uassert.AbortsWithMessage(t, tt.expectedAbortMessage, func() {
+					PoolGetPositionTokensOwed1(tt.poolPath, tt.positionKey)
+				})
+
+				return
+			} else {
+				liquidity = PoolGetPositionLiquidity(tt.poolPath, tt.positionKey)
+				feeGrowthInside0LastX128 = PoolGetPositionFeeGrowthInside0LastX128(tt.poolPath, tt.positionKey)
+				feeGrowthInside1LastX128 = PoolGetPositionFeeGrowthInside1LastX128(tt.poolPath, tt.positionKey)
+				tokensOwed0 = PoolGetPositionTokensOwed0(tt.poolPath, tt.positionKey)
+				tokensOwed1 = PoolGetPositionTokensOwed1(tt.poolPath, tt.positionKey)
 			}
-		})
 
-		t.Run("get position fee growth inside0 last x128", func(t *testing.T) {
-			feeGrowthInside0LastX128 := PoolGetPositionFeeGrowthInside0LastX128(validPoolPath, validPositionKey)
-			if feeGrowthInside0LastX128 != "2000000" {
-				t.Errorf("Expected fee growth inside0 last x128 [%s], got %s", "2000000", feeGrowthInside0LastX128)
-			}
+			uassert.Equal(t, tt.expectedLiquidity, liquidity.ToString())
+			uassert.Equal(t, tt.expectedFeeGrowthInside0LastX128, feeGrowthInside0LastX128.ToString())
+			uassert.Equal(t, tt.expectedFeeGrowthInside1LastX128, feeGrowthInside1LastX128.ToString())
+			uassert.Equal(t, tt.expectedTokensOwed0, tokensOwed0.ToString())
+			uassert.Equal(t, tt.expectedTokensOwed1, tokensOwed1.ToString())
 		})
-
-		t.Run("get position fee growth inside1 last x128", func(t *testing.T) {
-			feeGrowthInside1LastX128 := PoolGetPositionFeeGrowthInside1LastX128(validPoolPath, validPositionKey)
-			if feeGrowthInside1LastX128 != "3000000" {
-				t.Errorf("Expected fee growth inside1 last x128 [%s], got %s", "3000000", feeGrowthInside1LastX128)
-			}
-		})
-
-		t.Run("get position tokens owed0", func(t *testing.T) {
-			tokensOwed0 := PoolGetPositionTokensOwed0(validPoolPath, validPositionKey)
-			if tokensOwed0 != "4000000" {
-				t.Errorf("Expected tokens owed0 [%s], got %s", "4000000", tokensOwed0)
-			}
-		})
-
-		t.Run("get position tokens owed1", func(t *testing.T) {
-			tokensOwed1 := PoolGetPositionTokensOwed1(validPoolPath, validPositionKey)
-			if tokensOwed1 != "5000000" {
-				t.Errorf("Expected tokens owed1 [%s], got %s", "5000000", tokensOwed1)
-			}
-		})
-	})
+	}
 
 	t.Run("invalid position", func(t *testing.T) {
 		validPoolPath := "token0:token1:3000"        // pool must valid

--- a/contract/r/gnoswap/pool/pool.gno
+++ b/contract/r/gnoswap/pool/pool.gno
@@ -68,7 +68,7 @@ func Mint(cur realm,
 
 	pool := GetPool(token0Path, token1Path, fee)
 	liquidityDelta := safeConvertToInt128(liquidity)
-	positionParam := newModifyPositionParams(recipient, tickLower, tickUpper, liquidityDelta)
+	positionParam := newModifyPositionParams(positionCaller, tickLower, tickUpper, liquidityDelta)
 	_, amount0, amount1 := pool.modifyPosition(positionParam)
 
 	if amount0.Gt(u256.Zero()) {
@@ -110,6 +110,7 @@ func Burn(
 	tickLower int32,
 	tickUpper int32,
 	liquidityAmount string, // uint128
+	positionCaller std.Address,
 ) (string, string) { // uint256 x2
 	assertOnlyNotHalted()
 	if common.GetLimitCaller() {
@@ -117,11 +118,10 @@ func Burn(
 	}
 	pool := GetPool(token0Path, token1Path, fee)
 
-	caller := getPrevAddr()
 	liqAmount := u256.MustFromDecimal(liquidityAmount)
 	liqAmountInt256 := safeConvertToInt128(liqAmount)
 	liqDelta := i256.Zero().Neg(liqAmountInt256)
-	posParams := newModifyPositionParams(caller, tickLower, tickUpper, liqDelta)
+	posParams := newModifyPositionParams(positionCaller, tickLower, tickUpper, liqDelta)
 	position, amount0, amount1 := pool.modifyPosition(posParams)
 
 	if amount0.Gt(u256.Zero()) || amount1.Gt(u256.Zero()) {
@@ -131,7 +131,7 @@ func Burn(
 		position.tokensOwed1 = new(u256.Uint).Add(position.tokensOwed1, amount1)
 	}
 
-	positionKey := getPositionKey(caller, tickLower, tickUpper)
+	positionKey := getPositionKey(positionCaller, tickLower, tickUpper)
 	pool.setPosition(positionKey, position)
 
 	// mustGetPosition() is called to ensure the position exists

--- a/contract/r/gnoswap/pool/testutils.gno
+++ b/contract/r/gnoswap/pool/testutils.gno
@@ -1,0 +1,18 @@
+package pool
+
+import (
+	"testing"
+
+	"gno.land/p/demo/avl"
+)
+
+func InitPoolTest(t *testing.T) {
+	t.Helper()
+
+	func(cur realm) {
+		pools = avl.NewTree()
+		slot0FeeProtocol = 0
+		poolCreationFee = 100_000_000
+		withdrawalFeeBPS = 100
+	}(cross)
+}

--- a/contract/r/gnoswap/position/_helper_test.gno
+++ b/contract/r/gnoswap/position/_helper_test.gno
@@ -447,11 +447,8 @@ func MakeMintPositionWithoutFee(t *testing.T) (uint64, string, string, string) {
 
 func LPTokenApprove(t *testing.T, owner, operator std.Address, positionId uint64) {
 	t.Helper()
-	testing.SetRealm(std.NewUserRealm(owner))
-	func() {
-		testing.SetRealm(std.NewCodeRealm("gno.land/r/gnoswap/v1/gnft"))
-		gnft.Approve(cross, operator, positionIdFrom(positionId))
-	}()
+	testing.SetOriginCaller(owner)
+	gnft.Approve(cross, operator, positionIdFrom(positionId))
 }
 
 // func LPTokenStake(t *testing.T, owner std.Address, positionId uint64) {

--- a/contract/r/gnoswap/position/api_test.gno
+++ b/contract/r/gnoswap/position/api_test.gno
@@ -13,8 +13,6 @@ func setupPositions(t *testing.T) {
 }
 
 func TestApiGetPositions_ResponseStructure(t *testing.T) {
-	setupPositions(t)
-
 	tests := []struct {
 		name         string
 		apiCall      func() string
@@ -59,18 +57,19 @@ func TestApiGetPositions_ResponseStructure(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			initPositionTest(t)
+			setupPositions(t)
+
 			if tt.setRealm {
 				testing.SetRealm(adminRealm)
 			}
+
 			runApiTest(t, tt.apiCall, tt.expectedSize, tt.validator)
 		})
 	}
 }
 
 func TestApiGetPositionsFee(t *testing.T) {
-	initPositionTest(t)
-	setupPositions(t)
-
 	tests := []struct {
 		name         string
 		apiCall      func() string
@@ -101,6 +100,9 @@ func TestApiGetPositionsFee(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			initPositionTest(t)
+			setupPositions(t)
+
 			runApiTest(t, tt.apiCall, tt.expectedSize, tt.validator)
 		})
 	}

--- a/contract/r/gnoswap/position/api_test.gno
+++ b/contract/r/gnoswap/position/api_test.gno
@@ -68,6 +68,7 @@ func TestApiGetPositions_ResponseStructure(t *testing.T) {
 }
 
 func TestApiGetPositionsFee(t *testing.T) {
+	initPositionTest(t)
 	setupPositions(t)
 
 	tests := []struct {

--- a/contract/r/gnoswap/position/burn.gno
+++ b/contract/r/gnoswap/position/burn.gno
@@ -43,7 +43,7 @@ func decreaseLiquidity(params DecreaseLiquidityParams) (uint64, *u256.Uint, *u25
 	beforeWugnotBalance := wugnot.BalanceOf(caller) // before unwrap
 
 	pToken0, pToken1, pFee := splitOf(position.poolKey)
-	burn0, burn1 := pl.Burn(cross, pToken0, pToken1, pFee, position.tickLower, position.tickUpper, liquidityToRemove.ToString())
+	burn0, burn1 := pl.Burn(cross, pToken0, pToken1, pFee, position.tickLower, position.tickUpper, liquidityToRemove.ToString(), params.caller)
 
 	burnedAmount0 := u256.MustFromDecimal(burn0)
 	burnedAmount1 := u256.MustFromDecimal(burn1)

--- a/contract/r/gnoswap/position/burn.gno
+++ b/contract/r/gnoswap/position/burn.gno
@@ -17,8 +17,10 @@ import (
 func decreaseLiquidity(params DecreaseLiquidityParams) (uint64, *u256.Uint, *u256.Uint, *u256.Uint, *u256.Uint, *u256.Uint, string) {
 	verifyTokenIdAndOwnership(params.positionId)
 
+	caller := params.caller
+
 	// BEFORE DECREASE LIQUIDITY, COLLECT FEE FIRST
-	_, fee0Str, fee1Str, _, _, _ := CollectFee(cross, params.positionId, params.unwrapResult)
+	_, fee0Str, fee1Str, _, _, _ := CollectFee(cross, params.positionId, params.unwrapResult, params.caller)
 	fee0 := u256.MustFromDecimal(fee0Str)
 	fee1 := u256.MustFromDecimal(fee1Str)
 
@@ -39,17 +41,16 @@ func decreaseLiquidity(params DecreaseLiquidityParams) (uint64, *u256.Uint, *u25
 		))
 	}
 
-	caller := getPrevAddr()
 	beforeWugnotBalance := wugnot.BalanceOf(caller) // before unwrap
 
 	pToken0, pToken1, pFee := splitOf(position.poolKey)
-	burn0, burn1 := pl.Burn(cross, pToken0, pToken1, pFee, position.tickLower, position.tickUpper, liquidityToRemove.ToString(), params.caller)
+	burn0, burn1 := pl.Burn(cross, pToken0, pToken1, pFee, position.tickLower, position.tickUpper, liquidityToRemove.ToString(), caller)
 
 	burnedAmount0 := u256.MustFromDecimal(burn0)
 	burnedAmount1 := u256.MustFromDecimal(burn1)
 	verifySlippageAmounts(burnedAmount0, burnedAmount1, params.amount0Min, params.amount1Min)
 
-	positionKey := computePositionKey(GetOrigPkgAddr(), position.tickLower, position.tickUpper)
+	positionKey := computePositionKey(caller, position.tickLower, position.tickUpper)
 	pool := pl.GetPoolFromPoolPath(position.poolKey)
 	feeGrowthInside0LastX128 := new(u256.Uint).Set(pool.PositionFeeGrowthInside0LastX128(positionKey))
 	feeGrowthInside1LastX128 := new(u256.Uint).Set(pool.PositionFeeGrowthInside1LastX128(positionKey))

--- a/contract/r/gnoswap/position/burn.gno
+++ b/contract/r/gnoswap/position/burn.gno
@@ -20,7 +20,7 @@ func decreaseLiquidity(params DecreaseLiquidityParams) (uint64, *u256.Uint, *u25
 	caller := params.caller
 
 	// BEFORE DECREASE LIQUIDITY, COLLECT FEE FIRST
-	_, fee0Str, fee1Str, _, _, _ := CollectFee(cross, params.positionId, params.unwrapResult, params.caller)
+	_, fee0Str, fee1Str, _, _, _ := collectFee(cross, params.positionId, params.unwrapResult, params.caller)
 	fee0 := u256.MustFromDecimal(fee0Str)
 	fee1 := u256.MustFromDecimal(fee1Str)
 

--- a/contract/r/gnoswap/position/getter_test.gno
+++ b/contract/r/gnoswap/position/getter_test.gno
@@ -44,7 +44,7 @@ func TestPositionGetter(t *testing.T) {
 		expected any
 	}{
 		{
-			name: "GetPosition - poolKey",
+			name: "get position is success by poolKey",
 			testFunc: func() any {
 				position := PositionGetPosition(positionId)
 				return position.poolKey
@@ -52,7 +52,7 @@ func TestPositionGetter(t *testing.T) {
 			expected: poolKey,
 		},
 		{
-			name: "GetPosition - tickLower",
+			name: "get position is success by tickLower",
 			testFunc: func() any {
 				position := PositionGetPosition(positionId)
 				return position.tickLower
@@ -60,7 +60,7 @@ func TestPositionGetter(t *testing.T) {
 			expected: int32(-10000),
 		},
 		{
-			name: "GetPosition - tickUpper",
+			name: "get position is success by tickUpper",
 			testFunc: func() any {
 				position := PositionGetPosition(positionId)
 				return position.tickUpper
@@ -68,7 +68,7 @@ func TestPositionGetter(t *testing.T) {
 			expected: int32(10000),
 		},
 		{
-			name: "GetPosition - liquidity",
+			name: "get position is success by liquidity",
 			testFunc: func() any {
 				position := PositionGetPosition(positionId)
 				return position.liquidity.ToString()
@@ -76,7 +76,7 @@ func TestPositionGetter(t *testing.T) {
 			expected: "1000000",
 		},
 		{
-			name: "GetPosition - feeGrowthInside0LastX128",
+			name: "get position is success by feeGrowthInside0LastX128",
 			testFunc: func() any {
 				position := PositionGetPosition(positionId)
 				return position.feeGrowthInside0LastX128.ToString()
@@ -84,7 +84,7 @@ func TestPositionGetter(t *testing.T) {
 			expected: "0",
 		},
 		{
-			name: "GetPosition - feeGrowthInside1LastX128",
+			name: "get position is success by feeGrowthInside1LastX128",
 			testFunc: func() any {
 				position := PositionGetPosition(positionId)
 				return position.feeGrowthInside1LastX128.ToString()
@@ -92,7 +92,7 @@ func TestPositionGetter(t *testing.T) {
 			expected: "0",
 		},
 		{
-			name: "GetPosition - tokensOwed0",
+			name: "get position is success by tokensOwed0",
 			testFunc: func() any {
 				position := PositionGetPosition(positionId)
 				return position.tokensOwed0.ToString()
@@ -100,7 +100,7 @@ func TestPositionGetter(t *testing.T) {
 			expected: "0",
 		},
 		{
-			name: "GetPosition - tokensOwed1",
+			name: "get position is success by tokensOwed1",
 			testFunc: func() any {
 				position := PositionGetPosition(positionId)
 				return position.tokensOwed1.ToString()
@@ -108,7 +108,7 @@ func TestPositionGetter(t *testing.T) {
 			expected: "0",
 		},
 		{
-			name: "GetPosition - burned",
+			name: "get position is success by burned",
 			testFunc: func() any {
 				position := PositionGetPosition(positionId)
 				return position.burned
@@ -116,133 +116,133 @@ func TestPositionGetter(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "GetPositionNonce",
+			name: "get position is success by nonce",
 			testFunc: func() any {
 				return PositionGetPositionNonce(positionId).ToString()
 			},
 			expected: "0",
 		},
 		{
-			name: "GetPositionOperator",
+			name: "get position is success by operator",
 			testFunc: func() any {
 				return PositionGetPositionOperator(positionId)
 			},
 			expected: positionAddr,
 		},
 		{
-			name: "GetPositionPoolKey",
+			name: "get position is success by poolKey",
 			testFunc: func() any {
 				return PositionGetPositionPoolKey(positionId)
 			},
 			expected: poolKey,
 		},
 		{
-			name: "GetPositionTickLower",
+			name: "get position is success by tickLower",
 			testFunc: func() any {
 				return PositionGetPositionTickLower(positionId)
 			},
 			expected: int32(-10000),
 		},
 		{
-			name: "GetPositionTickUpper",
+			name: "get position is success by tickUpper",
 			testFunc: func() any {
 				return PositionGetPositionTickUpper(positionId)
 			},
 			expected: int32(10000),
 		},
 		{
-			name: "GetPositionLiquidity",
+			name: "get position is success by liquidity",
 			testFunc: func() any {
 				return PositionGetPositionLiquidity(positionId).ToString()
 			},
 			expected: "1000000",
 		},
 		{
-			name: "GetPositionFeeGrowthInside0LastX128",
+			name: "get position is success by feeGrowthInside0LastX128",
 			testFunc: func() any {
 				return PositionGetPositionFeeGrowthInside0LastX128(positionId).ToString()
 			},
 			expected: "0",
 		},
 		{
-			name: "GetPositionFeeGrowthInside1LastX128",
+			name: "get position is success by feeGrowthInside1LastX128",
 			testFunc: func() any {
 				return PositionGetPositionFeeGrowthInside1LastX128(positionId).ToString()
 			},
 			expected: "0",
 		},
 		{
-			name: "GetPositionTokensOwed0",
+			name: "get position is success by tokensOwed0",
 			testFunc: func() any {
 				return PositionGetPositionTokensOwed0(positionId).ToString()
 			},
 			expected: "0",
 		},
 		{
-			name: "GetPositionTokensOwed1",
+			name: "get position is success by tokensOwed1",
 			testFunc: func() any {
 				return PositionGetPositionTokensOwed1(positionId).ToString()
 			},
 			expected: "0",
 		},
 		{
-			name: "GetPositionIsBurned",
+			name: "get position is success by isBurned",
 			testFunc: func() any {
 				return PositionGetPositionIsBurned(positionId)
 			},
 			expected: false,
 		},
 		{
-			name: "IsInRange",
+			name: "get position is success by isInRange",
 			testFunc: func() any {
 				return PositionIsInRange(positionId)
 			},
 			expected: true,
 		},
 		{
-			name: "GetPositionNonceStr",
+			name: "get position is success by nonceStr",
 			testFunc: func() any {
 				return PositionGetPositionNonceStr(positionId)
 			},
 			expected: "0",
 		},
 		{
-			name: "GetPositionOperatorStr",
+			name: "get position is success by operatorStr",
 			testFunc: func() any {
 				return PositionGetPositionOperatorStr(positionId)
 			},
 			expected: string(positionAddr),
 		},
 		{
-			name: "GetPositionLiquidityStr",
+			name: "get position is success by liquidityStr",
 			testFunc: func() any {
 				return PositionGetPositionLiquidityStr(positionId)
 			},
 			expected: "1000000",
 		},
 		{
-			name: "GetPositionFeeGrowthInside0LastX128Str",
+			name: "get position is success by feeGrowthInside0LastX128Str",
 			testFunc: func() any {
 				return PositionGetPositionFeeGrowthInside0LastX128Str(positionId)
 			},
 			expected: "0",
 		},
 		{
-			name: "GetPositionFeeGrowthInside1LastX128Str",
+			name: "get position is success by feeGrowthInside1LastX128Str",
 			testFunc: func() any {
 				return PositionGetPositionFeeGrowthInside1LastX128Str(positionId)
 			},
 			expected: "0",
 		},
 		{
-			name: "GetPositionTokensOwed0Str",
+			name: "get position is success by tokensOwed0Str",
 			testFunc: func() any {
 				return PositionGetPositionTokensOwed0Str(positionId)
 			},
 			expected: "0",
 		},
 		{
-			name: "GetPositionTokensOwed1Str",
+			name: "get position is success by tokensOwed1Str",
 			testFunc: func() any {
 				return PositionGetPositionTokensOwed1Str(positionId)
 			},

--- a/contract/r/gnoswap/position/getter_test.gno
+++ b/contract/r/gnoswap/position/getter_test.gno
@@ -33,6 +33,8 @@ func setupPositionGetter(t *testing.T) {
 }
 
 func TestPositionGetter(t *testing.T) {
+	initPositionTest(t)
+
 	positionId := uint64(1)
 	setupPositionGetter(t)
 

--- a/contract/r/gnoswap/position/liquidity_management_test.gno
+++ b/contract/r/gnoswap/position/liquidity_management_test.gno
@@ -33,7 +33,7 @@ func TestAddLiquidity(t *testing.T) {
 		expectedMessage string
 	}{
 		{
-			name: "Successful Liquidity Addition",
+			name: "add liquidity is success by successful liquidity addition",
 			params: AddLiquidityParams{
 				poolKey:        poolKey,
 				tickLower:      -600,
@@ -49,7 +49,7 @@ func TestAddLiquidity(t *testing.T) {
 			expectedAmount1: "1000000",
 		},
 		{
-			name: "Invalid slippage amount, should panic",
+			name: "add liquidity is failed by invalid slippage amount",
 			params: AddLiquidityParams{
 				poolKey:        poolKey,
 				tickLower:      -600,
@@ -65,7 +65,7 @@ func TestAddLiquidity(t *testing.T) {
 			expectedMessage: "[GNOSWAP-POSITION-002] slippage failed || Price Slippage Check(amount0(1000000) >= amount0Min(1100000), amount1(1000000) >= amount1Min(2200000))",
 		},
 		{
-			name: "Zero Liquidity, should abort",
+			name: "add liquidity is failed by zero liquidity",
 			params: AddLiquidityParams{
 				poolKey:        poolKey,
 				tickLower:      -100,
@@ -83,7 +83,7 @@ func TestAddLiquidity(t *testing.T) {
 			expectedMessage: "[GNOSWAP-POOL-010] zero liquidity",
 		},
 		{
-			name: "Invalid Tick Range Test (tickLower > tickUpper)",
+			name: "add liquidity is failed by invalid tick range",
 			params: AddLiquidityParams{
 				poolKey:        poolKey,
 				tickLower:      600,
@@ -99,7 +99,7 @@ func TestAddLiquidity(t *testing.T) {
 			expectedMessage: "[GNOSWAP-POOL-024] tickLower is greater than or equal to tickUpper || tickLower(600), tickUpper(-600)",
 		},
 		{
-			name: "Non-existent Pool Test",
+			name: "add liquidity is failed by non-existent pool",
 			params: AddLiquidityParams{
 				poolKey:        "invalid/pool/path",
 				tickLower:      -600,
@@ -115,7 +115,7 @@ func TestAddLiquidity(t *testing.T) {
 			expectedMessage: "[GNOSWAP-POOL-008] requested data not found || expected poolPath(invalid/pool/path) to exist",
 		},
 		{
-			name: "Insufficient Balance Test",
+			name: "add liquidity is failed by insufficient balance",
 			params: AddLiquidityParams{
 				poolKey:        poolKey,
 				tickLower:      -600,
@@ -131,7 +131,7 @@ func TestAddLiquidity(t *testing.T) {
 			expectedMessage: "[GNOSWAP-POOL-021] token transfer failed || insufficient balance",
 		},
 		{
-			name: "Same Tick Range Test",
+			name: "add liquidity is failed by same tick range",
 			params: AddLiquidityParams{
 				poolKey:        poolKey,
 				tickLower:      0,
@@ -150,6 +150,8 @@ func TestAddLiquidity(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			initPositionTest(t)
+
 			initialSetup(t)
 			testing.SetRealm(posRealm)
 			TokenApprove(t, gnsPath, alice, poolAddr, tt.params.amount0Desired.Int64())

--- a/contract/r/gnoswap/position/mint.gno
+++ b/contract/r/gnoswap/position/mint.gno
@@ -256,8 +256,8 @@ func processTokens(
 
 func increaseLiquidity(params IncreaseLiquidityParams) (uint64, *u256.Uint, *u256.Uint, *u256.Uint, string) {
 	// verify position ID exists
+	caller := params.caller
 	assertTokenExists(params.positionId)
-	caller := getPrevAddr()
 	assertOnlyOwnerOfToken(params.positionId, caller)
 
 	position := MustGetPosition(params.positionId)
@@ -275,7 +275,7 @@ func increaseLiquidity(params IncreaseLiquidityParams) (uint64, *u256.Uint, *u25
 	)
 
 	pool := pl.GetPoolFromPoolPath(position.poolKey)
-	positionKey := computePositionKey(GetOrigPkgAddr(), position.tickLower, position.tickUpper)
+	positionKey := computePositionKey(caller, position.tickLower, position.tickUpper)
 	feeGrowthInside0LastX128 := new(u256.Uint).Set(pool.PositionFeeGrowthInside0LastX128(positionKey))
 	feeGrowthInside1LastX128 := new(u256.Uint).Set(pool.PositionFeeGrowthInside1LastX128(positionKey))
 

--- a/contract/r/gnoswap/position/mint.gno
+++ b/contract/r/gnoswap/position/mint.gno
@@ -75,7 +75,7 @@ func mint(params MintParams) (uint64, *u256.Uint, *u256.Uint, *u256.Uint) {
 	gnft.Mint(cross, params.mintTo, positionIdFrom(id)) // owner, position ID
 
 	pool := pl.GetPoolFromPoolPath(poolKey)
-	positionKey := computePositionKey(GetOrigPkgAddr(), params.tickLower, params.tickUpper)
+	positionKey := computePositionKey(params.caller, params.tickLower, params.tickUpper)
 
 	position := Position{
 		nonce:                    u256.Zero(),

--- a/contract/r/gnoswap/position/mint_test.gno
+++ b/contract/r/gnoswap/position/mint_test.gno
@@ -24,7 +24,7 @@ func TestMintInternal_PositionMint(t *testing.T) {
 		expectedAmount1   string
 	}{
 		{
-			name: "successful mint",
+			name: "mint is success by successful mint",
 			params: MintParams{
 				token0:         "gno.land/r/onbloc/bar",
 				token1:         "gno.land/r/onbloc/baz",
@@ -45,7 +45,7 @@ func TestMintInternal_PositionMint(t *testing.T) {
 			expectedAmount1:   "100000",
 		},
 		{
-			name: "zero liquidity should fail",
+			name: "mint is failed by zero liquidity",
 			params: MintParams{
 				token0:         "gno.land/r/onbloc/bar",
 				token1:         "gno.land/r/onbloc/baz",

--- a/contract/r/gnoswap/position/mint_test.gno
+++ b/contract/r/gnoswap/position/mint_test.gno
@@ -66,6 +66,8 @@ func TestMintInternal_PositionMint(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			initPositionTest(t)
+
 			testing.SetRealm(adminRealm)
 			pl.SetPoolCreationFeeByAdmin(cross, 0)
 			CreatePool(t, tt.params.token0, tt.params.token1, tt.params.fee, "79228162514264337593543950336", adminAddr)

--- a/contract/r/gnoswap/position/native_token_test.gno
+++ b/contract/r/gnoswap/position/native_token_test.gno
@@ -21,7 +21,7 @@ func TestTransferUGNOT(t *testing.T) {
 		shouldPanic bool
 	}{
 		{
-			name: "Success - Zero amount",
+			name: "transferUGNOT is success by zero amount",
 			action: func(t *testing.T, from, to std.Address) {
 				transferUGNOT(from, to, 0)
 			},
@@ -34,7 +34,7 @@ func TestTransferUGNOT(t *testing.T) {
 			shouldPanic: false,
 		},
 		{
-			name: "Success - Valid transfer",
+			name: "transferUGNOT is success by valid transfer",
 			action: func(t *testing.T, from, to std.Address) {
 				ugnotFaucet(t, from, 100)
 				testing.SetRealm(std.NewUserRealm(from))
@@ -78,7 +78,7 @@ func TestWrapInPosition(t *testing.T) {
 		expectedErrMsg string
 	}{
 		{
-			name: "Failure - Amount less than minimum",
+			name: "wrap is failed by amount less than minimum",
 			action: func(t *testing.T, from, to std.Address) error {
 				return wrap(999, to)
 			},
@@ -89,7 +89,7 @@ func TestWrapInPosition(t *testing.T) {
 			shouldPanic:    true,
 		},
 		{
-			name: "Failure - Zero amount",
+			name: "wrap is failed by zero amount",
 			action: func(t *testing.T, from, to std.Address) error {
 				return wrap(0, to)
 			},
@@ -100,7 +100,7 @@ func TestWrapInPosition(t *testing.T) {
 			shouldPanic:    true,
 		},
 		{
-			name: "Success - Valid amount",
+			name: "wrap is success by valid amount",
 			action: func(t *testing.T, from, to std.Address) error {
 				ugnotFaucet(t, from, 1000)
 				testing.SetRealm(std.NewUserRealm(from))
@@ -141,7 +141,7 @@ func TestUnWrap(t *testing.T) {
 		shouldPanic bool
 	}{
 		{
-			name: "Failure - Zero amount",
+			name: "unwrap is failed by zero amount",
 			action: func(t *testing.T, from, to std.Address) error {
 				return unwrap(0, to)
 			},
@@ -152,7 +152,7 @@ func TestUnWrap(t *testing.T) {
 			shouldPanic: true,
 		},
 		{
-			name: "Success - Valid amount",
+			name: "unwrap is success by valid amount",
 			action: func(t *testing.T, from, to std.Address) error {
 				ugnotFaucet(t, from, 1000)
 
@@ -199,22 +199,22 @@ func TestIsNative(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "Native Token - GNOT",
+			name:     "isNative is success by native token",
 			token:    "gnot",
 			expected: true,
 		},
 		{
-			name:     "Non-Native Token",
+			name:     "isNative is failed by non-native token",
 			token:    "usdt",
 			expected: false,
 		},
 		{
-			name:     "Empty Token",
+			name:     "isNative is failed by empty token",
 			token:    "",
 			expected: false,
 		},
 		{
-			name:     "Similar but Different Token",
+			name:     "isNative is failed by similar but different token",
 			token:    "GNOT",
 			expected: false,
 		},
@@ -235,22 +235,22 @@ func TestIsWrappedToken(t *testing.T) {
 		expected  bool
 	}{
 		{
-			name:      "Success - Token is Wrapped WUGNOT",
+			name:      "isWrappedToken is success by wrapped WUGNOT",
 			tokenPath: consts.WRAPPED_WUGNOT,
 			expected:  true,
 		},
 		{
-			name:      "Fail - Token is not Wrapped WUGNOT",
+			name:      "isWrappedToken is failed by non-wrapped WUGNOT",
 			tokenPath: "gno.land/r/demo/ugnot",
 			expected:  false,
 		},
 		{
-			name:      "Fail - Empty tokenPath",
+			name:      "isWrappedToken is failed by empty tokenPath",
 			tokenPath: "",
 			expected:  false,
 		},
 		{
-			name:      "Fail - Similar but Different Token Path",
+			name:      "isWrappedToken is failed by similar but different tokenPath",
 			tokenPath: "gno.land/r/demo/Wugnot",
 			expected:  false,
 		},
@@ -281,7 +281,7 @@ func TestSafeWrapNativeToken(t *testing.T) {
 		expectedError string
 	}{
 		{
-			name:          "Panic - Zero UGNOT",
+			name:          "safeWrapNativeToken is failed by zero UGNOT",
 			amountDesired: "50",
 			userAddress:   alice,
 			sentAmount:    0,
@@ -289,7 +289,7 @@ func TestSafeWrapNativeToken(t *testing.T) {
 			expectedError: "[GNOSWAP-POSITION-008] can not wrap less than minimum amount || amount(50) < minimum(1000)",
 		},
 		{
-			name:          "Panic - Insufficient UGNOT",
+			name:          "safeWrapNativeToken is failed by insufficient UGNOT",
 			amountDesired: "150",
 			userAddress:   alice,
 			sentAmount:    100,
@@ -297,7 +297,7 @@ func TestSafeWrapNativeToken(t *testing.T) {
 			expectedError: "[GNOSWAP-POSITION-008] can not wrap less than minimum amount || amount(150) < minimum(1000)",
 		},
 		{
-			name:          "Panic - Invalid Desired Amount",
+			name:          "safeWrapNativeToken is failed by invalid desired amount",
 			amountDesired: "invalid",
 			userAddress:   alice,
 			sentAmount:    200,
@@ -305,7 +305,7 @@ func TestSafeWrapNativeToken(t *testing.T) {
 			expectedError: "[GNOSWAP-POSITION-003] wrap, unwrap failed || strconv.ParseInt: parsing \"invalid\": invalid syntax",
 		},
 		{
-			name:          "Successful wrap - Exact Amount",
+			name:          "safeWrapNativeToken is success by exact amount",
 			amountDesired: "1050",
 			userAddress:   alice,
 			sentAmount:    1050,
@@ -313,7 +313,7 @@ func TestSafeWrapNativeToken(t *testing.T) {
 			expectedWrap:  1050,
 		},
 		{
-			name:          "Excess Refund",
+			name:          "safeWrapNativeToken is success by excess refund",
 			amountDesired: "1000",
 			userAddress:   alice,
 			sentAmount:    1500,
@@ -321,7 +321,7 @@ func TestSafeWrapNativeToken(t *testing.T) {
 			expectedWrap:  1000,
 		},
 		{
-			name:          "Boundary Test - Exact Match",
+			name:          "safeWrapNativeToken is success by boundary test",
 			amountDesired: "1000",
 			userAddress:   alice,
 			sentAmount:    1000,
@@ -329,7 +329,7 @@ func TestSafeWrapNativeToken(t *testing.T) {
 			expectedWrap:  1000,
 		},
 		{
-			name:          "Zero Desired Amount", // unable to catch this panic
+			name:          "safeWrapNativeToken is failed by zero desired amount", // unable to catch this panic
 			amountDesired: "0",
 			userAddress:   alice,
 			sentAmount:    100,
@@ -337,7 +337,7 @@ func TestSafeWrapNativeToken(t *testing.T) {
 			expectedError: "[GNOSWAP-POSITION-004] zero wrapped amount || amount requested to wrap is zero",
 		},
 		{
-			name:          "Wrap Error Test",
+			name:          "safeWrapNativeToken is failed by wrap error",
 			amountDesired: "100",
 			userAddress:   alice,
 			sentAmount:    100,

--- a/contract/r/gnoswap/position/position.gno
+++ b/contract/r/gnoswap/position/position.gno
@@ -190,6 +190,7 @@ func IncreaseLiquidity(
 	if err != nil {
 		panic(newErrorWithDetail(err, ufmt.Sprintf("token0(%s), token1(%s)", token0, token1)))
 	}
+
 	caller := getPrevAddr()
 
 	wrappedAmount := int64(0)
@@ -207,6 +208,7 @@ func IncreaseLiquidity(
 		amount0Min:     amount0Min,
 		amount1Min:     amount1Min,
 		deadline:       deadline,
+		caller:         caller,
 	}
 
 	_, liquidity, amount0, amount1, poolPath := increaseLiquidity(increaseLiquidityParams)
@@ -313,6 +315,7 @@ func CollectFee(
 	cur realm,
 	positionId uint64,
 	unwrapResult bool,
+	caller std.Address,
 ) (uint64, string, string, string, string, string) {
 	assertOnlyNotHalted()
 	assertTokenExists(positionId)
@@ -322,7 +325,6 @@ func CollectFee(
 	// verify position
 	position := MustGetPosition(positionId)
 	token0, token1, fee := splitOf(position.poolKey)
-	caller := getPrevAddr()
 
 	pl.Burn(
 		cross,

--- a/contract/r/gnoswap/position/position.gno
+++ b/contract/r/gnoswap/position/position.gno
@@ -315,6 +315,16 @@ func CollectFee(
 	cur realm,
 	positionId uint64,
 	unwrapResult bool,
+) (uint64, string, string, string, string, string) {
+	caller := getPrevAddr()
+
+	return collectFee(cur, positionId, unwrapResult, caller)
+}
+
+func collectFee(
+	cur realm,
+	positionId uint64,
+	unwrapResult bool,
 	caller std.Address,
 ) (uint64, string, string, string, string, string) {
 	assertOnlyNotHalted()

--- a/contract/r/gnoswap/position/position.gno
+++ b/contract/r/gnoswap/position/position.gno
@@ -263,12 +263,12 @@ func DecreaseLiquidity(
 	unwrapResult bool,
 ) (uint64, string, string, string, string, string, string) {
 	assertOnlyNotHalted()
-	isAuthorizedForToken(positionId)
+	assertAuthorizedForToken(positionId)
 	checkDeadline(deadline)
 	assertValidLiquidityAmount(liquidityStr)
-
 	mintAndDistributeGnsCallback()
 
+	caller := getPrevAddr()
 	amount0Min := u256.MustFromDecimal(amount0MinStr)
 	amount1Min := u256.MustFromDecimal(amount1MinStr)
 	decreaseLiquidityParams := DecreaseLiquidityParams{
@@ -278,6 +278,7 @@ func DecreaseLiquidity(
 		amount1Min:   amount1Min,
 		deadline:     deadline,
 		unwrapResult: unwrapResult,
+		caller:       caller,
 	}
 
 	positionId, liquidity, fee0, fee1, amount0, amount1, poolPath := decreaseLiquidity(decreaseLiquidityParams)
@@ -310,17 +311,18 @@ func DecreaseLiquidity(
 // ref: https://docs.gnoswap.io/contracts/position/position.gno#collectfee
 func CollectFee(
 	cur realm,
-	postionId uint64,
+	positionId uint64,
 	unwrapResult bool,
 ) (uint64, string, string, string, string, string) {
 	assertOnlyNotHalted()
-	assertTokenExists(postionId)
-	isAuthorizedForToken(postionId)
+	assertTokenExists(positionId)
+	assertAuthorizedForToken(positionId)
 	mintAndDistributeGnsCallback()
 
 	// verify position
-	position := MustGetPosition(postionId)
+	position := MustGetPosition(positionId)
 	token0, token1, fee := splitOf(position.poolKey)
+	caller := getPrevAddr()
 
 	pl.Burn(
 		cross,
@@ -330,9 +332,10 @@ func CollectFee(
 		position.tickLower,
 		position.tickUpper,
 		ZERO_LIQUIDITY_FOR_FEE_COLLECTION, // burn '0' liquidity to collect fee
+		caller,
 	)
 
-	currentFeeGrowth, err := getCurrentFeeGrowth(position)
+	currentFeeGrowth, err := getCurrentFeeGrowth(position, caller)
 	if err != nil {
 		panic(newErrorWithDetail(err, "failed to get current fee growth"))
 	}
@@ -344,7 +347,6 @@ func CollectFee(
 
 	// check user wugnot amount
 	// need this value to unwrap fee
-	caller := getPrevAddr()
 	userWugnot := wugnot.BalanceOf(caller)
 
 	// collect fee
@@ -360,12 +362,12 @@ func CollectFee(
 	// instead of the actual amount so we can burn the token
 	position.tokensOwed0 = new(u256.Uint).Sub(tokensOwed0, u256.MustFromDecimal(amount0))
 	position.tokensOwed1 = new(u256.Uint).Sub(tokensOwed1, u256.MustFromDecimal(amount1))
-	mustUpdatePosition(postionId, position)
+	mustUpdatePosition(positionId, position)
 
 	// handle withdrawal fee
 	withoutFee0, withoutFee1 := pl.CollectWithdrawalFee(
 		cross,
-		postionId,
+		positionId,
 		token0,
 		amount0,
 		token1,
@@ -384,14 +386,14 @@ func CollectFee(
 		"CollectSwapFee",
 		"prevAddr", prevAddr,
 		"prevRealm", prevPkgPath,
-		"lpPositionId", formatUint(postionId),
+		"lpPositionId", formatUint(positionId),
 		"feeAmount0", withoutFee0,
 		"feeAmount1", withoutFee1,
 		"poolPath", position.poolKey,
 		"unwrapResult", formatBool(unwrapResult),
 	)
 
-	return postionId, withoutFee0, withoutFee1, position.poolKey, amount0, amount1
+	return positionId, withoutFee0, withoutFee1, position.poolKey, amount0, amount1
 }
 
 func SetPositionOperator(
@@ -440,9 +442,9 @@ func computePositionKey(
 	return encoded
 }
 
-func getCurrentFeeGrowth(position Position) (FeeGrowthInside, error) {
+func getCurrentFeeGrowth(position Position, owner std.Address) (FeeGrowthInside, error) {
 	pool := pl.GetPoolFromPoolPath(position.poolKey)
-	positionKey := computePositionKey(GetOrigPkgAddr(), position.tickLower, position.tickUpper)
+	positionKey := computePositionKey(owner, position.tickLower, position.tickUpper)
 
 	feeGrowthInside0 := new(u256.Uint).Set(pool.PositionFeeGrowthInside0LastX128(positionKey))
 	feeGrowthInside1 := new(u256.Uint).Set(pool.PositionFeeGrowthInside1LastX128(positionKey))

--- a/contract/r/gnoswap/position/position_test.gno
+++ b/contract/r/gnoswap/position/position_test.gno
@@ -6,13 +6,17 @@ import (
 	"testing"
 	"time"
 
+	u256 "gno.land/p/gnoswap/uint256"
+
 	"gno.land/p/demo/testutils"
 	"gno.land/p/demo/uassert"
-	u256 "gno.land/p/gnoswap/uint256"
+	"gno.land/p/demo/ufmt"
+
+	pl "gno.land/r/gnoswap/v1/pool"
 
 	"gno.land/p/gnoswap/consts"
 	"gno.land/r/gnoswap/v1/gnft"
-	pl "gno.land/r/gnoswap/v1/pool"
+	"gno.land/r/gnoswap/v1/rbac"
 	"gno.land/r/gnoswap/v1/referral"
 )
 
@@ -516,15 +520,15 @@ func TestProcessTokens(t *testing.T) {
 
 func TestProcessMintInput(t *testing.T) {
 	tests := []struct {
-		name            string
-		input           MintInput
-		expectedToken0  string
-		expectedToken1  string
-		expectedAmount0 string
-		expectedAmount1 string
-		expectedTickL   int32
-		expectedTickU   int32
-		expectError     bool
+		name             string
+		input            MintInput
+		expectedToken0   string
+		expectedToken1   string
+		expectedAmount0  string
+		expectedAmount1  string
+		expectedTickL    int32
+		expectedTickU    int32
+		expectError      bool
 		expectedErrorMsg string
 	}{
 		{
@@ -582,7 +586,7 @@ func TestProcessMintInput(t *testing.T) {
 				tickUpper:      5000,
 				caller:         alice,
 			},
-			expectError: true,
+			expectError:      true,
 			expectedErrorMsg: "[GNOSWAP-POSITION-005] invalid input data || input string : invalid",
 		},
 	}
@@ -658,7 +662,7 @@ func TestMintInternal(t *testing.T) {
 				mintTo:         alice,
 			},
 			expectPanic:   true,
-			errKind: "panic",
+			errKind:       "panic",
 			expectedError: "[GNOSWAP-POSITION-011] position with same positionId already exists || positionId(1)",
 			positionId:    1,
 		},
@@ -678,7 +682,7 @@ func TestMintInternal(t *testing.T) {
 				mintTo:         alice,
 			},
 			expectPanic:   true,
-			errKind: "abort",
+			errKind:       "abort",
 			expectedError: "[GNOSWAP-POOL-010] zero liquidity",
 			positionId:    0,
 		},
@@ -733,101 +737,101 @@ func TestMintInternal(t *testing.T) {
 
 func TestMint(t *testing.T) {
 	tests := []struct {
-		name            string
-		token0          string
-		token1          string
-		fee             uint32
-		tickLower       int32
-		tickUpper       int32
-		amount0         string
-		amount1         string
-		minAmount0      string
-		minAmount1      string
-		deadline        int64
-		mintTo          std.Address
-		caller          std.Address
-		shouldError     bool
+		name               string
+		token0             string
+		token1             string
+		fee                uint32
+		tickLower          int32
+		tickUpper          int32
+		amount0            string
+		amount1            string
+		minAmount0         string
+		minAmount1         string
+		deadline           int64
+		mintTo             std.Address
+		caller             std.Address
+		shouldError        bool
 		expectedErrorMsg   string
 		expectedPositionId uint64
-		expectedAmount0 uint64
-		expectedAmount1 uint64
-		referrer        string
+		expectedAmount0    uint64
+		expectedAmount1    uint64
+		referrer           string
 	}{
 		{
-			name:            "Success - With valid referral",
-			token0:          barPath,
-			token1:          fooPath,
-			fee:             fee500,
-			tickLower:       -500,
-			tickUpper:       500,
-			amount0:         "1000000",
-			amount1:         "2000000",
-			minAmount0:      "950000",
-			minAmount1:      "900000",
-			deadline:        time.Now().Add(10 * time.Minute).Unix(),
-			mintTo:          alice,
-			caller:          alice,
+			name:               "Success - With valid referral",
+			token0:             barPath,
+			token1:             fooPath,
+			fee:                fee500,
+			tickLower:          -500,
+			tickUpper:          500,
+			amount0:            "1000000",
+			amount1:            "2000000",
+			minAmount0:         "950000",
+			minAmount1:         "900000",
+			deadline:           time.Now().Add(10 * time.Minute).Unix(),
+			mintTo:             alice,
+			caller:             alice,
 			expectedPositionId: 1,
-			expectedAmount0: 1000000,
-			expectedAmount1: 1000000,
-			referrer:        testutils.TestAddress("carol").String(),
+			expectedAmount0:    1000000,
+			expectedAmount1:    1000000,
+			referrer:           testutils.TestAddress("carol").String(),
 		},
 		{
-			name:            "Fail - Deadline exceeded",
-			token0:          barPath,
-			token1:          fooPath,
-			fee:             fee500,
-			tickLower:       -500,
-			tickUpper:       500,
-			amount0:         "1000000",
-			amount1:         "2000000",
-			minAmount0:      "950000",
-			minAmount1:      "1900000",
-			deadline:        time.Now().Add(-10 * time.Minute).Unix(),
-			mintTo:          alice,
-			caller:          alice,
-			shouldError:     true,
-			expectedErrorMsg:   "[GNOSWAP-POSITION-007] transaction expired || transaction too old, now(1234567890) > deadline(1234567290)",
-			expectedAmount0: 950000,
-			expectedAmount1: 1900000,
+			name:             "Fail - Deadline exceeded",
+			token0:           barPath,
+			token1:           fooPath,
+			fee:              fee500,
+			tickLower:        -500,
+			tickUpper:        500,
+			amount0:          "1000000",
+			amount1:          "2000000",
+			minAmount0:       "950000",
+			minAmount1:       "1900000",
+			deadline:         time.Now().Add(-10 * time.Minute).Unix(),
+			mintTo:           alice,
+			caller:           alice,
+			shouldError:      true,
+			expectedErrorMsg: "[GNOSWAP-POSITION-007] transaction expired || transaction too old, now(1234567890) > deadline(1234567290)",
+			expectedAmount0:  950000,
+			expectedAmount1:  1900000,
 		},
 		{
-			name:            "Fail - Invalid tick range",
-			token0:          barPath,
-			token1:          fooPath,
-			fee:             fee500,
-			tickLower:       600,
-			tickUpper:       500,
-			amount0:         "1000000",
-			amount1:         "2000000",
-			minAmount0:      "950000",
-			minAmount1:      "1900000",
-			deadline:        time.Now().Add(10 * time.Minute).Unix(),
-			mintTo:          alice,
-			caller:          alice,
-			shouldError:     true,
-			expectedErrorMsg:   "[GNOSWAP-POOL-024] tickLower is greater than or equal to tickUpper || tickLower(600), tickUpper(500)",
-			expectedAmount0: 950000,
-			expectedAmount1: 1900000,
+			name:             "Fail - Invalid tick range",
+			token0:           barPath,
+			token1:           fooPath,
+			fee:              fee500,
+			tickLower:        600,
+			tickUpper:        500,
+			amount0:          "1000000",
+			amount1:          "2000000",
+			minAmount0:       "950000",
+			minAmount1:       "1900000",
+			deadline:         time.Now().Add(10 * time.Minute).Unix(),
+			mintTo:           alice,
+			caller:           alice,
+			shouldError:      true,
+			expectedErrorMsg: "[GNOSWAP-POOL-024] tickLower is greater than or equal to tickUpper || tickLower(600), tickUpper(500)",
+			expectedAmount0:  950000,
+			expectedAmount1:  1900000,
 		},
 		{
-			name:            "Fail - Caller not authorized",
-			token0:          barPath,
-			token1:          fooPath,
-			fee:             fee500,
-			tickLower:       -500,
-			tickUpper:       500,
-			amount0:         "1000000",
-			amount1:         "2000000",
-			minAmount0:      "950000",
-			minAmount1:      "1900000",
-			deadline:        time.Now().Add(10 * time.Minute).Unix(),
-			mintTo:          adminAddr,
-			caller:          alice,
-			shouldError:     true,
-			expectedErrorMsg:   "[GNOSWAP-POSITION-012] invalid address || (g1v9kxjcm9ta047h6lta047h6lta047h6lzd40gh, g17290cwvmrapvp869xfnhhawa8sm9edpufzat7d)",
-			expectedAmount0: 950000,
-			expectedAmount1: 1900000,
+			name:             "Fail - Caller not authorized",
+			token0:           barPath,
+			token1:           fooPath,
+			fee:              fee500,
+			tickLower:        -500,
+			tickUpper:        500,
+			amount0:          "1000000",
+			amount1:          "2000000",
+			minAmount0:       "950000",
+			minAmount1:       "1900000",
+			deadline:         time.Now().Add(10 * time.Minute).Unix(),
+			mintTo:           adminAddr,
+			caller:           alice,
+			shouldError:      true,
+			expectedErrorMsg: "[GNOSWAP-POSITION-012] invalid address || (g1v9kxjcm9ta047h6lta047h6lta047h6lzd40gh, g17290cwvmrapvp869xfnhhawa8sm9edpufzat7d)",
+			expectedAmount0:  950000,
+			expectedAmount1:  1900000,
 		},
 	}
 
@@ -1022,175 +1026,176 @@ func TestIncreaseLiquidity(t *testing.T) {
 	}
 }
 
-// func TestDecreaseLiquidity(t *testing.T) {
-// 	testing.SetRealm(adminRealm)
+func TestDecreaseLiquidity(t *testing.T) {
+	testing.SetRealm(adminRealm)
 
-// 	pl.SetPoolCreationFeeByAdmin(cross, 0)
-// 	CreatePool(t, barPath, fooPath, fee500, "79228162514264337593543950336", adminAddr)
+	pl.SetPoolCreationFeeByAdmin(cross, 0)
+	CreatePool(t, barPath, fooPath, fee500, "79228162514264337593543950336", adminAddr)
 
-// 	TokenFaucet(t, barPath, alice)
-// 	TokenFaucet(t, fooPath, alice)
+	TokenFaucet(t, barPath, alice)
+	TokenFaucet(t, fooPath, alice)
 
-// 	testing.SetRealm(posRealm)
-// 	TokenApprove(t, barPath, adminAddr, poolAddr, maxApprove)
-// 	TokenApprove(t, fooPath, adminAddr, poolAddr, maxApprove)
+	testing.SetRealm(posRealm)
+	TokenApprove(t, barPath, adminAddr, poolAddr, maxApprove)
+	TokenApprove(t, fooPath, adminAddr, poolAddr, maxApprove)
 
-// 	tests := []struct {
-// 		name              string
-// 		beforeIncrease    bool
-// 		increaseAmount0   string
-// 		increaseAmount1   string
-// 		liquidityToRemove string
-// 		amount0Min        string
-// 		amount1Min        string
-// 		deadlineOffset    time.Duration
-// 		unwrapResult      bool
-// 		expectPanic       bool
-// 		expectedErrorMsg  string
-// 		expectedLiquidity string
-// 		expectedFee0      string
-// 		expectedFee1      string
-// 	}{
-// 		{
-// 			name:              "Success - Decrease 50% Liquidity",
-// 			liquidityToRemove: "400000",
-// 			amount0Min:        "8000",
-// 			amount1Min:        "15000",
-// 			deadlineOffset:    time.Hour,
-// 			unwrapResult:      false,
-// 			expectPanic:       false,
-// 			expectedLiquidity: "400000",
-// 			expectedFee0:      "0",
-// 			expectedFee1:      "0",
-// 		},
-// 		{
-// 			name:              "Success - Decrease 100% Liquidity",
-// 			liquidityToRemove: "600000",
-// 			amount0Min:        "10000",
-// 			amount1Min:        "20000",
-// 			deadlineOffset:    time.Hour,
-// 			unwrapResult:      false,
-// 			expectPanic:       false,
-// 			expectedLiquidity: "600000",
-// 			expectedFee0:      "0",
-// 			expectedFee1:      "0",
-// 			expectedErrorMsg:  "",
-// 		},
-// 		{
-// 			name:              "Fail - Zero Liquidity",
-// 			liquidityToRemove: "0",
-// 			amount0Min:        "10000",
-// 			amount1Min:        "20000",
-// 			deadlineOffset:    time.Hour,
-// 			unwrapResult:      false,
-// 			expectPanic:       true,
-// 			expectedErrorMsg:  "[GNOSWAP-POSITION-010] zero liquidity || liquidity amount must be greater than 0, got 0",
-// 		},
-// 		{
-// 			name:              "Fail - Underflow",
-// 			liquidityToRemove: "1541592",
-// 			amount0Min:        "200000",
-// 			amount1Min:        "400000",
-// 			deadlineOffset:    time.Hour,
-// 			unwrapResult:      false,
-// 			expectPanic:       true,
-// 			expectedErrorMsg:  "[GNOSWAP-POOL-010] zero liquidity || both liquidityDelta and current position's liquidity are zero",
-// 		},
-// 		{
-// 			name:              "Fail - Deadline Exceeded",
-// 			liquidityToRemove: "50",
-// 			amount0Min:        "10000",
-// 			amount1Min:        "20000",
-// 			deadlineOffset:    -time.Hour,
-// 			unwrapResult:      false,
-// 			expectPanic:       true,
-// 			expectedErrorMsg:  "[GNOSWAP-POSITION-007] transaction expired || transaction too old, now(1234567890) > deadline(1234564290)",
-// 		},
-// 		{
-// 			name:              "Success - Increase and Decrease",
-// 			beforeIncrease:    true,
-// 			increaseAmount0:   "500000",
-// 			increaseAmount1:   "1000000",
-// 			liquidityToRemove: "1270796",
-// 			amount0Min:        "12000",
-// 			amount1Min:        "25000",
-// 			deadlineOffset:    time.Hour,
-// 			unwrapResult:      false,
-// 			expectPanic:       false,
-// 			expectedLiquidity: "1270796",
-// 			expectedFee0:      "0",
-// 			expectedFee1:      "0",
-// 		},
-// 	}
+	tests := []struct {
+		name              string
+		beforeIncrease    bool
+		increaseAmount0   string
+		increaseAmount1   string
+		liquidityToRemove string
+		amount0Min        string
+		amount1Min        string
+		deadlineOffset    time.Duration
+		unwrapResult      bool
+		expectPanic       bool
+		expectedErrorMsg  string
+		expectedLiquidity string
+		expectedFee0      string
+		expectedFee1      string
+	}{
+		{
+			name:              "Success - Decrease 50% Liquidity",
+			liquidityToRemove: "400000",
+			amount0Min:        "8000",
+			amount1Min:        "15000",
+			deadlineOffset:    time.Hour,
+			unwrapResult:      false,
+			expectPanic:       false,
+			expectedLiquidity: "400000",
+			expectedFee0:      "0",
+			expectedFee1:      "0",
+		},
+		{
+			name:              "Success - Decrease 100% Liquidity",
+			liquidityToRemove: "600000",
+			amount0Min:        "10000",
+			amount1Min:        "20000",
+			deadlineOffset:    time.Hour,
+			unwrapResult:      false,
+			expectPanic:       false,
+			expectedLiquidity: "600000",
+			expectedFee0:      "0",
+			expectedFee1:      "0",
+			expectedErrorMsg:  "",
+		},
+		{
+			name:              "Fail - Zero Liquidity",
+			liquidityToRemove: "0",
+			amount0Min:        "10000",
+			amount1Min:        "20000",
+			deadlineOffset:    time.Hour,
+			unwrapResult:      false,
+			expectPanic:       true,
+			expectedErrorMsg:  "[GNOSWAP-POSITION-010] zero liquidity || liquidity amount must be greater than 0, got 0",
+		},
+		{
+			name:              "Fail - Underflow",
+			liquidityToRemove: "1541592",
+			amount0Min:        "200000",
+			amount1Min:        "400000",
+			deadlineOffset:    time.Hour,
+			unwrapResult:      false,
+			expectPanic:       true,
+			expectedErrorMsg:  "[GNOSWAP-POOL-010] zero liquidity || both liquidityDelta and current position's liquidity are zero",
+		},
+		{
+			name:              "Fail - Deadline Exceeded",
+			liquidityToRemove: "50",
+			amount0Min:        "10000",
+			amount1Min:        "20000",
+			deadlineOffset:    -time.Hour,
+			unwrapResult:      false,
+			expectPanic:       true,
+			expectedErrorMsg:  "[GNOSWAP-POSITION-007] transaction expired || transaction too old, now(1234567890) > deadline(1234564290)",
+		},
+		{
+			name:              "Success - Increase and Decrease",
+			beforeIncrease:    true,
+			increaseAmount0:   "500000",
+			increaseAmount1:   "1000000",
+			liquidityToRemove: "1270796",
+			amount0Min:        "12000",
+			amount1Min:        "25000",
+			deadlineOffset:    time.Hour,
+			unwrapResult:      false,
+			expectPanic:       false,
+			expectedLiquidity: "1270796",
+			expectedFee0:      "0",
+			expectedFee1:      "0",
+		},
+	}
 
-// 	testing.SetRealm(adminRealm)
-// 	positionId, _, _, _ := Mint(
-// 		cross,
-// 		barPath,
-// 		fooPath,
-// 		fee500,
-// 		-10000,
-// 		10000,
-// 		"1000000",
-// 		"1000000",
-// 		"0",
-// 		"0",
-// 		time.Now().Add(time.Hour).Unix(),
-// 		adminAddr,
-// 		adminAddr,
-// 		"",
-// 	)
-// 	for _, tc := range tests {
-// 		t.Run(tc.name, func(t *testing.T) {
-// 			deadline := time.Now().Add(tc.deadlineOffset).Unix()
-// 			if tc.beforeIncrease {
-// 				testing.SetRealm(adminRealm)
-// 				_, _, _, _, _ = IncreaseLiquidity(
-// 					cross,
-// 					positionId,
-// 					tc.increaseAmount0,
-// 					tc.increaseAmount1,
-// 					"0",
-// 					"0",
-// 					deadline,
-// 				)
-// 			}
+	testing.SetRealm(adminRealm)
+	positionId, _, _, _ := Mint(
+		cross,
+		barPath,
+		fooPath,
+		fee500,
+		-10000,
+		10000,
+		"1000000",
+		"1000000",
+		"0",
+		"0",
+		time.Now().Add(time.Hour).Unix(),
+		adminAddr,
+		adminAddr,
+		"",
+	)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			deadline := time.Now().Add(tc.deadlineOffset).Unix()
+			if tc.beforeIncrease {
+				testing.SetRealm(adminRealm)
+				_, _, _, _, _ = IncreaseLiquidity(
+					cross,
+					positionId,
+					tc.increaseAmount0,
+					tc.increaseAmount1,
+					"0",
+					"0",
+					deadline,
+				)
+			}
 
-// 			if tc.expectPanic {
-// 				testing.SetRealm(adminRealm)
-// 				uassert.PanicsWithMessage(t, tc.expectedErrorMsg, func() {
-// 					DecreaseLiquidity(
-// 					cross,
-// 					positionId,
-// 					tc.liquidityToRemove,
-// 					tc.amount0Min,
-// 					tc.amount1Min,
-// 					deadline,
-// 					tc.unwrapResult,
-// 					)
-// 				})
-// 			} else {
-// 				testing.SetRealm(adminRealm)
-// 				_, liquidity, fee0, fee1, _, _, _ := DecreaseLiquidity(
-// 					cross,
-// 					positionId,
-// 					tc.liquidityToRemove,
-// 					tc.amount0Min,
-// 					tc.amount1Min,
-// 					deadline,
-// 					tc.unwrapResult,
-// 				)
-// 				uassert.Equal(t, tc.expectedLiquidity, liquidity)
-// 				uassert.Equal(t, tc.expectedFee0, fee0)
-// 				uassert.Equal(t, tc.expectedFee1, fee1)
-// 			}
-// 		})
-// 	}
-// }
+			if tc.expectPanic {
+				testing.SetRealm(adminRealm)
+				uassert.PanicsWithMessage(t, tc.expectedErrorMsg, func() {
+					DecreaseLiquidity(
+						cross,
+						positionId,
+						tc.liquidityToRemove,
+						tc.amount0Min,
+						tc.amount1Min,
+						deadline,
+						tc.unwrapResult,
+					)
+				})
+			} else {
+				testing.SetRealm(adminRealm)
+				_, liquidity, fee0, fee1, _, _, _ := DecreaseLiquidity(
+					cross,
+					positionId,
+					tc.liquidityToRemove,
+					tc.amount0Min,
+					tc.amount1Min,
+					deadline,
+					tc.unwrapResult,
+				)
+				uassert.Equal(t, tc.expectedLiquidity, liquidity)
+				uassert.Equal(t, tc.expectedFee0, fee0)
+				uassert.Equal(t, tc.expectedFee1, fee1)
+			}
+		})
+	}
+}
 
 func TestCollectFees(t *testing.T) {
 	tests := []struct {
 		name               string
+		caller             std.Address
 		mintAmount0        string
 		mintAmount1        string
 		increaseAmount0    string
@@ -1201,11 +1206,12 @@ func TestCollectFees(t *testing.T) {
 		expectedFee1       string
 		expectedAmount0    string
 		expectedAmount1    string
-		expectPanic        bool
-		expectedPanicError string
+		expectedHasAbort   bool
+		expectedAbortError string
 	}{
 		{
-			name:              "Success - Collect fee after multiple mints",
+			name:              "collect fees is success by multiple mints",
+			caller:            adminAddr,
 			mintAmount0:       "1000000",
 			mintAmount1:       "2000000",
 			increaseAmount0:   "500000",
@@ -1216,10 +1222,11 @@ func TestCollectFees(t *testing.T) {
 			expectedFee1:      "0",
 			expectedAmount0:   "0",
 			expectedAmount1:   "0",
-			expectPanic:       false,
+			expectedHasAbort:  false,
 		},
 		{
-			name:              "Success - Collect fee after full liquidity removal",
+			name:              "collect fees is success by full liquidity removal",
+			caller:            adminAddr,
 			mintAmount0:       "1000000",
 			mintAmount1:       "2000000",
 			liquidityToRemove: "100",
@@ -1228,16 +1235,105 @@ func TestCollectFees(t *testing.T) {
 			expectedFee1:      "0",
 			expectedAmount0:   "0",
 			expectedAmount1:   "0",
-			expectPanic:       false,
+			expectedHasAbort:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupPositionStakerPermission(t)
+
+			testing.SetOriginCaller(adminAddr)
+			CreatePoolWithoutFee(t)
+
+			testing.SetRealm(posRealm)
+			TokenApprove(t, barPath, adminAddr, poolAddr, maxApprove)
+			TokenApprove(t, fooPath, adminAddr, poolAddr, maxApprove)
+
+			testing.SetOriginCaller(adminAddr)
+
+			// Mint liquidity
+			positionId, _, _, _ := Mint(
+				cross,
+				barPath,
+				fooPath,
+				fee500,
+				-10000,
+				10000,
+				tt.mintAmount0,
+				tt.mintAmount1,
+				"0",
+				"0",
+				time.Now().Add(time.Hour).Unix(),
+				adminAddr,
+				adminAddr,
+				"",
+			)
+
+			testing.SetOriginCaller(adminAddr)
+			gnft.Approve(cross, posRealm.Address(), positionIdFrom(positionId))
+
+			if tt.expectedHasAbort {
+				uassert.AbortsWithMessage(t, tt.expectedAbortError, func() {
+					CollectFee(cross, positionId, tt.unwrapResult)
+				})
+			} else {
+				_, fee0, fee1, _, amount0, amount1 := CollectFee(cross, positionId, tt.unwrapResult)
+				uassert.Equal(t, tt.expectedFee0, fee0)
+				uassert.Equal(t, tt.expectedFee1, fee1)
+				uassert.Equal(t, tt.expectedAmount0, amount0)
+				uassert.Equal(t, tt.expectedAmount1, amount1)
+			}
+		})
+	}
+}
+
+func TestReposition(t *testing.T) {
+	tests := []struct {
+		name               string
+		mintAmount0        string
+		mintAmount1        string
+		increaseAmount0    string
+		increaseAmount1    string
+		liquidityToRemove  string
+		tickLower          int32
+		tickUpper          int32
+		expectPanic        bool
+		expectedPanicError string
+	}{
+		{
+			name:               "Fail - Reposition after full liquidity removal",
+			mintAmount0:        "1000000",
+			mintAmount1:        "2000000",
+			increaseAmount0:    "500000",
+			increaseAmount1:    "1000000",
+			liquidityToRemove:  "100",
+			tickLower:          -5000,
+			tickUpper:          5000,
+			expectPanic:        true,
+			expectedPanicError: "[GNOSWAP-POSITION-009] position is not clear || position(10) isn't clear(liquidity:3812288, tokensOwed0:0, tokensOwed1:0)",
 		},
 		{
-			name:               "Fail - No liquidity to collect",
-			mintAmount0:        "100000",
-			mintAmount1:        "200000",
-			liquidityToRemove:  "0",
-			unwrapResult:       false,
+			name:               "Fail - Reposition with partial liquidity removal",
+			mintAmount0:        "1000000",
+			mintAmount1:        "2000000",
+			increaseAmount0:    "500000",
+			increaseAmount1:    "1000000",
+			liquidityToRemove:  "50",
+			tickLower:          -3000,
+			tickUpper:          3000,
 			expectPanic:        true,
-			expectedPanicError: "[GNOSWAP-POSITION-010] zero liquidity || liquidity amount must be greater than 0, got 0",
+			expectedPanicError: "[GNOSWAP-POSITION-009] position is not clear || position(10) isn't clear(liquidity:5083034, tokensOwed0:0, tokensOwed1:0)",
+		},
+		{
+			name:               "Fail - Reposition on non-existent positionId",
+			mintAmount0:        "1000000",
+			mintAmount1:        "2000000",
+			liquidityToRemove:  "10",
+			tickLower:          -4000,
+			tickUpper:          4000,
+			expectPanic:        true,
+			expectedPanicError: "[GNOSWAP-POSITION-009] position is not clear || position(10) isn't clear(liquidity:5083024, tokensOwed0:0, tokensOwed1:0)",
 		},
 	}
 
@@ -1246,7 +1342,7 @@ func TestCollectFees(t *testing.T) {
 	TokenApprove(t, barPath, adminAddr, poolAddr, maxApprove)
 	TokenApprove(t, fooPath, adminAddr, poolAddr, maxApprove)
 
-	// Mint liquidity
+	// Step 1: Mint a position
 	positionId, _, _, _ := Mint(
 		cross,
 		barPath,
@@ -1266,17 +1362,7 @@ func TestCollectFees(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			defer func() {
-				if r := recover(); r != nil {
-					if !tt.expectPanic {
-						t.Errorf("unexpected panic: %v", r)
-					} else {
-						uassert.Equal(t, tt.expectedPanicError, r)
-					}
-				}
-			}()
-
-			// Increase liquidity if specified
+			// Step 2: Increase liquidity
 			if tt.increaseAmount0 != "" && tt.increaseAmount1 != "" {
 				_, _, _, _, _ = IncreaseLiquidity(
 					cross,
@@ -1289,7 +1375,7 @@ func TestCollectFees(t *testing.T) {
 				)
 			}
 
-			// Decrease liquidity
+			// Step 3: Decrease liquidity to clear the position
 			_, _, _, _, _, _, _ = DecreaseLiquidity(
 				cross,
 				positionId,
@@ -1300,147 +1386,52 @@ func TestCollectFees(t *testing.T) {
 				false,
 			)
 
+			// Step 4: Attempt Reposition
 			if tt.expectPanic {
 				uassert.PanicsWithMessage(t, tt.expectedPanicError, func() {
-					CollectFee(cross, positionId, tt.unwrapResult)
+					Reposition(
+						positionId,
+						tt.tickLower,
+						tt.tickUpper,
+						tt.mintAmount0,
+						tt.mintAmount1,
+						"0",
+						"0",
+					)
 				})
 			} else {
-				_, fee0, fee1, _, amount0, amount1 := CollectFee(cross,positionId, tt.unwrapResult)
-				uassert.Equal(t, tt.expectedFee0, fee0)
-				uassert.Equal(t, tt.expectedFee1, fee1)
-				uassert.Equal(t, tt.expectedAmount0, amount0)
-				uassert.Equal(t, tt.expectedAmount1, amount1)
+				// positionId, liquidity.ToString(), tickLower, tickUpper, amount0.ToString(), amount1.ToString()
+				tid, _, tickL, tickH, _, _ := Reposition(
+					positionId,
+					tt.tickLower,
+					tt.tickUpper,
+					tt.mintAmount0,
+					tt.mintAmount1,
+					"0",
+					"0",
+				)
+				uassert.Equal(t, tid, positionId)
+				uassert.Equal(t, tickL, tt.tickLower)
+				uassert.Equal(t, tickH, tt.tickUpper)
 			}
 		})
 	}
 }
 
-// func TestReposition(t *testing.T) {
-// 	tests := []struct {
-// 		name               string
-// 		mintAmount0        string
-// 		mintAmount1        string
-// 		increaseAmount0    string
-// 		increaseAmount1    string
-// 		liquidityToRemove  string
-// 		tickLower          int32
-// 		tickUpper          int32
-// 		expectPanic        bool
-// 		expectedPanicError string
-// 	}{
-// 		{
-// 			name:               "Fail - Reposition after full liquidity removal",
-// 			mintAmount0:        "1000000",
-// 			mintAmount1:        "2000000",
-// 			increaseAmount0:    "500000",
-// 			increaseAmount1:    "1000000",
-// 			liquidityToRemove:  "100",
-// 			tickLower:          -5000,
-// 			tickUpper:          5000,
-// 			expectPanic:        true,
-// 			expectedPanicError: "[GNOSWAP-POSITION-009] position is not clear || position(10) isn't clear(liquidity:3812288, tokensOwed0:0, tokensOwed1:0)",
-// 		},
-// 		{
-// 			name:               "Fail - Reposition with partial liquidity removal",
-// 			mintAmount0:        "1000000",
-// 			mintAmount1:        "2000000",
-// 			increaseAmount0:    "500000",
-// 			increaseAmount1:    "1000000",
-// 			liquidityToRemove:  "50",
-// 			tickLower:          -3000,
-// 			tickUpper:          3000,
-// 			expectPanic:        true,
-// 			expectedPanicError: "[GNOSWAP-POSITION-009] position is not clear || position(10) isn't clear(liquidity:5083034, tokensOwed0:0, tokensOwed1:0)",
-// 		},
-// 		{
-// 			name:               "Fail - Reposition on non-existent positionId",
-// 			mintAmount0:        "1000000",
-// 			mintAmount1:        "2000000",
-// 			liquidityToRemove:  "10",
-// 			tickLower:          -4000,
-// 			tickUpper:          4000,
-// 			expectPanic:        true,
-// 			expectedPanicError: "[GNOSWAP-POSITION-009] position is not clear || position(10) isn't clear(liquidity:5083024, tokensOwed0:0, tokensOwed1:0)",
-// 		},
-// 	}
+func setupPositionStakerPermission(t *testing.T) {
+	t.Helper()
 
-// 	CreatePoolWithoutFee(t)
-// 	testing.SetRealm(std.NewUserRealm(adminAddr))
-// 	TokenApprove(t, barPath, adminAddr, poolAddr, maxApprove)
-// 	TokenApprove(t, fooPath, adminAddr, poolAddr, maxApprove)
+	adminAddr := testutils.TestAddress("admin")
 
-// 	// Step 1: Mint a position
-// 	positionId, _, _, _ := Mint(
-// 		cross,
-// 		barPath,
-// 		fooPath,
-// 		fee500,
-// 		-10000,
-// 		10000,
-// 		"1000000",
-// 		"1000000",
-// 		"0",
-// 		"0",
-// 		time.Now().Add(time.Hour).Unix(),
-// 		adminAddr,
-// 		adminAddr,
-// 		"",
-// 	)
+	testing.SetOriginCaller(adminAddr)
+	testing.SetRealm(std.NewUserRealm(adminAddr))
 
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			// Step 2: Increase liquidity
-// 			if tt.increaseAmount0 != "" && tt.increaseAmount1 != "" {
-// 				_, _, _, _, _ = IncreaseLiquidity(
-// 					cross,
-// 					positionId,
-// 					tt.increaseAmount0,
-// 					tt.increaseAmount1,
-// 					"0",
-// 					"0",
-// 					time.Now().Add(time.Hour).Unix(),
-// 				)
-// 			}
+	globalManager := rbac.GlobalManager()
+	globalManager.UpdatePermission("staker", "access", func(addr std.Address) error {
+		if addr != adminAddr {
+			return ufmt.Errorf("caller is not staker")
+		}
 
-// 			// Step 3: Decrease liquidity to clear the position
-// 			_, _, _, _, _, _, _ = DecreaseLiquidity(
-// 				cross,
-// 				positionId,
-// 				tt.liquidityToRemove,
-// 				"0",
-// 				"0",
-// 				time.Now().Add(time.Hour).Unix(),
-// 				false,
-// 			)
-
-// 			// Step 4: Attempt Reposition
-// 			if tt.expectPanic {
-// 				uassert.PanicsWithMessage(t, tt.expectedPanicError, func() {
-// 					Reposition(
-// 						positionId,
-// 						tt.tickLower,
-// 						tt.tickUpper,
-// 						tt.mintAmount0,
-// 						tt.mintAmount1,
-// 						"0",
-// 						"0",
-// 					)
-// 				})
-// 			} else {
-// 				// positionId, liquidity.ToString(), tickLower, tickUpper, amount0.ToString(), amount1.ToString()
-// 				tid, _, tickL, tickH, _, _ := Reposition(
-// 					positionId,
-// 					tt.tickLower,
-// 					tt.tickUpper,
-// 					tt.mintAmount0,
-// 					tt.mintAmount1,
-// 					"0",
-// 					"0",
-// 				)
-// 				uassert.Equal(t, tid, positionId)
-// 				uassert.Equal(t, tickL, tt.tickLower)
-// 				uassert.Equal(t, tickH, tt.tickUpper)
-// 			}
-// 		})
-// 	}
-// }
+		return nil
+	})
+}

--- a/contract/r/gnoswap/position/position_test.gno
+++ b/contract/r/gnoswap/position/position_test.gno
@@ -914,7 +914,7 @@ func TestIncreaseLiquidity(t *testing.T) {
 	TokenApprove(t, barPath, adminAddr, poolAddr, maxApprove)
 	TokenApprove(t, fooPath, adminAddr, poolAddr, maxApprove)
 
-	testing.SetRealm(adminRealm)
+	testing.SetOriginCaller(adminAddr)
 	positionId, _, _, _ := Mint(
 		cross,
 		barPath,
@@ -994,6 +994,8 @@ func TestIncreaseLiquidity(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			testing.SetOriginCaller(adminAddr)
+
 			if tc.expectPanic {
 				uassert.AbortsWithMessage(t,
 					tc.expectedErrorMsg,
@@ -1049,7 +1051,7 @@ func TestDecreaseLiquidity(t *testing.T) {
 		amount1Min        string
 		deadlineOffset    time.Duration
 		unwrapResult      bool
-		expectPanic       bool
+		expectedHasAbort  bool
 		expectedErrorMsg  string
 		expectedLiquidity string
 		expectedFee0      string
@@ -1062,7 +1064,7 @@ func TestDecreaseLiquidity(t *testing.T) {
 			amount1Min:        "15000",
 			deadlineOffset:    time.Hour,
 			unwrapResult:      false,
-			expectPanic:       false,
+			expectedHasAbort:  false,
 			expectedLiquidity: "400000",
 			expectedFee0:      "0",
 			expectedFee1:      "0",
@@ -1074,7 +1076,7 @@ func TestDecreaseLiquidity(t *testing.T) {
 			amount1Min:        "20000",
 			deadlineOffset:    time.Hour,
 			unwrapResult:      false,
-			expectPanic:       false,
+			expectedHasAbort:  false,
 			expectedLiquidity: "600000",
 			expectedFee0:      "0",
 			expectedFee1:      "0",
@@ -1087,18 +1089,20 @@ func TestDecreaseLiquidity(t *testing.T) {
 			amount1Min:        "20000",
 			deadlineOffset:    time.Hour,
 			unwrapResult:      false,
-			expectPanic:       true,
+			expectedHasAbort:  true,
 			expectedErrorMsg:  "[GNOSWAP-POSITION-010] zero liquidity || liquidity amount must be greater than 0, got 0",
 		},
 		{
 			name:              "Fail - Underflow",
-			liquidityToRemove: "1541592",
+			liquidityToRemove: "1541593",
 			amount0Min:        "200000",
 			amount1Min:        "400000",
 			deadlineOffset:    time.Hour,
 			unwrapResult:      false,
-			expectPanic:       true,
-			expectedErrorMsg:  "[GNOSWAP-POOL-010] zero liquidity || both liquidityDelta and current position's liquidity are zero",
+			expectedHasAbort:  true,
+			expectedFee0:      "0",
+			expectedFee1:      "0",
+			expectedErrorMsg:  "[GNOSWAP-POSITION-019] invalid liquidity || Liquidity requested(1541593) is greater than liquidity held(1541592)",
 		},
 		{
 			name:              "Fail - Deadline Exceeded",
@@ -1107,7 +1111,7 @@ func TestDecreaseLiquidity(t *testing.T) {
 			amount1Min:        "20000",
 			deadlineOffset:    -time.Hour,
 			unwrapResult:      false,
-			expectPanic:       true,
+			expectedHasAbort:  true,
 			expectedErrorMsg:  "[GNOSWAP-POSITION-007] transaction expired || transaction too old, now(1234567890) > deadline(1234564290)",
 		},
 		{
@@ -1120,7 +1124,7 @@ func TestDecreaseLiquidity(t *testing.T) {
 			amount1Min:        "25000",
 			deadlineOffset:    time.Hour,
 			unwrapResult:      false,
-			expectPanic:       false,
+			expectedHasAbort:  false,
 			expectedLiquidity: "1270796",
 			expectedFee0:      "0",
 			expectedFee1:      "0",
@@ -1146,6 +1150,9 @@ func TestDecreaseLiquidity(t *testing.T) {
 	)
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			testing.SetOriginCaller(adminAddr)
+			gnft.Approve(cross, posRealm.Address(), positionIdFrom(positionId))
+
 			deadline := time.Now().Add(tc.deadlineOffset).Unix()
 			if tc.beforeIncrease {
 				testing.SetRealm(adminRealm)
@@ -1160,9 +1167,8 @@ func TestDecreaseLiquidity(t *testing.T) {
 				)
 			}
 
-			if tc.expectPanic {
-				testing.SetRealm(adminRealm)
-				uassert.PanicsWithMessage(t, tc.expectedErrorMsg, func() {
+			if tc.expectedHasAbort {
+				uassert.AbortsWithMessage(t, tc.expectedErrorMsg, func() {
 					DecreaseLiquidity(
 						cross,
 						positionId,
@@ -1174,7 +1180,6 @@ func TestDecreaseLiquidity(t *testing.T) {
 					)
 				})
 			} else {
-				testing.SetRealm(adminRealm)
 				_, liquidity, fee0, fee1, _, _, _ := DecreaseLiquidity(
 					cross,
 					positionId,
@@ -1275,10 +1280,10 @@ func TestCollectFees(t *testing.T) {
 
 			if tt.expectedHasAbort {
 				uassert.AbortsWithMessage(t, tt.expectedAbortError, func() {
-					CollectFee(cross, positionId, tt.unwrapResult)
+					CollectFee(cross, positionId, tt.unwrapResult, adminAddr)
 				})
 			} else {
-				_, fee0, fee1, _, amount0, amount1 := CollectFee(cross, positionId, tt.unwrapResult)
+				_, fee0, fee1, _, amount0, amount1 := CollectFee(cross, positionId, tt.unwrapResult, adminAddr)
 				uassert.Equal(t, tt.expectedFee0, fee0)
 				uassert.Equal(t, tt.expectedFee1, fee1)
 				uassert.Equal(t, tt.expectedAmount0, amount0)
@@ -1290,78 +1295,84 @@ func TestCollectFees(t *testing.T) {
 
 func TestReposition(t *testing.T) {
 	tests := []struct {
-		name               string
-		mintAmount0        string
-		mintAmount1        string
-		increaseAmount0    string
-		increaseAmount1    string
-		liquidityToRemove  string
-		tickLower          int32
-		tickUpper          int32
-		expectPanic        bool
-		expectedPanicError string
+		name                 string
+		mintAmount0          string
+		mintAmount1          string
+		increaseAmount0      string
+		increaseAmount1      string
+		liquidityToRemove    string
+		tickLower            int32
+		tickUpper            int32
+		expectedHasAbort     bool
+		expectedAbortMessage string
 	}{
 		{
-			name:               "Fail - Reposition after full liquidity removal",
-			mintAmount0:        "1000000",
-			mintAmount1:        "2000000",
-			increaseAmount0:    "500000",
-			increaseAmount1:    "1000000",
-			liquidityToRemove:  "100",
-			tickLower:          -5000,
-			tickUpper:          5000,
-			expectPanic:        true,
-			expectedPanicError: "[GNOSWAP-POSITION-009] position is not clear || position(10) isn't clear(liquidity:3812288, tokensOwed0:0, tokensOwed1:0)",
+			name:                 "Fail - Reposition after full liquidity removal",
+			mintAmount0:          "1000000",
+			mintAmount1:          "2000000",
+			increaseAmount0:      "500000",
+			increaseAmount1:      "1000000",
+			liquidityToRemove:    "100",
+			tickLower:            -5000,
+			tickUpper:            5000,
+			expectedHasAbort:     true,
+			expectedAbortMessage: "[GNOSWAP-POSITION-009] position is not clear || position(1) isn't clear(liquidity:3812288, tokensOwed0:0, tokensOwed1:0)",
 		},
 		{
-			name:               "Fail - Reposition with partial liquidity removal",
-			mintAmount0:        "1000000",
-			mintAmount1:        "2000000",
-			increaseAmount0:    "500000",
-			increaseAmount1:    "1000000",
-			liquidityToRemove:  "50",
-			tickLower:          -3000,
-			tickUpper:          3000,
-			expectPanic:        true,
-			expectedPanicError: "[GNOSWAP-POSITION-009] position is not clear || position(10) isn't clear(liquidity:5083034, tokensOwed0:0, tokensOwed1:0)",
+			name:                 "Fail - Reposition with partial liquidity removal",
+			mintAmount0:          "1000000",
+			mintAmount1:          "2000000",
+			increaseAmount0:      "500000",
+			increaseAmount1:      "1000000",
+			liquidityToRemove:    "50",
+			tickLower:            -3000,
+			tickUpper:            3000,
+			expectedHasAbort:     true,
+			expectedAbortMessage: "[GNOSWAP-POSITION-009] position is not clear || position(2) isn't clear(liquidity:3812338, tokensOwed0:0, tokensOwed1:0)",
 		},
 		{
-			name:               "Fail - Reposition on non-existent positionId",
-			mintAmount0:        "1000000",
-			mintAmount1:        "2000000",
-			liquidityToRemove:  "10",
-			tickLower:          -4000,
-			tickUpper:          4000,
-			expectPanic:        true,
-			expectedPanicError: "[GNOSWAP-POSITION-009] position is not clear || position(10) isn't clear(liquidity:5083024, tokensOwed0:0, tokensOwed1:0)",
+			name:                 "Fail - Reposition on non-existent positionId",
+			mintAmount0:          "1000000",
+			mintAmount1:          "2000000",
+			liquidityToRemove:    "10",
+			tickLower:            -4000,
+			tickUpper:            4000,
+			expectedHasAbort:     true,
+			expectedAbortMessage: "[GNOSWAP-POSITION-009] position is not clear || position(3) isn't clear(liquidity:2541582, tokensOwed0:0, tokensOwed1:0)",
 		},
 	}
 
-	CreatePoolWithoutFee(t)
-	testing.SetRealm(std.NewUserRealm(adminAddr))
-	TokenApprove(t, barPath, adminAddr, poolAddr, maxApprove)
-	TokenApprove(t, fooPath, adminAddr, poolAddr, maxApprove)
-
-	// Step 1: Mint a position
-	positionId, _, _, _ := Mint(
-		cross,
-		barPath,
-		fooPath,
-		fee500,
-		-10000,
-		10000,
-		"1000000",
-		"1000000",
-		"0",
-		"0",
-		time.Now().Add(time.Hour).Unix(),
-		adminAddr,
-		adminAddr,
-		"",
-	)
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			testing.SetOriginCaller(adminAddr)
+			CreatePoolWithoutFee(t)
+
+			testing.SetRealm(posRealm)
+			TokenApprove(t, barPath, adminAddr, poolAddr, maxApprove)
+			TokenApprove(t, fooPath, adminAddr, poolAddr, maxApprove)
+
+			testing.SetOriginCaller(adminAddr)
+			// Step 1: Mint a position
+			positionId, _, _, _ := Mint(
+				cross,
+				barPath,
+				fooPath,
+				fee500,
+				-10000,
+				10000,
+				"1000000",
+				"1000000",
+				"0",
+				"0",
+				time.Now().Add(time.Hour).Unix(),
+				adminAddr,
+				adminAddr,
+				"",
+			)
+
+			testing.SetOriginCaller(adminAddr)
+			gnft.Approve(cross, posRealm.Address(), positionIdFrom(positionId))
+
 			// Step 2: Increase liquidity
 			if tt.increaseAmount0 != "" && tt.increaseAmount1 != "" {
 				_, _, _, _, _ = IncreaseLiquidity(
@@ -1387,9 +1398,10 @@ func TestReposition(t *testing.T) {
 			)
 
 			// Step 4: Attempt Reposition
-			if tt.expectPanic {
-				uassert.PanicsWithMessage(t, tt.expectedPanicError, func() {
+			if tt.expectedHasAbort {
+				uassert.AbortsWithMessage(t, tt.expectedAbortMessage, func() {
 					Reposition(
+						cross,
 						positionId,
 						tt.tickLower,
 						tt.tickUpper,
@@ -1402,6 +1414,7 @@ func TestReposition(t *testing.T) {
 			} else {
 				// positionId, liquidity.ToString(), tickLower, tickUpper, amount0.ToString(), amount1.ToString()
 				tid, _, tickL, tickH, _, _ := Reposition(
+					cross,
 					positionId,
 					tt.tickLower,
 					tt.tickUpper,

--- a/contract/r/gnoswap/position/position_test.gno
+++ b/contract/r/gnoswap/position/position_test.gno
@@ -60,105 +60,178 @@ func newDummyPosition(id uint64) Position {
 }
 
 func TestMustGetPosition(t *testing.T) {
-	id := GetNextId()
-	nftId := gnft.TotalSupply()
-	var newId uint64
-	if id > uint64(nftId) {
-		newId = id
-	} else {
-		newId = uint64(nftId)
+	tests := []struct {
+		name                 string
+		positionId           uint64
+		inputPosition        Position
+		inputPositionId      uint64
+		expectedPosition     Position
+		expectedHasPanic     bool
+		expectedPanicMessage string
+	}{
+		{
+			name:                 "MustGetPosition is success by existing position",
+			positionId:           1,
+			inputPosition:        newDummyPosition(1),
+			inputPositionId:      1,
+			expectedPosition:     newDummyPosition(1),
+			expectedHasPanic:     false,
+			expectedPanicMessage: "",
+		},
+		{
+			name:                 "MustGetPosition is failed by non-existent position",
+			positionId:           1,
+			inputPosition:        newDummyPosition(1),
+			inputPositionId:      999,
+			expectedPosition:     Position{},
+			expectedHasPanic:     true,
+			expectedPanicMessage: "[GNOSWAP-POSITION-013] position does not exist || position with position ID(999) doesn't exist",
+		},
 	}
-	position := newDummyPosition(newId)
-	createNewPosition(newId, position)
 
-	t.Run("Success - Get existing position", func(t *testing.T) {
-		result := MustGetPosition(newId)
-		uassert.Equal(t, position.nonce.ToString(), result.nonce.ToString())
-		uassert.Equal(t, position.operator, result.operator)
-		uassert.Equal(t, position.poolKey, result.poolKey)
-		uassert.Equal(t, position.tickLower, result.tickLower)
-		uassert.Equal(t, position.tickUpper, result.tickUpper)
-		uassert.Equal(t, position.liquidity.ToString(), result.liquidity.ToString())
-		uassert.Equal(t, position.feeGrowthInside0LastX128.ToString(), result.feeGrowthInside0LastX128.ToString())
-		uassert.Equal(t, position.feeGrowthInside1LastX128.ToString(), result.feeGrowthInside1LastX128.ToString())
-		uassert.Equal(t, position.tokensOwed0.ToString(), result.tokensOwed0.ToString())
-		uassert.Equal(t, position.tokensOwed1.ToString(), result.tokensOwed1.ToString())
-		uassert.Equal(t, position.burned, result.burned)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initPositionTest(t)
+			createNewPosition(tt.positionId, tt.inputPosition)
 
-	t.Run("Fail - Non-existent position", func(t *testing.T) {
-		uassert.PanicsWithMessage(t,
-			"[GNOSWAP-POSITION-013] position does not exist || position with position ID(999) doesn't exist",
-			func() {
-				MustGetPosition(999)
-			})
-	})
+			if tt.expectedHasPanic {
+				uassert.PanicsWithMessage(t, tt.expectedPanicMessage, func() {
+					MustGetPosition(tt.inputPositionId)
+				})
+			} else {
+				result := MustGetPosition(tt.inputPositionId)
+				uassert.Equal(t, tt.expectedPosition.nonce.ToString(), result.nonce.ToString())
+				uassert.Equal(t, tt.expectedPosition.operator, result.operator)
+				uassert.Equal(t, tt.expectedPosition.poolKey, result.poolKey)
+				uassert.Equal(t, tt.expectedPosition.tickLower, result.tickLower)
+				uassert.Equal(t, tt.expectedPosition.tickUpper, result.tickUpper)
+				uassert.Equal(t, tt.expectedPosition.liquidity.ToString(), result.liquidity.ToString())
+				uassert.Equal(t, tt.expectedPosition.feeGrowthInside0LastX128.ToString(), result.feeGrowthInside0LastX128.ToString())
+				uassert.Equal(t, tt.expectedPosition.feeGrowthInside1LastX128.ToString(), result.feeGrowthInside1LastX128.ToString())
+				uassert.Equal(t, tt.expectedPosition.tokensOwed0.ToString(), result.tokensOwed0.ToString())
+				uassert.Equal(t, tt.expectedPosition.tokensOwed1.ToString(), result.tokensOwed1.ToString())
+				uassert.Equal(t, tt.expectedPosition.burned, result.burned)
+			}
+		})
+	}
 }
 
 func TestSetPosition(t *testing.T) {
-	id := GetNextId()
-	position := newDummyPosition(id)
+	position := newDummyPosition(1)
+	changedPosition := newDummyPosition(1)
+	changedPosition.nonce = u256.NewUint(2)
+	changedPosition.operator = "user2"
+	changedPosition.poolKey = "poolKey2"
+	changedPosition.tickLower = -2000
+	changedPosition.tickUpper = 2000
+	changedPosition.liquidity = u256.NewUint(2000)
+	changedPosition.feeGrowthInside0LastX128 = u256.NewUint(20)
+	changedPosition.feeGrowthInside1LastX128 = u256.NewUint(40)
+	changedPosition.tokensOwed0 = u256.NewUint(60)
+	changedPosition.tokensOwed1 = u256.NewUint(80)
+	changedPosition.burned = true
 
-	t.Run("Success - Create new position", func(t *testing.T) {
-		isNew := setPosition(id, position)
-		uassert.False(t, isNew)
-		incrementNextId()
+	tests := []struct {
+		name          string
+		positionId    uint64
+		position      Position
+		inputPosition Position
+		expected      bool
+	}{
+		{
+			name:          "set position is success by existing position",
+			positionId:    1,
+			position:      position,
+			inputPosition: changedPosition,
+			expected:      false,
+		},
+	}
 
-		storedPosition, _ := GetPosition(id)
-		uassert.Equal(t, position.nonce.ToString(), storedPosition.nonce.ToString())
-		uassert.Equal(t, position.operator, storedPosition.operator)
-		uassert.Equal(t, position.poolKey, storedPosition.poolKey)
-		uassert.Equal(t, position.tickLower, storedPosition.tickLower)
-		uassert.Equal(t, position.tickUpper, storedPosition.tickUpper)
-		uassert.Equal(t, position.liquidity.ToString(), storedPosition.liquidity.ToString())
-		uassert.Equal(t, position.feeGrowthInside0LastX128.ToString(), storedPosition.feeGrowthInside0LastX128.ToString())
-		uassert.Equal(t, position.feeGrowthInside1LastX128.ToString(), storedPosition.feeGrowthInside1LastX128.ToString())
-		uassert.Equal(t, position.tokensOwed0.ToString(), storedPosition.tokensOwed0.ToString())
-		uassert.Equal(t, position.tokensOwed1.ToString(), storedPosition.tokensOwed1.ToString())
-		uassert.Equal(t, position.burned, storedPosition.burned)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initPositionTest(t)
+			createNewPosition(tt.positionId, tt.position)
 
-	t.Run("Success - Update existing position", func(t *testing.T) {
-		position.tickUpper = 1000
-		isNew := setPosition(id, position)
-		uassert.True(t, isNew)
+			setPosition(tt.positionId, tt.inputPosition)
 
-		updatedPosition, _ := GetPosition(id)
-		uassert.Equal(t, int32(1000), updatedPosition.tickUpper)
-	})
+			storedPosition, _ := GetPosition(tt.positionId)
+			uassert.Equal(t, tt.inputPosition.nonce.ToString(), storedPosition.nonce.ToString())
+			uassert.Equal(t, tt.inputPosition.operator, storedPosition.operator)
+			uassert.Equal(t, tt.inputPosition.poolKey, storedPosition.poolKey)
+			uassert.Equal(t, tt.inputPosition.tickLower, storedPosition.tickLower)
+			uassert.Equal(t, tt.inputPosition.tickUpper, storedPosition.tickUpper)
+			uassert.Equal(t, tt.inputPosition.liquidity.ToString(), storedPosition.liquidity.ToString())
+			uassert.Equal(t, tt.inputPosition.feeGrowthInside0LastX128.ToString(), storedPosition.feeGrowthInside0LastX128.ToString())
+			uassert.Equal(t, tt.inputPosition.feeGrowthInside1LastX128.ToString(), storedPosition.feeGrowthInside1LastX128.ToString())
+			uassert.Equal(t, tt.inputPosition.tokensOwed0.ToString(), storedPosition.tokensOwed0.ToString())
+			uassert.Equal(t, tt.inputPosition.tokensOwed1.ToString(), storedPosition.tokensOwed1.ToString())
+			uassert.Equal(t, tt.inputPosition.burned, storedPosition.burned)
+		})
+	}
 }
 
 func TestRemovePosition(t *testing.T) {
-	id := GetNextId()
-	position := newDummyPosition(id)
+	tests := []struct {
+		name            string
+		positionId      uint64
+		inputPositionId uint64
+	}{
+		{
+			name:            "remove position is success by existing position",
+			positionId:      1,
+			inputPositionId: 1,
+		},
+		{
+			name:            "remove position is failed by non-existent position",
+			positionId:      1,
+			inputPositionId: 999,
+		},
+	}
 
-	t.Run("Success - Remove existing position", func(t *testing.T) {
-		createNewPosition(id, position)
-		removePosition(id)
-		_, found := GetPosition(id)
-		uassert.False(t, found)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initPositionTest(t)
 
-	t.Run("Success - Remove non-existent position", func(t *testing.T) {
-		removePosition(id)
-		_, found := GetPosition(id)
-		uassert.False(t, found)
-	})
+			createNewPosition(tt.positionId, newDummyPosition(tt.positionId))
+
+			removePosition(tt.inputPositionId)
+
+			_, found := GetPosition(tt.inputPositionId)
+			uassert.False(t, found)
+		})
+	}
 }
 
 func TestExistPosition(t *testing.T) {
-	id := GetNextId()
-	position := newDummyPosition(id)
+	tests := []struct {
+		name            string
+		positionId      uint64
+		inputPositionId uint64
+		expectedExist   bool
+	}{
+		{
+			name:            "ExistPosition is failed by position does not exist",
+			positionId:      1,
+			inputPositionId: 999,
+			expectedExist:   false,
+		},
+		{
+			name:            "ExistPosition is success by position exists",
+			positionId:      1,
+			inputPositionId: 1,
+			expectedExist:   true,
+		},
+	}
 
-	t.Run("False - Position does not exist", func(t *testing.T) {
-		uassert.False(t, ExistPosition(id))
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initPositionTest(t)
 
-	t.Run("True - Position exists", func(t *testing.T) {
-		createNewPosition(id, position)
-		uassert.True(t, ExistPosition(id))
-		removePosition(id)
-	})
+			createNewPosition(tt.positionId, newDummyPosition(tt.positionId))
+
+			uassert.Equal(t, tt.expectedExist, ExistPosition(tt.inputPositionId))
+		})
+	}
 }
 
 func TestComputePositionKey(t *testing.T) {
@@ -170,28 +243,28 @@ func TestComputePositionKey(t *testing.T) {
 		expected  string
 	}{
 		{
-			name:      "Basic Position Key",
+			name:      "computePositionKey is success by basic position key",
 			owner:     alice,
 			tickLower: -100,
 			tickUpper: 200,
 			expected:  "ZzF2OWt4amNtOXRhMDQ3aDZsdGEwNDdoNmx0YTA0N2g2bHpkNDBnaF9fLTEwMF9fMjAw", // Base64 of "g1v9kxjcm9ta047h6lta047h6lta047h6lzd40gh__-100__200"
 		},
 		{
-			name:      "Zero Ticks",
+			name:      "computePositionKey is failed by zero ticks",
 			owner:     alice,
 			tickLower: 0,
 			tickUpper: 0,
 			expected:  "ZzF2OWt4amNtOXRhMDQ3aDZsdGEwNDdoNmx0YTA0N2g2bHpkNDBnaF9fMF9fMA==", // Base64 of "g1v9kxjcm9ta047h6lta047h6lta047h6lzd40gh__0__0"
 		},
 		{
-			name:      "Negative Lower Tick",
+			name:      "computePositionKey is failed by negative lower tick",
 			owner:     alice,
 			tickLower: -50,
 			tickUpper: 150,
 			expected:  "ZzF2OWt4amNtOXRhMDQ3aDZsdGEwNDdoNmx0YTA0N2g2bHpkNDBnaF9fLTUwX18xNTA=", // Base64 of "g1v9kxjcm9ta047h6lta047h6lta047h6lzd40gh__-50__150"
 		},
 		{
-			name:      "Same Tick Bounds",
+			name:      "computePositionKey is failed by same tick bounds",
 			owner:     alice,
 			tickLower: 300,
 			tickUpper: 300,
@@ -280,13 +353,13 @@ func TestIsValidTokenPath(t *testing.T) {
 		expected  bool
 	}{
 		{
-			name:      "Valid Token Path",
+			name:      "isValidTokenPath is success by valid token path",
 			tokenPath: gnsPath,
 			register:  true,
 			expected:  true,
 		},
 		{
-			name:      "Invalid Token Path",
+			name:      "isValidTokenPath is failed by invalid token path",
 			tokenPath: "invalid/path",
 			register:  false,
 			expected:  false,
@@ -311,7 +384,7 @@ func TestValidateTokenPath(t *testing.T) {
 		expected  error
 	}{
 		{
-			name:      "Valid Token Path",
+			name:      "validateTokenPath is success by valid token path",
 			token0:    gnsPath,
 			token1:    barPath,
 			register0: true,
@@ -319,7 +392,7 @@ func TestValidateTokenPath(t *testing.T) {
 			expected:  nil,
 		},
 		{
-			name:      "Same Token Path",
+			name:      "validateTokenPath is failed by same token path",
 			token0:    "tokenA",
 			token1:    "tokenA",
 			register0: true,
@@ -327,7 +400,7 @@ func TestValidateTokenPath(t *testing.T) {
 			expected:  errInvalidTokenPath,
 		},
 		{
-			name:      "Conflicting Tokens (GNOT ↔ WUGNOT)",
+			name:      "validateTokenPath is failed by conflicting tokens (GNOT ↔ WUGNOT)",
 			token0:    consts.GNOT,
 			token1:    consts.WRAPPED_WUGNOT,
 			register0: true,
@@ -335,7 +408,7 @@ func TestValidateTokenPath(t *testing.T) {
 			expected:  errInvalidTokenPath,
 		},
 		{
-			name:      "Invalid Token Path",
+			name:      "validateTokenPath is failed by invalid token path",
 			token0:    "tokenX",
 			token1:    "tokenY",
 			register0: false,
@@ -343,7 +416,7 @@ func TestValidateTokenPath(t *testing.T) {
 			expected:  errInvalidTokenPath,
 		},
 		{
-			name:      "Both Invalid Tokens",
+			name:      "validateTokenPath is failed by both invalid tokens",
 			token0:    "invalidA",
 			token1:    "invalidB",
 			register0: false,
@@ -398,7 +471,7 @@ func TestProcessTokens(t *testing.T) {
 		expectMsg      string
 	}{
 		{
-			name:           "Both tokens valid and not native",
+			name:           "processTokens is failed by both tokens are valid and not native",
 			token0:         gnsPath,
 			token1:         "tokenB",
 			amount0Desired: "100",
@@ -413,7 +486,7 @@ func TestProcessTokens(t *testing.T) {
 			expectMsg:      "[GNOSWAP-POSITION-016] invalid token address || token0(gno.land/r/gnoswap/v1/gns), token1(tokenB)",
 		},
 		{
-			name:           "token0 is native",
+			name:           "processTokens is failed by token0 is native",
 			token0:         consts.GNOT,
 			token1:         gnsPath,
 			amount0Desired: "1300",
@@ -428,7 +501,7 @@ func TestProcessTokens(t *testing.T) {
 			expectMsg:      "[GNOSWAP-POSITION-016] invalid token address || token0(gnot), token1(gno.land/r/gnoswap/v1/gns)",
 		},
 		{
-			name:           "token1 is native",
+			name:           "processTokens is failed by token1 is native",
 			token0:         gnsPath,
 			token1:         consts.GNOT,
 			amount0Desired: "150",
@@ -442,7 +515,7 @@ func TestProcessTokens(t *testing.T) {
 			expectPanic:    false,
 		},
 		{
-			name:           "Both tokens are native",
+			name:           "processTokens is failed by both tokens are native",
 			token0:         consts.GNOT,
 			token1:         consts.GNOT,
 			amount0Desired: "1100",
@@ -457,7 +530,7 @@ func TestProcessTokens(t *testing.T) {
 			expectMsg:      "[GNOSWAP-POSITION-016] invalid token address || token0(gnot), token1(gnot)",
 		},
 		{
-			name:           "Invalid token path",
+			name:           "processTokens is failed by invalid token path",
 			token0:         "invalidToken",
 			token1:         "tokenB",
 			amount0Desired: "150",
@@ -532,7 +605,7 @@ func TestProcessMintInput(t *testing.T) {
 		expectedErrorMsg string
 	}{
 		{
-			name: "Standard Mint - Token0 < Token1",
+			name: "processMintInput is success by standard mint",
 			input: MintInput{
 				token0:         gnsPath,
 				token1:         barPath,
@@ -553,7 +626,7 @@ func TestProcessMintInput(t *testing.T) {
 			expectError:     false,
 		},
 		{
-			name: "Token Swap - Token1 < Token0",
+			name: "processMintInput is success by token swap",
 			input: MintInput{
 				token0:         barPath,
 				token1:         gnsPath,
@@ -574,7 +647,7 @@ func TestProcessMintInput(t *testing.T) {
 			expectError:     false,
 		},
 		{
-			name: "Error Case - Invalid Amounts",
+			name: "processMintInput is failed by invalid amounts",
 			input: MintInput{
 				token0:         gnsPath,
 				token1:         barPath,
@@ -625,7 +698,7 @@ func TestMintInternal(t *testing.T) {
 		positionId        uint64
 	}{
 		{
-			name: "Successful Mint",
+			name: "internal mint is success by successful mint",
 			params: MintParams{
 				token0:         barPath,
 				token1:         fooPath,
@@ -647,7 +720,7 @@ func TestMintInternal(t *testing.T) {
 			positionId:        0,
 		},
 		{
-			name: "Position Exists",
+			name: "internal mint is failed by position already exists",
 			params: MintParams{
 				token0:         barPath,
 				token1:         fooPath,
@@ -667,7 +740,7 @@ func TestMintInternal(t *testing.T) {
 			positionId:    1,
 		},
 		{
-			name: "Zero Liquidity Mint",
+			name: "internal mint is failed by zero liquidity",
 			params: MintParams{
 				token0:         barPath,
 				token1:         fooPath,
@@ -758,7 +831,7 @@ func TestMint(t *testing.T) {
 		referrer           string
 	}{
 		{
-			name:               "Success - With valid referral",
+			name:               "mint is success by valid referral",
 			token0:             barPath,
 			token1:             fooPath,
 			fee:                fee500,
@@ -777,7 +850,7 @@ func TestMint(t *testing.T) {
 			referrer:           testutils.TestAddress("carol").String(),
 		},
 		{
-			name:             "Fail - Deadline exceeded",
+			name:             "mint is failed by deadline exceeded",
 			token0:           barPath,
 			token1:           fooPath,
 			fee:              fee500,
@@ -796,7 +869,7 @@ func TestMint(t *testing.T) {
 			expectedAmount1:  1900000,
 		},
 		{
-			name:             "Fail - Invalid tick range",
+			name:             "mint is failed by invalid tick range",
 			token0:           barPath,
 			token1:           fooPath,
 			fee:              fee500,
@@ -815,7 +888,7 @@ func TestMint(t *testing.T) {
 			expectedAmount1:  1900000,
 		},
 		{
-			name:             "Fail - Caller not authorized",
+			name:             "mint is failed by caller not authorized",
 			token0:           barPath,
 			token1:           fooPath,
 			fee:              fee500,
@@ -918,7 +991,7 @@ func TestIncreaseLiquidity(t *testing.T) {
 		expectedErrorMsg string
 	}{
 		{
-			name:            "Success - Valid Increase",
+			name:            "increase liquidity is success by valid increase",
 			positionId:      1,
 			amount0Desired:  "1000000",
 			amount1Desired:  "2000000",
@@ -930,7 +1003,7 @@ func TestIncreaseLiquidity(t *testing.T) {
 			expectPanic:     false,
 		},
 		{
-			name:             "Fail - Deadline Exceeded",
+			name:             "increase liquidity is failed by deadline exceeded",
 			positionId:       1,
 			amount0Desired:   "1000000",
 			amount1Desired:   "2000000",
@@ -941,7 +1014,7 @@ func TestIncreaseLiquidity(t *testing.T) {
 			expectedErrorMsg: "[GNOSWAP-POSITION-007] transaction expired || transaction too old, now(1234567890) > deadline(1234567290)",
 		},
 		{
-			name:             "Fail - Invalid Amount String",
+			name:             "increase liquidity is failed by invalid amount string",
 			positionId:       1,
 			amount0Desired:   "invalid_amount",
 			amount1Desired:   "2000000",
@@ -952,7 +1025,7 @@ func TestIncreaseLiquidity(t *testing.T) {
 			expectedErrorMsg: "[GNOSWAP-POSITION-005] invalid input data || input string : invalid_amount",
 		},
 		{
-			name:             "Fail - Position Does Not Exist",
+			name:             "increase liquidity is failed by position does not exist",
 			positionId:       999,
 			amount0Desired:   "1000000",
 			amount1Desired:   "2000000",
@@ -1282,10 +1355,10 @@ func TestCollectFees(t *testing.T) {
 
 			if tt.expectedHasAbort {
 				uassert.AbortsWithMessage(t, tt.expectedAbortError, func() {
-					CollectFee(cross, positionId, tt.unwrapResult, adminAddr)
+					CollectFee(cross, positionId, tt.unwrapResult)
 				})
 			} else {
-				_, fee0, fee1, _, amount0, amount1 := CollectFee(cross, positionId, tt.unwrapResult, adminAddr)
+				_, fee0, fee1, _, amount0, amount1 := CollectFee(cross, positionId, tt.unwrapResult)
 				uassert.Equal(t, tt.expectedFee0, fee0)
 				uassert.Equal(t, tt.expectedFee1, fee1)
 				uassert.Equal(t, tt.expectedAmount0, amount0)

--- a/contract/r/gnoswap/position/position_test.gno
+++ b/contract/r/gnoswap/position/position_test.gno
@@ -837,6 +837,8 @@ func TestMint(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			initPositionTest(t)
+
 			testing.SetRealm(adminRealm)
 			pl.SetPoolCreationFeeByAdmin(cross, 0)
 			CreatePool(t, barPath, fooPath, fee500, "79228162514264337593543950336", adminAddr)
@@ -902,36 +904,6 @@ func TestMint(t *testing.T) {
 }
 
 func TestIncreaseLiquidity(t *testing.T) {
-	testing.SetRealm(adminRealm)
-
-	pl.SetPoolCreationFeeByAdmin(cross, 0)
-	CreatePool(t, barPath, fooPath, fee500, "79228162514264337593543950336", adminAddr)
-
-	TokenFaucet(t, barPath, alice)
-	TokenFaucet(t, fooPath, alice)
-
-	testing.SetRealm(posRealm)
-	TokenApprove(t, barPath, adminAddr, poolAddr, maxApprove)
-	TokenApprove(t, fooPath, adminAddr, poolAddr, maxApprove)
-
-	testing.SetOriginCaller(adminAddr)
-	positionId, _, _, _ := Mint(
-		cross,
-		barPath,
-		fooPath,
-		fee500,
-		-10000,
-		10000,
-		"1000000",
-		"1000000",
-		"0",
-		"0",
-		time.Now().Add(time.Hour).Unix(),
-		adminAddr,
-		adminAddr,
-		"",
-	)
-
 	tests := []struct {
 		name             string
 		positionId       uint64
@@ -947,7 +919,7 @@ func TestIncreaseLiquidity(t *testing.T) {
 	}{
 		{
 			name:            "Success - Valid Increase",
-			positionId:      positionId,
+			positionId:      1,
 			amount0Desired:  "1000000",
 			amount1Desired:  "2000000",
 			amount0Min:      "950000",
@@ -959,7 +931,7 @@ func TestIncreaseLiquidity(t *testing.T) {
 		},
 		{
 			name:             "Fail - Deadline Exceeded",
-			positionId:       positionId,
+			positionId:       1,
 			amount0Desired:   "1000000",
 			amount1Desired:   "2000000",
 			amount0Min:       "950000",
@@ -970,7 +942,7 @@ func TestIncreaseLiquidity(t *testing.T) {
 		},
 		{
 			name:             "Fail - Invalid Amount String",
-			positionId:       positionId,
+			positionId:       1,
 			amount0Desired:   "invalid_amount",
 			amount1Desired:   "2000000",
 			amount0Min:       "950000",
@@ -994,7 +966,36 @@ func TestIncreaseLiquidity(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			initPositionTest(t)
+			testing.SetRealm(adminRealm)
+
+			pl.SetPoolCreationFeeByAdmin(cross, 0)
+			CreatePool(t, barPath, fooPath, fee500, "79228162514264337593543950336", adminAddr)
+
+			TokenFaucet(t, barPath, alice)
+			TokenFaucet(t, fooPath, alice)
+
+			testing.SetRealm(posRealm)
+			TokenApprove(t, barPath, adminAddr, poolAddr, maxApprove)
+			TokenApprove(t, fooPath, adminAddr, poolAddr, maxApprove)
+
 			testing.SetOriginCaller(adminAddr)
+			_, _, _, _ = Mint(
+				cross,
+				barPath,
+				fooPath,
+				fee500,
+				-10000,
+				10000,
+				"1000000",
+				"1000000",
+				"0",
+				"0",
+				time.Now().Add(time.Hour).Unix(),
+				adminAddr,
+				adminAddr,
+				"",
+			)
 
 			if tc.expectPanic {
 				uassert.AbortsWithMessage(t,
@@ -1029,18 +1030,6 @@ func TestIncreaseLiquidity(t *testing.T) {
 }
 
 func TestDecreaseLiquidity(t *testing.T) {
-	testing.SetRealm(adminRealm)
-
-	pl.SetPoolCreationFeeByAdmin(cross, 0)
-	CreatePool(t, barPath, fooPath, fee500, "79228162514264337593543950336", adminAddr)
-
-	TokenFaucet(t, barPath, alice)
-	TokenFaucet(t, fooPath, alice)
-
-	testing.SetRealm(posRealm)
-	TokenApprove(t, barPath, adminAddr, poolAddr, maxApprove)
-	TokenApprove(t, fooPath, adminAddr, poolAddr, maxApprove)
-
 	tests := []struct {
 		name              string
 		beforeIncrease    bool
@@ -1058,7 +1047,7 @@ func TestDecreaseLiquidity(t *testing.T) {
 		expectedFee1      string
 	}{
 		{
-			name:              "Success - Decrease 50% Liquidity",
+			name:              "decrease liquidity is success by 50%",
 			liquidityToRemove: "400000",
 			amount0Min:        "8000",
 			amount1Min:        "15000",
@@ -1070,7 +1059,7 @@ func TestDecreaseLiquidity(t *testing.T) {
 			expectedFee1:      "0",
 		},
 		{
-			name:              "Success - Decrease 100% Liquidity",
+			name:              "decrease liquidity is success by 100%",
 			liquidityToRemove: "600000",
 			amount0Min:        "10000",
 			amount1Min:        "20000",
@@ -1083,7 +1072,7 @@ func TestDecreaseLiquidity(t *testing.T) {
 			expectedErrorMsg:  "",
 		},
 		{
-			name:              "Fail - Zero Liquidity",
+			name:              "decrease liquidity is fail by zero liquidity",
 			liquidityToRemove: "0",
 			amount0Min:        "10000",
 			amount1Min:        "20000",
@@ -1093,8 +1082,8 @@ func TestDecreaseLiquidity(t *testing.T) {
 			expectedErrorMsg:  "[GNOSWAP-POSITION-010] zero liquidity || liquidity amount must be greater than 0, got 0",
 		},
 		{
-			name:              "Fail - Underflow",
-			liquidityToRemove: "1541593",
+			name:              "decrease liquidity is fail by underflow",
+			liquidityToRemove: "2541593",
 			amount0Min:        "200000",
 			amount1Min:        "400000",
 			deadlineOffset:    time.Hour,
@@ -1102,10 +1091,10 @@ func TestDecreaseLiquidity(t *testing.T) {
 			expectedHasAbort:  true,
 			expectedFee0:      "0",
 			expectedFee1:      "0",
-			expectedErrorMsg:  "[GNOSWAP-POSITION-019] invalid liquidity || Liquidity requested(1541593) is greater than liquidity held(1541592)",
+			expectedErrorMsg:  "[GNOSWAP-POSITION-019] invalid liquidity || Liquidity requested(2541593) is greater than liquidity held(2541592)",
 		},
 		{
-			name:              "Fail - Deadline Exceeded",
+			name:              "decrease liquidity is fail by deadline exceeded",
 			liquidityToRemove: "50",
 			amount0Min:        "10000",
 			amount1Min:        "20000",
@@ -1115,7 +1104,7 @@ func TestDecreaseLiquidity(t *testing.T) {
 			expectedErrorMsg:  "[GNOSWAP-POSITION-007] transaction expired || transaction too old, now(1234567890) > deadline(1234564290)",
 		},
 		{
-			name:              "Success - Increase and Decrease",
+			name:              "decrease liquidity is success by increase and decrease",
 			beforeIncrease:    true,
 			increaseAmount0:   "500000",
 			increaseAmount1:   "1000000",
@@ -1131,26 +1120,39 @@ func TestDecreaseLiquidity(t *testing.T) {
 		},
 	}
 
-	testing.SetRealm(adminRealm)
-	positionId, _, _, _ := Mint(
-		cross,
-		barPath,
-		fooPath,
-		fee500,
-		-10000,
-		10000,
-		"1000000",
-		"1000000",
-		"0",
-		"0",
-		time.Now().Add(time.Hour).Unix(),
-		adminAddr,
-		adminAddr,
-		"",
-	)
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			initPositionTest(t)
+			testing.SetRealm(adminRealm)
+
+			pl.SetPoolCreationFeeByAdmin(cross, 0)
+			CreatePool(t, barPath, fooPath, fee500, "79228162514264337593543950336", adminAddr)
+
+			TokenFaucet(t, barPath, alice)
+			TokenFaucet(t, fooPath, alice)
+
+			testing.SetRealm(posRealm)
+			TokenApprove(t, barPath, adminAddr, poolAddr, maxApprove)
+			TokenApprove(t, fooPath, adminAddr, poolAddr, maxApprove)
+
 			testing.SetOriginCaller(adminAddr)
+			positionId, _, _, _ := Mint(
+				cross,
+				barPath,
+				fooPath,
+				fee500,
+				-10000,
+				10000,
+				"1000000",
+				"1000000",
+				"0",
+				"0",
+				time.Now().Add(time.Hour).Unix(),
+				adminAddr,
+				adminAddr,
+				"",
+			)
+
 			gnft.Approve(cross, posRealm.Address(), positionIdFrom(positionId))
 
 			deadline := time.Now().Add(tc.deadlineOffset).Unix()
@@ -1307,7 +1309,7 @@ func TestReposition(t *testing.T) {
 		expectedAbortMessage string
 	}{
 		{
-			name:                 "Fail - Reposition after full liquidity removal",
+			name:                 "reposition is failed by full liquidity removal",
 			mintAmount0:          "1000000",
 			mintAmount1:          "2000000",
 			increaseAmount0:      "500000",
@@ -1319,7 +1321,7 @@ func TestReposition(t *testing.T) {
 			expectedAbortMessage: "[GNOSWAP-POSITION-009] position is not clear || position(1) isn't clear(liquidity:3812288, tokensOwed0:0, tokensOwed1:0)",
 		},
 		{
-			name:                 "Fail - Reposition with partial liquidity removal",
+			name:                 "reposition is failed by partial liquidity removal",
 			mintAmount0:          "1000000",
 			mintAmount1:          "2000000",
 			increaseAmount0:      "500000",
@@ -1328,22 +1330,24 @@ func TestReposition(t *testing.T) {
 			tickLower:            -3000,
 			tickUpper:            3000,
 			expectedHasAbort:     true,
-			expectedAbortMessage: "[GNOSWAP-POSITION-009] position is not clear || position(2) isn't clear(liquidity:3812338, tokensOwed0:0, tokensOwed1:0)",
+			expectedAbortMessage: "[GNOSWAP-POSITION-009] position is not clear || position(1) isn't clear(liquidity:3812338, tokensOwed0:0, tokensOwed1:0)",
 		},
 		{
-			name:                 "Fail - Reposition on non-existent positionId",
+			name:                 "reposition is failed by non-existent positionId",
 			mintAmount0:          "1000000",
 			mintAmount1:          "2000000",
 			liquidityToRemove:    "10",
 			tickLower:            -4000,
 			tickUpper:            4000,
 			expectedHasAbort:     true,
-			expectedAbortMessage: "[GNOSWAP-POSITION-009] position is not clear || position(3) isn't clear(liquidity:2541582, tokensOwed0:0, tokensOwed1:0)",
+			expectedAbortMessage: "[GNOSWAP-POSITION-009] position is not clear || position(1) isn't clear(liquidity:2541582, tokensOwed0:0, tokensOwed1:0)",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			initPositionTest(t)
+
 			testing.SetOriginCaller(adminAddr)
 			CreatePoolWithoutFee(t)
 

--- a/contract/r/gnoswap/position/reposition.gno
+++ b/contract/r/gnoswap/position/reposition.gno
@@ -33,6 +33,7 @@ func Reposition(
 
 	// position should be burned to reposition
 	position := MustGetPosition(positionId)
+	caller := getPrevAddr()
 	oldTickLower := position.tickLower
 	oldTickUpper := position.tickUpper
 
@@ -49,7 +50,6 @@ func Reposition(
 		))
 	}
 
-	caller := getPrevAddr()
 	token0, token1, _ := splitOf(position.poolKey)
 	token0, token1, _, _, _ = processTokens(token0, token1, amount0DesiredStr, amount1DesiredStr, caller)
 
@@ -71,7 +71,7 @@ func Reposition(
 	position.tickLower = tickLower
 	position.tickUpper = tickUpper
 
-	currentFeeGrowth, err := getCurrentFeeGrowth(position)
+	currentFeeGrowth, err := getCurrentFeeGrowth(position, caller)
 	if err != nil {
 		panic(newErrorWithDetail(err, "failed to get current fee growth"))
 	}

--- a/contract/r/gnoswap/position/reposition.gno
+++ b/contract/r/gnoswap/position/reposition.gno
@@ -19,6 +19,7 @@ import (
 // Returns Position ID, liquidity, tickLower, tickUpper, amount0, amount1
 // ref: https://docs.gnoswap.io/contracts/position/position.gno#reposition
 func Reposition(
+	cur realm,
 	positionId uint64,
 	tickLower int32,
 	tickUpper int32,

--- a/contract/r/gnoswap/position/testutils.gno
+++ b/contract/r/gnoswap/position/testutils.gno
@@ -1,0 +1,27 @@
+package position
+
+import (
+	"testing"
+
+	"gno.land/p/demo/avl"
+
+	"gno.land/r/gnoswap/v1/gnft"
+	"gno.land/r/gnoswap/v1/pool"
+)
+
+func InitPositionTest(t *testing.T) {
+	t.Helper()
+
+	func(cur realm) {
+		positions = avl.NewTree()
+		nextId = 1
+	}(cross)
+}
+
+func initPositionTest(t *testing.T) {
+	t.Helper()
+
+	InitPositionTest(t)
+	pool.InitPoolTest(t)
+	gnft.InitGNFTTest(t)
+}

--- a/contract/r/gnoswap/position/type.gno
+++ b/contract/r/gnoswap/position/type.gno
@@ -69,12 +69,13 @@ func newMintParams(input ProcessedMintInput, mintInput MintInput) MintParams {
 }
 
 type IncreaseLiquidityParams struct {
-	positionId     uint64     // positionId of the position to increase liquidity
-	amount0Desired *u256.Uint // desired amount of token0 to be minted
-	amount1Desired *u256.Uint // desired amount of token1 to be minted
-	amount0Min     *u256.Uint // minimum amount of token0 to be minted
-	amount1Min     *u256.Uint // minimum amount of token1 to be minted
-	deadline       int64      // time by which the transaction must be included to effect the change
+	positionId     uint64      // positionId of the position to increase liquidity
+	amount0Desired *u256.Uint  // desired amount of token0 to be minted
+	amount1Desired *u256.Uint  // desired amount of token1 to be minted
+	amount0Min     *u256.Uint  // minimum amount of token0 to be minted
+	amount1Min     *u256.Uint  // minimum amount of token1 to be minted
+	deadline       int64       // time by which the transaction must be included to effect the change
+	caller         std.Address // address to call the function
 }
 
 type DecreaseLiquidityParams struct {

--- a/contract/r/gnoswap/position/type.gno
+++ b/contract/r/gnoswap/position/type.gno
@@ -78,12 +78,13 @@ type IncreaseLiquidityParams struct {
 }
 
 type DecreaseLiquidityParams struct {
-	positionId   uint64     // positionId of the position to decrease liquidity
-	liquidity    string     // amount of liquidity to decrease
-	amount0Min   *u256.Uint // minimum amount of token0 to be minted
-	amount1Min   *u256.Uint // minimum amount of token1 to be minted
-	deadline     int64      // time by which the transaction must be included to effect the change
-	unwrapResult bool       // whether to unwrap the token if it's wrapped native token
+	positionId   uint64      // positionId of the position to decrease liquidity
+	liquidity    string      // amount of liquidity to decrease
+	amount0Min   *u256.Uint  // minimum amount of token0 to be minted
+	amount1Min   *u256.Uint  // minimum amount of token1 to be minted
+	deadline     int64       // time by which the transaction must be included to effect the change
+	unwrapResult bool        // whether to unwrap the token if it's wrapped native token
+	caller       std.Address // address to call the function
 }
 
 type MintInput struct {

--- a/contract/r/gnoswap/position/utils_test.gno
+++ b/contract/r/gnoswap/position/utils_test.gno
@@ -6,7 +6,6 @@ import (
 
 	"gno.land/p/demo/grc/grc721"
 	"gno.land/p/demo/uassert"
-	"gno.land/p/demo/ufmt"
 )
 
 func assertPanic(t *testing.T, expectedMsg string, fn func()) {
@@ -28,7 +27,7 @@ func TestGetOrigPkgAddr(t *testing.T) {
 		expected std.Address
 	}{
 		{
-			name:     "Success - getOrigPkgAddr",
+			name:     "getOrigPkgAddr is success",
 			expected: positionAddr,
 		},
 	}
@@ -41,34 +40,47 @@ func TestGetOrigPkgAddr(t *testing.T) {
 }
 
 func TestAssertTokenExists(t *testing.T) {
-	// Mock setup
-	// mockTokenId := uint64(1)
-	mockInvalidTokenId := uint64(9999)
+	tests := []struct {
+		name                 string
+		positionId           uint64
+		expected             bool
+		expectedHasPanic     bool
+		expectedPanicMessage string
+	}{
+		{
+			name:             "assertTokenExists is success by token exists",
+			positionId:       1,
+			expected:         true,
+			expectedHasPanic: false,
+		},
+		{
+			name:                 "assertTokenExists is failed by positionId is zero",
+			positionId:           0,
+			expected:             false,
+			expectedHasPanic:     true,
+			expectedPanicMessage: "[GNOSWAP-POSITION-006] requested data not found || positionId(0) doesn't exist",
+		},
+		{
+			name:                 "assertTokenExists is failed by token does not exist",
+			positionId:           9999,
+			expected:             false,
+			expectedHasPanic:     true,
+			expectedPanicMessage: "[GNOSWAP-POSITION-006] requested data not found || positionId(9999) doesn't exist",
+		},
+	}
 
-	// t.Run("Token Exists - No Panic", func(t *testing.T) {
-	// 	defer func() {
-	// 		if r := recover(); r != nil {
-	// 			t.Errorf("unexpected panic for existing positionId(%d): %v", mockTokenId, r)
-	// 		}
-	// 	}()
-	// 	assertTokenExists(mockTokenId) // Should not panic
-	// })
-
-	t.Run("Token Does Not Exist - Panic Expected", func(t *testing.T) {
-		expectedErr := ufmt.Sprintf("[GNOSWAP-POSITION-006] requested data not found || positionId(%d) doesn't exist", mockInvalidTokenId)
-		uassert.PanicsWithMessage(t, expectedErr, func() {
-			assertTokenExists(mockInvalidTokenId) // Should panic
-		})
-	})
-
-	t.Run("Boundary Case - PositionId Zero", func(t *testing.T) {
-		defer func() {
-			if r := recover(); r == nil {
-				t.Errorf("expected panic for positionId(0) but did not occur")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.expectedHasPanic {
+				uassert.PanicsWithMessage(t, tc.expectedPanicMessage, func() {
+					assertTokenExists(tc.positionId)
+				})
+			} else {
+				assertTokenExists(tc.positionId)
+				uassert.Equal(t, true, true)
 			}
-		}()
-		assertTokenExists(0) // Assume positionId 0 does not exist
-	})
+		})
+	}
 }
 
 func TestAssertOnlyUserOrStaker(t *testing.T) {
@@ -78,17 +90,17 @@ func TestAssertOnlyUserOrStaker(t *testing.T) {
 		expected     bool
 	}{
 		{
-			name:         "Failure - Not User or Staker",
+			name:         "assertOnlyUserOrStaker is failed by Not User or Staker",
 			originCaller: routerAddr,
 			expected:     false,
 		},
 		{
-			name:         "Success - User Call",
+			name:         "assertOnlyUserOrStaker is success by User Call",
 			originCaller: adminAddr,
 			expected:     true,
 		},
 		{
-			name:         "Success - Staker Call",
+			name:         "assertOnlyUserOrStaker is success by Staker Call",
 			originCaller: stakerAddr,
 			expected:     true,
 		},
@@ -112,12 +124,12 @@ func TestAssertOnlyValidAddress(t *testing.T) {
 		errorMsg string
 	}{
 		{
-			name:     "Success - valid address",
+			name:     "assertOnlyValidAddress is success by valid address",
 			addr:     adminAddr,
 			expected: true,
 		},
 		{
-			name:     "Failure - invalid address",
+			name:     "assertOnlyValidAddress is failed by invalid address",
 			addr:     "g1lmvrrrr4er2us84h2732sru76c9zl2nvknha8", // invalid length
 			expected: false,
 			errorMsg: "[GNOSWAP-POSITION-012] invalid address || (g1lmvrrrr4er2us84h2732sru76c9zl2nvknha8)",
@@ -147,13 +159,13 @@ func TestAssertOnlyValidAddressWith(t *testing.T) {
 		errorMsg string
 	}{
 		{
-			name:     "Success - validation address check to compare with other address",
+			name:     "assertOnlyValidAddressWith is success by validation address check to compare with other address",
 			addr:     adminAddr,
 			other:    std.Address("g17290cwvmrapvp869xfnhhawa8sm9edpufzat7d"),
 			expected: true,
 		},
 		{
-			name:     "Failure - two address is different",
+			name:     "assertOnlyValidAddressWith is failed by two address is different",
 			addr:     "g1lmvrrrr4er2us84h2732sru76c9zl2nvknha8",
 			other:    "g17290cwvmrapvp869xfnhhawa8sm9edpufzat7d",
 			expected: false,
@@ -183,54 +195,54 @@ func TestAssertValidNumberString(t *testing.T) {
 	}{
 		// Valid Cases
 		{
-			name:        "Valid Positive Number",
+			name:        "assertValidNumberString is success by valid positive number",
 			input:       "12345",
 			expectPanic: false,
 		},
 		{
-			name:        "Valid Negative Number",
+			name:        "assertValidNumberString is success by valid negative number",
 			input:       "-98765",
 			expectPanic: false,
 		},
 		{
-			name:        "Zero",
+			name:        "assertValidNumberString is success by zero",
 			input:       "0",
 			expectPanic: false,
 		},
 		{
-			name:        "Negative Zero",
+			name:        "assertValidNumberString is success by negative zero",
 			input:       "-0",
 			expectPanic: false,
 		},
 
 		// Invalid Cases
 		{
-			name:        "Empty String",
+			name:        "assertValidNumberString is failed by empty string",
 			input:       "",
 			expectPanic: true,
 		},
 		{
-			name:        "Alphabet in String",
+			name:        "assertValidNumberString is failed by alphabet in string",
 			input:       "12a45",
 			expectPanic: true,
 		},
 		{
-			name:        "Special Characters",
+			name:        "assertValidNumberString is failed by special characters",
 			input:       "123@45",
 			expectPanic: true,
 		},
 		{
-			name:        "Leading Plus Sign",
+			name:        "assertValidNumberString is failed by leading plus sign",
 			input:       "+12345",
 			expectPanic: true,
 		},
 		{
-			name:        "Multiple Negative Signs",
+			name:        "assertValidNumberString is failed by multiple negative signs",
 			input:       "--12345",
 			expectPanic: true,
 		},
 		{
-			name:        "Space in String",
+			name:        "assertValidNumberString is failed by space in string",
 			input:       "123 45",
 			expectPanic: true,
 		},
@@ -263,7 +275,7 @@ func TestDerivePkgAddr(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "Success - derivePkgAddr",
+			name:     "derivePkgAddr is success by derivePkgAddr",
 			input:    pkgPath,
 			expected: "g1q646ctzhvn60v492x8ucvyqnrj2w30cwh6efk5",
 		},
@@ -283,7 +295,7 @@ func TestGetPrevRealm(t *testing.T) {
 		expected     []string
 	}{
 		{
-			name:         "Success - prevRealm is User",
+			name:         "getPrevRealm is success by prevRealm is User",
 			originCaller: adminAddr,
 			expected:     []string{"g17290cwvmrapvp869xfnhhawa8sm9edpufzat7d", ""},
 		},
@@ -308,7 +320,7 @@ func TestGetPrevAddr(t *testing.T) {
 		expected     std.Address
 	}{
 		{
-			name:         "Success - prev Address is User",
+			name:         "getPrevAddr is success by prev Address is User",
 			originCaller: adminAddr,
 			expected:     "g17290cwvmrapvp869xfnhhawa8sm9edpufzat7d",
 		},
@@ -332,7 +344,7 @@ func TestGetPrevAsString(t *testing.T) {
 		expected     []string
 	}{
 		{
-			name:         "Success - prev Realm of user info as string",
+			name:         "getPrevAsString is success by prev Realm of user info as string",
 			originCaller: adminAddr,
 			expected:     []string{"g17290cwvmrapvp869xfnhhawa8sm9edpufzat7d", ""},
 		},
@@ -358,19 +370,19 @@ func TestCheckDeadline(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "Success - checkDeadline",
+			name:     "checkDeadline is success by deadline is greater than now",
 			deadline: 1234567890 + 100,
 			now:      1234567890,
 			expected: "",
 		},
 		{
-			name:     "Failure - checkDeadline",
+			name:     "checkDeadline is failed by deadline is less than now",
 			deadline: 1234567890 - 100,
 			now:      1234567890,
 			expected: "[GNOSWAP-POSITION-007] transaction expired || transaction too old, now(1234567890) > deadline(1234567790)",
 		},
 		{
-			name:     "Success - deadline equals now",
+			name:     "checkDeadline is success by deadline equals now",
 			deadline: 1234567890,
 			now:      1234567890,
 			expected: "",
@@ -399,37 +411,37 @@ func TestPositionIdFrom(t *testing.T) {
 		shouldPanic bool
 	}{
 		{
-			name:        "Panic - nil",
+			name:        "positionIdFrom is failed by nil",
 			input:       nil,
 			expected:    "[GNOSWAP-POSITION-005] invalid input data || positionId is nil",
 			shouldPanic: true,
 		},
 		{
-			name:        "Panic - unsupported type",
+			name:        "positionIdFrom is failed by unsupported type",
 			input:       float64(1),
 			expected:    "[GNOSWAP-POSITION-005] invalid input data || unsupported positionId type",
 			shouldPanic: true,
 		},
 		{
-			name:        "Success - string",
+			name:        "positionIdFrom is success by string",
 			input:       "1",
 			expected:    "1",
 			shouldPanic: false,
 		},
 		{
-			name:        "Success - int",
+			name:        "positionIdFrom is success by int",
 			input:       int(1),
 			expected:    "1",
 			shouldPanic: false,
 		},
 		{
-			name:        "Success - uint64",
+			name:        "positionIdFrom is success by uint64",
 			input:       uint64(1),
 			expected:    "1",
 			shouldPanic: false,
 		},
 		{
-			name:        "Success - grc721.TokenID",
+			name:        "positionIdFrom is success by grc721.TokenID",
 			input:       grc721.TokenID("1"),
 			expected:    "1",
 			shouldPanic: false,
@@ -478,16 +490,16 @@ func TestIsOwner(t *testing.T) {
 		expected   bool
 	}{
 		{
-			name:       "Fail - is not owner",
-			positionId: 1,
-			addr:       alice,
-			expected:   false,
-		},
-		{
-			name:       "Success - is owner",
+			name:       "is owner is success by is owner",
 			positionId: 1,
 			addr:       adminAddr,
 			expected:   true,
+		},
+		{
+			name:       "is owner is failed by is not owner",
+			positionId: 1,
+			addr:       alice,
+			expected:   false,
 		},
 	}
 	for _, tc := range tests {
@@ -544,13 +556,7 @@ func TestPoolKeyDivide(t *testing.T) {
 		shouldPanic   bool
 	}{
 		{
-			name:          "Fail - invalid poolKey",
-			poolKey:       "gno.land/r/onbloc",
-			expectedError: "[GNOSWAP-POSITION-005] invalid input data || invalid poolKey(gno.land/r/onbloc)",
-			shouldPanic:   true,
-		},
-		{
-			name:          "Success - split poolKey",
+			name:          "pool key divide is success by valid poolKey",
 			poolKey:       "gno.land/r/gnoswap/v1/gns:gno.land/r/demo/wugnot:500",
 			expectedPath0: gnsPath,
 			expectedPath1: wugnotPath,
@@ -558,7 +564,13 @@ func TestPoolKeyDivide(t *testing.T) {
 			shouldPanic:   false,
 		},
 		{
-			name:          "Fail -empty poolKey",
+			name:          "pool key divide is failed by invalid poolKey",
+			poolKey:       "gno.land/r/onbloc",
+			expectedError: "[GNOSWAP-POSITION-005] invalid input data || invalid poolKey(gno.land/r/onbloc)",
+			shouldPanic:   true,
+		},
+		{
+			name:          "pool key divide is failed by empty poolKey",
 			poolKey:       "",
 			expectedError: "[GNOSWAP-POSITION-005] invalid input data || invalid poolKey()",
 			shouldPanic:   true,
@@ -612,37 +624,37 @@ func TestSplitOf(t *testing.T) {
 		shouldPanic   bool
 	}{
 		{
-			name:          "Fail - empty poolKey",
+			name:          "split of is failed by empty poolKey",
 			poolKey:       "",
 			expectedError: "[GNOSWAP-POSITION-005] invalid input data || invalid poolKey()",
 			shouldPanic:   true,
 		},
 		{
-			name:          "Fail - invalid delimiter",
+			name:          "split of is failed by invalid delimiter",
 			poolKey:       "gno.land/r/gnoswap:v1/gns:gno.land/r/demo/wugnot-500",
 			expectedError: "[GNOSWAP-POSITION-005] invalid input data || invalid fee(gno.land/r/demo/wugnot-500)",
 			shouldPanic:   true,
 		},
 		{
-			name:          "Fail - non-numeric fee",
+			name:          "split of is failed by non-numeric fee",
 			poolKey:       "gno.land/r/gnoswap/v1/gns:gno.land/r/demo/wugnot:fee",
 			expectedError: "[GNOSWAP-POSITION-005] invalid input data || invalid fee(fee)",
 			shouldPanic:   true,
 		},
 		{
-			name:          "Fail - missing fee part",
+			name:          "split of is failed by missing fee part",
 			poolKey:       "gno.land/r/gnoswap/v1/gns:gno.land/r/demo/wugnot:",
 			expectedError: "[GNOSWAP-POSITION-005] invalid input data || invalid fee()",
 			shouldPanic:   true,
 		},
 		{
-			name:          "Fail - insufficient parts",
+			name:          "split of is failed by insufficient parts",
 			poolKey:       "gno.land/r/gnoswap/v1/gns:gno.land/r/demo",
 			expectedError: "[GNOSWAP-POSITION-005] invalid input data || invalid poolKey(gno.land/r/gnoswap/v1/gns:gno.land/r/demo)",
 			shouldPanic:   true,
 		},
 		{
-			name:          "Success - valid poolKey",
+			name:          "split of is success by valid poolKey",
 			poolKey:       "gno.land/r/gnoswap/v1/gns:gno.land/r/demo/wugnot:500",
 			expectedPath0: "gno.land/r/gnoswap/v1/gns",
 			expectedPath1: "gno.land/r/demo/wugnot",
@@ -650,7 +662,7 @@ func TestSplitOf(t *testing.T) {
 			shouldPanic:   false,
 		},
 		{
-			name:          "Success - poolKey with large fee",
+			name:          "split of is success by poolKey with large fee",
 			poolKey:       "gno.land/r/gnoswap/v1/gns:gno.land/r/demo/wugnot:10000",
 			expectedPath0: "gno.land/r/gnoswap/v1/gns",
 			expectedPath1: "gno.land/r/demo/wugnot",
@@ -658,7 +670,7 @@ func TestSplitOf(t *testing.T) {
 			shouldPanic:   false,
 		},
 		{
-			name:          "Success - poolKey with minimal fee",
+			name:          "split of is success by poolKey with minimal fee",
 			poolKey:       "gno.land/r/gnoswap/v1/gns:gno.land/r/demo/wugnot:1",
 			expectedPath0: "gno.land/r/gnoswap/v1/gns",
 			expectedPath1: "gno.land/r/demo/wugnot",

--- a/contract/r/gnoswap/position/utils_test.gno
+++ b/contract/r/gnoswap/position/utils_test.gno
@@ -521,9 +521,12 @@ func TestIsOperator(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			testing.SetOriginCaller(adminAddr)
+
 			if tc.expected {
 				LPTokenApprove(t, adminAddr, tc.addr, tc.positionId)
 			}
+
 			got := isOperator(tc.positionId, tc.addr)
 			uassert.Equal(t, tc.expected, got)
 		})


### PR DESCRIPTION
## Descriptions

This PR introduces explicit caller (positionCaller) parameters to position-related methods in the Gnoswap contracts, such as Mint, Burn, DecreaseLiquidity, and CollectFee.

### Motivation

Previously, these methods relied on getPrevAddr() to determine the caller or owner of a position. However, this approach causes critical issues when contracts interact with each other, especially between the pool and position contracts:

- **Incorrect Caller Attribution in Contract-to-Contract Calls**:  
  When the pool contract calls the position contract (e.g., during liquidity operations), getPrevAddr() returns the address of the calling contract (the pool), not the original user or intended position owner. This leads to incorrect position key computation, ownership checks, and fee accounting, as the contract address is used instead of the actual user.
- **Security and Logic Errors**:  
  This misattribution can result in unauthorized access, failed permission checks, or even loss of user funds, since the logic assumes the contract is the owner.
- **Explicitness and Correctness**:  
  By explicitly passing the caller (position owner) as a parameter, we ensure that all position-related operations use the correct user address, regardless of how many contract layers are involved in the call chain.

### Changes

- Added positionCaller (std.Address) parameter to Mint, Burn, and related internal methods.
- All internal calls and position key computations now use the explicit caller parameter instead of getPrevAddr().
- Refactored fee growth and position state logic to use the provided caller address.

### Impact

- This change is not backward-compatible for direct contract calls; the new parameter is now required.
- It resolves critical issues in contract-to-contract interactions, ensuring correct attribution and security for all position operations.