### PR TITLE
fix(governance): Add proposer stake validation in `Cancel` function

### DIFF
--- a/contract/r/gnoswap/gov/governance/errors.gno
+++ b/contract/r/gnoswap/gov/governance/errors.gno
@@ -28,6 +28,7 @@ var (
 	errAlreadyActiveProposal                          = errors.New("[GNOSWAP-GOVERNANCE-019] already active proposal")
 	errProposalNotFound                               = errors.New("[GNOSWAP-GOVERNANCE-020] proposal not found")
 	errProposalNotExecutable                          = errors.New("[GNOSWAP-GOVERNANCE-021] proposal not executable")
+	errNotAuthorized                                  = errors.New("[GNOSWAP-GOVERNANCE-022] not authorized")
 )
 
 func makeErrorWithDetails(err error, detail string) error {

--- a/contract/r/gnoswap/gov/governance/governance_execute.gno
+++ b/contract/r/gnoswap/gov/governance/governance_execute.gno
@@ -6,6 +6,7 @@ import (
 
 	"gno.land/r/gnoswap/v1/common"
 	en "gno.land/r/gnoswap/v1/emission"
+	"gno.land/r/gnoswap/v1/gns"
 	"gno.land/r/gnoswap/v1/halt"
 )
 
@@ -189,6 +190,21 @@ func cancel(proposalID, canceledAt, canceledHeight int64, canceledBy std.Address
 	proposal, ok := getProposal(proposalID)
 	if !ok {
 		return nil, errDataNotFound
+	}
+
+	// Check if the caller is the proposer or if proposer's stake has fallen below threshold
+	if canceledBy != proposal.proposer {
+		// If not the proposer, check if proposer's stake is below threshold
+		config, ok := getCurrentConfig()
+		if !ok {
+			return nil, errDataNotFound
+		}
+
+		proposerGnsBalance := gns.BalanceOf(proposal.proposer)
+		if proposerGnsBalance >= config.ProposalCreationThreshold {
+			// Proposer still has enough stake, only proposer can cancel
+			return nil, errNotAuthorized
+		}
 	}
 
 	// Attempt to cancel the proposal (this validates cancellation conditions)

--- a/contract/r/gnoswap/gov/governance/governance_execute_test.gno
+++ b/contract/r/gnoswap/gov/governance/governance_execute_test.gno
@@ -998,6 +998,7 @@ func TestGovernanceExecute_CancellationScenarios(t *testing.T) {
 		expectedError      string
 		expectedHasAbort   bool
 		description        string
+		setupGnsBalance    bool
 	}{
 		{
 			name:               "fail - proposer cancels upcoming proposal",
@@ -1030,6 +1031,19 @@ func TestGovernanceExecute_CancellationScenarios(t *testing.T) {
 			proposerThreshold:  1_000_000_000,
 			proposerCurrentGns: 500_000_000, // Below threshold
 			expectedHasAbort:   false,
+			setupGnsBalance:    true,
+		},
+		{
+			name:               "fail - others cannot cancel when proposer has enough stake",
+			proposalTime:       now,
+			cancellationTime:   now.Add(-time.Second * time.Duration(testConfig.VotingStartDelay+testConfig.VotingPeriod+testConfig.ExecutionDelay)),
+			canceler:           testutils.TestAddress("other"),
+			proposer:           testutils.TestAddress("proposer"),
+			proposerThreshold:  1_000_000_000,
+			proposerCurrentGns: 2_000_000_000, // Above threshold
+			expectedError:      "[GNOSWAP-GOVERNANCE-022] not authorized",
+			expectedHasAbort:   true,
+			setupGnsBalance:    true,
 		},
 		{
 			name:               "fail - cancel nonexistent proposal",
@@ -1066,6 +1080,13 @@ func TestGovernanceExecute_CancellationScenarios(t *testing.T) {
 					100,
 				)
 				setupExecuteTestProposal(t, proposal)
+
+				// Setup proposer's GNS balance if needed
+				if tt.setupGnsBalance {
+					// First, ensure proposer has initial GNS balance
+					testing.SetRealm(adminRealm)
+					gns.Transfer(cross, tt.proposer, tt.proposerCurrentGns)
+				}
 			}
 
 			testing.SetRealm(std.NewUserRealm(tt.canceler))


### PR DESCRIPTION
# Description

This PR adds missing proposer stake validation logic to the `Cancel` function in the governance module. Previously, any address could cancel any proposal regardless of the proposer's stake status.

## Changes
1. Added stake validation in cancel function
    - Check if the caller is the original proposer
    - If not the proposer, verify that the proposer's GNS balance has fallen below `ProposalCreationThreshold`
    - Return `errNotAuthorized` if non-proposer attempts to cancel when proposer still has sufficient stake

2. Added new error type
    - Added `errNotAuthorized` error for unauthorized cancellation attempts

3. Updated previous test
    - Added `setupGnsBalance` field to properly set up GNS balances in tests
    - Added new faulure case: "others cannot cancel when proposer has enough stake"
    - Fixed existing test to properly verify stake validation logic

