### PR TITLE
fix(p/int256): fix int256 MinInt64 overflow and simplify Int64 implementation

### DIFF
--- a/contract/p/gnoswap/int256/conversion.gno
+++ b/contract/p/gnoswap/int256/conversion.gno
@@ -5,19 +5,24 @@ import (
 )
 
 // SetInt64 sets z to x and returns z.
+//
+// This implementation uses two's complement to handle the edge case of math.MinInt64.
+// When x = math.MinInt64 (-2^63), negating it would cause an overflow since 2^63
+// cannot be represented as a positive int64. By converting to uint64 first and then
+// applying two's complement (^u + 1) when negative, we correctly handle all int64
+// values including the minimum value without overflow.
 func (z *Int) SetInt64(x int64) *Int {
 	z = z.initiateAbs()
-
-	neg := false
-	if x < 0 {
-		neg = true
-		x = -x
-	}
 	if z.abs == nil {
-		panic("int256_SetInt64()__abs is nil")
+		panic("int256_SetInt64(): abs is nil")
 	}
-	z.abs = z.abs.SetUint64(uint64(x))
-	z.neg = neg
+	u := uint64(x)
+	neg := x < 0
+	if neg {
+		u = ^u + 1 // |x| = two's complement magnitude
+	}
+	z.abs = z.abs.SetUint64(u)
+	z.neg = neg && u != 0 // -0 방지
 	return z
 }
 
@@ -26,7 +31,7 @@ func (z *Int) SetUint64(x uint64) *Int {
 	z = z.initiateAbs()
 
 	if z.abs == nil {
-		panic("int256_SetUint64()__abs is nil")
+		panic("int256_SetUint64(): abs is nil")
 	}
 	z.abs = z.abs.SetUint64(x)
 	z.neg = false
@@ -38,28 +43,18 @@ func (z *Int) Uint64() uint64 {
 	return z.abs.Uint64()
 }
 
-// Int64 returns the lower 64-bits of z
+// Int64 returns the lower 64 bits of z, interpreted as a signed int64 (two's complement).
+//
+// Since int64 already uses two's complement representation internally,
+// we can simply apply two's complement to the unsigned magnitude when negative and cast
+// to int64. This approach correctly handles all edge cases including when the magnitude
+// equals 2^63 (which represents math.MinInt64 when negative) without special casing.
 func (z *Int) Int64() int64 {
-	u := z.abs.Uint64()
-
-	if u == 1<<63 {
-		return -1 << 63 // always return int64 min value
-	}
-
-	if u < 1<<63 {
-		if z.neg {
-			return -int64(u)
-		}
-		return int64(u)
-	}
-
-	// convert uint64 to int64 safely using two's complement
-	// when the number is greater than 2^63
-	res := -int64(^u + 1)
+	u := z.abs.Uint64() // lower 64 bits of magnitude
 	if z.neg {
-		return -res
+		u = ^u + 1 // apply two's complement for negative sign
 	}
-	return res
+	return int64(u) // reinterpret as two's complement int64
 }
 
 // Neg sets z to -x and returns z.)

--- a/contract/p/gnoswap/int256/conversion_test.gno
+++ b/contract/p/gnoswap/int256/conversion_test.gno
@@ -3,6 +3,8 @@ package int256
 import (
 	"testing"
 
+	"gno.land/p/demo/ufmt"
+
 	"gno.land/p/gnoswap/uint256"
 )
 
@@ -26,6 +28,78 @@ func TestSetInt64(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("SetInt64(%d) = %s, want %s", tc.x, got, tc.want)
 		}
+	}
+}
+
+func TestSetInt64MinValueOverflow(t *testing.T) {
+	const minInt64 = -9223372036854775808 // -2^63
+	const maxInt64 = 9223372036854775807  // 2^63 - 1
+
+	tests := []struct {
+		name string
+		x    int64
+		want string
+	}{
+		{
+			name: "MinInt64 should not cause overflow",
+			x:    minInt64,
+			want: "-9223372036854775808",
+		},
+		{
+			name: "MaxInt64 works correctly",
+			x:    maxInt64,
+			want: "9223372036854775807",
+		},
+		{
+			name: "MinInt64 + 1",
+			x:    minInt64 + 1,
+			want: "-9223372036854775807",
+		},
+		{
+			name: "Negative one",
+			x:    -1,
+			want: "-1",
+		},
+		{
+			name: "Zero",
+			x:    0,
+			want: "0",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var z Int
+			z.SetInt64(tc.x)
+
+			got := z.ToString()
+			if got != tc.want {
+				t.Errorf("SetInt64(%d) = %s, want %s", tc.x, got, tc.want)
+			}
+
+			// Verify the internal representation is correct
+			if tc.x < 0 {
+				if !z.neg {
+					t.Errorf("SetInt64(%d): expected neg=true, got neg=false", tc.x)
+				}
+				// Check magnitude for MinInt64
+				if tc.x == minInt64 {
+					expectedMag := uint64(1 << 63) // 2^63
+					gotMag := z.abs.Uint64()
+					if gotMag != expectedMag {
+						t.Errorf("SetInt64(%d): magnitude = %d, want %d", tc.x, gotMag, expectedMag)
+					}
+				}
+			} else if tc.x > 0 {
+				if z.neg {
+					t.Errorf("SetInt64(%d): expected neg=false, got neg=true", tc.x)
+				}
+			} else { // tc.x == 0
+				if z.neg {
+					t.Errorf("SetInt64(0): expected neg=false (no -0), got neg=true")
+				}
+			}
+		})
 	}
 }
 
@@ -102,6 +176,140 @@ func TestInt64(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("Int64(%s) = %d, want %d", tc.x, got, tc.want)
 		}
+	}
+}
+
+func TestInt64EdgeCases(t *testing.T) {
+	const minInt64 = -9223372036854775808 // -2^63
+	const maxInt64 = 9223372036854775807  // 2^63 - 1
+
+	tests := []struct {
+		name        string
+		setupInt    func() *Int
+		want        int64
+		description string
+	}{
+		{
+			name: "MinInt64 from SetInt64",
+			setupInt: func() *Int {
+				z := new(Int)
+				return z.SetInt64(minInt64)
+			},
+			want:        minInt64,
+			description: "SetInt64(MinInt64) should round-trip correctly",
+		},
+		{
+			name: "MaxInt64 from SetInt64",
+			setupInt: func() *Int {
+				z := new(Int)
+				return z.SetInt64(maxInt64)
+			},
+			want:        maxInt64,
+			description: "SetInt64(MaxInt64) should round-trip correctly",
+		},
+		{
+			name: "Magnitude 2^63 with negative sign",
+			setupInt: func() *Int {
+				// Create Int with magnitude = 2^63 and neg = true
+				z := new(Int)
+				z.abs = uint256.NewUint(1 << 63)
+				z.neg = true
+				return z
+			},
+			want:        minInt64,
+			description: "Magnitude 2^63 with neg=true should return MinInt64",
+		},
+		{
+			name: "Magnitude 2^63 with positive sign",
+			setupInt: func() *Int {
+				// Create Int with magnitude = 2^63 and neg = false
+				z := new(Int)
+				z.abs = uint256.NewUint(1 << 63)
+				z.neg = false
+				return z
+			},
+			want:        minInt64, // Wraps around due to two's complement
+			description: "Magnitude 2^63 with neg=false wraps to MinInt64",
+		},
+		{
+			name: "Large positive value wrapping",
+			setupInt: func() *Int {
+				// 2^64 - 1 (max uint64)
+				z := new(Int)
+				z.abs = uint256.NewUint(18446744073709551615)
+				z.neg = false
+				return z
+			},
+			want:        -1,
+			description: "Max uint64 wraps to -1 in int64",
+		},
+		{
+			name: "Negative large value",
+			setupInt: func() *Int {
+				// -(2^64 - 1)
+				z := new(Int)
+				z.abs = uint256.NewUint(18446744073709551615)
+				z.neg = true
+				return z
+			},
+			want:        1,
+			description: "-(Max uint64) becomes 1 due to two's complement",
+		},
+		{
+			name: "Zero",
+			setupInt: func() *Int {
+				return Zero()
+			},
+			want:        0,
+			description: "Zero should return 0",
+		},
+		{
+			name: "Negative zero prevention",
+			setupInt: func() *Int {
+				z := new(Int)
+				z.abs = uint256.NewUint(0)
+				z.neg = true // This should be normalized to false
+				return z
+			},
+			want:        0,
+			description: "Negative zero should return 0",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			z := tc.setupInt()
+			got := z.Int64()
+
+			if got != tc.want {
+				t.Errorf("%s: got %d, want %d", tc.description, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestInt64RoundTrip verifies that SetInt64 and Int64 work correctly together
+func TestInt64RoundTrip(t *testing.T) {
+	// Test all interesting int64 values
+	values := []int64{
+		0, 1, -1,
+		127, -128, // int8 boundaries
+		32767, -32768, // int16 boundaries
+		2147483647, -2147483648, // int32 boundaries
+		9223372036854775807, -9223372036854775808, // int64 boundaries (MaxInt64, MinInt64)
+		1234567890, -1234567890,
+	}
+
+	for _, v := range values {
+		t.Run(ufmt.Sprintf("RoundTrip_%d", v), func(t *testing.T) {
+			z := new(Int)
+			z.SetInt64(v)
+
+			got := z.Int64()
+			if got != v {
+				t.Errorf("Round trip failed: SetInt64(%d).Int64() = %d", v, got)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
# Summary

This PR fixes a overflow issue in `SetInt64` when handling `math.MinInt64` and simplifies the `Int64` method implementation using proper two's complement arithmetic.

## Problem

The previous `SetInt64` implementation had an integer overflow bug:

```go
if x < 0 {
    neg = true
    x = -x   // BUG: Overflow when `x == math.MinInt64`
}
```

When `x = math.MinInt64` (-2^63), negating it causes an overflow because 2^63 cannot be represented as a positive `int64`.

## Solution

1. **SetInt64**: Now uses two's complement to handle the magnitude correctly:
   - Convert to uint64 first
   - Apply two's complement `(^u + 1)` for negative values
   - This correctly handles all int64 values including `MinInt64` without overflow

2. **Int64**: Simplified implementation that leverages two's complement:
   - Removed unnecessary special cases and complex branching
   - Since `int64` already uses two's complement internally, we simply apply it to the unsigned magnitude when negative
   - Handles all edge cases naturally without special casing

## Changes

- Modified `SetInt64` to use two's complement for handling negative values
- Simplified `Int64` implementation from ~20 lines to ~5 lines
- Added comprehensive tests for `MinInt64` overflow scenarios
- Added edge case tests for `Int64` conversion
- Added round-trip tests to ensure `SetInt64` and `Int64` work correctly together

## Testing

New test cases verify:

- `MinInt64` can be set without overflow
- Internal representation (magnitude and sign) is correct
- Round-trip conversion (`SetInt64` → `Int64`) preserves values
- Edge cases like 2^63 magnitude with different signs
- Prevention of negative zero