### PR TITLE
test(router): Unit test for `handleMultiSwap`

### DIFF
--- a/contract/r/gnoswap/router/router_test.gno
+++ b/contract/r/gnoswap/router/router_test.gno
@@ -19,6 +19,11 @@ import (
 	"gno.land/r/gnoswap/v1/gns"
 	pl "gno.land/r/gnoswap/v1/pool"
 	pn "gno.land/r/gnoswap/v1/position"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/baz"
+	"gno.land/r/onbloc/foo"
+	"gno.land/r/onbloc/qux"
 )
 
 func TestFinalizeSwap(t *testing.T) {
@@ -515,201 +520,6 @@ func TestCompareExactInAndDrySwapWithWhenLiquidityAdded(t *testing.T) {
 	}
 }
 
-func TestCompareExactInAndDrySwapWithWhenLiquidityPartiallyRemoved(t *testing.T) {
-	t.Skip("permission problem")
-	const wugnotTokenPath = "gno.land/r/demo/wugnot"
-	const gnsTokenPath = "gno.land/r/gnoswap/v1/gns"
-	const routerPath = consts.ROUTER_PATH
-	const maxTimeout int64 = 9999999999
-	const wugnotGnsPoolPath = "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:10000"
-
-	routerContract := routerAddr
-	poolContract := poolAddr
-	positionContract := positionAddr
-
-	alice := testutils.TestAddress("alice")
-	positionOwner := admin
-
-	tests := []struct {
-		name             string
-		tokenPath0       string
-		tokenPath1       string
-		feeTier          uint32
-		recipient        std.Address
-		tickLower        int32
-		tickUpper        int32
-		amount0Requested string
-		amount1Requested string
-		feeProtocol0     uint8
-		feeProtocol1     uint8
-		inputToken       string
-		outputToken      string
-		amountIn         string
-		routeArr         string
-		quoteArr         string
-		amountOutMin     string
-		expectedAmount0  string
-		expectedAmount1  string
-		expectPanic      bool
-	}{
-		{
-			name:             "success - gnot -> gns",
-			tokenPath0:       wugnotTokenPath,
-			tokenPath1:       gnsTokenPath,
-			feeTier:          pl.FeeTier10000,
-			recipient:        alice,
-			tickLower:        -200,
-			tickUpper:        200,
-			amount0Requested: "100000000",
-			amount1Requested: "100000000",
-			feeProtocol0:     10,
-			feeProtocol1:     10,
-			inputToken:       wugnotTokenPath,
-			outputToken:      gnsTokenPath,
-			amountIn:         "10000000",
-			routeArr:         wugnotGnsPoolPath,
-			quoteArr:         "100",
-			amountOutMin:     "850000",
-			expectedAmount0:  "10000000",
-			expectedAmount1:  "-9872994",
-			expectPanic:      true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			initRouterTest(t)
-
-			// Pool Creation
-			testing.SetRealm(std.NewUserRealm(positionOwner))
-			pl.SetPoolCreationFeeByAdmin(cross, 0)
-			if !pl.DoesPoolPathExist(pl.GetPoolPath(tt.tokenPath0, tt.tokenPath1, tt.feeTier)) {
-				pl.CreatePool(cross, tt.tokenPath0, tt.tokenPath1, tt.feeTier, "79228162514264337593543950336")
-			}
-
-			if tt.feeProtocol0 != 0 || tt.feeProtocol1 != 0 {
-				pool := pl.GetPool(tt.tokenPath0, tt.tokenPath1, tt.feeTier)
-				pl.SetFeeProtocolByAdmin(cross, tt.feeProtocol0, tt.feeProtocol1)
-				uassert.Equal(t, tt.feeProtocol0, pool.Slot0FeeProtocol()%16)
-				uassert.Equal(t, tt.feeProtocol1, pool.Slot0FeeProtocol()>>4)
-			}
-
-			testing.SetOriginCaller(positionOwner)
-			newCoins := std.Coins{{"ugnot", int64(20000000000)}}
-			testing.IssueCoins(positionOwner, newCoins)
-			testing.SetOriginSend(newCoins)
-			banker := std.NewBanker(std.BankerTypeRealmSend)
-			banker.SendCoins(positionOwner, consts.WUGNOT_ADDR, std.Coins{{"ugnot", int64(10000000000)}})
-			wugnot.Deposit(cross)
-			if tt.recipient != positionOwner {
-				wugnot.Transfer(cross, tt.recipient, 10000000000)
-			}
-			banker.SendCoins(positionOwner, tt.recipient, std.Coins{{"ugnot", int64(10000000000)}})
-			gns.Transfer(cross, tt.recipient, 10000000000)
-
-			testing.SetRealm(std.NewUserRealm(tt.recipient))
-			wugnot.Approve(cross, poolContract, maxApprove)
-			gns.Approve(cross, poolContract, maxApprove)
-
-			func(cur realm) {
-				teller := common.GetTokenTeller(wugnotTokenPath)
-				teller.Approve(poolContract, maxApprove)
-			}(cross)
-
-			// Position Creation
-			positionId, liquidity, _, _ := pn.Mint(
-				cross,
-				tt.tokenPath0,
-				tt.tokenPath1,
-				tt.feeTier,
-				tt.tickLower,
-				tt.tickUpper,
-				tt.amount0Requested,
-				tt.amount1Requested,
-				"0",
-				"0",
-				maxTimeout,
-				tt.recipient,
-				tt.recipient,
-				"",
-			)
-			testing.SkipHeights(1)
-
-			// Decrease Liquidity
-			testing.SetRealm(std.NewUserRealm(tt.recipient))
-			wugnot.Approve(cross, poolContract, maxApprove)
-			gns.Approve(cross, poolContract, maxApprove)
-			wugnot.Approve(cross, positionContract, maxApprove)
-			gns.Approve(cross, positionContract, maxApprove)
-			liquidityUint64, _ := strconv.ParseUint(liquidity, 10, 64)
-			partialLiquidity := liquidityUint64 / 5
-			reqLiquidity := strconv.FormatUint(partialLiquidity, 10)
-
-			testing.SetOriginCaller(tt.recipient)
-			pn.DecreaseLiquidity(
-				cross,
-				positionId,
-				reqLiquidity,
-				"0",
-				"0",
-				maxTimeout,
-				true,
-			)
-
-			// Swap
-			testing.SetOriginCaller(tt.recipient)
-			wugnot.Transfer(cross, routerContract, 20000000)
-			gns.Transfer(cross, routerContract, 20000000)
-			wugnot.Approve(cross, routerContract, maxApprove)
-			gns.Approve(cross, routerContract, maxApprove)
-			beforeWugnotBalance := wugnot.BalanceOf(tt.recipient)
-
-			testing.SetRealm(std.NewCodeRealm(routerPath))
-			wugnot.Approve(cross, poolContract, maxApprove)
-
-			DrySwapRoute(
-				tt.inputToken,
-				tt.outputToken,
-				tt.amountIn,
-				"EXACT_IN",
-				tt.routeArr,
-				tt.quoteArr,
-				tt.amountOutMin,
-			)
-
-			amountIn, amountOut := ExactInSwapRoute(
-				cross,
-				tt.inputToken,
-				tt.outputToken,
-				tt.amountIn,
-				tt.routeArr,
-				tt.quoteArr,
-				tt.amountOutMin,
-				time.Now().Add(time.Hour).Unix(),
-				"", // referrer
-			)
-			testing.SkipHeights(1)
-			afterWugnotBalance := wugnot.BalanceOf(tt.recipient)
-
-			defer func() {
-				if r := recover(); r != nil {
-					if tt.expectPanic {
-						if errMsg, ok := r.(string); ok {
-							uassert.Equal(t, "not authorized", errMsg)
-						}
-					} else {
-						t.Errorf("expected panic but got none")
-					}
-				}
-			}()
-
-			uassert.Equal(t, tt.expectedAmount0, amountIn)
-			uassert.Equal(t, tt.expectedAmount1, amountOut)
-			uassert.Equal(t, tt.expectedAmount0, strconv.FormatInt(int64(beforeWugnotBalance-afterWugnotBalance), 10))
-		})
-	}
-}
-
 func TestCompareExactInAndDrySwapWithWhenZeroForOneIsFalse(t *testing.T) {
 	const wugnotTokenPath = "gno.land/r/demo/wugnot"
 	const gnsTokenPath = "gno.land/r/gnoswap/v1/gns"
@@ -963,4 +773,212 @@ func TestValidateQuoteSum(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHandleMultiSwap(t *testing.T) {
+	tests := []struct {
+		name              string
+		swapType          SwapType
+		route             string
+		numHops           int
+		amountSpecified   string
+		expectedAmountIn  string
+		expectedAmountOut string
+		shouldPanic       bool
+		panicMsg          string
+	}{
+		{
+			name:              "ExactIn - 2 hops",
+			swapType:          ExactIn,
+			route:             "gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:500*POOL*gno.land/r/onbloc/baz:gno.land/r/onbloc/qux:500",
+			numHops:           2,
+			amountSpecified:   "1000",
+			expectedAmountIn:  "1000",
+			expectedAmountOut: "7337",
+		},
+		{
+			name:              "ExactOut - 2 hops",
+			swapType:          ExactOut,
+			route:             "gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:500*POOL*gno.land/r/onbloc/baz:gno.land/r/onbloc/qux:500",
+			numHops:           2,
+			amountSpecified:   "1000",
+			expectedAmountIn:  "370",
+			expectedAmountOut: "2711",
+		},
+		{
+			name:              "ExactIn - 3 hops",
+			swapType:          ExactIn,
+			route:             "gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:500*POOL*gno.land/r/onbloc/baz:gno.land/r/onbloc/qux:500*POOL*gno.land/r/onbloc/qux:gno.land/r/onbloc/foo:500",
+			numHops:           3,
+			amountSpecified:   "1000",
+			expectedAmountIn:  "1000",
+			expectedAmountOut: "19740",
+		},
+		{
+			name:            "Invalid SwapType",
+			swapType:        SwapType(99),
+			route:           "gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:500*POOL*gno.land/r/onbloc/baz:gno.land/r/onbloc/qux:500",
+			numHops:         2,
+			amountSpecified: "1000",
+			shouldPanic:     true,
+			panicMsg:        "invalid swap type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initRouterTest(t)
+			createMultiHopPools(t)
+
+			if tt.shouldPanic {
+				defer func() {
+					r := recover()
+					if r == nil {
+						t.Errorf("Expected panic but got none")
+						return
+					}
+					if errMsg, ok := r.(string); ok {
+						if !strings.Contains(errMsg, tt.panicMsg) {
+							t.Errorf("Expected panic message containing %q, got %q", tt.panicMsg, errMsg)
+						}
+					}
+				}()
+			}
+
+			amountSpecified := i256.MustFromDecimal(tt.amountSpecified)
+
+			amountIn, amountOut := handleMultiSwap(
+				tt.swapType,
+				tt.route,
+				tt.numHops,
+				amountSpecified,
+			)
+
+			if !tt.shouldPanic {
+				uassert.Equal(t, tt.expectedAmountIn, amountIn.ToString())
+				uassert.Equal(t, tt.expectedAmountOut, amountOut.ToString())
+			}
+		})
+	}
+}
+
+func TestProcessRoute_MultiHops(t *testing.T) {
+	tests := []struct {
+		name              string
+		route             string
+		toSwap            string
+		swapType          SwapType
+		expectedAmountIn  string
+		expectedAmountOut string
+		expectError       bool
+		errorMsg          string
+	}{
+		{
+			name:              "Single hop route - ExactIn",
+			route:             "gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:500",
+			toSwap:            "1000",
+			swapType:          ExactIn,
+			expectedAmountIn:  "1000",
+			expectedAmountOut: "2711",
+			expectError:       false,
+		},
+		{
+			name:              "Multi hop route (2 hops) - ExactIn - triggers default case",
+			route:             "gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:500*POOL*gno.land/r/onbloc/baz:gno.land/r/onbloc/qux:500",
+			toSwap:            "1000",
+			swapType:          ExactIn,
+			expectedAmountIn:  "1000",
+			expectedAmountOut: "7337",
+			expectError:       false,
+		},
+		{
+			name:              "Multi hop route (3 hops) - ExactIn - triggers default case",
+			route:             "gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:500*POOL*gno.land/r/onbloc/baz:gno.land/r/onbloc/qux:500*POOL*gno.land/r/onbloc/qux:gno.land/r/onbloc/foo:500",
+			toSwap:            "1000",
+			swapType:          ExactIn,
+			expectedAmountIn:  "1000",
+			expectedAmountOut: "19740",
+			expectError:       false,
+		},
+		{
+			name:              "Multi hop route (2 hops) - ExactOut - triggers default case",
+			route:             "gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:500*POOL*gno.land/r/onbloc/baz:gno.land/r/onbloc/qux:500",
+			toSwap:            "1000",
+			swapType:          ExactOut,
+			expectedAmountIn:  "370",
+			expectedAmountOut: "2711",
+			expectError:       false,
+		},
+		{
+			name:              "Empty route",
+			route:             "",
+			toSwap:            "1000",
+			swapType:          ExactIn,
+			expectedAmountIn:  "",
+			expectedAmountOut: "",
+			expectError:       true,
+			errorMsg:          "[GNOSWAP-ROUTER-009] invalid pool path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initRouterTest(t)
+			createMultiHopPools(t)
+
+			op := &baseSwapOperation{
+				amountSpecified: i256.MustFromDecimal(tt.toSwap),
+			}
+
+			if tt.expectError {
+				defer func() {
+					r := recover()
+					if r == nil {
+						t.Errorf("Expected error but got none")
+						return
+					}
+					if errMsg, ok := r.(string); ok {
+						if !strings.Contains(errMsg, tt.errorMsg) {
+							t.Errorf("Expected error message containing %q, got %q", tt.errorMsg, errMsg)
+						}
+					}
+				}()
+			}
+
+			toSwapAmount := i256.MustFromDecimal(tt.toSwap)
+			amountIn, amountOut, err := op.processRoute(tt.route, toSwapAmount, tt.swapType)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				uassert.Equal(t, tt.expectedAmountIn, amountIn.ToString())
+				uassert.Equal(t, tt.expectedAmountOut, amountOut.ToString())
+			}
+		})
+	}
+}
+
+func createMultiHopPools(t *testing.T) {
+	t.Helper()
+	testing.SetRealm(adminRealm)
+
+	gns.Approve(cross, poolAddr, pl.GetPoolCreationFee()*3)
+
+	pl.CreatePool(cross, barPath, bazPath, uint32(500), "130621891405341611593710811006") // tick = 10_000
+	pl.CreatePool(cross, bazPath, quxPath, uint32(500), "130621891405341611593710811006") // tick = 10_000
+	pl.CreatePool(cross, quxPath, fooPath, uint32(500), "130621891405341611593710811006") // tick = 10_000
+
+	bar.Approve(cross, poolAddr, maxApprove)
+	baz.Approve(cross, poolAddr, maxApprove)
+	qux.Approve(cross, poolAddr, maxApprove)
+	foo.Approve(cross, poolAddr, maxApprove)
+
+	pn.Mint(cross, barPath, bazPath, uint32(500), int32(9000), int32(11000), "100000", "100000", "0", "0", 9999999999, adminAddr, adminAddr, "")
+	pn.Mint(cross, bazPath, quxPath, uint32(500), int32(9000), int32(11000), "100000", "100000", "0", "0", 9999999999, adminAddr, adminAddr, "")
+	pn.Mint(cross, quxPath, fooPath, uint32(500), int32(9000), int32(11000), "100000", "100000", "0", "0", 9999999999, adminAddr, adminAddr, "")
 }


### PR DESCRIPTION
# Description

Add unit tests to test the default cases of the `handleMultiSwap` and `processRoute` functions, which are not covered by test before.

## Coverage

base.gno: 82.4% -> 95.6%

### Previous
<img width="1013" height="886" alt="prev" src="https://github.com/user-attachments/assets/846415b2-c9e7-44cc-997d-d85ddddfa8f3" />

### After

<img width="1013" height="886" alt="after" src="https://github.com/user-attachments/assets/c57159e2-e484-430f-8d02-3f07ab08331e" />

### Total `handleMultiSwap` Coverage

<img width="1013" height="886" alt="handleMultiSwap" src="https://github.com/user-attachments/assets/6f2c50ea-04f2-4774-97cb-cfdee32f28cf" />
