### PR TITLE
perf(staker): Optimize `PoolTier` counting with cached counters

### DIFF
--- a/contract/r/gnoswap/v1/staker/reward_calculation_pool_tier.gno
+++ b/contract/r/gnoswap/v1/staker/reward_calculation_pool_tier.gno
@@ -96,7 +96,7 @@ type PoolTier struct {
 	counts [AllTierCount]uint64
 
 	lastRewardCacheTimestamp int64
-	lastRewardCacheHeight int64
+	lastRewardCacheHeight    int64
 
 	currentEmission int64
 
@@ -187,17 +187,17 @@ func (self *PoolTier) changeTier(currentHeight int64, currentTime int64, pools *
 		return
 	}
 
+	// decrement count from current tier if it exists
+	if currentTier > 0 {
+		if self.counts[currentTier] == 0 {
+			panic("counts underflow: removing from empty tier")
+		}
+		self.counts[currentTier]--
+	}
+
 	if nextTier == 0 {
 		// removed from the tier
 		self.membership.Remove(poolPath)
-
-		// count decrement
-		if currentTier > 0 {
-			if self.counts[currentTier] == 0 {
-				panic("counts underflow: removing from empty tier")
-			}
-			self.counts[currentTier]--
-		}
 		pool, ok := pools.Get(poolPath)
 		if !ok {
 			panic("changeTier: pool not found")
@@ -206,17 +206,10 @@ func (self *PoolTier) changeTier(currentHeight int64, currentTime int64, pools *
 	} else {
 		// handle all move/add operations
 		self.membership.Set(poolPath, nextTier)
-		if currentTier > 0 {
-			if self.counts[currentTier] == 0 {
-				panic("counts underflow: removing from empty tier")
-			}
-			self.counts[currentTier]--
-		}
 		self.counts[nextTier]++
 	}
 
 	self.tierRatio = TierRatioFromCounts(self.counts[Tier1], self.counts[Tier2], self.counts[Tier3])
-
 	currentEmission := self.getEmission()
 
 	// Cache updated reward for each tiered pool

--- a/contract/r/gnoswap/v1/staker/reward_calculation_pool_tier.gno
+++ b/contract/r/gnoswap/v1/staker/reward_calculation_pool_tier.gno
@@ -5,7 +5,6 @@ import (
 	"gno.land/p/demo/ufmt"
 )
 
-// TODO: define Tier type as uint8 size
 const (
 	AllTierCount = 4 // 0, 1, 2, 3
 	Tier1        = 1

--- a/contract/r/gnoswap/v1/staker/reward_calculation_pool_tier.gno
+++ b/contract/r/gnoswap/v1/staker/reward_calculation_pool_tier.gno
@@ -5,6 +5,7 @@ import (
 	"gno.land/p/demo/ufmt"
 )
 
+// TODO: define Tier type as uint8 size
 const (
 	AllTierCount = 4 // 0, 1, 2, 3
 	Tier1        = 1
@@ -92,8 +93,9 @@ type PoolTier struct {
 
 	tierRatio TierRatio
 
-	lastRewardCacheTimestamp int64
+	counts [AllTierCount]uint64
 
+	lastRewardCacheTimestamp int64
 	lastRewardCacheHeight int64
 
 	currentEmission int64
@@ -136,33 +138,29 @@ func NewPoolTier(pools *Pools, currentHeight int64, currentTime int64, initialPo
 // CurrentReward returns the current per-pool reward for the given tier.
 func (self *PoolTier) CurrentReward(tier uint64) int64 {
 	currentEmission := self.getEmission()
-	return currentEmission * int64(self.tierRatio.Get(tier)) / int64(self.CurrentCount(tier)) / 100
+	tierRatio := self.tierRatio.Get(tier)
+	count := int64(self.CurrentCount(tier))
+
+	// check for zero count to avoid division by zero
+	if count == 0 {
+		return 0
+	}
+	return currentEmission * int64(tierRatio) / count / 100
 }
 
 // CurrentCount returns the current count of pools in the given tier.
 func (self *PoolTier) CurrentCount(tier uint64) int {
-	count := 0
-	self.membership.Iterate("", "", func(key string, value any) bool {
-		if value.(uint64) == tier {
-			count++
-		}
-		return false
-	})
-	return count
+	if tier >= AllTierCount {
+		return 0
+	}
+	return int(self.counts[tier])
 }
 
 // CurrentAllTierCounts returns the current count of pools in each tier.
 func (self *PoolTier) CurrentAllTierCounts() []uint64 {
-	count := make([]uint64, AllTierCount)
-	self.membership.Iterate("", "", func(key string, value any) bool {
-		if v, ok := value.(uint64); !ok {
-			panic("failed to cast value to uint64")
-		} else {
-			count[v]++
-		}
-		return false
-	})
-	return count
+	out := make([]uint64, AllTierCount)
+	copy(out, self.counts[:])
+	return out // returning snapshot
 }
 
 // CurrentTier returns the tier of the given pool.
@@ -192,19 +190,32 @@ func (self *PoolTier) changeTier(currentHeight int64, currentTime int64, pools *
 	if nextTier == 0 {
 		// removed from the tier
 		self.membership.Remove(poolPath)
+
+		// count decrement
+		if currentTier > 0 {
+			if self.counts[currentTier] == 0 {
+				panic("counts underflow: removing from empty tier")
+			}
+			self.counts[currentTier]--
+		}
 		pool, ok := pools.Get(poolPath)
 		if !ok {
 			panic("changeTier: pool not found")
 		}
-
-		// caching reward to 0
 		pool.cacheReward(currentTime, int64(0))
 	} else {
+		// handle all move/add operations
 		self.membership.Set(poolPath, nextTier)
+		if currentTier > 0 {
+			if self.counts[currentTier] == 0 {
+				panic("counts underflow: removing from empty tier")
+			}
+			self.counts[currentTier]--
+		}
+		self.counts[nextTier]++
 	}
 
-	counts := self.CurrentAllTierCounts()
-	self.tierRatio = TierRatioFromCounts(counts[Tier1], counts[Tier2], counts[Tier3])
+	self.tierRatio = TierRatioFromCounts(self.counts[Tier1], self.counts[Tier2], self.counts[Tier3])
 
 	currentEmission := self.getEmission()
 
@@ -218,7 +229,14 @@ func (self *PoolTier) changeTier(currentHeight int64, currentTime int64, pools *
 		if !ok {
 			panic("failed to cast value to uint64")
 		}
-		poolReward := currentEmission * int64(self.tierRatio.Get(tier)) / 100 / int64(counts[tier])
+
+		tierRatio := int64(self.tierRatio.Get(tier))
+		tierCount := int64(self.counts[tier])
+		if tierCount == 0 {
+			return false // Skip if no pools in tier
+		}
+
+		poolReward := currentEmission * tierRatio / tierCount / 100
 		pool.cacheReward(currentTime, poolReward)
 		return false
 	})

--- a/contract/r/gnoswap/v1/staker/reward_calculation_pool_tier_test.gno
+++ b/contract/r/gnoswap/v1/staker/reward_calculation_pool_tier_test.gno
@@ -1,33 +1,12 @@
 package staker
 
 import (
-	"std"
 	"testing"
 
-	"gno.land/p/demo/testutils"
 	pl "gno.land/r/gnoswap/v1/pool"
-	"gno.land/r/onbloc/bar"
-	"gno.land/r/onbloc/baz"
-	"gno.land/r/onbloc/qux"
 )
 
 func TestTierRatioFromCounts(t *testing.T) {
-	t.Skip("fix insufficient allowance error")
-	CreateSecondPoolWithoutFee(t)
-	MakeMintPositionWithoutFee(t)
-
-	user1Addr := testutils.TestAddress("user1")
-	user1Realm := std.NewUserRealm(user1Addr)
-
-	testing.SetRealm(user1Realm)
-	func() {
-		testing.SetRealm(user1Realm)
-		bar.Approve(cross, routerAddr, maxApprove)
-		baz.Approve(cross, routerAddr, maxApprove)
-		qux.Approve(cross, routerAddr, maxApprove)
-		TokenFaucet(t, barPath, user1Addr)
-	}()
-
 	tests := []struct {
 		tier1Count uint64
 		tier2Count uint64

--- a/contract/r/gnoswap/v1/staker/reward_calculation_pool_tier_test.gno
+++ b/contract/r/gnoswap/v1/staker/reward_calculation_pool_tier_test.gno
@@ -54,7 +54,7 @@ func TestNewPoolTier(t *testing.T) {
 
 func TestCacheReward(t *testing.T) {
 	currentHeight := int64(250)
-	currentTime := int64(250000) // Arbitrary time for testing
+	currentTime := int64(250000)
 	// Simulate emission updates
 	poolTier := NewPoolTier(NewPools(), currentHeight, currentTime, "testPool", func() int64 { return 1000 }, func(startHeight int64, endHeight int64) ([]int64, []int64) {
 		return []int64{100, 150, 200}, []int64{1000, 500, 250}
@@ -77,4 +77,157 @@ func SetupPoolTier(t *testing.T) *PoolTier {
 
 	poolTier.changeTier(1, int64(1000), pools, test_gnousdc, 1)
 	return poolTier
+}
+
+func TestTierRatioGet(t *testing.T) {
+	ratio := TierRatio{Tier1: 50, Tier2: 30, Tier3: 20}
+
+	tests := []struct {
+		tier     uint64
+		expected uint64
+	}{
+		{1, 50},
+		{2, 30},
+		{3, 20},
+	}
+
+	for _, tt := range tests {
+		result := ratio.Get(tt.tier)
+		if result != tt.expected {
+			t.Errorf("Get(%d) = %d; want %d", tt.tier, result, tt.expected)
+		}
+	}
+
+	// Test panic for invalid tier
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Get(4) should panic for invalid tier")
+		}
+	}()
+	ratio.Get(4)
+}
+
+func TestPoolTierChangeTier(t *testing.T) {
+	pools := NewPools()
+	currentHeight := int64(100)
+	currentTime := int64(100000)
+	testPool1 := pl.GetPoolPath("gno.land/r/onbloc/bar", "gno.land/r/onbloc/baz", 3000)
+	testPool2 := pl.GetPoolPath("gno.land/r/onbloc/foo", "gno.land/r/onbloc/qux", 3000)
+
+	poolTier := NewPoolTier(pools, currentHeight, currentTime, testPool1,
+		func() int64 { return 1000000 },
+		func(start, end int64) ([]int64, []int64) { return nil, nil })
+
+	// Add second pool to tier 2
+	pools.set(testPool2, NewPool(testPool2, currentTime+1))
+	poolTier.changeTier(currentHeight+1, currentTime+1, pools, testPool2, 2)
+
+	// Verify tier assignments
+	if tier := poolTier.CurrentTier(testPool1); tier != 1 {
+		t.Errorf("Expected pool1 to be in tier 1, got %d", tier)
+	}
+	if tier := poolTier.CurrentTier(testPool2); tier != 2 {
+		t.Errorf("Expected pool2 to be in tier 2, got %d", tier)
+	}
+
+	// Verify ratio changed to 70/30/0
+	if poolTier.tierRatio.Tier1 != 70 || poolTier.tierRatio.Tier2 != 30 || poolTier.tierRatio.Tier3 != 0 {
+		t.Errorf("Expected ratio 70/30/0, got %d/%d/%d",
+			poolTier.tierRatio.Tier1, poolTier.tierRatio.Tier2, poolTier.tierRatio.Tier3)
+	}
+
+	// Test removing pool from tier (tier 0)
+	poolTier.changeTier(currentHeight+2, currentTime+2, pools, testPool2, 0)
+	if tier := poolTier.CurrentTier(testPool2); tier != 0 {
+		t.Errorf("Expected pool2 to be removed (tier 0), got %d", tier)
+	}
+}
+
+func TestCurrentAllTierCounts(t *testing.T) {
+	pools := NewPools()
+	currentHeight := int64(100)
+	currentTime := int64(100000)
+	testPool1 := pl.GetPoolPath("gno.land/r/onbloc/bar", "gno.land/r/onbloc/baz", 3000)
+	testPool2 := pl.GetPoolPath("gno.land/r/onbloc/foo", "gno.land/r/onbloc/qux", 3000)
+	testPool3 := pl.GetPoolPath("gno.land/r/demo/wugnot", "gno.land/r/onbloc/bar", 3000)
+
+	poolTier := NewPoolTier(pools, currentHeight, currentTime, testPool1,
+		func() int64 { return 1000000 },
+		func(start, end int64) ([]int64, []int64) { return nil, nil })
+
+	// Add pools to different tiers
+	pools.set(testPool2, NewPool(testPool2, currentTime+1))
+	poolTier.changeTier(currentHeight+1, currentTime+1, pools, testPool2, 2)
+
+	pools.set(testPool3, NewPool(testPool3, currentTime+2))
+	poolTier.changeTier(currentHeight+2, currentTime+2, pools, testPool3, 3)
+
+	counts := poolTier.CurrentAllTierCounts()
+
+	// Should be [0, 1, 1, 1] for tiers 0, 1, 2, 3
+	expected := []uint64{0, 1, 1, 1}
+	for i, count := range counts {
+		if count != expected[i] {
+			t.Errorf("Tier %d count = %d; want %d", i, count, expected[i])
+		}
+	}
+}
+
+func TestIsInternallyIncentivizedPool(t *testing.T) {
+	pools := NewPools()
+	currentHeight := int64(100)
+	currentTime := int64(100000)
+	testPool1 := pl.GetPoolPath("gno.land/r/onbloc/bar", "gno.land/r/onbloc/baz", 3000)
+	testPool2 := pl.GetPoolPath("gno.land/r/onbloc/foo", "gno.land/r/onbloc/qux", 3000)
+
+	poolTier := NewPoolTier(pools, currentHeight, currentTime, testPool1,
+		func() int64 { return 1000000 },
+		func(start, end int64) ([]int64, []int64) { return nil, nil })
+
+	// testPool1 is in tier 1, should be incentivized
+	if !poolTier.IsInternallyIncentivizedPool(testPool1) {
+		t.Errorf("Expected pool1 to be internally incentivized")
+	}
+
+	// testPool2 is not in any tier, should not be incentivized
+	if poolTier.IsInternallyIncentivizedPool(testPool2) {
+		t.Errorf("Expected pool2 to not be internally incentivized")
+	}
+}
+
+func TestCurrentRewardPerPool(t *testing.T) {
+	pools := NewPools()
+	currentHeight := int64(100)
+	currentTime := int64(100000)
+	emission := int64(1000000)
+	testPool1 := pl.GetPoolPath("gno.land/r/onbloc/bar", "gno.land/r/onbloc/baz", 3000)
+	testPool2 := pl.GetPoolPath("gno.land/r/onbloc/foo", "gno.land/r/onbloc/qux", 3000)
+
+	poolTier := NewPoolTier(pools, currentHeight, currentTime, testPool1,
+		func() int64 { return emission },
+		func(start, end int64) ([]int64, []int64) { return nil, nil })
+
+	// With only tier 1 pool, it should get 100% of emission
+	reward1 := poolTier.CurrentRewardPerPool(testPool1)
+	expectedReward1 := emission * 100 / 100 / 1 // 100% ratio, 1 pool
+	if reward1 != expectedReward1 {
+		t.Errorf("Expected reward %d, got %d", expectedReward1, reward1)
+	}
+
+	// Add pool to tier 2
+	pools.set(testPool2, NewPool(testPool2, currentTime+1))
+	poolTier.changeTier(currentHeight+1, currentTime+1, pools, testPool2, 2)
+
+	// Now tier1 gets 70%, tier2 gets 30%
+	reward1After := poolTier.CurrentRewardPerPool(testPool1)
+	expectedReward1After := emission * 70 / 100 / 1 // 70% ratio, 1 pool
+	if reward1After != expectedReward1After {
+		t.Errorf("Expected tier1 reward %d, got %d", expectedReward1After, reward1After)
+	}
+
+	reward2 := poolTier.CurrentRewardPerPool(testPool2)
+	expectedReward2 := emission * 30 / 100 / 1 // 30% ratio, 1 pool
+	if reward2 != expectedReward2 {
+		t.Errorf("Expected tier2 reward %d, got %d", expectedReward2, reward2)
+	}
 }


### PR DESCRIPTION
## Description

Optimizes the way `PoolTier` tracks the number of pools per tier.

Previously, methods like `CurrentAllTierCounts()` and `CurrentCount()` scanned the entire `membership` tree on every call. This made counting $O(n)$ with respect to the number of pools, even though counts only change when a pool moves tiers.

### Changes

- Added a `counts` field to `PoolTier` as a cached counter
- Updated `changeTier()` to inc/dec the counts whenever a pool is added, removed or moved between tiers
- Updated `CurrentCount()` and `CurrentAllTierCounts()` to return results directly from the cached counter

By doing so, all tier count queries are now $o(1)$, avoiding repeated full-tree iteration.

dependent with #828 