### PR TITLE
feat(gov/xgns): remove withdrawal halt in gov/xgns

### DIFF
--- a/contract/r/gnoswap/gov/xgns/xgns.gno
+++ b/contract/r/gnoswap/gov/xgns/xgns.gno
@@ -96,7 +96,6 @@ func Render(path string) string {
 // - Propagates any error from the ledger.Mint function.
 func Mint(cur realm, to std.Address, amount int64) {
 	halt.AssertIsNotHaltedXGns()
-	halt.AssertIsNotHaltedWithdraw()
 
 	// only gov staker contract can call Mint
 	caller := std.PreviousRealm().Address()
@@ -121,7 +120,6 @@ func Mint(cur realm, to std.Address, amount int64) {
 // - Propagates any error from the ledger.Mint function.
 func MintByLaunchPad(cur realm, to std.Address, amount int64) {
 	halt.AssertIsNotHaltedXGns()
-	halt.AssertIsNotHaltedWithdraw()
 
 	// only launchpad contract can call MintByLaunchPad
 	caller := std.PreviousRealm().Address()
@@ -147,7 +145,6 @@ func MintByLaunchPad(cur realm, to std.Address, amount int64) {
 // - Propagates any error from the ledger.Burn function.
 func Burn(cur realm, from std.Address, amount int64) {
 	halt.AssertIsNotHaltedXGns()
-	halt.AssertIsNotHaltedWithdraw()
 
 	// only gov staker contract can call Burn
 	caller := std.PreviousRealm().Address()
@@ -158,7 +155,6 @@ func Burn(cur realm, from std.Address, amount int64) {
 
 func BurnByLaunchPad(cur realm, from std.Address, amount int64) {
 	halt.AssertIsNotHaltedXGns()
-	halt.AssertIsNotHaltedWithdraw()
 
 	// only launchpad contract can call BurnByLaunchPad
 	caller := std.PreviousRealm().Address()


### PR DESCRIPTION
## Descriptions

Removed withdrawal halt validation from xGNS mint and burn operations to allow xGNS token management to function independently of withdrawal restrictions.

### Key Changes

#### **Removed Withdrawal Halt Checks**
- **File**: `contract/r/gnoswap/gov/xgns/xgns.gno`
- **Updated Functions**:
  - `Mint()` - Removed `halt.AssertIsNotHaltedWithdraw()`
  - `MintByLaunchPad()` - Removed `halt.AssertIsNotHaltedWithdraw()`
  - `Burn()` - Removed `halt.AssertIsNotHaltedWithdraw()`
  - `BurnByLaunchPad()` - Removed `halt.AssertIsNotHaltedWithdraw()`

#### **Before: Dual Halt Validation**
```go
func Mint(cur realm, to std.Address, amount int64) {
    halt.AssertIsNotHaltedXGns()      // xGNS-specific halt
    halt.AssertIsNotHaltedWithdraw()  // Withdrawal halt (REMOVED)
    
    // ... mint logic
}
```

#### **After: Targeted Halt Validation**
```go
func Mint(cur realm, to std.Address, amount int64) {
    halt.AssertIsNotHaltedXGns()      // Only xGNS-specific halt
    
    // ... mint logic
}
```