### PR TITLE
fix(staker): Allow Unstaking from De-tired Pools

### DIFF
--- a/contract/r/gnoswap/v1/staker/staker.gno
+++ b/contract/r/gnoswap/v1/staker/staker.gno
@@ -712,14 +712,6 @@ func applyUnStake(positionId uint64) error {
 	deposits.remove(positionId)
 	stakers.removeDeposit(deposit.owner, positionId)
 
-	owner := gnft.MustOwnerOf(positionIdFrom(positionId))
-	caller := std.PreviousRealm().Address()
-
-	_, _, err := getPositionStakeTokenAmount(positionId, owner, caller)
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/contract/r/scenario/staker/unstake_after_tier_removal_filetest.gno
+++ b/contract/r/scenario/staker/unstake_after_tier_removal_filetest.gno
@@ -1,0 +1,258 @@
+// Test file to verify unstaking works after tier removal
+// This test demonstrates the bug where positions CANNOT be unstaked from pools that have been de-tiered
+
+package main
+
+import (
+	"std"
+	"strconv"
+	"testing"
+	"time"
+
+	"gno.land/p/demo/tokens/grc721"
+	"gno.land/p/nt/ufmt"
+
+	"gno.land/r/gnoswap/access"
+	en "gno.land/r/gnoswap/emission"
+
+	_ "gno.land/r/gnoswap/gns"
+	"gno.land/r/gnoswap/v1/gnft"
+
+	pl "gno.land/r/gnoswap/v1/pool"
+	pn "gno.land/r/gnoswap/v1/position"
+	sr "gno.land/r/gnoswap/v1/staker"
+
+	prabc "gno.land/p/gnoswap/rbac"
+	_ "gno.land/r/gnoswap/rbac"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/baz"
+)
+
+var (
+	adminAddr, _ = access.GetAddress(prabc.ROLE_ADMIN.String())
+	adminUser    = adminAddr
+	adminRealm   = std.NewUserRealm(adminAddr)
+
+	stakerAddr, _ = access.GetAddress(prabc.ROLE_STAKER.String())
+	poolAddr, _   = access.GetAddress(prabc.ROLE_POOL.String())
+
+	barPath = "gno.land/r/onbloc/bar"
+	bazPath = "gno.land/r/onbloc/baz"
+
+	fee3000 uint32 = 3000
+
+	maxTimeout int64 = 9999999999
+	maxInt64   int64 = 9223372036854775807
+)
+
+func main() {
+	println("=== TEST: Unstaking After Tier Removal ===")
+	println()
+	println("This test demonstrates a critical bug where users cannot unstake")
+	println("positions from pools that have been removed from the tier system.")
+	println()
+
+	println("[STEP 1] Initialize and setup")
+	initAndSetup()
+
+	println("[STEP 2] Create pool and set to tier 2")
+	createPoolAndSetTier()
+
+	println("[STEP 3] Mint and stake position")
+	positionId := mintAndStakePosition()
+
+	println("[STEP 4] Verify position is staked")
+	verifyStaked(positionId)
+
+	println("[STEP 5] Remove pool from tier system")
+	removePoolTier()
+
+	println("[STEP 6] Attempt to unstake position after tier removal")
+	attemptUnstake(positionId)
+
+	println("[STEP 7] Verify unstaking was successful")
+	verifyUnstaked(positionId)
+}
+
+func initAndSetup() {
+	testing.SetRealm(adminRealm)
+	en.SetDistributionStartTime(cross, time.Now().Unix()+1)
+
+	// Set unstaking fee to 0
+	sr.SetUnStakingFee(cross, 0)
+
+	// Set pool creation fee to 0
+	pl.SetPoolCreationFee(cross, 0)
+
+	testing.SkipHeights(1)
+	println("[INFO] Initialized")
+}
+
+func createPoolAndSetTier() {
+	testing.SetRealm(adminRealm)
+
+	// Create pool
+	pl.CreatePool(cross, barPath, bazPath, fee3000, "79228162514264337593543950337")
+
+	// Set pool to tier 2
+	sr.SetPoolTier(cross, "gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:3000", 2)
+
+	tier := sr.GetPoolTier("gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:3000")
+	ufmt.Printf("[INFO] Pool created and set to tier %d\n", tier)
+
+	testing.SkipHeights(1)
+}
+
+func mintAndStakePosition() uint64 {
+	testing.SetRealm(adminRealm)
+
+	// Approve tokens
+	bar.Approve(cross, poolAddr, maxInt64)
+	baz.Approve(cross, poolAddr, maxInt64)
+
+	// Mint position
+	// fee3000 has tick spacing of 60, so ticks must be multiples of 60
+	positionId, liquidity, _, _ := pn.Mint(
+		cross,
+		barPath,
+		bazPath,
+		fee3000,
+		int32(-1020), // -1020 is divisible by 60
+		int32(1020),  // 1020 is divisible by 60
+		"1000",
+		"1000",
+		"1",
+		"1",
+		maxTimeout,
+		adminUser,
+		adminUser,
+		"",
+	)
+
+	ufmt.Printf("[INFO] Minted position %d with liquidity %s\n", positionId, liquidity)
+
+	// Approve and stake
+	gnft.Approve(cross, stakerAddr, positionIdFrom(positionId))
+	sr.StakeToken(cross, positionId, "")
+
+	println("[INFO] Position staked")
+	testing.SkipHeights(1)
+
+	return positionId
+}
+
+func verifyStaked(positionId uint64) {
+	isStaked := sr.IsStaked(positionId)
+	ufmt.Printf("[INFO] Position %d staked status: %v\n", positionId, isStaked)
+
+	if !isStaked {
+		panic("Position should be staked")
+	}
+}
+
+func removePoolTier() {
+	testing.SetRealm(adminRealm)
+
+	println("Removing pool from tier system...")
+	sr.RemovePoolTier(cross, "gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:3000")
+
+	tier := sr.GetPoolTier("gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:3000")
+	ufmt.Printf("[INFO] Pool tier after removal: %d (0 means no tier)\n", tier)
+
+	if tier != 0 {
+		panic("Pool should have no tier after removal")
+	}
+
+	testing.SkipHeights(1)
+}
+
+// This should now work after the fix
+func attemptUnstake(positionId uint64) {
+	testing.SetRealm(adminRealm)
+
+	println("Attempting to unstake position from de-tiered pool...")
+
+	// This should now succeed after the fix
+	poolPath, token0Amount, token1Amount := sr.UnStakeToken(cross, positionId, false)
+
+	println("[INFO] poolPath: ", poolPath)
+	println("[INFO] token0Amount: ", token0Amount)
+	println("[INFO] token1Amount: ", token1Amount)
+
+	println()
+	println("=== BUG FIXED ===")
+	println("Users CAN NOW unstake positions from pools that have been removed from the tier system.")
+}
+
+func verifyUnstaked(positionId uint64) {
+	isStaked := sr.IsStaked(positionId)
+	ufmt.Printf("[INFO] Position %d staked status after unstaking: %v\n", positionId, isStaked)
+
+	if isStaked {
+		panic("Position should not be staked after unstaking")
+	}
+
+	// Verify NFT ownership returned to user
+	owner, err := gnft.OwnerOf(positionIdFrom(positionId))
+	if err != nil {
+		panic(err)
+	}
+
+	if owner != adminUser {
+		panic(ufmt.Sprintf("NFT should be owned by admin after unstaking, but owned by %s", owner))
+	}
+
+	println("[INFO] NFT ownership successfully returned to user")
+	println()
+	println("=== TEST PASSED ===")
+	println("The bug has been fixed! Users can unstake from de-tiered pools.")
+}
+
+func positionIdFrom(positionId any) grc721.TokenID {
+	switch positionId := positionId.(type) {
+	case string:
+		return grc721.TokenID(positionId)
+	case int:
+		return grc721.TokenID(strconv.Itoa(positionId))
+	case uint64:
+		return grc721.TokenID(strconv.Itoa(int(positionId)))
+	case grc721.TokenID:
+		return positionId
+	default:
+		panic("unsupported positionId type")
+	}
+}
+
+// Output:
+// === TEST: Unstaking After Tier Removal ===
+//
+// This test demonstrates a critical bug where users cannot unstake
+// positions from pools that have been removed from the tier system.
+//
+// [STEP 1] Initialize and setup
+// [INFO] Initialized
+// [STEP 2] Create pool and set to tier 2
+// [INFO] Pool created and set to tier 2
+// [STEP 3] Mint and stake position
+// [INFO] Minted position 1 with liquidity 20113
+// [INFO] Position staked
+// [STEP 4] Verify position is staked
+// [INFO] Position 1 staked status: true
+// [STEP 5] Remove pool from tier system
+// Removing pool from tier system...
+// [INFO] Pool tier after removal: 0 (0 means no tier)
+// [STEP 6] Attempt to unstake position after tier removal
+// Attempting to unstake position from de-tiered pool...
+// [INFO] poolPath:  gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:3000
+// [INFO] token0Amount:  1000
+// [INFO] token1Amount:  1000
+//
+// === BUG FIXED ===
+// Users CAN NOW unstake positions from pools that have been removed from the tier system.
+// [STEP 7] Verify unstaking was successful
+// [INFO] Position 1 staked status after unstaking: false
+// [INFO] NFT ownership successfully returned to user
+//
+// === TEST PASSED ===
+// The bug has been fixed! Users can unstake from de-tiered pools.


### PR DESCRIPTION
# Description

This PR fixes a bug where users cannot unstake their positions from pools that have been removed from the incentive their system and have no external incentives.

## Problem Description

### Vulnerability
Users were unable to unstake their LP positions from pools that:
1. Had their tier removed (tier = 0) via `RemovePoolTier`
2. Had no external incentives

This resulted in user funds being permanently locked in the staker contract.

### Root Cause
The `applyUnstake` function was calling `getPositionStakeTokenAmount`, which internally validates that the pool has incentives through `poolHasIncentives`. This validation is appropriate for staking operations but inappropriate for unstaking.

```go
// Problematic code in applyUnstake (lines 718-721)
_, _, err := getPositionStakeTokenAmount(positionId, owner, caller)
if err != nil {
    return err
}
```

The validation chain:
- `applyUnstake` → `getPositionStakeTokenAmount` → `poolHasIncentives`
- `poolHasIncentives` checks if pool has internal incentives (tier > 0) OR external incentives
- If neither exists, it returns an error, blocking the unstake operation

## Solution

### Changes

Removed the unnecessary incentive validation from the `applyUnstake` function:

```diff
func applyUnStake(positionId uint64) error {
    // ... existing logic ...
    
    deposits.remove(positionId)
    stakers.removeDeposit(deposit.owner, positionId)
    
-    owner := gnft.MustOwnerOf(positionIdFrom(positionId))
-    caller := std.PreviousRealm().Address()
-    
-    _, _, err := getPositionStakeTokenAmount(positionId, owner, caller)
-    if err != nil {
-        return err
-    }
    
    return nil
}
```

### Modification Direction and Rationale

The initial approach considered maintaining incentive information when `RemovePoolTier` is executed, but this could have significant impact on the entire system. Instead, I chose to remove only the unnecessary validation during unstake, which is the root cause of the problem.

Also, `poolHasIncentives` validation is logic to check "can new positions be staked?". During unstake, we're retrieving already staked positions, so the current pool state is irrelevant. therefore, asymmetric validation is needed for stake and unstake operation.

## Testing

A test newly added to verify the issue and fix:

1. Create a pool and set it to tier 2
2. Mint and stake a position
3. Verify the position is staked
4. Remove the pool from the tier system (tier → 0)
5. Attempt to unstake the position
6. Verify successful unstaking and NFT return

### Test Results

```plain
[STEP 6] Attempt to unstake position after tier removal
Attempting to unstake position from de-tiered pool...
[INFO] poolPath: gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:3000
[INFO] token0Amount: 1000
[INFO] token1Amount: 1000

=== BUG FIXED ===
Users CAN NOW unstake positions from pools that have been removed from the tier system.
[STEP 7] Verify unstaking was successful
[INFO] Position 1 staked status after unstaking: false
[INFO] NFT ownership successfully returned to user

=== TEST PASSED ===
```

- **Before Fix**: Unstaking failed with "pool is not incentivized" error
- **After Fix**: Unstaking succeeds, tokens are returned, NFT ownership is restored
