### PR TITLE
fix(governance): Remove unnecessary `success` fields

### DIFF
--- a/contract/r/gnoswap/gov/governance/consts.gno
+++ b/contract/r/gnoswap/gov/governance/consts.gno
@@ -7,10 +7,10 @@ const (
 	// To execute a message, we need to parse the message and call the corresponding function
 	// with the given parameters
 	parameterSeparator = "*EXE*"
-	
+
 	messageSeparator = "*GOV*"
 
-	maxTitleLength = 255
+	maxTitleLength       = 255
 	maxDescriptionLength = 10_000
 	maxNumberOfExecution = 10
 )

--- a/contract/r/gnoswap/gov/governance/governance_execute.gno
+++ b/contract/r/gnoswap/gov/governance/governance_execute.gno
@@ -120,8 +120,6 @@ func executeProposal(
 		}
 	}
 
-	// Mark execution as successful
-	proposal.status.updateExecuteResult(true)
 
 	return proposal, nil
 }

--- a/contract/r/gnoswap/gov/governance/governance_propose.gno
+++ b/contract/r/gnoswap/gov/governance/governance_propose.gno
@@ -33,7 +33,6 @@ func ProposeText(
 	description string,
 ) (newProposalId int64) {
 	halt.AssertIsNotHaltedGovernance()
-	halt.AssertIsNotHaltedWithdraw()
 
 	// Get caller information for proposal creation
 	callerAddress := std.PreviousRealm().Address()
@@ -237,7 +236,6 @@ func ProposeParameterChange(
 	executions string,
 ) (newProposalId int64) {
 	halt.AssertIsNotHaltedGovernance()
-	halt.AssertIsNotHaltedWithdraw()
 
 	// Get caller information for proposal creation
 	callerAddress := std.PreviousRealm().Address()

--- a/contract/r/gnoswap/gov/governance/proposal.gno
+++ b/contract/r/gnoswap/gov/governance/proposal.gno
@@ -50,14 +50,14 @@ func (p ProposalType) IsExecutable() bool {
 // Proposal represents a governance proposal with all its associated data and state.
 // This is the core structure that tracks proposal lifecycle from creation to execution.
 type Proposal struct {
-	id            int64               // Unique identifier for the proposal
-	proposer      std.Address         // The address of the proposer
-	configVersion int64               // The version of the governance config used
-	status        *ProposalStatus     // Current status and voting information
-	metadata      *ProposalMetadata   // Title and description
-	data          *ProposalData       // Type-specific proposal data
-	createdAt     int64               // Creation timestamp
-	createdHeight int64               // Block height at creation
+	id            int64             // Unique identifier for the proposal
+	proposer      std.Address       // The address of the proposer
+	configVersion int64             // The version of the governance config used
+	status        *ProposalStatus   // Current status and voting information
+	metadata      *ProposalMetadata // Title and description
+	data          *ProposalData     // Type-specific proposal data
+	createdAt     int64             // Creation timestamp
+	createdHeight int64             // Block height at creation
 }
 
 // ID returns the unique identifier of the proposal.
@@ -333,15 +333,6 @@ func (p *Proposal) execute(executedAt int64, executedHeight int64, executedBy st
 
 	// Mark proposal as executed
 	return p.status.execute(executedAt, executedHeight, executedBy)
-}
-
-// updateExecuteResult updates the execution result status.
-// This is called after execution attempt to record success or failure.
-//
-// Parameters:
-//   - success: true if execution was successful
-func (p *Proposal) updateExecuteResult(success bool) {
-	p.status.updateExecuteResult(success)
 }
 
 // cancel marks the proposal as canceled and records cancellation details.

--- a/contract/r/gnoswap/gov/governance/proposal_action_status.gno
+++ b/contract/r/gnoswap/gov/governance/proposal_action_status.gno
@@ -14,9 +14,8 @@ type ProposalActionStatus struct {
 	executedAt     int64       // Timestamp when proposal was executed
 	executedHeight int64       // Block height when proposal was executed
 	executedBy     std.Address // Who executed the proposal
-	
+
 	executable bool // Whether this proposal type supports execution
-	success    bool // Whether the execution was successful (only meaningful if executed)
 }
 
 // IsCanceled returns whether the proposal has been canceled.
@@ -77,7 +76,7 @@ func (p *ProposalActionStatus) cancel(canceledAt int64, canceledHeight int64, ca
 	if !p.executable {
 		return errProposalNotExecutable
 	}
-	
+
 	// Record cancellation details
 	p.canceled = true
 	p.canceledAt = canceledAt
@@ -112,29 +111,6 @@ func (p *ProposalActionStatus) execute(executedAt int64, executedHeight int64, e
 	return nil
 }
 
-// IsSuccess returns whether the proposal execution was successful.
-// Only meaningful for executed proposals.
-//
-// Returns:
-//   - bool: true if proposal was executed successfully
-func (p *ProposalActionStatus) IsSuccess() bool {
-	// Can only be successful if actually executed
-	if !p.executed {
-		return false
-	}
-
-	return p.success
-}
-
-// updateResult updates the execution success status.
-// This is called after execution attempt to record the outcome.
-//
-// Parameters:
-//   - success: true if execution was successful
-func (p *ProposalActionStatus) updateResult(success bool) {
-	p.success = success
-}
-
 // NewProposalActionStatus creates a new action status for a proposal.
 // Initializes the status with default values and the executable flag.
 //
@@ -145,9 +121,8 @@ func (p *ProposalActionStatus) updateResult(success bool) {
 //   - *ProposalActionStatus: new action status instance
 func NewProposalActionStatus(executable bool) *ProposalActionStatus {
 	return &ProposalActionStatus{
-		canceled:   false, // Proposal starts as not canceled
-		executed:   false, // Proposal starts as not executed
-		success:    false, // Execution success starts as false
+		canceled:   false,      // Proposal starts as not canceled
+		executed:   false,      // Proposal starts as not executed
 		executable: executable, // Set based on proposal type
 	}
 }

--- a/contract/r/gnoswap/gov/governance/proposal_action_status_test.gno
+++ b/contract/r/gnoswap/gov/governance/proposal_action_status_test.gno
@@ -10,18 +10,18 @@ import (
 // TestProposalActionStatus_CancelAndExecute tests cancel and execute operations
 func TestProposalActionStatus_CancelAndExecute(t *testing.T) {
 	tests := []struct {
-		name                string
-		executable         bool
-		operation          string // "cancel" or "execute"
-		timestamp          int64
-		height             int64
-		actor              std.Address
-		expectedError      bool
-		expectedSuccess    bool
+		name            string
+		executable      bool
+		operation       string // "cancel" or "execute"
+		timestamp       int64
+		height          int64
+		actor           std.Address
+		expectedError   bool
+		expectedSuccess bool
 	}{
 		{
-			name:           "Success - Cancel executable proposal",
-			executable:     true,
+			name:          "Success - Cancel executable proposal",
+			executable:    true,
 			operation:     "cancel",
 			timestamp:     1000,
 			height:        100,
@@ -29,8 +29,8 @@ func TestProposalActionStatus_CancelAndExecute(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name:           "Success - Execute executable proposal",
-			executable:     true,
+			name:          "Success - Execute executable proposal",
+			executable:    true,
 			operation:     "execute",
 			timestamp:     1000,
 			height:        100,
@@ -38,8 +38,8 @@ func TestProposalActionStatus_CancelAndExecute(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name:           "Failure - Cancel non-executable proposal",
-			executable:     false,
+			name:          "Failure - Cancel non-executable proposal",
+			executable:    false,
 			operation:     "cancel",
 			timestamp:     1000,
 			height:        100,
@@ -47,8 +47,8 @@ func TestProposalActionStatus_CancelAndExecute(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name:           "Failure - Execute non-executable proposal",
-			executable:     false,
+			name:          "Failure - Execute non-executable proposal",
+			executable:    false,
 			operation:     "execute",
 			timestamp:     1000,
 			height:        100,
@@ -87,55 +87,6 @@ func TestProposalActionStatus_CancelAndExecute(t *testing.T) {
 	}
 }
 
-// TestProposalActionStatus_UpdateResult tests result update functionality
-func TestProposalActionStatus_UpdateResult(t *testing.T) {
-	tests := []struct {
-		name           string
-		executable     bool
-		executeFirst   bool
-		success        bool
-		expectedSuccess bool
-	}{
-		{
-			name:            "Success - Update result after execution",
-			executable:      true,
-			executeFirst:    true,
-			success:         true,
-			expectedSuccess: true,
-		},
-		{
-			name:            "Success - Update result without execution",
-			executable:      true,
-			executeFirst:    false,
-			success:         true,
-			expectedSuccess: false,
-		},
-		{
-			name:            "Success - Update result with failure",
-			executable:      true,
-			executeFirst:    true,
-			success:         false,
-			expectedSuccess: false,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			// given
-			status := NewProposalActionStatus(tc.executable)
-			if tc.executeFirst {
-				_ = status.execute(1000, 100, std.Address("g1executor"))
-			}
-
-			// when
-			status.updateResult(tc.success)
-
-			// then
-			uassert.Equal(t, status.IsSuccess(), tc.expectedSuccess)
-		})
-	}
-}
-
 // TestNewProposalActionStatus tests the creation of new action status
 func TestNewProposalActionStatus(t *testing.T) {
 	tests := []struct {
@@ -162,7 +113,6 @@ func TestNewProposalActionStatus(t *testing.T) {
 			uassert.Equal(t, status.IsExecutable(), tc.executable)
 			uassert.False(t, status.IsCanceled())
 			uassert.False(t, status.IsExecuted())
-			uassert.False(t, status.IsSuccess())
 		})
 	}
-} 
+}

--- a/contract/r/gnoswap/gov/governance/proposal_status.gno
+++ b/contract/r/gnoswap/gov/governance/proposal_status.gno
@@ -10,14 +10,14 @@ type ProposalStatusType int
 
 const (
 	_                ProposalStatusType = iota
-	StatusUpcoming   // Proposal created but voting hasn't started yet
-	StatusActive     // Proposal is in voting period
-	StatusPassed     // Proposal has passed but hasn't been executed (or is text proposal)
-	StatusRejected   // Proposal failed to meet voting requirements
-	StatusExecutable // Proposal can be executed (passed and in execution window)
-	StatusExecuted   // Proposal has been successfully executed
-	StatusExpired    // Proposal execution window has passed
-	StatusCanceled   // Proposal has been canceled
+	StatusUpcoming                      // Proposal created but voting hasn't started yet
+	StatusActive                        // Proposal is in voting period
+	StatusPassed                        // Proposal has passed but hasn't been executed (or is text proposal)
+	StatusRejected                      // Proposal failed to meet voting requirements
+	StatusExecutable                    // Proposal can be executed (passed and in execution window)
+	StatusExecuted                      // Proposal has been successfully executed
+	StatusExpired                       // Proposal execution window has passed
+	StatusCanceled                      // Proposal has been canceled
 )
 
 // String returns the string representation of ProposalStatusType for display purposes.
@@ -247,15 +247,6 @@ func (p *ProposalStatus) execute(executedAt int64, executedHeight int64, execute
 	return p.actionStatus.execute(executedAt, executedHeight, executedBy)
 }
 
-// updateExecuteResult updates the execution result status.
-// This records whether the execution was successful or failed.
-//
-// Parameters:
-//   - success: true if execution was successful
-func (p *ProposalStatus) updateExecuteResult(success bool) {
-	p.actionStatus.updateResult(success)
-}
-
 // vote records a vote on the proposal and updates vote tallies.
 // This delegates to the vote status for actual vote recording.
 //
@@ -321,4 +312,3 @@ func NewProposalStatus(
 		),
 	}
 }
-

--- a/contract/r/gnoswap/gov/governance/proposal_status_test.gno
+++ b/contract/r/gnoswap/gov/governance/proposal_status_test.gno
@@ -13,20 +13,20 @@ func TestProposalStatus_StatusType(t *testing.T) {
 	baseTime := time.Unix(1000, 0)
 	config := Config{
 		VotingStartDelay: 100,
-		VotingPeriod:    200,
-		ExecutionDelay:  100,
-		ExecutionWindow: 200,
-		Quorum:         50,
+		VotingPeriod:     200,
+		ExecutionDelay:   100,
+		ExecutionWindow:  200,
+		Quorum:           50,
 	}
 
 	tests := []struct {
-		name           string
-		currentTime    time.Time
+		name            string
+		currentTime     time.Time
 		maxVotingWeight int64
-		executable     bool
-		isExecuted     bool
-		isCanceled     bool
-		expectedStatus ProposalStatusType
+		executable      bool
+		isExecuted      bool
+		isCanceled      bool
+		expectedStatus  ProposalStatusType
 	}{
 		{
 			name:            "Status Upcoming",
@@ -125,10 +125,10 @@ func TestProposalStatus_VotingOperations(t *testing.T) {
 			// given
 			config := Config{
 				VotingStartDelay: 100,
-				VotingPeriod:    200,
-				ExecutionDelay:  100,
-				ExecutionWindow: 200,
-				Quorum:         tc.quorum,
+				VotingPeriod:     200,
+				ExecutionDelay:   100,
+				ExecutionWindow:  200,
+				Quorum:           tc.quorum,
 			}
 			status := NewProposalStatus(config, tc.maxVotingWeight, true, time.Now().Unix())
 
@@ -148,72 +148,3 @@ func TestProposalStatus_VotingOperations(t *testing.T) {
 		})
 	}
 }
-
-// TestProposalStatus_ExecutionOperations tests execution operations
-func TestProposalStatus_ExecutionOperations(t *testing.T) {
-	tests := []struct {
-		name           string
-		executable     bool
-		operation     string // "execute" or "cancel"
-		success       bool
-		expectedError bool
-	}{
-		{
-			name:          "Execute successful proposal",
-			executable:    true,
-			operation:    "execute",
-			success:      true,
-			expectedError: false,
-		},
-		{
-			name:          "Cancel executable proposal",
-			executable:    true,
-			operation:    "cancel",
-			expectedError: false,
-		},
-		{
-			name:          "Execute non-executable proposal",
-			executable:    false,
-			operation:    "execute",
-			expectedError: true,
-		},
-		{
-			name:          "Cancel non-executable proposal",
-			executable:    false,
-			operation:    "cancel",
-			expectedError: true,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			// given
-			config := Config{
-				VotingStartDelay: 100,
-				VotingPeriod:    200,
-				ExecutionDelay:  100,
-				ExecutionWindow: 200,
-				Quorum:         50,
-			}
-			status := NewProposalStatus(config, 1000, tc.executable, time.Now().Unix())
-
-			// when
-			var err error
-			if tc.operation == "execute" {
-				err = status.execute(time.Now().Unix(), 100, std.Address("g1executor"))
-				if err == nil && tc.success {
-					status.updateExecuteResult(true)
-				}
-			} else {
-				err = status.cancel(time.Now().Unix(), 100, std.Address("g1canceler"))
-			}
-
-			// then
-			if tc.expectedError {
-				uassert.NotNil(t, err)
-			} else {
-				uassert.Nil(t, err)
-			}
-		})
-	}
-} 


### PR DESCRIPTION
# Description

- Removed success field from `ProposalActionStatus`
- Removed `IsSuccess()` method that was never called
- Removed `updateResult()` and `updateExecuteResult()` methods
- Since proposal execution either succeeds or panics, tracking success state was redundant
- Removed `halt.AssertIsNotHaltedWithdraw()` from `ProposeText` and `ProposeParameterChange` to follows the halt-checking documentation