### PR TITLE
fix(router): Remove `consts` Dependencies from `Router` Contract

### DIFF
--- a/contract/r/gnoswap/gnft/gnft_test.gno
+++ b/contract/r/gnoswap/gnft/gnft_test.gno
@@ -9,7 +9,6 @@ import (
 	"gno.land/p/demo/testutils"
 	"gno.land/p/demo/uassert"
 
-	"gno.land/p/gnoswap/consts"
 	prbac "gno.land/p/gnoswap/rbac"
 
 	"gno.land/r/gnoswap/v1/access"
@@ -21,7 +20,8 @@ const (
 )
 
 var (
-	positionRealm = std.NewCodeRealm(consts.POSITION_PATH)
+	positionPath = "gno.land/r/gnoswap/v1/position"
+	positionRealm = std.NewCodeRealm(positionPath)
 
 	addr01      = testutils.TestAddress("addr01")
 	addr01Realm = std.NewUserRealm(addr01)
@@ -354,7 +354,7 @@ func TestMint(t *testing.T) {
 	}{
 		{
 			name:          "mint first nft to addr01",
-			callerRealm:   std.NewCodeRealm(consts.POSITION_PATH),
+			callerRealm:   positionRealm,
 			tokenIdToMint: 1,
 			addressToMint: addr01,
 			expected:      "1",
@@ -364,7 +364,7 @@ func TestMint(t *testing.T) {
 		},
 		{
 			name:          "mint second nft to addr02",
-			callerRealm:   std.NewCodeRealm(consts.POSITION_PATH),
+			callerRealm:   positionRealm,
 			tokenIdToMint: 2,
 			addressToMint: addr02,
 			expected:      "2",
@@ -407,7 +407,7 @@ func TestBurn(t *testing.T) {
 		},
 		{
 			name:          "burn non-existent token id",
-			callerRealm:   std.NewCodeRealm(consts.POSITION_PATH),
+			callerRealm:   positionRealm,
 			tokenIdToBurn: 99,
 			shouldPanic:   true,
 			panicMsg:      errInvalidTokenId,

--- a/contract/r/gnoswap/gov/governance/_helper_test.gno
+++ b/contract/r/gnoswap/gov/governance/_helper_test.gno
@@ -31,10 +31,17 @@ var (
 var (
 	adminRealm = std.NewUserRealm(admin)
 
-	posRealm = std.NewCodeRealm(consts.POSITION_PATH)
-	rouRealm = std.NewCodeRealm(consts.ROUTER_PATH)
-	stkRealm = std.NewCodeRealm(consts.STAKER_PATH)
-	govRealm = std.NewCodeRealm(consts.GOV_GOVERNANCE_PATH)
+	posPath  = "gno.land/r/gnoswap/v1/position"
+	posRealm = std.NewCodeRealm(posPath)
+
+	routerPath = "gno.land/r/gnoswap/v1/router"
+	rouRealm = std.NewCodeRealm(routerPath)
+
+	stakerPath = "gno.land/r/gnoswap/v1/staker"
+	stkRealm = std.NewCodeRealm(stakerPath)
+
+	govPath = "gno.land/r/gnoswap/v1/gov"
+	govRealm = std.NewCodeRealm(govPath)
 
 	govStakerAddr, _     = access.GetAddress(prbac.ROLE_GOV_STAKER.String())
 	communityPoolAddr, _ = access.GetAddress(prbac.ROLE_COMMUNITY_POOL.String())

--- a/contract/r/gnoswap/gov/governance/_helper_test.gno
+++ b/contract/r/gnoswap/gov/governance/_helper_test.gno
@@ -5,7 +5,6 @@ import (
 
 	"gno.land/p/demo/json"
 
-	"gno.land/p/gnoswap/consts"
 	prbac "gno.land/p/gnoswap/rbac"
 	"gno.land/r/gnoswap/v1/access"
 )
@@ -40,7 +39,7 @@ var (
 	stakerPath = "gno.land/r/gnoswap/v1/staker"
 	stkRealm = std.NewCodeRealm(stakerPath)
 
-	govPath = "gno.land/r/gnoswap/v1/gov"
+	govPath = "gno.land/r/gnoswap/v1/gov/governance"
 	govRealm = std.NewCodeRealm(govPath)
 
 	govStakerAddr, _     = access.GetAddress(prbac.ROLE_GOV_STAKER.String())

--- a/contract/r/gnoswap/gov/staker/_helper_test.gno
+++ b/contract/r/gnoswap/gov/staker/_helper_test.gno
@@ -24,6 +24,8 @@ var (
 	launchpadAddr, _     = access.GetAddress(prbac.ROLE_LAUNCHPAD.String())
 	devOpsAddr, _        = access.GetAddress(prbac.ROLE_DEVOPS.String())
 
+	wugnotAddr std.Address = "g1pf6dv9fjk3rn0m4jjcne306ga4he3mzmupfjl6"
+
 	fooPath  string = "gno.land/r/onbloc/foo"
 	barPath  string = "gno.land/r/onbloc/bar"
 	bazPath  string = "gno.land/r/onbloc/baz"
@@ -52,9 +54,14 @@ var (
 	user3Realm  = std.NewUserRealm(testutils.TestAddress("charlie"))
 	invalidAddr = testutils.TestAddress("invalid")
 
-	posRealm    = std.NewCodeRealm(consts.POSITION_PATH)
-	rouRealm    = std.NewCodeRealm(consts.ROUTER_PATH)
-	stakerRealm = std.NewCodeRealm(consts.STAKER_PATH)
+	posPath  = "gno.land/r/gnoswap/v1/position"
+	posRealm = std.NewCodeRealm(posPath)
+
+	routerPath = "gno.land/r/gnoswap/v1/router"
+	rouRealm   = std.NewCodeRealm(routerPath)
+
+	stakerPath  = "gno.land/r/gnoswap/v1/staker"
+	stakerRealm = std.NewCodeRealm(stakerPath)
 )
 
 func makeFakeAddress(name string) std.Address {
@@ -109,7 +116,6 @@ func ugnotFaucet(t *testing.T, to std.Address, amount uint64) {
 func ugnotDeposit(t *testing.T, addr std.Address, amount uint64) {
 	t.Helper()
 	testing.SetRealm(std.NewUserRealm(addr))
-	wugnotAddr := consts.WUGNOT_ADDR
 	banker := std.NewBanker(std.BankerTypeRealmSend)
 	banker.SendCoins(addr, wugnotAddr, std.Coins{{ugnotDenom, int64(amount)}})
 	wugnot.Deposit(cross)

--- a/contract/r/gnoswap/gov/staker/_helper_test.gno
+++ b/contract/r/gnoswap/gov/staker/_helper_test.gno
@@ -7,7 +7,6 @@ import (
 	"gno.land/p/demo/json"
 	"gno.land/p/demo/testutils"
 
-	"gno.land/p/gnoswap/consts"
 	prbac "gno.land/p/gnoswap/rbac"
 
 	"gno.land/r/demo/wugnot"

--- a/contract/r/gnoswap/pool/_helper_test.gno
+++ b/contract/r/gnoswap/pool/_helper_test.gno
@@ -67,10 +67,16 @@ var (
 	stakerAddr, _   = access.GetAddress(prabc.ROLE_STAKER.String())
 	emissionAddr, _ = access.GetAddress(prabc.ROLE_EMISSION.String())
 
+	wugnotAddr std.Address = "g1pf6dv9fjk3rn0m4jjcne306ga4he3mzmupfjl6"
+
 	alice      = testutils.TestAddress("alice")
 	adminRealm = std.NewUserRealm(adminAddr)
-	posRealm   = std.NewCodeRealm(consts.POSITION_PATH)
-	rouRealm   = std.NewCodeRealm(consts.ROUTER_PATH)
+
+	posPath  = "gno.land/r/gnoswap/v1/position"
+	posRealm = std.NewCodeRealm(posPath)
+
+	routerPath = "gno.land/r/gnoswap/v1/router"
+	rouRealm   = std.NewCodeRealm(routerPath)
 
 	// addresses used in tests
 	addrUsedInTest = []std.Address{addr01, addr02}
@@ -529,7 +535,6 @@ func ugnotFaucet(t *testing.T, to std.Address, amount int64) {
 func ugnotDeposit(t *testing.T, addr std.Address, amount int64) {
 	t.Helper()
 	testing.SetRealm(std.NewUserRealm(addr))
-	wugnotAddr := consts.WUGNOT_ADDR
 	banker := std.NewBanker(std.BankerTypeRealmSend)
 	banker.SendCoins(addr, wugnotAddr, std.Coins{{ugnotDenom, int64(amount)}})
 	wugnot.Deposit(cross)

--- a/contract/r/gnoswap/pool/_helper_test.gno
+++ b/contract/r/gnoswap/pool/_helper_test.gno
@@ -15,7 +15,6 @@ import (
 
 	"gno.land/p/demo/avl"
 	"gno.land/p/demo/testutils"
-	"gno.land/p/gnoswap/consts"
 
 	prabc "gno.land/p/gnoswap/rbac"
 

--- a/contract/r/gnoswap/position/_helper_test.gno
+++ b/contract/r/gnoswap/position/_helper_test.gno
@@ -57,20 +57,25 @@ var (
 )
 
 var (
-	adminAddr = rbac.DefaultRoleAddresses[prabc.ROLE_ADMIN]
+	adminAddr  = rbac.DefaultRoleAddresses[prabc.ROLE_ADMIN]
+	adminRealm = std.NewUserRealm(adminAddr)
 
 	alice = testutils.TestAddress("alice")
 	bob   = testutils.TestAddress("bob")
 
-	emissionAddr = rbac.DefaultRoleAddresses[prabc.ROLE_EMISSION]
-	poolAddr     = rbac.DefaultRoleAddresses[prabc.ROLE_POOL]
+	emissionAddr    = rbac.DefaultRoleAddresses[prabc.ROLE_EMISSION]
+	poolAddr        = rbac.DefaultRoleAddresses[prabc.ROLE_POOL]
 	protocolFeeAddr = rbac.DefaultRoleAddresses[prabc.ROLE_PROTOCOL_FEE]
-	routerAddr = rbac.DefaultRoleAddresses[prabc.ROLE_ROUTER]
-	devOpsAddr = rbac.DefaultRoleAddresses[prabc.ROLE_DEVOPS]
+	routerAddr      = rbac.DefaultRoleAddresses[prabc.ROLE_ROUTER]
+	devOpsAddr      = rbac.DefaultRoleAddresses[prabc.ROLE_DEVOPS]
 
-	adminRealm = std.NewUserRealm(adminAddr)
-	posRealm   = std.NewCodeRealm(consts.POSITION_PATH)
-	rouRealm   = std.NewCodeRealm(consts.ROUTER_PATH)
+	wugnotAddr std.Address = "g1pf6dv9fjk3rn0m4jjcne306ga4he3mzmupfjl6"
+
+	posPath  = "gno.land/r/gnoswap/v1/position"
+	posRealm = std.NewCodeRealm(posPath)
+
+	rouPath  = "gno.land/r/gnoswap/v1/router"
+	rouRealm = std.NewCodeRealm(rouPath)
 
 	// addresses used in tests
 	addrUsedInTest = []std.Address{addr01, addr02}
@@ -605,7 +610,7 @@ func ugnotFaucet(t *testing.T, to std.Address, amount int64) {
 func ugnotDeposit(t *testing.T, addr std.Address, amount int64) {
 	t.Helper()
 	testing.SetRealm(std.NewUserRealm(addr))
-	wugnotAddr := consts.WUGNOT_ADDR
+	wugnotAddr := wugnotAddr
 	banker := std.NewBanker(std.BankerTypeRealmSend)
 	banker.SendCoins(addr, wugnotAddr, std.Coins{{ugnotDenom, amount}})
 	wugnot.Deposit(cross)
@@ -665,7 +670,7 @@ func burnUsdc(addr std.Address) {
 func burnAllNFT(t *testing.T) {
 	t.Helper()
 
-	testing.SetRealm(std.NewCodeRealm(consts.POSITION_PATH))
+	testing.SetRealm(posRealm)
 	for i := int64(1); i <= gnft.TotalSupply(); i++ {
 		gnft.Burn(cross, positionIdFrom(i))
 	}

--- a/contract/r/gnoswap/position/_helper_test.gno
+++ b/contract/r/gnoswap/position/_helper_test.gno
@@ -7,7 +7,6 @@ import (
 	"gno.land/p/demo/avl"
 	"gno.land/p/demo/testutils"
 	"gno.land/p/demo/uassert"
-	"gno.land/p/gnoswap/consts"
 	prabc "gno.land/p/gnoswap/rbac"
 	"gno.land/r/gnoswap/v1/common"
 	"gno.land/r/gnoswap/v1/gnft"

--- a/contract/r/gnoswap/router/_helper_test.gno
+++ b/contract/r/gnoswap/router/_helper_test.gno
@@ -24,21 +24,15 @@ import (
 )
 
 const (
-	gnot string = "gnot"
-	wrappedWugnot string = "gno.land/r/demo/wugnot"
-
 	ugnotDenom string = "ugnot"
 	ugnotPath  string = "ugnot"
 
-	UGNOT_MIN_DEPOSIT_TO_WRAP uint64 = 1000
-
-	wugnotPath string = "gno.land/r/demo/wugnot"
-	gnsPath    string = "gno.land/r/gnoswap/v1/gns"
-	barPath    string = "gno.land/r/onbloc/bar"
-	bazPath    string = "gno.land/r/onbloc/baz"
-	fooPath    string = "gno.land/r/onbloc/foo"
-	oblPath    string = "gno.land/r/onbloc/obl"
-	quxPath    string = "gno.land/r/onbloc/qux"
+	gnsPath string = "gno.land/r/gnoswap/v1/gns"
+	barPath string = "gno.land/r/onbloc/bar"
+	bazPath string = "gno.land/r/onbloc/baz"
+	fooPath string = "gno.land/r/onbloc/foo"
+	oblPath string = "gno.land/r/onbloc/obl"
+	quxPath string = "gno.land/r/onbloc/qux"
 
 	fee100      uint32 = 100
 	fee500      uint32 = 500
@@ -51,11 +45,6 @@ const (
 	TIER_3 uint64 = 3
 
 	poolCreationFee = 100_000_000
-)
-
-const (
-	MIN_SQRT_RATIO string = "4295128739" // same as TickMathGetSqrtRatioAtTick(MIN_TICK)
-	MAX_SQRT_RATIO string = "1461446703485210103287273052203988822378723970342" // same as TickMathGetSqrtRatioAtTick(MAX_TICK)
 )
 
 const (
@@ -89,21 +78,15 @@ var (
 	alice = testutils.TestAddress("alice")
 	bob   = testutils.TestAddress("bob")
 
-	adminRealm  = std.NewUserRealm(admin)
+	adminRealm = std.NewUserRealm(admin)
 
-	poolAddr std.Address = "g148tjamj80yyrm309z7rk690an22thd2l3z8ank" 
-
-	routerPath = "gno.land/r/gnoswap/v1/router"
-	routerAddr std.Address = "g1lm2l7tf49h3mykesct7rhfml30yx8dw5xrval7"
+	routerPath  = "gno.land/r/gnoswap/v1/router"
 	routerRealm = std.NewUserRealm(routerAddr)
 
 	posPath  = "gno.land/r/gnoswap/v1/position"
 	posRealm = std.NewCodeRealm(posPath)
 
-	wugnotPath = "gno.land/r/demo/wugnot"
 	wugnotAddr std.Address = "g1pf6dv9fjk3rn0m4jjcne306ga4he3mzmupfjl6"
-
-	gnsPath = "gno.land/r/gnoswap/v1/gns"
 
 	// addresses used in tests
 	addrUsedInTest = []std.Address{addr01, addr02}

--- a/contract/r/gnoswap/router/_helper_test.gno
+++ b/contract/r/gnoswap/router/_helper_test.gno
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"gno.land/p/demo/testutils"
-	"gno.land/p/gnoswap/consts"
 	"gno.land/r/demo/wugnot"
 	"gno.land/r/gnoswap/v1/common"
 	"gno.land/r/gnoswap/v1/gnft"
@@ -25,8 +24,14 @@ import (
 )
 
 const (
+	gnot string = "gnot"
+	wrappedWugnot string = "gno.land/r/demo/wugnot"
+
 	ugnotDenom string = "ugnot"
 	ugnotPath  string = "ugnot"
+
+	UGNOT_MIN_DEPOSIT_TO_WRAP uint64 = 1000
+
 	wugnotPath string = "gno.land/r/demo/wugnot"
 	gnsPath    string = "gno.land/r/gnoswap/v1/gns"
 	barPath    string = "gno.land/r/onbloc/bar"
@@ -46,6 +51,11 @@ const (
 	TIER_3 uint64 = 3
 
 	poolCreationFee = 100_000_000
+)
+
+const (
+	MIN_SQRT_RATIO string = "4295128739" // same as TickMathGetSqrtRatioAtTick(MIN_TICK)
+	MAX_SQRT_RATIO string = "1461446703485210103287273052203988822378723970342" // same as TickMathGetSqrtRatioAtTick(MAX_TICK)
 )
 
 const (
@@ -80,8 +90,20 @@ var (
 	bob   = testutils.TestAddress("bob")
 
 	adminRealm  = std.NewUserRealm(admin)
+
+	poolAddr std.Address = "g148tjamj80yyrm309z7rk690an22thd2l3z8ank" 
+
+	routerPath = "gno.land/r/gnoswap/v1/router"
+	routerAddr std.Address = "g1lm2l7tf49h3mykesct7rhfml30yx8dw5xrval7"
 	routerRealm = std.NewUserRealm(routerAddr)
-	posRealm    = std.NewCodeRealm(consts.POSITION_PATH)
+
+	posPath  = "gno.land/r/gnoswap/v1/position"
+	posRealm = std.NewCodeRealm(posPath)
+
+	wugnotPath = "gno.land/r/demo/wugnot"
+	wugnotAddr std.Address = "g1pf6dv9fjk3rn0m4jjcne306ga4he3mzmupfjl6"
+
+	gnsPath = "gno.land/r/gnoswap/v1/gns"
 
 	// addresses used in tests
 	addrUsedInTest = []std.Address{addr01, addr02}
@@ -313,7 +335,7 @@ func ugnotFaucet(t *testing.T, to std.Address, amount int64) {
 func ugnotDeposit(t *testing.T, addr std.Address, amount uint64) {
 	t.Helper()
 	testing.SetRealm(std.NewUserRealm(addr))
-	wugnotAddr := consts.WUGNOT_ADDR
+	wugnotAddr := wugnotAddr
 	banker := std.NewBanker(std.BankerTypeRealmSend)
 	banker.SendCoins(addr, wugnotAddr, std.Coins{{ugnotDenom, int64(amount)}})
 	wugnot.Deposit(cross)

--- a/contract/r/gnoswap/router/base.gno
+++ b/contract/r/gnoswap/router/base.gno
@@ -24,6 +24,8 @@ const (
 	POOL_SEPARATOR = "*POOL*"
 )
 
+var wugnotPath string = "gno.land/r/demo/wugnot"
+
 type RouterOperation interface {
 	Validate() error
 	Process() (*SwapResult, error)

--- a/contract/r/gnoswap/router/base.gno
+++ b/contract/r/gnoswap/router/base.gno
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"gno.land/p/demo/ufmt"
-	"gno.land/p/gnoswap/consts"
 	i256 "gno.land/p/gnoswap/int256"
 	u256 "gno.land/p/gnoswap/uint256"
 
@@ -66,14 +65,14 @@ func (op *baseSwapOperation) handleNativeTokenWrapping(
 	specifiedAmount *i256.Int,
 ) error {
 	// no native token
-	if inputToken == consts.WUGNOT_PATH || outputToken == consts.WUGNOT_PATH {
+	if inputToken == wugnotPath || outputToken == wugnotPath {
 		return nil
 	}
 
 	// save current user's WGNOT amount
 	op.userBeforeWugnotBalance = wugnot.BalanceOf(std.PreviousRealm().Address())
 
-	if inputToken != consts.GNOT {
+	if inputToken != "gnot" {
 		return nil
 	}
 

--- a/contract/r/gnoswap/router/base.gno
+++ b/contract/r/gnoswap/router/base.gno
@@ -24,7 +24,11 @@ const (
 	POOL_SEPARATOR = "*POOL*"
 )
 
-var wugnotPath string = "gno.land/r/demo/wugnot"
+var (
+	gnot    string = "gnot"
+	wrappedWugnot string = "gno.land/r/demo/wugnot"
+	wugnotPath string = "gno.land/r/demo/wugnot"
+)
 
 type RouterOperation interface {
 	Validate() error

--- a/contract/r/gnoswap/router/exact_in_test.gno
+++ b/contract/r/gnoswap/router/exact_in_test.gno
@@ -8,7 +8,6 @@ import (
 
 	"gno.land/p/demo/testutils"
 	"gno.land/p/demo/uassert"
-	"gno.land/p/gnoswap/consts"
 
 	"gno.land/r/demo/wugnot"
 	"gno.land/r/gnoswap/v1/access"
@@ -458,9 +457,9 @@ func TestSwapRouteWugnotquxExactInDifferentAmountCoinShouldPanic(t *testing.T) {
 		func() {
 			ExactOutSwapRoute(
 				cross,
-				gnot, // inputToken
-				quxPath,     // outputToken
-				"3",         // amountSpecified
+				gnot,    // inputToken
+				quxPath, // outputToken
+				"3",     // amountSpecified
 				"gno.land/r/demo/wugnot:gno.land/r/onbloc/qux:3000", // strRouteArr
 				"100",   // quoteArr
 				"12345", // tokenAmountLimit

--- a/contract/r/gnoswap/router/exact_in_test.gno
+++ b/contract/r/gnoswap/router/exact_in_test.gno
@@ -273,17 +273,11 @@ func TestExactInSwapRouteWithReferral(t *testing.T) {
 }
 
 func TestExactInZeroForOneFalse(t *testing.T) {
-	const wugnotTokenPath = "gno.land/r/demo/wugnot"
-	const gnsTokenPath = "gno.land/r/gnoswap/v1/gns"
-	const positionContract = consts.POSITION_ADDR
-	const routerContract = consts.ROUTER_ADDR
-	const routerPath = consts.ROUTER_PATH
-	const poolContract = consts.POOL_ADDR
 	const maxTimeout int64 = 9999999999
 	const wugnotGnsPoolPath = "gno.land/r/gnoswap/v1/gns:gno.land/r/demo/wugnot:500"
 
 	alice := testutils.TestAddress("alice")
-	positionOwner := consts.ADMIN
+	positionOwner := adminAddr
 
 	tests := []struct {
 		name             string
@@ -309,8 +303,8 @@ func TestExactInZeroForOneFalse(t *testing.T) {
 	}{
 		{
 			name:             "success - gns -> gnot",
-			tokenPath0:       wugnotTokenPath,
-			tokenPath1:       gnsTokenPath,
+			tokenPath0:       wugnotPath,
+			tokenPath1:       gnsPath,
 			feeTier:          pl.FeeTier500,
 			recipient:        alice,
 			tickLower:        -200,
@@ -319,7 +313,7 @@ func TestExactInZeroForOneFalse(t *testing.T) {
 			amount1Requested: "100",
 			feeProtocol0:     10,
 			feeProtocol1:     10,
-			inputToken:       gnsTokenPath,
+			inputToken:       gnsPath,
 			outputToken:      "gnot",
 			amountIn:         "100",
 			routeArr:         wugnotGnsPoolPath,
@@ -352,7 +346,7 @@ func TestExactInZeroForOneFalse(t *testing.T) {
 			testing.IssueCoins(positionOwner, newCoins)
 			testing.SetOriginSend(newCoins)
 			banker := std.NewBanker(std.BankerTypeRealmSend)
-			banker.SendCoins(positionOwner, consts.WUGNOT_ADDR, newCoins)
+			banker.SendCoins(positionOwner, wugnotAddr, newCoins)
 			wugnot.Deposit(cross)
 			if tt.recipient != positionOwner {
 				wugnot.Transfer(cross, tt.recipient, 10000000000)
@@ -360,12 +354,12 @@ func TestExactInZeroForOneFalse(t *testing.T) {
 			gns.Transfer(cross, tt.recipient, 10000000000)
 
 			testing.SetRealm(std.NewUserRealm(tt.recipient))
-			wugnot.Approve(cross, poolContract, maxApprove)
-			gns.Approve(cross, poolContract, maxApprove)
+			wugnot.Approve(cross, poolAddr, maxApprove)
+			gns.Approve(cross, poolAddr, maxApprove)
 
 			func(cur realm) {
-				teller := common.GetTokenTeller(wugnotTokenPath)
-				teller.Approve(poolContract, maxApprove)
+				teller := common.GetTokenTeller(wugnotPath)
+				teller.Approve(poolAddr, maxApprove)
 			}(cross)
 
 			// Position Creation
@@ -389,14 +383,14 @@ func TestExactInZeroForOneFalse(t *testing.T) {
 
 			// Swap
 			testing.SetOriginCaller(tt.recipient)
-			wugnot.Transfer(cross, routerContract, 20000000)
-			gns.Transfer(cross, routerContract, 20000000)
-			wugnot.Approve(cross, routerContract, maxApprove)
-			gns.Approve(cross, routerContract, maxApprove)
+			wugnot.Transfer(cross, routerAddr, 20000000)
+			gns.Transfer(cross, routerAddr, 20000000)
+			wugnot.Approve(cross, routerAddr, maxApprove)
+			gns.Approve(cross, routerAddr, maxApprove)
 			beforeGnotBalance := uint64(banker.GetCoins(tt.recipient).AmountOf("ugnot"))
 
 			testing.SetRealm(std.NewCodeRealm(routerPath))
-			wugnot.Approve(cross, poolContract, maxApprove)
+			wugnot.Approve(cross, poolAddr, maxApprove)
 
 			testing.SetRealm(std.NewUserRealm(tt.recipient))
 			amountIn, amountOut := ExactInSwapRoute(
@@ -464,7 +458,7 @@ func TestSwapRouteWugnotquxExactInDifferentAmountCoinShouldPanic(t *testing.T) {
 		func() {
 			ExactOutSwapRoute(
 				cross,
-				consts.GNOT, // inputToken
+				gnot, // inputToken
 				quxPath,     // outputToken
 				"3",         // amountSpecified
 				"gno.land/r/demo/wugnot:gno.land/r/onbloc/qux:3000", // strRouteArr

--- a/contract/r/gnoswap/router/protocol_fee_swap.gno
+++ b/contract/r/gnoswap/router/protocol_fee_swap.gno
@@ -3,7 +3,6 @@ package router
 import (
 	"std"
 
-	"gno.land/p/gnoswap/consts"
 	"gno.land/r/gnoswap/v1/access"
 	"gno.land/r/gnoswap/v1/common"
 	"gno.land/r/gnoswap/v1/halt"
@@ -97,8 +96,8 @@ func handleSwapFee(
 		return amount
 	}
 
-	if outputToken == consts.GNOT {
-		outputToken = consts.WRAPPED_WUGNOT
+	if outputToken == gnot {
+		outputToken = wrappedWugnot
 	}
 
 	feeAmount := new(u256.Uint).Mul(amount, u256.NewUint(swapFee))

--- a/contract/r/gnoswap/router/router.gno
+++ b/contract/r/gnoswap/router/router.gno
@@ -8,7 +8,6 @@ import (
 	i256 "gno.land/p/gnoswap/int256"
 	u256 "gno.land/p/gnoswap/uint256"
 
-	"gno.land/p/gnoswap/consts"
 	"gno.land/r/demo/wugnot"
 )
 
@@ -237,9 +236,9 @@ func finalizeSwap(
 	handler.UpdateNewBalance()
 
 	var err error
-	if inputToken == consts.GNOT {
+	if inputToken == gnot {
 		err = handler.HandleInputSwap()
-	} else if outputToken == consts.GNOT {
+	} else if outputToken == gnot {
 		handler.HandleOutputSwap()
 	}
 

--- a/contract/r/gnoswap/router/router_test.gno
+++ b/contract/r/gnoswap/router/router_test.gno
@@ -27,7 +27,7 @@ import (
 )
 
 func TestFinalizeSwap(t *testing.T) {
-	gnot := consts.GNOT
+	gnot := "gnot"
 
 	newUint256 := func(val string) *u256.Uint {
 		return u256.MustFromDecimal(val)
@@ -166,7 +166,6 @@ func TestFinalizeSwap(t *testing.T) {
 func TestCompareExactInAndDrySwapWithNoLiquidityChanged(t *testing.T) {
 	const wugnotTokenPath = "gno.land/r/demo/wugnot"
 	const gnsTokenPath = "gno.land/r/gnoswap/v1/gns"
-	const routerPath = consts.ROUTER_PATH
 	const maxTimeout int64 = 9999999999
 	const wugnotGnsPoolPath = "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:500"
 
@@ -245,7 +244,7 @@ func TestCompareExactInAndDrySwapWithNoLiquidityChanged(t *testing.T) {
 			testing.IssueCoins(positionOwner, newCoins)
 			testing.SetOriginSend(newCoins)
 			banker := std.NewBanker(std.BankerTypeRealmSend)
-			banker.SendCoins(positionOwner, consts.WUGNOT_ADDR, newCoins)
+			banker.SendCoins(positionOwner, wugnotAddr, newCoins)
 			wugnot.Deposit(cross)
 			if tt.recipient != positionOwner {
 				wugnot.Transfer(cross, tt.recipient, 10000000000)
@@ -332,7 +331,6 @@ func TestCompareExactInAndDrySwapWithNoLiquidityChanged(t *testing.T) {
 func TestCompareExactInAndDrySwapWithWhenLiquidityAdded(t *testing.T) {
 	const wugnotTokenPath = "gno.land/r/demo/wugnot"
 	const gnsTokenPath = "gno.land/r/gnoswap/v1/gns"
-	const routerPath = consts.ROUTER_PATH
 	const maxTimeout int64 = 9999999999
 	const wugnotGnsPoolPath = "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:500"
 
@@ -411,7 +409,7 @@ func TestCompareExactInAndDrySwapWithWhenLiquidityAdded(t *testing.T) {
 			testing.IssueCoins(positionOwner, newCoins)
 			testing.SetOriginSend(newCoins)
 			banker := std.NewBanker(std.BankerTypeRealmSend)
-			banker.SendCoins(positionOwner, consts.WUGNOT_ADDR, std.Coins{{"ugnot", int64(10000000000)}})
+			banker.SendCoins(positionOwner, wugnotAddr, std.Coins{{"ugnot", int64(10000000000)}})
 			wugnot.Deposit(cross)
 			if tt.recipient != positionOwner {
 				wugnot.Transfer(cross, tt.recipient, 10000000000)
@@ -523,7 +521,6 @@ func TestCompareExactInAndDrySwapWithWhenLiquidityAdded(t *testing.T) {
 func TestCompareExactInAndDrySwapWithWhenZeroForOneIsFalse(t *testing.T) {
 	const wugnotTokenPath = "gno.land/r/demo/wugnot"
 	const gnsTokenPath = "gno.land/r/gnoswap/v1/gns"
-	const routerPath = consts.ROUTER_PATH
 	const maxTimeout int64 = 9999999999
 	const gnsWugnotPoolPath = "gno.land/r/gnoswap/v1/gns:gno.land/r/demo/wugnot:10000"
 
@@ -602,7 +599,7 @@ func TestCompareExactInAndDrySwapWithWhenZeroForOneIsFalse(t *testing.T) {
 			testing.IssueCoins(positionOwner, newCoins)
 			testing.SetOriginSend(newCoins)
 			banker := std.NewBanker(std.BankerTypeRealmSend)
-			banker.SendCoins(positionOwner, consts.WUGNOT_ADDR, std.Coins{{"ugnot", int64(10000000000)}})
+			banker.SendCoins(positionOwner, wugnotAddr, std.Coins{{"ugnot", int64(10000000000)}})
 			wugnot.Deposit(cross)
 			if tt.recipient != positionOwner {
 				wugnot.Transfer(cross, tt.recipient, 10000000000)

--- a/contract/r/gnoswap/router/router_test.gno
+++ b/contract/r/gnoswap/router/router_test.gno
@@ -9,7 +9,6 @@ import (
 
 	"gno.land/p/demo/testutils"
 	"gno.land/p/demo/uassert"
-	"gno.land/p/gnoswap/consts"
 
 	i256 "gno.land/p/gnoswap/int256"
 	u256 "gno.land/p/gnoswap/uint256"

--- a/contract/r/gnoswap/router/swap_inner.gno
+++ b/contract/r/gnoswap/router/swap_inner.gno
@@ -5,7 +5,6 @@ import (
 
 	"gno.land/p/demo/ufmt"
 
-	"gno.land/p/gnoswap/consts"
 	"gno.land/r/gnoswap/v1/common"
 
 	i256 "gno.land/p/gnoswap/int256"
@@ -189,7 +188,7 @@ func calculateSqrtPriceLimitForSwap(zeroForOne bool, fee uint32, sqrtPriceLimitX
 		minTick := getMinTick(fee) + 1
 		sqrtPriceLimitX96 = new(u256.Uint).Set(common.TickMathGetSqrtRatioAtTick(minTick))
 		if sqrtPriceLimitX96.IsZero() {
-			sqrtPriceLimitX96 = u256.MustFromDecimal(consts.MIN_SQRT_RATIO)
+			sqrtPriceLimitX96 = u256.MustFromDecimal(MIN_SQRT_RATIO)
 		}
 		return new(u256.Uint).Add(sqrtPriceLimitX96, one)
 	}
@@ -197,7 +196,7 @@ func calculateSqrtPriceLimitForSwap(zeroForOne bool, fee uint32, sqrtPriceLimitX
 	maxTick := getMaxTick(fee) - 1
 	sqrtPriceLimitX96 = new(u256.Uint).Set(common.TickMathGetSqrtRatioAtTick(maxTick))
 	if sqrtPriceLimitX96.IsZero() {
-		sqrtPriceLimitX96 = u256.MustFromDecimal(consts.MAX_SQRT_RATIO)
+		sqrtPriceLimitX96 = u256.MustFromDecimal(MAX_SQRT_RATIO)
 	}
 	return new(u256.Uint).Sub(sqrtPriceLimitX96, one)
 }

--- a/contract/r/gnoswap/router/swap_inner.gno
+++ b/contract/r/gnoswap/router/swap_inner.gno
@@ -13,6 +13,11 @@ import (
 	pl "gno.land/r/gnoswap/v1/pool"
 )
 
+const (
+	MIN_SQRT_RATIO string = "4295128739"                                        // same as TickMathGetSqrtRatioAtTick(MIN_TICK)
+	MAX_SQRT_RATIO string = "1461446703485210103287273052203988822378723970342" // same as TickMathGetSqrtRatioAtTick(MAX_TICK)
+)
+
 // swapInner executes the core swap logic by interacting with the pool contract.
 // This is the main implementation of token swapping that handles both exact input and output swaps.
 //
@@ -81,7 +86,7 @@ func (e *RealSwapExecutor) execute(p *SingleSwapParams) (amountIn, amountOut *u2
 		cross,
 		p.amountSpecified,
 		previousRealmAddr, // if single swap => user will receive
-		zero,          // sqrtPriceLimitX96
+		zero,              // sqrtPriceLimitX96
 		newSwapCallbackData(p, previousRealmAddr),
 	)
 }

--- a/contract/r/gnoswap/router/wrap_unwrap.gno
+++ b/contract/r/gnoswap/router/wrap_unwrap.gno
@@ -6,7 +6,6 @@ import (
 	"gno.land/r/demo/wugnot"
 
 	"gno.land/p/demo/ufmt"
-	"gno.land/p/gnoswap/consts"
 )
 
 var (
@@ -19,15 +18,15 @@ func wrap(ugnotAmount int64) {
 		panic(addDetailToError(errWrapUnwrap, errFailedToWrapZeroUgnot))
 	}
 
-	if ugnotAmount < int64(consts.UGNOT_MIN_DEPOSIT_TO_WRAP) {
+	if ugnotAmount < int64(UGNOT_MIN_DEPOSIT_TO_WRAP) {
 		panic(addDetailToError(
 			errWugnotMinimum,
-			ufmt.Sprintf(errFailedToWrapBelowMin, ugnotAmount, consts.UGNOT_MIN_DEPOSIT_TO_WRAP),
+			ufmt.Sprintf(errFailedToWrapBelowMin, ugnotAmount, UGNOT_MIN_DEPOSIT_TO_WRAP),
 		))
 	}
 
 	// WRAP IT
-	wugnotAddr := std.DerivePkgAddr(consts.WRAPPED_WUGNOT)
+	wugnotAddr := std.DerivePkgAddr(wrappedWugnot)
 	banker := std.NewBanker(std.BankerTypeRealmSend)
 	banker.SendCoins(routerAddr, wugnotAddr, std.Coins{{"ugnot", int64(ugnotAmount)}})
 	wugnot.Deposit(cross) // ROUTER HAS WUGNOT

--- a/contract/r/gnoswap/router/wrap_unwrap.gno
+++ b/contract/r/gnoswap/router/wrap_unwrap.gno
@@ -8,6 +8,8 @@ import (
 	"gno.land/p/demo/ufmt"
 )
 
+const UGNOT_MIN_DEPOSIT_TO_WRAP uint64 = 1000
+
 var (
 	errFailedToWrapZeroUgnot = "cannot wrap 0 ugnot"
 	errFailedToWrapBelowMin  = "amount(%d) < minimum(%d)"

--- a/tests/scenario/router/exact_out_swap_route_with_multi_route_filetest.gno
+++ b/tests/scenario/router/exact_out_swap_route_with_multi_route_filetest.gno
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"gno.land/p/demo/ufmt"
-	"gno.land/p/gnoswap/consts"
 
 	"gno.land/r/gnoswap/v1/access"
 	"gno.land/r/gnoswap/v1/common"
@@ -35,6 +34,8 @@ var (
 
 	wugnotPath = "gno.land/r/demo/wugnot"
 	gnsPath    = "gno.land/r/gnoswap/v1/gns"
+
+	maxInt64 int64  = 9223372036854775807
 )
 
 var t *testing.T
@@ -60,7 +61,7 @@ func main() {
 
 	println("[SCENARIO] 5. ExactOutSwapRoute multi route (gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:500,gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000,gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:10000)")
 	exactOutSwapRouteBy(
-		consts.GNOT,
+		gnot,
 		gnsPath,
 		"1001502",
 		"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:500,gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000,gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:10000",
@@ -82,10 +83,10 @@ func initializeSetup() {
 	println("[INFO] GNS Balance of admin:", gns.BalanceOf(adminAddr))
 	println("[INFO] WUGNOT Balance of admin:", wugnot.BalanceOf(adminAddr))
 
-	gns.Approve(cross, poolAddr, consts.INT64_MAX)
-	wugnot.Approve(cross, poolAddr, consts.INT64_MAX)
-	gns.Approve(cross, routerAddr, consts.INT64_MAX)
-	wugnot.Approve(cross, routerAddr, consts.INT64_MAX)
+	gns.Approve(cross, poolAddr, maxInt64)
+	wugnot.Approve(cross, poolAddr, maxInt64)
+	gns.Approve(cross, routerAddr, maxInt64)
+	wugnot.Approve(cross, routerAddr, maxInt64)
 }
 
 func createPool(token0Path string, token1Path string, fee uint32, startTick int32) {

--- a/tests/scenario/router/exact_out_swap_route_with_multi_route_filetest.gno
+++ b/tests/scenario/router/exact_out_swap_route_with_multi_route_filetest.gno
@@ -61,7 +61,7 @@ func main() {
 
 	println("[SCENARIO] 5. ExactOutSwapRoute multi route (gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:500,gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000,gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:10000)")
 	exactOutSwapRouteBy(
-		gnot,
+		"gnot",
 		gnsPath,
 		"1001502",
 		"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:500,gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000,gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:10000",

--- a/tests/scenario/router/exact_out_swap_route_with_single_route_filetest.gno
+++ b/tests/scenario/router/exact_out_swap_route_with_single_route_filetest.gno
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"gno.land/p/demo/ufmt"
-	"gno.land/p/gnoswap/consts"
 
 	"gno.land/r/gnoswap/v1/access"
 	"gno.land/r/gnoswap/v1/common"

--- a/tests/scenario/router/exact_out_swap_route_with_single_route_filetest.gno
+++ b/tests/scenario/router/exact_out_swap_route_with_single_route_filetest.gno
@@ -35,6 +35,8 @@ var (
 
 	wugnotPath = "gno.land/r/demo/wugnot"
 	gnsPath    = "gno.land/r/gnoswap/v1/gns"
+
+	maxInt64 int64  = 9223372036854775807
 )
 
 var t *testing.T
@@ -60,7 +62,7 @@ func main() {
 
 	println("[SCENARIO] 5. ExactOutSwapRoute")
 	exactOutSwapRouteBy(
-		consts.GNOT,
+		"gnot",
 		gnsPath,
 		"1001502",
 		"gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:500",
@@ -82,10 +84,10 @@ func initializeSetup() {
 	println("[INFO] GNS Balance of admin:", gns.BalanceOf(adminAddr))
 	println("[INFO] WUGNOT Balance of admin:", wugnot.BalanceOf(adminAddr))
 
-	gns.Approve(cross, poolAddr, consts.INT64_MAX)
-	wugnot.Approve(cross, poolAddr, consts.INT64_MAX)
-	gns.Approve(cross, routerAddr, consts.INT64_MAX)
-	wugnot.Approve(cross, routerAddr, consts.INT64_MAX)
+	gns.Approve(cross, poolAddr, maxInt64)
+	wugnot.Approve(cross, poolAddr, maxInt64)
+	gns.Approve(cross, routerAddr, maxInt64)
+	wugnot.Approve(cross, routerAddr, maxInt64)
 }
 
 func createPool(token0Path string, token1Path string, fee uint32, startTick int32) {


### PR DESCRIPTION
# Description

Removed the dependency on consts from the router contract. To minimize impact on other tasks, individual PRs will be created for each contract.