### PR TITLE
fix: handle to time-based external reward

### DIFF
--- a/contract/r/gnoswap/v1/staker/calculate_pool_position_reward.gno
+++ b/contract/r/gnoswap/v1/staker/calculate_pool_position_reward.gno
@@ -1,8 +1,6 @@
 package staker
 
 import (
-	"time"
-
 	u256 "gno.land/p/gnoswap/uint256"
 )
 
@@ -24,21 +22,6 @@ type Reward struct {
 	InternalPenalty int64
 	External        map[string]int64 // Incentive ID -> TokenAmount
 	ExternalPenalty map[string]int64 // Incentive ID -> TokenAmount
-}
-
-// calculate position reward by each warmup
-func calcPositionRewardByWarmups(currentTimestamp int64, positionId uint64) []Reward {
-	currentTime := time.Now().Unix()
-	rewards := calculatePositionReward(CalcPositionRewardParam{
-		CurrentHeight: currentTimestamp,
-		CurrentTime:   currentTime,
-		Deposits:      deposits,
-		Pools:         pools,
-		PoolTier:      poolTier,
-		PositionId:    positionId,
-	})
-
-	return rewards
 }
 
 // calculate total position rewards and penalties

--- a/contract/r/gnoswap/v1/staker/external_incentive.gno
+++ b/contract/r/gnoswap/v1/staker/external_incentive.gno
@@ -55,8 +55,11 @@ func CreateExternalIncentive(
 	// deposit gns amount
 	gns.TransferFrom(cross, caller, stakerAddr, depositGnsAmount)
 
-	incentiveId := nextIncentiveID(caller, std.ChainHeight())
+	currentTime := time.Now().Unix()
+	currentHeight := std.ChainHeight()
+	incentiveId := nextIncentiveID(caller, currentTime)
 	pool := pools.GetOrCreate(targetPoolPath)
+
 	incentive := NewExternalIncentive(
 		incentiveId,
 		targetPoolPath,
@@ -65,9 +68,9 @@ func CreateExternalIncentive(
 		startTimestamp,
 		endTimestamp,
 		caller,
-		std.ChainHeight(),
+		currentHeight,
 		depositGnsAmount,
-		time.Now().Unix(),
+		currentTime,
 	)
 
 	if externalIncentives.Has(incentiveId) {
@@ -93,8 +96,8 @@ func CreateExternalIncentive(
 		"startTimestamp", formatInt(startTimestamp),
 		"endTimestamp", formatInt(endTimestamp),
 		"depositGnsAmount", formatInt(depositGnsAmount),
-		"currentHeight", formatInt(std.ChainHeight()),
-		"currentTime", formatInt(time.Now().Unix()),
+		"currentHeight", formatInt(currentHeight),
+		"currentTime", formatInt(currentTime),
 	)
 }
 

--- a/contract/r/gnoswap/v1/staker/reward_calculation_incentives.gno
+++ b/contract/r/gnoswap/v1/staker/reward_calculation_incentives.gno
@@ -2,29 +2,31 @@ package staker
 
 import (
 	"std"
+	"time"
 
 	"gno.land/p/demo/avl"
 )
 
-// Incentives is a collection of external incentives for a given pool.
+// Incentives represents a collection of external incentives for a specific pool.
 //
 // Fields:
-// - byTime: ExternalIncentive primarily indexed by startTime
-// - byHeight: ExternalIncentive primarily indexed by startHeight
-// - byEndHeight: ExternalIncentive primarily indexed by endHeight
-// - byCreator: ExternalIncentive primarily indexed by creator
-// - targetPoolPath: The target pool path for this incentive collection
 //
-//   - unclaimablePeriods:
-//     For each unclaimable period(start, end) for this pool,
-//     it stores (key: start) => (value: end)
-//     if end is 0, it means the unclaimable period is ongoing.
+//   - incentives: AVL tree storing ExternalIncentive objects indexed by incentiveId
+//     The incentiveId serves as the key to efficiently lookup incentive details
+//
+//   - targetPoolPath: String identifier for the pool this incentive collection belongs to
+//     Used to associate incentives with their corresponding liquidity pool
+//
+//   - unclaimablePeriods: Tree storing periods when rewards cannot be claimed
+//     Maps start timestamp (key) to end timestamp (value)
+//     An end timestamp of 0 indicates an ongoing unclaimable period
+//     Used to track intervals when staking rewards are not claimable
 type Incentives struct {
 	incentives *avl.Tree // (incentiveId) => ExternalIncentive
 
 	targetPoolPath string // The target pool path for this incentive collection
 
-	unclaimablePeriods *UintTree // startHeight => endHeight
+	unclaimablePeriods *UintTree // startTimestamp => endTimestamp
 }
 
 // NewIncentives creates a new Incentives instance.
@@ -36,7 +38,8 @@ func NewIncentives(targetPoolPath string) Incentives {
 	}
 
 	// initial unclaimable period starts, as there cannot be any staked positions yet.
-	result.unclaimablePeriods.set(std.ChainHeight(), int64(0))
+	currentTimestamp := time.Now().Unix()
+	result.unclaimablePeriods.set(currentTimestamp, int64(0))
 	return result
 }
 
@@ -88,7 +91,6 @@ func (self *Incentives) GetAllInTimestamps(startTimestamp, endTimestamp int64) m
 
 // Create a new external incentive
 // Panics if the incentive already exists.
-// Sets to byTime, byHeight, byEndHeight, byCreator
 func (self *Incentives) create(
 	creator std.Address,
 	incentive *ExternalIncentive,
@@ -105,33 +107,33 @@ func (self *Incentives) update(
 }
 
 // starts incentive unclaimable period for this pool
-func (self *Incentives) startUnclaimablePeriod(startHeight int64) {
-	self.unclaimablePeriods.set(startHeight, int64(0))
+func (self *Incentives) startUnclaimablePeriod(startTimestamp int64) {
+	self.unclaimablePeriods.set(startTimestamp, int64(0))
 }
 
 // ends incentive unclaimable period for this pool
 // ignores if currently not in unclaimable period
-func (self *Incentives) endUnclaimablePeriod(endHeight int64) {
-	startHeight := int64(0)
-	self.unclaimablePeriods.ReverseIterate(0, endHeight, func(key int64, value any) bool {
+func (self *Incentives) endUnclaimablePeriod(endTimestamp int64) {
+	startTimestamp := int64(0)
+	self.unclaimablePeriods.ReverseIterate(0, endTimestamp, func(key int64, value any) bool {
 		if value.(int64) != 0 {
 			// Already ended, no need to update
-			// keeping startHeight as 0 to indicate this
+			// keeping startTimestamp as 0 to indicate this
 			return true
 		}
-		startHeight = key
+		startTimestamp = key
 		return true
 	})
 
-	if startHeight == 0 {
+	if startTimestamp == 0 {
 		// No ongoing unclaimable period found
 		return
 	}
 
-	if startHeight == endHeight {
-		self.unclaimablePeriods.remove(startHeight)
+	if startTimestamp == endTimestamp {
+		self.unclaimablePeriods.remove(startTimestamp)
 	} else {
-		self.unclaimablePeriods.set(startHeight, endHeight)
+		self.unclaimablePeriods.set(startTimestamp, endTimestamp)
 	}
 }
 
@@ -142,9 +144,11 @@ func (self *Incentives) calculateUnclaimableReward(incentiveId string) int64 {
 		return 0
 	}
 
-	blocks := int64(0)
+	timeDiff := int64(0)
 
+	// Find unclaimable periods that end before or at incentive start
 	self.unclaimablePeriods.ReverseIterate(0, incentive.startTimestamp, func(key int64, value any) bool {
+		startTimestamp := key
 		endTimestamp := value.(int64)
 		if endTimestamp == 0 {
 			endTimestamp = incentive.endTimestamp
@@ -154,25 +158,66 @@ func (self *Incentives) calculateUnclaimableReward(incentiveId string) int64 {
 			return true
 		}
 
-		blocks += endTimestamp - incentive.startTimestamp
+		// Calculate duration of unclaimable period that overlaps with incentive period
+		duration := calculateUnClaimableDuration(
+			startTimestamp,
+			endTimestamp,
+			incentive.startTimestamp,
+			incentive.endTimestamp,
+		)
+
+		timeDiff += duration
 
 		return true
 	})
 
+	// Find unclaimable periods that start within incentive period
 	self.unclaimablePeriods.Iterate(incentive.startTimestamp, incentive.endTimestamp, func(key int64, value any) bool {
 		startTimestamp := key
 		endTimestamp, ok := value.(int64)
 		if !ok {
 			panic("failed to cast value to int64")
 		}
+
 		if endTimestamp == 0 {
 			endTimestamp = incentive.endTimestamp
 		}
 
-		blocks += endTimestamp - startTimestamp
+		// Calculate duration of unclaimable period that overlaps with incentive period
+		duration := calculateUnClaimableDuration(
+			startTimestamp,
+			endTimestamp,
+			incentive.startTimestamp,
+			incentive.endTimestamp,
+		)
+
+		timeDiff += duration
 
 		return false
 	})
 
-	return int64(blocks) * incentive.rewardPerSecond
+	return timeDiff * incentive.rewardPerSecond
+}
+
+// calculateUnClaimableDuration calculates the duration of overlap between an unclaimable period and incentive period
+func calculateUnClaimableDuration(unclaimableStart, unclaimableEnd, incentiveStartTimestamp, incentiveEndTimestamp int64) int64 {
+	// Use later timestamp between unclaimable start and incentive start
+	startTime := unclaimableStart
+	if startTime < incentiveStartTimestamp {
+		startTime = incentiveStartTimestamp
+	}
+
+	// Use earlier timestamp between unclaimable end and incentive end
+	endTime := unclaimableEnd
+	if endTime > incentiveEndTimestamp {
+		endTime = incentiveEndTimestamp
+	}
+
+	// Return 0 if no overlap
+	if endTime < startTime {
+		return 0
+	}
+
+	// Calculate overlap duration
+	return endTime - startTime
 }

--- a/contract/r/gnoswap/v1/staker/reward_calculation_pool_tier.gno
+++ b/contract/r/gnoswap/v1/staker/reward_calculation_pool_tier.gno
@@ -82,10 +82,10 @@ func (self *TierRatio) Get(tier uint64) uint64 {
 // - membership: Tracks which tier a pool belongs to (poolPath -> blockNumber -> tier).
 //
 // Methods:
-// - CurrentCount: Returns the current count of pools in a tier at a specific height.
-// - CurrentRatio: Returns the current ratio for a tier at a specific height.
-// - CurrentTier: Returns the tier of a specific pool at a given height.
-// - CurrentReward: Retrieves the reward for a tier at a specific height.
+// - CurrentCount: Returns the current count of pools in a tier at a specific timestamp.
+// - CurrentRatio: Returns the current ratio for a tier at a specific timestamp.
+// - CurrentTier: Returns the tier of a specific pool at a given timestamp.
+// - CurrentReward: Retrieves the reward for a tier at a specific timestamp.
 // - changeTier: Updates the tier of a pool and recalculates ratios.
 type PoolTier struct {
 	membership *avl.Tree // poolPath -> tier(1, 2, 3)
@@ -247,14 +247,14 @@ func (self *PoolTier) cacheReward(currentHeight int64, currentTimestamp int64, p
 
 	for i, hvTimestamp := range halvingTimestamps {
 		emission := halvingEmissions[i]
-		// caching: [lastHeight, hvBlock)
+		// caching: [lastTimestamp, hvTimestamp)
 		self.applyCacheToAllPools(pools, hvTimestamp, emission)
 
 		// halve emissions when halvingBlock is reached
 		self.currentEmission = emission
 	}
 
-	// remaining range [lastHalvingBlock, currentTimestamp)
+	// remaining range [lastTimestamp, currentTimestamp)
 	self.applyCacheToAllPools(pools, currentTimestamp, self.currentEmission)
 
 	// update lastRewardCacheHeight and currentEmission

--- a/contract/r/gnoswap/v1/staker/reward_calculation_types.gno
+++ b/contract/r/gnoswap/v1/staker/reward_calculation_types.gno
@@ -63,8 +63,8 @@ func DecodeInt64(s string) int64 {
 	return num
 }
 
-// UintTree is a wrapper around an AVL tree for storing block heights as strings.
-// Since block heights are defined as int64, we take int64 and convert it to uint64 for the tree.
+// UintTree is a wrapper around an AVL tree for storing block timestamps as strings.
+// Since block timestamps are defined as int64, we take int64 and convert it to uint64 for the tree.
 //
 // Methods:
 // - Get: Retrieves a value associated with a uint64 key.
@@ -74,7 +74,7 @@ func DecodeInt64(s string) int64 {
 // - Iterate: Iterates over keys and values in a range.
 // - ReverseIterate: Iterates in reverse order over keys and values in a range.
 type UintTree struct {
-	tree *avl.Tree // blockNumber -> any
+	tree *avl.Tree // blockTimestamp -> any
 }
 
 // NewUintTree creates a new UintTree instance.

--- a/contract/r/gnoswap/v1/staker/type.gno
+++ b/contract/r/gnoswap/v1/staker/type.gno
@@ -92,7 +92,7 @@ func (e ExternalIncentive) RewardAmount() int64 {
 }
 
 func (self *ExternalIncentive) RewardSpent(currentTimestamp int64) int64 {
-	// Still check heights for state validation
+	// Still check timestamps for state validation
 	if currentTimestamp < self.startTimestamp {
 		return 0
 	}
@@ -116,7 +116,7 @@ func (self *ExternalIncentive) RewardSpent(currentTimestamp int64) int64 {
 }
 
 func (self *ExternalIncentive) RewardLeft(currentTimestamp int64) int64 {
-	// Still check heights for state validation
+	// Still check timestamps for state validation
 	if currentTimestamp <= self.startTimestamp {
 		return int64(self.rewardAmount)
 	}

--- a/tests/scenario/staker/single_gns_external_ends_filetest.gno
+++ b/tests/scenario/staker/single_gns_external_ends_filetest.gno
@@ -204,7 +204,7 @@ func createExternalIncentiveGns() {
 	println("[INFO] create external incentive for 90 days")
 	testing.SkipHeights(1)
 
-	incentiveID := fmt.Sprintf("%s:%d:%d", externalCreatorAddr, std.ChainHeight(), 1)
+	incentiveID := fmt.Sprintf("%s:%d:%d", externalCreatorAddr, time.Now().Unix(), 1)
 	println("[INFO] create external incentive with incentiveID: ", incentiveID)
 	sr.CreateExternalIncentive(
 		cross,
@@ -270,7 +270,7 @@ func endExternalGnsIncentive() {
 	testing.SetRealm(externalCreatorRealm)
 	gnsBalanceBeforeEnds := gns.BalanceOf(externalCreatorUser)
 
-	incentiveID := "g1v4u8getjdeskcsmjv4shgmmjta047h6lua7mup:127:1"
+	incentiveID := "g1v4u8getjdeskcsmjv4shgmmjta047h6lua7mup:1234567910:1"
 	sr.EndExternalIncentive(
 		cross,
 		"gno.land/r/onbloc/bar:gno.land/r/onbloc/qux:100",
@@ -347,7 +347,7 @@ func positionIdFrom(positionId any) grc721.TokenID {
 // [INFO] transfer GNS to external creator
 // [INFO] approve GNS for external incentive creation
 // [INFO] create external incentive for 90 days
-// [INFO] create external incentive with incentiveID:  g1v4u8getjdeskcsmjv4shgmmjta047h6lua7mup:127:1
+// [INFO] create external incentive with incentiveID:  g1v4u8getjdeskcsmjv4shgmmjta047h6lua7mup:1234567910:1
 //
 // [SCENARIO] 6. Start external incentive
 // [INFO] skip blocks until external incentive starts

--- a/tests/scenario/staker/staker_native_create_collect_unstake_filetest.gno
+++ b/tests/scenario/staker/staker_native_create_collect_unstake_filetest.gno
@@ -288,7 +288,7 @@ func createExternalIncentiveNative() {
 	testing.SetOriginSend(std.Coins{{"ugnot", 10_000_000_000}})
 	wugnot.Approve(cross, stakerAddr, maxInt64)
 
-	incentiveID := fmt.Sprintf("%s:%d:%d", adminAddr, std.ChainHeight(), 1)
+	incentiveID := fmt.Sprintf("%s:%d:%d", adminAddr, time.Now().Unix(), 1)
 	println("[INFO] create external incentive with incentiveID: ", incentiveID)
 
 	sr.CreateExternalIncentive(
@@ -416,7 +416,7 @@ func endExternalIncentive() {
 	testing.SkipHeights(9999999)
 
 	println("[INFO] end external incentive")
-	incentiveID := "g17290cwvmrapvp869xfnhhawa8sm9edpufzat7d:150:1"
+	incentiveID := "g17290cwvmrapvp869xfnhhawa8sm9edpufzat7d:1234568025:1"
 	sr.EndExternalIncentive(
 		cross,
 		"gno.land/r/demo/wugnot:gno.land/r/gnoswap/gns:500",
@@ -506,7 +506,7 @@ func positionIdFrom(positionId any) grc721.TokenID {
 // [INFO] prepare 10_000_000_000 ugnot for external incentive
 // [INFO] add token and approve gns
 // [INFO] create external incentive with native coin
-// [INFO] create external incentive with incentiveID:  g17290cwvmrapvp869xfnhhawa8sm9edpufzat7d:150:1
+// [INFO] create external incentive with incentiveID:  g17290cwvmrapvp869xfnhhawa8sm9edpufzat7d:1234568025:1
 // [INFO] external incentive created - start: 1234569600, end: 1242345600
 // [EXPECTED] admin wugnot balance after external incentive: 0
 //


### PR DESCRIPTION
## Descriptions

This PR migrates the external incentive system from block height-based calculations to timestamp-based calculations for more accurate and consistent reward distribution.

## Changes Made

### Main Fix
- **Modified `external_incentive.gno`**: 
  - Changed incentive ID generation to use current timestamp instead of block height
  - Improved variable consistency by storing `currentTime` and `currentHeight` once
  
- **Enhanced `reward_calculation_incentives.gno`**:
  - Migrated from block height-based to timestamp-based unclaimable period tracking
  - Added comprehensive documentation for the `Incentives` struct
  - Implemented `calculateUnClaimableDuration` function for precise overlap calculations
  - Improved unclaimable reward calculation logic with proper time range handling

### Code Cleanup
- Removed unused function `calcPositionRewardByWarmups` from `calculate_pool_position_reward.gno`
- Updated comments and documentation to reflect timestamp-based approach
- Standardized variable naming conventions across related files

## Key Improvements

1. **Time-based Precision**: External incentives now use Unix timestamps for more accurate reward calculations
2. **Better Documentation**: Enhanced struct documentation with clear field descriptions
3. **Improved Logic**: More robust unclaimable period calculation with proper overlap handling