### PR TITLE
fix: check position owner and operator

### DIFF
--- a/contract/r/gnoswap/position/utils.gno
+++ b/contract/r/gnoswap/position/utils.gno
@@ -266,11 +266,8 @@ func isOwner(positionId uint64, addr std.Address) bool {
 // input: positionId uint64, addr std.Address
 // output: bool
 func isOperator(positionId uint64, addr std.Address) bool {
-	operator, err := gnft.GetApproved(positionIdFrom(positionId))
-	if err == nil && operator == addr {
-		return true
-	}
-	return false
+	operator := PositionGetPositionOperator(positionId)
+	return operator == addr
 }
 
 // isStaked checks whether positionId is staked
@@ -298,16 +295,13 @@ func isOwnerOrOperator(addr std.Address, positionId uint64) bool {
 	if !exists(positionId) {
 		return false
 	}
-	if isOwner(positionId, addr) || isOperator(positionId, addr) {
-		return true
+
+	staked := isStaked(positionIdFrom(positionId))
+	if staked {
+		return isOperator(positionId, addr)
 	}
-	if isStaked(positionIdFrom(positionId)) {
-		position, exist := GetPosition(positionId)
-		if exist && addr == position.operator {
-			return true
-		}
-	}
-	return false
+
+	return isOwner(positionId, addr)
 }
 
 func assertAuthorizedForToken(caller std.Address, positionId uint64) {


### PR DESCRIPTION
## Descriptions

This PR refactors the position authorization logic to improve clarity and consistency when checking position ownership and operator permissions.

### Changes

#### 1. Simplified `isOperator` function
- **Before**: Used `gnft.GetApproved()` with error handling to check operator status
- **After**: Directly use `PositionGetPositionOperator()` for consistent operator retrieval
- **Benefit**: Eliminates unnecessary error handling and provides a more direct approach

#### 2. Refactored `isOwnerOrOperator` function
- **Before**: Complex nested logic that checked owner/operator status with additional handling for staked positions
- **After**: Clear separation of logic based on staking status:
  - If position is staked → only check operator permissions
  - If position is not staked → only check owner permissions
- **Benefit**: Clearer code flow and more predictable authorization behavior

### Technical Details
- For **staked positions**: Only operator permissions are valid since the position is held by the staker contract
- For **non-staked positions**: Only owner permissions are valid since the user directly owns the NFT
- This change ensures proper access control based on the position's current state