### PR TITLE
fix: change the pointer object query method to internal method

### DIFF
--- a/contract/r/gnoswap/access/access.gno
+++ b/contract/r/gnoswap/access/access.gno
@@ -109,11 +109,12 @@ func declareNewRole(roleName string, addr std.Address) error {
 	return nil
 }
 
-// GetCurrentConfig returns the current configuration
-func GetCurrentConfig() *config {
+// getCurrentConfig returns the current configuration
+func getCurrentConfig() *config {
 	if currentConfig == nil {
 		return nil
 	}
+
 	return currentConfig
 }
 

--- a/contract/r/gnoswap/access/access_test.gno
+++ b/contract/r/gnoswap/access/access_test.gno
@@ -33,7 +33,7 @@ func TestInitialize(t *testing.T) {
 		err := initialize(cfg)
 		uassert.NoError(t, err)
 
-		actual := GetCurrentConfig()
+		actual := getCurrentConfig()
 
 		adminAddr := actual.roles["test_admin"]
 		routerAddr := actual.roles["test_router"]
@@ -60,7 +60,7 @@ func TestUpdateRoleAddress(t *testing.T) {
 		err = UpdateRoleAddress(cross, "another_test_admin", testRealm1Addr)
 		uassert.NoError(t, err)
 
-		actual := GetCurrentConfig()
+		actual := getCurrentConfig()
 		updatedAddr := actual.roles["another_test_admin"]
 		uassert.Equal(t, testRealm1Addr, updatedAddr)
 
@@ -98,7 +98,7 @@ func TestCreateRole(t *testing.T) {
 		err := CreateRole(cross, "custom_role", testNewRoleAddr)
 		uassert.NoError(t, err)
 
-		actual := GetCurrentConfig()
+		actual := getCurrentConfig()
 		roleAddr := actual.roles["custom_role"]
 		uassert.Equal(t, testNewRoleAddr, roleAddr)
 
@@ -142,7 +142,7 @@ func TestSetRole(t *testing.T) {
 		err := SetRole(cross, "test_auditor", testAuditorAddr)
 		uassert.NoError(t, err)
 
-		actual := GetCurrentConfig()
+		actual := getCurrentConfig()
 		uassert.Equal(t, testAuditorAddr, actual.roles["test_auditor"])
 
 		err = rbac.CheckPermission("test_auditor", PERM_ACCESS, testAuditorAddr)
@@ -156,7 +156,7 @@ func TestSetRole(t *testing.T) {
 		err := SetRole(cross, "custom_role_2", testNewRoleAddr)
 		uassert.NoError(t, err)
 
-		actual := GetCurrentConfig()
+		actual := getCurrentConfig()
 		roleAddr := actual.roles["custom_role_2"]
 		uassert.Equal(t, testNewRoleAddr, roleAddr)
 
@@ -178,7 +178,7 @@ func TestSetRole(t *testing.T) {
 		err = SetRole(cross, "test_reviewer", newReviewerAddr)
 		uassert.NoError(t, err)
 
-		actual := GetCurrentConfig()
+		actual := getCurrentConfig()
 		uassert.Equal(t, newReviewerAddr, actual.roles["test_reviewer"])
 
 		err = rbac.CheckPermission("test_reviewer", PERM_ACCESS, testReviewerAddr)


### PR DESCRIPTION
## Descriptions

This PR improves encapsulation by converting the `GetCurrentConfig()` function from a public method to an internal method `getCurrentConfig()`, restricting direct external access to the configuration pointer and following Go's encapsulation principles.

### Changes Made

#### 1. **Function Access Level Change**
- **Before**: `GetCurrentConfig()` - Public function (exported)
- **After**: `getCurrentConfig()` - Internal function (unexported)

```go
// Before: Public access
func GetCurrentConfig() *config {
    if currentConfig == nil {
        return nil
    }
    return currentConfig
}

// After: Internal access only
func getCurrentConfig() *config {
    if currentConfig == nil {
        return nil
    }

    return currentConfig
}
```

#### 2. **Updated Test References**
- Updated all test file references from `GetCurrentConfig()` to `getCurrentConfig()`
- Maintains test functionality while respecting the new access level

### Benefits

#### 1. **Improved Encapsulation**
- Prevents external packages from directly accessing internal configuration state
- Follows Go's convention of using capitalization to control access levels

#### 2. **Better Security**
- Restricts direct manipulation of configuration pointers from outside the package
- Reduces the attack surface by limiting external access points

#### 3. **Cleaner API Design**
- Internal configuration management should not be exposed as public API
- External packages should use dedicated getter functions like `GetAddress()` instead

### Impact
- **No breaking changes**: The function was only used internally within the access package and its tests
- **Improved maintainability**: Internal configuration management is now properly encapsulated