### PR TITLE
fix(launchpad): Enforce project conditions

### DIFF
--- a/contract/r/gnoswap/launchpad/_helper_test.gno
+++ b/contract/r/gnoswap/launchpad/_helper_test.gno
@@ -1,0 +1,349 @@
+package launchpad
+
+import (
+	"std"
+	"testing"
+
+	"gno.land/r/demo/wugnot"
+	"gno.land/r/gnoswap/v1/gns"
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/baz"
+	"gno.land/r/onbloc/foo"
+	"gno.land/r/onbloc/obl"
+	"gno.land/r/onbloc/qux"
+	"gno.land/r/onbloc/usdc"
+
+	"gno.land/p/demo/testutils"
+	"gno.land/p/gnoswap/consts"
+
+	"gno.land/r/gnoswap/v1/access"
+	"gno.land/r/gnoswap/v1/common"
+)
+
+const (
+	ugnotDenom string = "ugnot"
+	ugnotPath  string = "ugnot"
+	wugnotPath string = "gno.land/r/demo/wugnot"
+	gnsPath    string = "gno.land/r/gnoswap/v1/gns"
+	barPath    string = "gno.land/r/onbloc/bar"
+	bazPath    string = "gno.land/r/onbloc/baz"
+	fooPath    string = "gno.land/r/onbloc/foo"
+	oblPath    string = "gno.land/r/onbloc/obl"
+	quxPath    string = "gno.land/r/onbloc/qux"
+
+	fee100      uint32 = 100
+	fee500      uint32 = 500
+	fee3000     uint32 = 3000
+	maxApprove  int64  = 9223372036854775806
+	max_timeout int64  = 9999999999
+
+	maxSqrtPriceLimitX96 string = "1461373636630004318706518188784493106690254656249"
+)
+
+var (
+	// define addresses to use in tests
+	addr01 = testutils.TestAddress("addr01")
+	addr02 = testutils.TestAddress("addr02")
+)
+
+var (
+	fooToken = common.GetToken(fooPath)
+	barToken = common.GetToken(barPath)
+	bazToken = common.GetToken(bazPath)
+)
+
+var (
+	adminAddr, _  = access.GetAddress(access.ROLE_ADMIN)
+	devOpsAddr, _ = access.GetAddress(access.ROLE_DEVOPS)
+
+	govAddr, _      = access.GetAddress(access.ROLE_GOVERNANCE)
+	stakerAddr, _   = access.GetAddress(access.ROLE_STAKER)
+	emissionAddr, _ = access.GetAddress(access.ROLE_EMISSION)
+
+	alice      = testutils.TestAddress("alice")
+	adminRealm = std.NewUserRealm(adminAddr)
+	posRealm   = std.NewCodeRealm(consts.POSITION_PATH)
+	rouRealm   = std.NewCodeRealm(consts.ROUTER_PATH)
+
+	// addresses used in tests
+	addrUsedInTest = []std.Address{addr01, addr02}
+)
+
+func TokenFaucet(t *testing.T, tokenPath string, to std.Address) {
+	t.Helper()
+	testing.SetOriginCaller(adminAddr)
+	defaultAmount := int64(5_000_000_000)
+
+	func() {
+		testing.SetRealm(adminRealm)
+		switch tokenPath {
+		case wugnotPath:
+			wugnotTransfer(t, to, defaultAmount)
+		case gnsPath:
+			gnsTransfer(t, to, defaultAmount)
+		case barPath:
+			barTransfer(t, to, defaultAmount)
+		case bazPath:
+			bazTransfer(t, to, defaultAmount)
+		case fooPath:
+			fooTransfer(t, to, defaultAmount)
+		case oblPath:
+			oblTransfer(t, to, defaultAmount)
+		case quxPath:
+			quxTransfer(t, to, defaultAmount)
+		default:
+			panic("token not found")
+		}
+	}()
+}
+
+func TokenBalance(t *testing.T, tokenPath string, owner std.Address) int64 {
+	t.Helper()
+	switch tokenPath {
+	case wugnotPath:
+		return wugnot.BalanceOf(owner)
+	case gnsPath:
+		return gns.BalanceOf(owner)
+	case barPath:
+		return bar.BalanceOf(owner)
+	case bazPath:
+		return baz.BalanceOf(owner)
+	case fooPath:
+		return foo.BalanceOf(owner)
+	case oblPath:
+		return obl.BalanceOf(owner)
+	case quxPath:
+		return qux.BalanceOf(owner)
+	default:
+		panic("token not found")
+	}
+}
+
+func TokenAllowance(t *testing.T, tokenPath string, owner, spender std.Address) int64 {
+	t.Helper()
+	switch tokenPath {
+	case wugnotPath:
+		return wugnot.Allowance(owner, spender)
+	case gnsPath:
+		return gns.Allowance(owner, spender)
+	case barPath:
+		return bar.Allowance(owner, spender)
+	case bazPath:
+		return baz.Allowance(owner, spender)
+	case fooPath:
+		return foo.Allowance(owner, spender)
+	case oblPath:
+		return obl.Allowance(owner, spender)
+	case quxPath:
+		return qux.Allowance(owner, spender)
+	default:
+		panic("token not found")
+	}
+}
+
+func TokenApprove(t *testing.T, tokenPath string, owner, spender std.Address, amount int64) {
+	t.Helper()
+	switch tokenPath {
+	case wugnotPath:
+		wugnotApprove(t, owner, spender, amount)
+	case gnsPath:
+		gnsApprove(t, owner, spender, amount)
+	case barPath:
+		barApprove(t, owner, spender, amount)
+	case bazPath:
+		bazApprove(t, owner, spender, amount)
+	case fooPath:
+		fooApprove(t, owner, spender, amount)
+	case oblPath:
+		oblApprove(t, owner, spender, amount)
+	case quxPath:
+		quxApprove(t, owner, spender, amount)
+	default:
+		panic("token not found")
+	}
+}
+
+func wugnotApprove(t *testing.T, owner, spender std.Address, amount int64) {
+	t.Helper()
+	testing.SetRealm(std.NewUserRealm(owner))
+	wugnot.Approve(cross, spender, amount)
+}
+
+func gnsApprove(t *testing.T, owner, spender std.Address, amount int64) {
+	t.Helper()
+	testing.SetRealm(std.NewUserRealm(owner))
+	gns.Approve(cross, spender, amount)
+}
+
+func barApprove(t *testing.T, owner, spender std.Address, amount int64) {
+	t.Helper()
+	testing.SetRealm(std.NewUserRealm(owner))
+	bar.Approve(cross, spender, amount)
+}
+
+func bazApprove(t *testing.T, owner, spender std.Address, amount int64) {
+	t.Helper()
+	testing.SetRealm(std.NewUserRealm(owner))
+	baz.Approve(cross, spender, amount)
+}
+
+func fooApprove(t *testing.T, owner, spender std.Address, amount int64) {
+	t.Helper()
+	testing.SetRealm(std.NewUserRealm(owner))
+	foo.Approve(cross, spender, amount)
+}
+
+func oblApprove(t *testing.T, owner, spender std.Address, amount int64) {
+	t.Helper()
+	testing.SetRealm(std.NewUserRealm(owner))
+	obl.Approve(cross, spender, amount)
+}
+
+func quxApprove(t *testing.T, owner, spender std.Address, amount int64) {
+	t.Helper()
+	testing.SetRealm(std.NewUserRealm(owner))
+	qux.Approve(cross, spender, amount)
+}
+
+func wugnotTransfer(t *testing.T, to std.Address, amount int64) {
+	t.Helper()
+	testing.SetRealm(std.NewUserRealm(adminAddr))
+	wugnot.Transfer(cross, to, amount)
+}
+
+func gnsTransfer(t *testing.T, to std.Address, amount int64) {
+	t.Helper()
+	testing.SetRealm(std.NewUserRealm(adminAddr))
+	gns.Transfer(cross, to, amount)
+}
+
+func barTransfer(t *testing.T, to std.Address, amount int64) {
+	t.Helper()
+	testing.SetRealm(std.NewUserRealm(adminAddr))
+	bar.Transfer(cross, to, amount)
+}
+
+func bazTransfer(t *testing.T, to std.Address, amount int64) {
+	t.Helper()
+	testing.SetRealm(std.NewUserRealm(adminAddr))
+	baz.Transfer(cross, to, amount)
+}
+
+func fooTransfer(t *testing.T, to std.Address, amount int64) {
+	t.Helper()
+	testing.SetRealm(std.NewUserRealm(adminAddr))
+	foo.Transfer(cross, to, amount)
+}
+
+func oblTransfer(t *testing.T, to std.Address, amount int64) {
+	t.Helper()
+	testing.SetRealm(std.NewUserRealm(adminAddr))
+	obl.Transfer(cross, to, amount)
+}
+
+func quxTransfer(t *testing.T, to std.Address, amount int64) {
+	t.Helper()
+	testing.SetRealm(std.NewUserRealm(adminAddr))
+	qux.Transfer(cross, to, amount)
+}
+
+// ----------------------------------------------------------------------------
+// ugnot
+
+func ugnotTransfer(t *testing.T, from, to std.Address, amount int64) {
+	t.Helper()
+
+	testing.SetRealm(std.NewUserRealm(from))
+	testing.SetOriginSend(std.Coins{{ugnotDenom, amount}})
+	banker := std.NewBanker(std.BankerTypeRealmSend)
+	banker.SendCoins(from, to, std.Coins{{ugnotDenom, amount}})
+}
+
+func ugnotBalanceOf(t *testing.T, addr std.Address) int64 {
+	t.Helper()
+
+	banker := std.NewBanker(std.BankerTypeRealmIssue)
+	coins := banker.GetCoins(addr)
+	if len(coins) == 0 {
+		return 0
+	}
+
+	return coins.AmountOf(ugnotDenom)
+}
+
+func ugnotMint(t *testing.T, addr std.Address, denom string, amount int64) {
+	t.Helper()
+	testing.IssueCoins(addr, std.Coins{{denom, amount}})
+}
+
+func ugnotBurn(t *testing.T, addr std.Address, denom string, amount int64) {
+	t.Helper()
+	banker := std.NewBanker(std.BankerTypeRealmIssue)
+	banker.RemoveCoin(addr, denom, amount)
+}
+
+func ugnotFaucet(t *testing.T, to std.Address, amount int64) {
+	t.Helper()
+	faucetAddress := adminAddr
+	testing.SetOriginCaller(faucetAddress)
+
+	if ugnotBalanceOf(t, faucetAddress) < amount {
+		newCoins := std.Coins{{ugnotDenom, int64(amount)}}
+		ugnotMint(t, faucetAddress, newCoins[0].Denom, newCoins[0].Amount)
+		testing.SetOriginSend(newCoins)
+	}
+	ugnotTransfer(t, faucetAddress, to, amount)
+}
+
+func ugnotDeposit(t *testing.T, addr std.Address, amount int64) {
+	t.Helper()
+	testing.SetRealm(std.NewUserRealm(addr))
+	wugnotAddr := consts.WUGNOT_ADDR
+	banker := std.NewBanker(std.BankerTypeRealmSend)
+	banker.SendCoins(addr, wugnotAddr, std.Coins{{ugnotDenom, int64(amount)}})
+	wugnot.Deposit(cross)
+}
+
+func burnTokens(t *testing.T) {
+	t.Helper()
+
+	// burn tokens
+	for _, addr := range addrUsedInTest {
+		burnFoo(addr)
+		burnBar(addr)
+		burnBaz(addr)
+		burnQux(addr)
+		burnObl(addr)
+		burnUsdc(addr)
+	}
+}
+
+func burnFoo(addr std.Address) {
+	testing.SetRealm(std.NewUserRealm(adminAddr))
+	foo.Burn(cross, addr, foo.BalanceOf(addr))
+}
+
+func burnBar(addr std.Address) {
+	testing.SetRealm(std.NewUserRealm(adminAddr))
+	bar.Burn(cross, addr, bar.BalanceOf(addr))
+}
+
+func burnBaz(addr std.Address) {
+	testing.SetRealm(std.NewUserRealm(adminAddr))
+	baz.Burn(cross, addr, baz.BalanceOf(addr))
+}
+
+func burnQux(addr std.Address) {
+	testing.SetRealm(std.NewUserRealm(adminAddr))
+	qux.Burn(cross, addr, qux.BalanceOf(addr))
+}
+
+func burnObl(addr std.Address) {
+	testing.SetRealm(std.NewUserRealm(adminAddr))
+	obl.Burn(cross, addr, obl.BalanceOf(addr))
+}
+
+func burnUsdc(addr std.Address) {
+	testing.SetRealm(std.NewUserRealm(adminAddr))
+	usdc.Burn(cross, addr, usdc.BalanceOf(addr))
+}

--- a/contract/r/gnoswap/launchpad/launchpad_reward.gno
+++ b/contract/r/gnoswap/launchpad/launchpad_reward.gno
@@ -4,6 +4,10 @@ import (
 	"std"
 
 	"gno.land/p/demo/ufmt"
+	"gno.land/p/gnoswap/consts"
+
+	"gno.land/r/gnoswap/v1/common"
+	"gno.land/r/gnoswap/v1/gov/xgns"
 )
 
 // CollectRewardByDepositId collects reward from a specific deposit.
@@ -34,6 +38,23 @@ func CollectRewardByDepositId(cur realm, depositID string) int64 {
 
 	if !deposit.IsOwner(previousAddress) {
 		panic(makeErrorWithDetails(errInvalidOwner, ufmt.Sprintf("(%s)", previousAddress.String())).Error())
+	}
+
+	// Check project conditions before allowing reward collection
+	project, err := getProject(deposit.ProjectID())
+	if err != nil {
+		panic(err.Error())
+	}
+
+	balanceOfFn := func(tokenPath string, caller std.Address) int64 {
+		if tokenPath == consts.GOV_XGNS_PATH {
+			return xgns.BalanceOf(caller)
+		}
+		return common.BalanceOf(tokenPath, caller)
+	}
+
+	if err := project.CheckConditions(previousAddress, balanceOfFn); err != nil {
+		panic(err.Error())
 	}
 
 	currentHeight := std.ChainHeight()

--- a/contract/r/gnoswap/launchpad/launchpad_reward_test.gno
+++ b/contract/r/gnoswap/launchpad/launchpad_reward_test.gno
@@ -1,0 +1,92 @@
+package launchpad
+
+import (
+	"std"
+	"testing"
+	"time"
+
+	"gno.land/p/demo/testutils"
+	"gno.land/p/demo/uassert"
+
+	"gno.land/r/gnoswap/v1/access"
+	"gno.land/r/gnoswap/v1/gns"
+	"gno.land/r/onbloc/foo"
+	"gno.land/r/onbloc/obl"
+)
+
+func TestConditionCheckedAtAllStages(t *testing.T) {
+	initLaunchpadProjectTest(t)
+	initLaunchpadProjectTestAvgBlockTime(t, 2000)
+
+	adminAddr, _ := access.GetAddress(access.ROLE_ADMIN)
+	launchpadAddr, _ := access.GetAddress(access.ROLE_LAUNCHPAD)
+	user := testutils.TestAddress("user")
+
+	testing.SetOriginCaller(adminAddr)
+	obl.Approve(cross, launchpadAddr, 1_000_000_000)
+
+	currentTime := time.Now().Unix()
+	currentHeight := std.ChainHeight()
+
+	project, err := createProject(
+		&createProjectParams{
+			name:               "Test Project",
+			tokenPath:          "gno.land/r/onbloc/obl",
+			depositAmount:      1_000_000_000,
+			conditionTokens:    "gno.land/r/onbloc/foo",
+			conditionAmounts:   "1000",
+			tier30Ratio:        100,
+			tier90Ratio:        0,
+			tier180Ratio:       0,
+			averageBlockTimeMs: 2000,
+			recipient:          testutils.TestAddress("project"),
+			startTime:          currentTime + 3600,
+			currentTime:        currentTime,
+			currentHeight:      currentHeight,
+		},
+	)
+	uassert.NoError(t, err)
+	projects.Set(project.ID(), project)
+
+	testing.SkipHeights(1800)
+
+	// Give user tokens to meet condition
+	testing.SetOriginCaller(user)
+	TokenFaucet(t, fooPath, user)
+	TokenFaucet(t, gnsPath, user)
+	gns.Approve(cross, launchpadAddr, 1_000_000)
+
+	// verify user meets condition
+	fooBalance := foo.BalanceOf(user)
+	uassert.True(t, fooBalance >= 1000, "User should have enough FOO tokens")
+
+	// user deposits successfully
+	deposit, _, _, _, err := depositGns(project.ID(), 30, 1_000_000, user)
+	uassert.NoError(t, err, "Deposit should succeed with condition met")
+	deposits.Set(deposit.ID(), deposit)
+
+	// user gets rid of all foo tokens
+	foo.Transfer(cross, testutils.TestAddress("burn"), foo.BalanceOf(user))
+	uassert.Equal(t, int64(0), foo.BalanceOf(user), "User should have 0 FOO")
+
+	// wait for rewards to accumulate
+	testing.SkipHeights(1000)
+	expectedPanicMsg := "[GNOSWAP-LAUNCHPAD-016] invalid data || input amount(0) is less than minimum amount(1000)"
+	// user cannot collect rewards without foo tokens anymore
+	func() {
+		uassert.AbortsWithMessage(t, expectedPanicMsg, func() {
+			CollectRewardByDepositId(cross, deposit.ID())
+		})
+	}()
+
+	// fast forward to end of tier
+	projectTier, _ := project.getTier(30)
+	testing.SetHeight(projectTier.EndHeight() + 1)
+
+	// user cannot withdraw deposit without foo tokens anymore
+	func() {
+		uassert.AbortsWithMessage(t, expectedPanicMsg, func() {
+			CollectDepositGns(cross, deposit.ID())
+		})
+	}()
+}

--- a/contract/r/gnoswap/launchpad/launchpad_withdraw.gno
+++ b/contract/r/gnoswap/launchpad/launchpad_withdraw.gno
@@ -4,9 +4,12 @@ import (
 	"std"
 
 	"gno.land/p/demo/ufmt"
+	"gno.land/p/gnoswap/consts"
 
+	"gno.land/r/gnoswap/v1/common"
 	"gno.land/r/gnoswap/v1/emission"
 	gov_staker "gno.land/r/gnoswap/v1/gov/staker"
+	"gno.land/r/gnoswap/v1/gov/xgns"
 )
 
 // CollectDepositGns collects rewards from all deposits associated with the caller.
@@ -36,6 +39,23 @@ func CollectDepositGns(cur realm, depositID string) (int64, error) {
 
 	if !deposit.IsOwner(previousAddress) {
 		panic(makeErrorWithDetails(errInvalidOwner, ufmt.Sprintf("(%s)", previousAddress.String())).Error())
+	}
+
+	// Check project conditions before allowing withdrawal
+	project, err := getProject(deposit.ProjectID())
+	if err != nil {
+		panic(err.Error())
+	}
+
+	balanceOfFn := func(tokenPath string, caller std.Address) int64 {
+		if tokenPath == consts.GOV_XGNS_PATH {
+			return xgns.BalanceOf(caller)
+		}
+		return common.BalanceOf(tokenPath, caller)
+	}
+
+	if err := project.CheckConditions(previousAddress, balanceOfFn); err != nil {
+		panic(err.Error())
 	}
 
 	recipient, withdrawalAmount, err := withdrawDeposit(deposit, std.ChainHeight())


### PR DESCRIPTION
# Description

The launchpad contract only validated project conditions (e.g., minimum token holdings) at the time of deposit. This allowed users to circumvent the requirements by:

1. Temporarily acquiring the required tokens
2. Making a deposit
3. Immediately disposing of the tokens
4. Still being able to collect rewards and withdraw deposits without meeting conditions

This behavior undermined the purpose of project conditions, which are meant to ensure participants maintain certain qualifications throughout their participation.

## Changes

- Modified `CollectRewardByDepositId` to validate project conditions before allowing reward collection
- Modified `CollectDepositGns` to validate project conditions before allowing deposit withdrawal
- Added test `TestConditionCheckedAtAllStages` to verify conditions are enforced at all stages

## Impact

- Users can no longer bypass project requirements by temporarily acquiring tokens
- Project conditions are now consistently enforced throughout the deposit lifecycle