### PR TITLE
feat: improve underflow checks

### DIFF
--- a/contract/r/gnoswap/v1/pool/position.gno
+++ b/contract/r/gnoswap/v1/pool/position.gno
@@ -346,7 +346,8 @@ func (p *Pool) updatePosition(positionParams ModifyPositionParams, tick int32) (
 	feeGrowthGlobal1X128 := p.FeeGrowthGlobal1X128().Clone()
 
 	var flippedLower, flippedUpper bool
-	if !(positionParams.liquidityDelta.IsZero()) {
+
+	if !positionParams.liquidityDelta.IsZero() {
 		flippedLower = p.tickUpdate(
 			positionParams.tickLower,
 			tick,

--- a/contract/r/gnoswap/v1/pool/tick.gno
+++ b/contract/r/gnoswap/v1/pool/tick.gno
@@ -220,8 +220,24 @@ func (p *Pool) tickCross(
 ) *i256.Int {
 	thisTick := p.getTick(tick)
 
-	thisTick.feeGrowthOutside0X128 = u256.Zero().Sub(feeGrowthGlobal0X128, thisTick.feeGrowthOutside0X128)
-	thisTick.feeGrowthOutside1X128 = u256.Zero().Sub(feeGrowthGlobal1X128, thisTick.feeGrowthOutside1X128)
+	feeGrowthOutside0X128, underflow := u256.Zero().SubOverflow(feeGrowthGlobal0X128, thisTick.feeGrowthOutside0X128)
+	if underflow {
+		panic(newErrorWithDetail(
+			errLiquidityCalculation,
+			ufmt.Sprintf("feeGrowthOutside0X128(%s) underflows feeGrowthGlobal0X128(%s)", thisTick.feeGrowthOutside0X128.ToString(), feeGrowthGlobal0X128.ToString()),
+		))
+	}
+
+	feeGrowthOutside1X128, underflow := u256.Zero().SubOverflow(feeGrowthGlobal1X128, thisTick.feeGrowthOutside1X128)
+	if underflow {
+		panic(newErrorWithDetail(
+			errLiquidityCalculation,
+			ufmt.Sprintf("feeGrowthOutside0X128(%s) underflows feeGrowthGlobal0X128(%s)", thisTick.feeGrowthOutside0X128.ToString(), feeGrowthGlobal0X128.ToString()),
+		))
+	}
+
+	thisTick.feeGrowthOutside0X128 = feeGrowthOutside0X128
+	thisTick.feeGrowthOutside1X128 = feeGrowthOutside1X128
 
 	p.setTick(tick, thisTick)
 


### PR DESCRIPTION
## Descriptions

This PR enhances the robustness of fee growth calculations in the `tickCross` function by implementing explicit underflow detection and proper error handling for arithmetic operations.

### Changes

**Before:**
- Used direct subtraction with `u256.Zero().Sub()` which could silently underflow
- No validation for arithmetic underflow conditions
- Potential for unexpected behavior when subtraction results in negative values

**After:**
- Replaced `Sub()` with `SubOverflow()` to detect underflow conditions
- Added explicit underflow checks with descriptive error messages
- Proper error handling using the existing `errLiquidityCalculation` error type

### Technical Details

1. **Enhanced arithmetic safety**: 
   - Changed from `thisTick.feeGrowthOutside0X128 = u256.Zero().Sub(feeGrowthGlobal0X128, thisTick.feeGrowthOutside0X128)` 
   - To `feeGrowthOutside0X128, underflow := u256.Zero().SubOverflow(feeGrowthGlobal0X128, thisTick.feeGrowthOutside0X128)`

2. **Explicit underflow detection**: 
   - The `SubOverflow` method returns both the result and a boolean indicating whether underflow occurred
   - Added conditional checks to panic with descriptive error messages when underflow is detected

3. **Improved error reporting**: 
   - Detailed error messages include the actual values that caused the underflow
   - Uses the standardized `errLiquidityCalculation` error type for consistency

4. **Function context**: 
   - The `tickCross` function updates tick state when price crosses tick boundaries
   - Fee growth outside calculations are critical for accurate fee distribution
   - Underflow in these calculations could lead to incorrect fee accounting