### PR TITLE
fix(gns): `GetHalvingYearInfo` calculation error

### DIFF
--- a/contract/r/gnoswap/gns/_helper_test.gno
+++ b/contract/r/gnoswap/gns/_helper_test.gno
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"gno.land/p/nt/grc/grc20"
+	"gno.land/p/demo/tokens/grc20"
 	"gno.land/p/nt/ownable"
 
 	prabc "gno.land/p/gnoswap/rbac"

--- a/contract/r/gnoswap/gns/getter.gno
+++ b/contract/r/gnoswap/gns/getter.gno
@@ -146,12 +146,18 @@ func GetEmissionEndTimestamp() int64 {
 func GetHalvingYearInfo(timestamp int64) (int64, int64, int64) {
 	state := getEmissionState()
 
-	endTimestamp := state.getEndTimestamp()
-	startTimestamp := state.getStartTimestamp()
+	year := state.getCurrentYear(timestamp)
 
-	year := getEmissionState().getCurrentYear(timestamp)
+	// If outside emission period, return 0 values
+	if year == 0 {
+		return 0, 0, 0
+	}
 
-	return year, startTimestamp + (SECONDS_IN_YEAR * year), endTimestamp
+	// Calculate year-specific start and end timestamps
+	yearStartTimestamp := state.getStartTimestamp() + (SECONDS_IN_YEAR * (year - 1))
+	yearEndTimestamp := yearStartTimestamp + SECONDS_IN_YEAR - 1
+
+	return year, yearStartTimestamp, yearEndTimestamp
 }
 
 // GetHalvingInfo returns comprehensive halving information as JSON string.

--- a/contract/r/gnoswap/gns/getter_test.gno
+++ b/contract/r/gnoswap/gns/getter_test.gno
@@ -1,0 +1,110 @@
+package gns
+
+import (
+	"testing"
+)
+
+// TestGetHalvingYearInfo verifies that GetHalvingYearInfo correctly calculates
+// year-specific start and end timestamps and maintains consistency with other functions.
+func TestGetHalvingYearInfo(t *testing.T) {
+	const testStartTimestamp = int64(1000)
+	emissionState = NewEmissionState(1, testStartTimestamp)
+	halvingData := emissionState.getHalvingData()
+
+	tests := []struct {
+		name              string
+		timestamp         int64
+		expectedYear      int64
+		expectedStartTime int64
+		expectedEndTime   int64
+	}{
+		{
+			name:              "Year 1 - Beginning",
+			timestamp:         testStartTimestamp,
+			expectedYear:      1,
+			expectedStartTime: testStartTimestamp,
+			expectedEndTime:   testStartTimestamp + SECONDS_IN_YEAR - 1,
+		},
+		{
+			name:              "Year 1 - Middle",
+			timestamp:         testStartTimestamp + SECONDS_IN_YEAR/2,
+			expectedYear:      1,
+			expectedStartTime: testStartTimestamp,
+			expectedEndTime:   testStartTimestamp + SECONDS_IN_YEAR - 1,
+		},
+		{
+			name:              "Year 2 - Beginning",
+			timestamp:         testStartTimestamp + SECONDS_IN_YEAR,
+			expectedYear:      2,
+			expectedStartTime: testStartTimestamp + SECONDS_IN_YEAR,
+			expectedEndTime:   testStartTimestamp + (2 * SECONDS_IN_YEAR) - 1,
+		},
+		{
+			name:              "Year 12 - End of year",
+			timestamp:         testStartTimestamp + (12 * SECONDS_IN_YEAR) - 1,
+			expectedYear:      12,
+			expectedStartTime: testStartTimestamp + (11 * SECONDS_IN_YEAR),
+			expectedEndTime:   testStartTimestamp + (12 * SECONDS_IN_YEAR) - 1,
+		},
+		{
+			name:              "Before emission start",
+			timestamp:         testStartTimestamp - 1,
+			expectedYear:      0,
+			expectedStartTime: 0,
+			expectedEndTime:   0,
+		},
+		{
+			name:              "After emission end",
+			timestamp:         testStartTimestamp + (12 * SECONDS_IN_YEAR),
+			expectedYear:      0,
+			expectedStartTime: 0,
+			expectedEndTime:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			year, startTime, endTime := GetHalvingYearInfo(tt.timestamp)
+
+			if year != tt.expectedYear {
+				t.Errorf("Expected year %d, got %d", tt.expectedYear, year)
+			}
+			if startTime != tt.expectedStartTime {
+				t.Errorf("Expected start time %d, got %d", tt.expectedStartTime, startTime)
+			}
+			if endTime != tt.expectedEndTime {
+				t.Errorf("Expected end time %d, got %d", tt.expectedEndTime, endTime)
+			}
+
+			// For valid years, verify consistency with other functions and HalvingData
+			if year > 0 && year <= HALVING_END_YEAR {
+				// Consistency with HalvingData
+				halvingStart := halvingData.getStartTimestamp(year)
+				halvingEnd := halvingData.getEndTimestamp(year)
+
+				if startTime != halvingStart {
+					t.Errorf("Start time mismatch with HalvingData: got %d, expected %d", startTime, halvingStart)
+				}
+				if endTime != halvingEnd {
+					t.Errorf("End time mismatch with HalvingData: got %d, expected %d", endTime, halvingEnd)
+				}
+
+				// Consistency with other getter functions
+				halvingYear := GetHalvingYear(tt.timestamp)
+				if year != halvingYear {
+					t.Errorf("GetHalvingYearInfo year %d != GetHalvingYear %d", year, halvingYear)
+				}
+
+				expectedStart := GetHalvingYearStartTimestamp(year)
+				expectedEnd := GetHalvingYearEndTimestamp(year)
+
+				if startTime != expectedStart {
+					t.Errorf("Start time %d != GetHalvingYearStartTimestamp %d", startTime, expectedStart)
+				}
+				if endTime != expectedEnd {
+					t.Errorf("End time %d != GetHalvingYearEndTimestamp %d", endTime, expectedEnd)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes two calculation errors in the `GetHalvingYearInfo` function that were causing incorrect timestamp calculations for halving years.

## Issues Fixed

### 1. Off-by-one error in year start timestamp calculation
The function was incorrectly calculating the start timestamp by using `year * SECONDS_IN_YEAR` instead of `(year - 1) * SECONDS_IN_YEAR`, causing all year start times to be shifted forward by one year.

### 2. Incorrect end timestamp for all years
The function was returning the overall emission end timestamp for all years instead of calculating year-specific end timestamps.

## Behavior Comparison

### Year Start Timestamps (with emission starting at timestamp 1000)

| Year | Before (Incorrect) | After (Correct) |
|------|-------------------|-----------------|
| 1    | 31,537,000       | 1,000           |
| 2    | 63,073,000       | 31,537,000      |
| 3    | 94,609,000       | 63,073,000      |
| 12   | 378,433,000      | 346,897,000     |

### Year End Timestamps

| Year | Before (Incorrect) | After (Correct) |
|------|-------------------|-----------------|
| 1    | 378,432,999*     | 31,536,999      |
| 2    | 378,432,999*     | 63,072,999      |
| 3    | 378,432,999*     | 94,608,999      |
| 12   | 378,432,999      | 378,432,999     |

*All years were returning the overall emission end timestamp