### PR TITLE
fix: `*.Int64()` -> `safeConvertToInt64()`

### DIFF
--- a/contract/p/gnoswap/int256/conversion.gno
+++ b/contract/p/gnoswap/int256/conversion.gno
@@ -22,7 +22,7 @@ func (z *Int) SetInt64(x int64) *Int {
 		u = ^u + 1 // |x| = two's complement magnitude
 	}
 	z.abs = z.abs.SetUint64(u)
-	z.neg = neg && u != 0 // -0 방지
+	z.neg = neg && u != 0 // prevent -0
 	return z
 }
 

--- a/contract/r/gnoswap/v1/gov/staker/emission_reward_state.gno
+++ b/contract/r/gnoswap/v1/gov/staker/emission_reward_state.gno
@@ -94,7 +94,7 @@ func (e *EmissionRewardState) calculateClaimableRewards(
 		q128,
 	)
 
-	return rewardAmount.Int64(), nil
+	return safeConvertToInt64(rewardAmount), nil
 }
 
 // addStake increases the staked amount for this address.

--- a/contract/r/gnoswap/v1/gov/staker/protocol_fee_reward_state.gno
+++ b/contract/r/gnoswap/v1/gov/staker/protocol_fee_reward_state.gno
@@ -103,7 +103,7 @@ func (p *ProtocolFeeRewardState) calculateClaimableRewards(
 			q128,
 		)
 
-		rewardAmounts[token] = rewardAmount.Int64()
+		rewardAmounts[token] = safeConvertToInt64(rewardAmount)
 	}
 
 	return rewardAmounts, nil

--- a/contract/r/gnoswap/v1/gov/staker/util.gno
+++ b/contract/r/gnoswap/v1/gov/staker/util.gno
@@ -7,6 +7,7 @@ import (
 	"gno.land/p/demo/avl"
 	"gno.land/p/demo/json"
 	"gno.land/p/demo/ufmt"
+	u256 "gno.land/p/gnoswap/uint256"
 )
 
 // marshal data to json string
@@ -91,4 +92,33 @@ func getOrCreateInnerTree(tree *avl.Tree, key string) *avl.Tree {
 func milliToSec(ms int64) int64 {
 	var msPerSec int64 = 1000
 	return ms / msPerSec
+}
+
+// safeConvertToInt64 safely converts a *u256.Uint value to an int64, ensuring no overflow.
+//
+// This function attempts to convert the given *u256.Uint value to an int64. If the value exceeds
+// the maximum allowable range for int64 (`2^63 - 1`), it triggers a panic with a descriptive error message.
+//
+// Parameters:
+// - value (*u256.Uint): The unsigned 256-bit integer to be converted.
+//
+// Returns:
+// - int64: The converted value if it falls within the int64 range.
+//
+// Panics:
+//   - If the `value` exceeds the range of int64, the function will panic with an error indicating
+//     the overflow and the original value.
+func safeConvertToInt64(value *u256.Uint) int64 {
+	const INT64_MAX = 9223372036854775807
+	const MAX_INT64 = "9223372036854775807"
+	
+	res, overflow := value.Uint64WithOverflow()
+	if overflow || res > uint64(INT64_MAX) {
+		panic(ufmt.Sprintf(
+			"amount(%s) overflows int64 range (max %s)",
+			value.ToString(),
+			MAX_INT64,
+		))
+	}
+	return int64(res)
 }

--- a/contract/r/gnoswap/v1/pool/pool.gno
+++ b/contract/r/gnoswap/v1/pool/pool.gno
@@ -221,14 +221,14 @@ func Collect(
 	if amount0.Gt(u256.Zero()) {
 		position.tokensOwed0 = u256.Zero().Sub(position.tokensOwed0, amount0)
 		pool.balances.token0 = u256.Zero().Sub(pool.balances.token0, amount0)
-		if err := common.Approve(cross, pool.token0Path, positionAddr, amount0.Int64()); err != nil {
+		if err := common.Approve(cross, pool.token0Path, positionAddr, safeConvertToInt64(amount0)); err != nil {
 			panic(err)
 		}
 	}
 	if amount1.Gt(u256.Zero()) {
 		position.tokensOwed1 = u256.Zero().Sub(position.tokensOwed1, amount1)
 		pool.balances.token1 = u256.Zero().Sub(pool.balances.token1, amount1)
-		if err := common.Approve(cross, pool.token1Path, positionAddr, amount1.Int64()); err != nil {
+		if err := common.Approve(cross, pool.token1Path, positionAddr, safeConvertToInt64(amount1)); err != nil {
 			panic(err)
 		}
 	}
@@ -344,8 +344,8 @@ func collectProtocol(
 	amount1 := u256Min(amount1Req, pool.ProtocolFeesToken1())
 
 	amount0, amount1 = pool.saveProtocolFees(amount0.Clone(), amount1.Clone())
-	uAmount0 := amount0.Int64()
-	uAmount1 := amount1.Int64()
+	uAmount0 := safeConvertToInt64(amount0)
+	uAmount1 := safeConvertToInt64(amount1)
 
 	checkTransferError(common.Transfer(cross, pool.token0Path, recipient, uAmount0))
 	newBalanceToken0, err := updatePoolBalance(pool.BalanceToken0(), pool.BalanceToken1(), amount0, true)

--- a/contract/r/gnoswap/v1/pool/protocol_fee.gno
+++ b/contract/r/gnoswap/v1/pool/protocol_fee.gno
@@ -71,10 +71,10 @@ func HandleWithdrawalFee(
 	feeAmount0, afterAmount0 := calculateAmountWithFee(u256.MustFromDecimal(amount0), u256.NewUint(fee))
 	feeAmount1, afterAmount1 := calculateAmountWithFee(u256.MustFromDecimal(amount1), u256.NewUint(fee))
 
-	checkTransferError(common.TransferFrom(cross, token0Path, positionCaller, protocolFeeAddr, feeAmount0.Int64()))
-	pf.AddToProtocolFee(cross, token0Path, feeAmount0.Int64())
-	checkTransferError(common.TransferFrom(cross, token1Path, positionCaller, protocolFeeAddr, feeAmount1.Int64()))
-	pf.AddToProtocolFee(cross, token1Path, feeAmount1.Int64())
+	checkTransferError(common.TransferFrom(cross, token0Path, positionCaller, protocolFeeAddr, safeConvertToInt64(feeAmount0)))
+	pf.AddToProtocolFee(cross, token0Path, safeConvertToInt64(feeAmount0))
+	checkTransferError(common.TransferFrom(cross, token1Path, positionCaller, protocolFeeAddr, safeConvertToInt64(feeAmount1)))
+	pf.AddToProtocolFee(cross, token1Path, safeConvertToInt64(feeAmount1))
 
 	previousRealm := std.PreviousRealm()
 	std.Emit(

--- a/contract/r/gnoswap/v1/position/burn.gno
+++ b/contract/r/gnoswap/v1/position/burn.gno
@@ -129,15 +129,15 @@ func decreaseLiquidity(params DecreaseLiquidityParams) (uint64, string, string, 
 	poolAddr, _ := access.GetAddress(prabc.ROLE_POOL.String())
 
 	if isWrappedToken(pToken0) && params.unwrapResult {
-		unwrapWithTransferFrom(poolAddr, caller, collectAmount0.Int64())
+		unwrapWithTransferFrom(poolAddr, caller, safeConvertToInt64(collectAmount0))
 	} else {
-		common.TransferFrom(cross, pToken0, poolAddr, caller, collectAmount0.Int64())
+		common.TransferFrom(cross, pToken0, poolAddr, caller, safeConvertToInt64(collectAmount0))
 	}
 
 	if isWrappedToken(pToken1) && params.unwrapResult {
-		unwrapWithTransferFrom(poolAddr, caller, collectAmount1.Int64())
+		unwrapWithTransferFrom(poolAddr, caller, safeConvertToInt64(collectAmount1))
 	} else {
-		common.TransferFrom(cross, pToken1, poolAddr, caller, collectAmount1.Int64())
+		common.TransferFrom(cross, pToken1, poolAddr, caller, safeConvertToInt64(collectAmount1))
 	}
 
 	underflow := false

--- a/contract/r/gnoswap/v1/position/position.gno
+++ b/contract/r/gnoswap/v1/position/position.gno
@@ -130,15 +130,15 @@ func Mint(
 	id, liquidity, amount0, amount1 := mint(params)
 
 	// refund leftover wrapped tokens
-	if processedInput.tokenPair.token0IsNative && processedInput.tokenPair.wrappedAmount > amount0.Int64() {
-		err = unwrap(processedInput.tokenPair.wrappedAmount-amount0.Int64(), caller)
+	if processedInput.tokenPair.token0IsNative && processedInput.tokenPair.wrappedAmount > safeConvertToInt64(amount0) {
+		err = unwrap(processedInput.tokenPair.wrappedAmount-safeConvertToInt64(amount0), caller)
 		if err != nil {
 			panic(newErrorWithDetail(errWrapUnwrap, err.Error()))
 		}
 	}
 
-	if processedInput.tokenPair.token1IsNative && processedInput.tokenPair.wrappedAmount > amount1.Int64() {
-		err = unwrap(processedInput.tokenPair.wrappedAmount-amount1.Int64(), caller)
+	if processedInput.tokenPair.token1IsNative && processedInput.tokenPair.wrappedAmount > safeConvertToInt64(amount1) {
+		err = unwrap(processedInput.tokenPair.wrappedAmount-safeConvertToInt64(amount1), caller)
 		if err != nil {
 			panic(newErrorWithDetail(errWrapUnwrap, err.Error()))
 		}
@@ -230,10 +230,10 @@ func IncreaseLiquidity(
 		panic(err)
 	}
 
-	if err := unwrapLeftoverWrappedToken(token0, wrappedAmount, amount0.Int64(), caller); err != nil {
+	if err := unwrapLeftoverWrappedToken(token0, wrappedAmount, safeConvertToInt64(amount0), caller); err != nil {
 		panic(err)
 	}
-	if err := unwrapLeftoverWrappedToken(token1, wrappedAmount, amount1.Int64(), caller); err != nil {
+	if err := unwrapLeftoverWrappedToken(token1, wrappedAmount, safeConvertToInt64(amount1), caller); err != nil {
 		panic(err)
 	}
 
@@ -460,7 +460,7 @@ var feeAmountDivisor = u256.NewUint(10000)
 
 func calculateAmountWithWithdrawalFee(amount string, fee uint64) (int64, int64) {
 	if fee == 0 {
-		return u256.MustFromDecimal(amount).Int64(), 0
+		return safeConvertToInt64(u256.MustFromDecimal(amount)), 0
 	}
 
 	amountUint := u256.MustFromDecimal(amount)
@@ -470,7 +470,7 @@ func calculateAmountWithWithdrawalFee(amount string, fee uint64) (int64, int64) 
 	feeAmount = u256.Zero().Div(feeAmount, feeAmountDivisor)
 	amountWithoutFee := u256.Zero().Sub(amountUint, feeAmount)
 
-	return amountWithoutFee.Int64(), feeAmount.Int64()
+	return safeConvertToInt64(amountWithoutFee), safeConvertToInt64(feeAmount)
 }
 
 func SetPositionOperator(

--- a/contract/r/gnoswap/v1/position/utils.gno
+++ b/contract/r/gnoswap/v1/position/utils.gno
@@ -194,3 +194,32 @@ func subUint256(x, y *u256.Uint) *u256.Uint {
 
 	return u256.Zero().Sub(x, y)
 }
+
+// safeConvertToInt64 safely converts a *u256.Uint value to an int64, ensuring no overflow.
+//
+// This function attempts to convert the given *u256.Uint value to an int64. If the value exceeds
+// the maximum allowable range for int64 (`2^63 - 1`), it triggers a panic with a descriptive error message.
+//
+// Parameters:
+// - value (*u256.Uint): The unsigned 256-bit integer to be converted.
+//
+// Returns:
+// - int64: The converted value if it falls within the int64 range.
+//
+// Panics:
+//   - If the `value` exceeds the range of int64, the function will panic with an error indicating
+//     the overflow and the original value.
+func safeConvertToInt64(value *u256.Uint) int64 {
+	const INT64_MAX = 9223372036854775807
+	const MAX_INT64 = "9223372036854775807"
+	
+	res, overflow := value.Uint64WithOverflow()
+	if overflow || res > uint64(INT64_MAX) {
+		panic(ufmt.Sprintf(
+			"amount(%s) overflows int64 range (max %s)",
+			value.ToString(),
+			MAX_INT64,
+		))
+	}
+	return int64(res)
+}

--- a/contract/r/gnoswap/v1/router/base.gno
+++ b/contract/r/gnoswap/v1/router/base.gno
@@ -83,7 +83,7 @@ func (op *baseSwapOperation) handleNativeTokenWrapping(
 
 	sent := std.OriginSend()
 	ugnotSentByUser := sent.AmountOf("ugnot")
-	amountSpecified := specifiedAmount.Int64()
+	amountSpecified := safeConvertToInt64(specifiedAmount.Abs())
 
 	if ugnotSentByUser != amountSpecified {
 		return ufmt.Errorf("ugnot sent by user(%d) is not equal to amountSpecified(%d)", ugnotSentByUser, amountSpecified)

--- a/contract/r/gnoswap/v1/router/protocol_fee_swap.gno
+++ b/contract/r/gnoswap/v1/router/protocol_fee_swap.gno
@@ -76,7 +76,7 @@ func handleSwapFee(
 
 	feeAmount := u256.Zero().Mul(amount, u256.NewUint(swapFee))
 	feeAmount = u256.Zero().Div(feeAmount, u256.NewUint(10000))
-	feeAmountInt64 := feeAmount.Int64()
+	feeAmountInt64 := safeConvertToInt64(feeAmount)
 
 	if outputToken == gnot {
 		outputToken = wugnotPath

--- a/contract/r/gnoswap/v1/router/swap_inner.gno
+++ b/contract/r/gnoswap/v1/router/swap_inner.gno
@@ -46,7 +46,7 @@ func swapInner(
 	sqrtPriceLimitX96 = calculateSqrtPriceLimitForSwap(zeroForOne, data.fee, sqrtPriceLimitX96)
 
 	// approve only the required amount
-	approveAmount := amountSpecified.Abs().Int64()
+	approveAmount := safeConvertToInt64(amountSpecified.Abs())
 
 	// approves pool as spender
 	common.Approve(cross, data.tokenIn, poolAddr, approveAmount)

--- a/contract/r/gnoswap/v1/router/swap_inner_test.gno
+++ b/contract/r/gnoswap/v1/router/swap_inner_test.gno
@@ -131,7 +131,7 @@ func TestSwapInner(t *testing.T) {
 			expectedRecv:     "0",
 			expectedOut:      "0",
 			expectError:      true,
-			expectedErrorMsg: "[GNOSWAP-POOL-005] out of range for numeric value: amount(92267581029952440000000) overflows int64 range (max 9223372036854775807)",
+			expectedErrorMsg: "amount(92267581029952440000000) overflows int64 range (max 9223372036854775807)",
 		},
 	}
 

--- a/contract/r/gnoswap/v1/router/utils.gno
+++ b/contract/r/gnoswap/v1/router/utils.gno
@@ -166,3 +166,32 @@ func formatInt64(v any) string {
 		panic(ufmt.Sprintf("invalid type %T", v))
 	}
 }
+
+// safeConvertToInt64 safely converts a *u256.Uint value to an int64, ensuring no overflow.
+//
+// This function attempts to convert the given *u256.Uint value to an int64. If the value exceeds
+// the maximum allowable range for int64 (`2^63 - 1`), it triggers a panic with a descriptive error message.
+//
+// Parameters:
+// - value (*u256.Uint): The unsigned 256-bit integer to be converted.
+//
+// Returns:
+// - int64: The converted value if it falls within the int64 range.
+//
+// Panics:
+//   - If the `value` exceeds the range of int64, the function will panic with an error indicating
+//     the overflow and the original value.
+func safeConvertToInt64(value *u256.Uint) int64 {
+	const INT64_MAX = 9223372036854775807
+	const MAX_INT64 = "9223372036854775807"
+	
+	res, overflow := value.Uint64WithOverflow()
+	if overflow || res > uint64(INT64_MAX) {
+		panic(ufmt.Sprintf(
+			"amount(%s) overflows int64 range (max %s)",
+			value.ToString(),
+			MAX_INT64,
+		))
+	}
+	return int64(res)
+}

--- a/contract/r/gnoswap/v1/staker/reward_calculation_pool.gno
+++ b/contract/r/gnoswap/v1/staker/reward_calculation_pool.gno
@@ -415,7 +415,7 @@ func (self *RewardState) rewardPerWarmup(startTime, endTime int64, rewardPerSeco
 
 			rewardAcc = u256.MulDiv(rewardAcc, u256.NewUintFromInt64(rewardPerSecond), q128)
 
-			self.rewards[i] += rewardAcc.Int64()
+			self.rewards[i] += safeConvertToInt64(rewardAcc)
 			// done
 			break
 		}
@@ -437,7 +437,7 @@ func (self *RewardState) rewardPerWarmup(startTime, endTime int64, rewardPerSeco
 		}
 
 		rewardAcc = u256.MulDiv(rewardAcc, u256.NewUintFromInt64(rewardPerSecond), q128)
-		self.rewards[i] += rewardAcc.Int64()
+		self.rewards[i] += safeConvertToInt64(rewardAcc)
 
 		startTime = warmup.NextWarmupTime
 	}

--- a/contract/r/gnoswap/v1/staker/reward_calculation_warmup.gno
+++ b/contract/r/gnoswap/v1/staker/reward_calculation_warmup.gno
@@ -99,7 +99,7 @@ func (warmup *Warmup) apply(poolReward int64, positionLiquidity, stakedLiquidity
 	totalReward = u256.Zero().Div(totalReward, divisor)
 	totalPenalty := u256.Zero().Mul(perPositionReward, penaltyRatio)
 	totalPenalty = u256.Zero().Div(totalPenalty, divisor)
-	return totalReward.Int64(), totalPenalty.Int64()
+	return safeConvertToInt64(totalReward), safeConvertToInt64(totalPenalty)
 }
 
 func (self *Deposit) FindWarmup(currentTime int64) int {

--- a/contract/r/gnoswap/v1/staker/utils.gno
+++ b/contract/r/gnoswap/v1/staker/utils.gno
@@ -8,6 +8,7 @@ import (
 	"gno.land/p/demo/grc/grc721"
 	"gno.land/p/demo/ufmt"
 	prbac "gno.land/p/gnoswap/rbac"
+	u256 "gno.land/p/gnoswap/uint256"
 
 	"gno.land/r/gnoswap/access"
 	"gno.land/r/gnoswap/rbac"
@@ -171,4 +172,33 @@ func getRoleAddress(role prbac.SystemRole) std.Address {
 	}
 
 	return addr
+}
+
+// safeConvertToInt64 safely converts a *u256.Uint value to an int64, ensuring no overflow.
+//
+// This function attempts to convert the given *u256.Uint value to an int64. If the value exceeds
+// the maximum allowable range for int64 (`2^63 - 1`), it triggers a panic with a descriptive error message.
+//
+// Parameters:
+// - value (*u256.Uint): The unsigned 256-bit integer to be converted.
+//
+// Returns:
+// - int64: The converted value if it falls within the int64 range.
+//
+// Panics:
+//   - If the `value` exceeds the range of int64, the function will panic with an error indicating
+//     the overflow and the original value.
+func safeConvertToInt64(value *u256.Uint) int64 {
+	const INT64_MAX = 9223372036854775807
+	const MAX_INT64 = "9223372036854775807"
+	
+	res, overflow := value.Uint64WithOverflow()
+	if overflow || res > uint64(INT64_MAX) {
+		panic(ufmt.Sprintf(
+			"amount(%s) overflows int64 range (max %s)",
+			value.ToString(),
+			MAX_INT64,
+		))
+	}
+	return int64(res)
 }


### PR DESCRIPTION
# Description

Use safe type conversion