### PR TITLE
fix(staker): Add validation to ensure last warmup tier maintains infinite duration

### DIFF
--- a/contract/r/gnoswap/v1/staker/reward_calculation_warmup.gno
+++ b/contract/r/gnoswap/v1/staker/reward_calculation_warmup.gno
@@ -7,6 +7,8 @@ import (
 	"gno.land/p/nt/ufmt"
 )
 
+const maxDurationOneYear = int64(365 * 86400) // 31,536,000 seconds
+
 type Warmup struct {
 	Index          int
 	TimeDuration   int64
@@ -64,11 +66,18 @@ func modifyWarmup(index int, timeDuration int64) {
 		panic(ufmt.Sprintf("index(%d) is out of range", index))
 	}
 
-	// Ensure the last warmup tier has infinite duration (math.MaxInt64)
-	// This guarantees permanent reward accessibility. If the final tier has a finite
-	// duration, rewards become unobtainable once that time period expires.
-	if index == len(warmupTemplate)-1 && timeDuration != math.MaxInt64 {
-		panic(ufmt.Sprintf("last warmup tier must have duration of math.MaxInt64, got %d", timeDuration))
+	// Early return for last tier - must always be math.MaxInt64
+	if index == len(warmupTemplate)-1 {
+		if timeDuration != math.MaxInt64 {
+			panic(ufmt.Sprintf("last warmup tier must have duration of math.MaxInt64, got %d", timeDuration))
+		}
+		// No modification needed as it's already math.MaxInt64
+		return
+	}
+
+	// Limit non-final tier durations to 1 year (365 days)
+	if timeDuration > maxDurationOneYear {
+		panic(ufmt.Sprintf("warmup duration cannot exceed 1 year (365 days), got %d seconds", timeDuration))
 	}
 
 	warmupTemplate[index].TimeDuration = timeDuration
@@ -76,11 +85,8 @@ func modifyWarmup(index int, timeDuration int64) {
 
 func instantiateWarmup(currentTime int64) []Warmup {
 	warmups := make([]Warmup, 0)
-	for _, warmup := range warmupTemplate {
-		nextWarmupTime := currentTime + warmup.TimeDuration
-		if nextWarmupTime < 0 {
-			nextWarmupTime = math.MaxInt64
-		}
+	for i, warmup := range warmupTemplate {
+		nextWarmupTime := safeAddTime(currentTime, warmup.TimeDuration)
 
 		warmups = append(warmups, Warmup{
 			Index:          warmup.Index,
@@ -88,9 +94,27 @@ func instantiateWarmup(currentTime int64) []Warmup {
 			NextWarmupTime: nextWarmupTime,
 			WarmupRatio:    warmup.WarmupRatio,
 		})
-		currentTime += warmup.TimeDuration
+
+		// Only update currentTime if not the last tier
+		if i < len(warmupTemplate)-1 {
+			currentTime = safeAddTime(currentTime, warmup.TimeDuration)
+		}
 	}
 	return warmups
+}
+
+// safeAddTime performs safe addition with overflow protection
+func safeAddTime(currentTime, duration int64) int64 {
+	if duration == math.MaxInt64 {
+		return math.MaxInt64
+	}
+
+	// Check for overflow before addition
+	if currentTime > 0 && duration > math.MaxInt64-currentTime {
+		return math.MaxInt64
+	}
+
+	return currentTime + duration
 }
 
 func (warmup *Warmup) apply(poolReward int64, positionLiquidity, stakedLiquidity *u256.Uint) (int64, int64) {

--- a/contract/r/gnoswap/v1/staker/reward_calculation_warmup.gno
+++ b/contract/r/gnoswap/v1/staker/reward_calculation_warmup.gno
@@ -3,8 +3,8 @@ package staker
 import (
 	"math"
 
-	"gno.land/p/nt/ufmt"
 	u256 "gno.land/p/gnoswap/uint256"
+	"gno.land/p/nt/ufmt"
 )
 
 type Warmup struct {
@@ -62,6 +62,13 @@ func DefaultWarmupTemplate() []Warmup {
 func modifyWarmup(index int, timeDuration int64) {
 	if index >= len(warmupTemplate) {
 		panic(ufmt.Sprintf("index(%d) is out of range", index))
+	}
+
+	// Ensure the last warmup tier has infinite duration (math.MaxInt64)
+	// This guarantees permanent reward accessibility. If the final tier has a finite
+	// duration, rewards become unobtainable once that time period expires.
+	if index == len(warmupTemplate)-1 && timeDuration != math.MaxInt64 {
+		panic(ufmt.Sprintf("last warmup tier must have duration of math.MaxInt64, got %d", timeDuration))
 	}
 
 	warmupTemplate[index].TimeDuration = timeDuration

--- a/contract/r/gnoswap/v1/staker/reward_calculation_warmup_test.gno
+++ b/contract/r/gnoswap/v1/staker/reward_calculation_warmup_test.gno
@@ -287,3 +287,65 @@ func TestMultipleWarmupPeriods(t *testing.T) {
 		})
 	}
 }
+
+func TestModifyWarmupLastTierValidation(t *testing.T) {
+	tests := []struct {
+		name           string
+		modifyLastTier bool
+		newDuration    int64
+		expectPanic    bool
+		validateAfter  func(t *testing.T)
+	}{
+		{
+			name:           "modify non-last tier should succeed",
+			modifyLastTier: false,
+			newDuration:    86400, // 1 day
+			expectPanic:    false,
+			validateAfter: func(t *testing.T) {
+				uassert.Equal(t, int64(86400), warmupTemplate[0].TimeDuration)
+				uassert.Equal(t, int64(math.MaxInt64), warmupTemplate[3].TimeDuration)
+			},
+		},
+		{
+			name:           "modify last tier to finite duration should panic",
+			modifyLastTier: true,
+			newDuration:    86400 * 60, // 60 days
+			expectPanic:    true,
+			validateAfter: func(t *testing.T) {
+				// Should never reach here due to panic
+			},
+		},
+		{
+			name:           "modify last tier to MaxInt64 should succeed",
+			modifyLastTier: true,
+			newDuration:    math.MaxInt64,
+			expectPanic:    false,
+			validateAfter: func(t *testing.T) {
+				uassert.Equal(t, int64(math.MaxInt64), warmupTemplate[3].TimeDuration)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset warmupTemplate to default before each test
+			warmupTemplate = DefaultWarmupTemplate()
+
+			index := 0
+			if tt.modifyLastTier {
+				index = 3
+			}
+
+			if tt.expectPanic {
+				uassert.PanicsContains(t, "duration of math.MaxInt64", func() {
+					modifyWarmup(index, tt.newDuration)
+				})
+			} else {
+				modifyWarmup(index, tt.newDuration)
+				if tt.validateAfter != nil {
+					tt.validateAfter(t)
+				}
+			}
+		})
+	}
+}

--- a/contract/r/gnoswap/v1/staker/reward_calculation_warmup_test.gno
+++ b/contract/r/gnoswap/v1/staker/reward_calculation_warmup_test.gno
@@ -292,35 +292,65 @@ func TestModifyWarmupLastTierValidation(t *testing.T) {
 	tests := []struct {
 		name           string
 		modifyLastTier bool
+		tierIndex      int
 		newDuration    int64
 		expectPanic    bool
+		panicMessage   string
 		validateAfter  func(t *testing.T)
 	}{
 		{
-			name:           "modify non-last tier should succeed",
+			name:           "modify non-last tier within 1 year should succeed",
 			modifyLastTier: false,
-			newDuration:    86400, // 1 day
+			tierIndex:      0,
+			newDuration:    86400 * 30, // 30 days
 			expectPanic:    false,
 			validateAfter: func(t *testing.T) {
-				uassert.Equal(t, int64(86400), warmupTemplate[0].TimeDuration)
+				uassert.Equal(t, int64(86400*30), warmupTemplate[0].TimeDuration)
 				uassert.Equal(t, int64(math.MaxInt64), warmupTemplate[3].TimeDuration)
+			},
+		},
+		{
+			name:           "modify non-last tier to exactly 1 year should succeed",
+			modifyLastTier: false,
+			tierIndex:      1,
+			newDuration:    365 * 86400, // exactly 365 days
+			expectPanic:    false,
+			validateAfter: func(t *testing.T) {
+				uassert.Equal(t, int64(365*86400), warmupTemplate[1].TimeDuration)
+			},
+		},
+		{
+			name:           "modify non-last tier exceeding 1 year should panic",
+			modifyLastTier: false,
+			tierIndex:      0,
+			newDuration:    366 * 86400, // 366 days (over 1 year)
+			expectPanic:    true,
+			panicMessage:   "warmup duration cannot exceed 1 year",
+			validateAfter: func(t *testing.T) {
+				// Should never reach here due to panic
+				t.Fatal("should not reach here")
 			},
 		},
 		{
 			name:           "modify last tier to finite duration should panic",
 			modifyLastTier: true,
+			tierIndex:      3,
 			newDuration:    86400 * 60, // 60 days
 			expectPanic:    true,
+			panicMessage:   "duration of math.MaxInt64",
 			validateAfter: func(t *testing.T) {
 				// Should never reach here due to panic
+				t.Fatal("should not reach here")
 			},
 		},
 		{
-			name:           "modify last tier to MaxInt64 should succeed",
+			name:           "modify last tier to MaxInt64 should return early without change",
 			modifyLastTier: true,
+			tierIndex:      3,
 			newDuration:    math.MaxInt64,
 			expectPanic:    false,
 			validateAfter: func(t *testing.T) {
+				// Verify it's still MaxInt64 (no actual modification)
 				uassert.Equal(t, int64(math.MaxInt64), warmupTemplate[3].TimeDuration)
 			},
 		},
@@ -331,17 +361,12 @@ func TestModifyWarmupLastTierValidation(t *testing.T) {
 			// Reset warmupTemplate to default before each test
 			warmupTemplate = DefaultWarmupTemplate()
 
-			index := 0
-			if tt.modifyLastTier {
-				index = 3
-			}
-
 			if tt.expectPanic {
-				uassert.PanicsContains(t, "duration of math.MaxInt64", func() {
-					modifyWarmup(index, tt.newDuration)
+				uassert.PanicsContains(t, tt.panicMessage, func() {
+					modifyWarmup(tt.tierIndex, tt.newDuration)
 				})
 			} else {
-				modifyWarmup(index, tt.newDuration)
+				modifyWarmup(tt.tierIndex, tt.newDuration)
 				if tt.validateAfter != nil {
 					tt.validateAfter(t)
 				}

--- a/contract/r/gnoswap/v1/staker/reward_calculation_warmup_test.gno
+++ b/contract/r/gnoswap/v1/staker/reward_calculation_warmup_test.gno
@@ -290,67 +290,54 @@ func TestMultipleWarmupPeriods(t *testing.T) {
 
 func TestModifyWarmupLastTierValidation(t *testing.T) {
 	tests := []struct {
-		name           string
-		modifyLastTier bool
-		tierIndex      int
-		newDuration    int64
-		expectPanic    bool
-		panicMessage   string
-		validateAfter  func(t *testing.T)
+		name          string
+		tierIndex     int
+		newDuration   int64
+		expectPanic   bool
+		panicMessage  string
+		validateAfter func(t *testing.T)
 	}{
+		// Non-last tier tests
 		{
-			name:           "modify non-last tier within 1 year should succeed",
-			modifyLastTier: false,
-			tierIndex:      0,
-			newDuration:    86400 * 30, // 30 days
-			expectPanic:    false,
+			name:        "modify non-last tier within 1 year should succeed",
+			tierIndex:   0,
+			newDuration: 86400 * 30, // 30 days
+			expectPanic: false,
 			validateAfter: func(t *testing.T) {
 				uassert.Equal(t, int64(86400*30), warmupTemplate[0].TimeDuration)
 				uassert.Equal(t, int64(math.MaxInt64), warmupTemplate[3].TimeDuration)
 			},
 		},
 		{
-			name:           "modify non-last tier to exactly 1 year should succeed",
-			modifyLastTier: false,
-			tierIndex:      1,
-			newDuration:    365 * 86400, // exactly 365 days
-			expectPanic:    false,
+			name:        "modify non-last tier to exactly 1 year should succeed",
+			tierIndex:   1,
+			newDuration: 365 * 86400, // exactly 365 days
+			expectPanic: false,
 			validateAfter: func(t *testing.T) {
 				uassert.Equal(t, int64(365*86400), warmupTemplate[1].TimeDuration)
 			},
 		},
 		{
-			name:           "modify non-last tier exceeding 1 year should panic",
-			modifyLastTier: false,
-			tierIndex:      0,
-			newDuration:    366 * 86400, // 366 days (over 1 year)
-			expectPanic:    true,
-			panicMessage:   "warmup duration cannot exceed 1 year",
-			validateAfter: func(t *testing.T) {
-				// Should never reach here due to panic
-				t.Fatal("should not reach here")
-			},
+			name:         "modify non-last tier exceeding 1 year should panic",
+			tierIndex:    0,
+			newDuration:  366 * 86400, // 366 days (over 1 year)
+			expectPanic:  true,
+			panicMessage: "warmup duration cannot exceed 1 year",
+		},
+		// Last tier tests
+		{
+			name:         "modify last tier to finite duration should panic",
+			tierIndex:    3,
+			newDuration:  86400 * 60, // 60 days
+			expectPanic:  true,
+			panicMessage: "duration of math.MaxInt64",
 		},
 		{
-			name:           "modify last tier to finite duration should panic",
-			modifyLastTier: true,
-			tierIndex:      3,
-			newDuration:    86400 * 60, // 60 days
-			expectPanic:    true,
-			panicMessage:   "duration of math.MaxInt64",
+			name:        "modify last tier to MaxInt64 should return early without change",
+			tierIndex:   3,
+			newDuration: math.MaxInt64,
+			expectPanic: false,
 			validateAfter: func(t *testing.T) {
-				// Should never reach here due to panic
-				t.Fatal("should not reach here")
-			},
-		},
-		{
-			name:           "modify last tier to MaxInt64 should return early without change",
-			modifyLastTier: true,
-			tierIndex:      3,
-			newDuration:    math.MaxInt64,
-			expectPanic:    false,
-			validateAfter: func(t *testing.T) {
-				// Verify it's still MaxInt64 (no actual modification)
 				uassert.Equal(t, int64(math.MaxInt64), warmupTemplate[3].TimeDuration)
 			},
 		},
@@ -373,4 +360,98 @@ func TestModifyWarmupLastTierValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWarmupOverflowProtection(t *testing.T) {
+	t.Run("safeAddTime overflow handling", func(t *testing.T) {
+		tests := []struct {
+			name        string
+			currentTime int64
+			duration    int64
+			expected    int64
+		}{
+			{
+				name:        "normal addition",
+				currentTime: 1000,
+				duration:    2000,
+				expected:    3000,
+			},
+			{
+				name:        "MaxInt64 duration",
+				currentTime: 1000,
+				duration:    math.MaxInt64,
+				expected:    math.MaxInt64,
+			},
+			{
+				name:        "overflow case",
+				currentTime: math.MaxInt64 - 100,
+				duration:    200,
+				expected:    math.MaxInt64,
+			},
+			{
+				name:        "edge case at boundary",
+				currentTime: math.MaxInt64 - 1,
+				duration:    1,
+				expected:    math.MaxInt64,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				result := safeAddTime(tt.currentTime, tt.duration)
+				uassert.Equal(t, tt.expected, result,
+					ufmt.Sprintf("safeAddTime(%d, %d) should return %d, got %d",
+						tt.currentTime, tt.duration, tt.expected, result))
+			})
+		}
+	})
+
+	t.Run("instantiate warmup with overflow protection and last tier validation", func(t *testing.T) {
+		// Reset to default template
+		warmupTemplate = DefaultWarmupTemplate()
+
+		// Verify last tier has MaxInt64 duration
+		lastTier := warmupTemplate[len(warmupTemplate)-1]
+		if math.MaxInt64 != lastTier.TimeDuration {
+			t.Fatalf("Last tier must have MaxInt64 duration")
+		}
+
+		// Test case where currentTime is near MaxInt64
+		nearMaxTime := math.MaxInt64 - int64(86400) // MaxInt64 minus 1 day
+		warmups := instantiateWarmup(nearMaxTime)
+
+		// First few warmups should overflow to MaxInt64
+		for i := 0; i < len(warmups)-1; i++ {
+			if math.MaxInt64 != int64(warmups[i].NextWarmupTime) {
+				t.Fatalf("Warmup %d should overflow to MaxInt64", i)
+			}
+		}
+
+		// Last warmup should always be MaxInt64
+		if math.MaxInt64 != int64(warmups[len(warmups)-1].NextWarmupTime) {
+			t.Fatalf("Last warmup should always be MaxInt64")
+		}
+
+		// Test time progression scenarios
+		currentTime := int64(1000000)
+		normalWarmups := instantiateWarmup(currentTime)
+		lastWarmup := normalWarmups[len(normalWarmups)-1]
+
+		if math.MaxInt64 != lastWarmup.NextWarmupTime {
+			t.Fatalf("Last warmup NextWarmupTime must be MaxInt64")
+		}
+
+		// Simulate time progression - should never exceed last warmup
+		futureTime := currentTime + 86400*365*10 // 10 years later
+		deposit := &Deposit{warmups: normalWarmups}
+		warmupIndex := deposit.FindWarmup(futureTime)
+
+		uassert.Equal(t, len(normalWarmups)-1, warmupIndex,
+			"Should always find the last warmup tier for any future time")
+
+		// Even at MaxInt64-1, should still be in last tier
+		warmupIndex = deposit.FindWarmup(math.MaxInt64 - 1)
+		uassert.Equal(t, len(normalWarmups)-1, warmupIndex,
+			"Should be in last tier even at MaxInt64-1")
+	})
 }


### PR DESCRIPTION
# Description

Added validation in the `modifyWarmup` function to ensure the last warmup tier always maintains `math.MaxInt64` duration.