### PR TITLE
feat: handle transfer grc20 safe transfers

### DIFF
--- a/contract/r/gnoswap/v1/common/grc20reg_helper.gno
+++ b/contract/r/gnoswap/v1/common/grc20reg_helper.gno
@@ -84,3 +84,24 @@ func TransferFrom(cur realm, path string, from, to std.Address, amount int64) er
 func Approve(cur realm, path string, spender std.Address, amount int64) error {
 	return GetTokenTeller(path).Approve(spender, amount)
 }
+
+// SafeGRC20Transfer performs a token transfer and panics if it fails.
+func SafeGRC20Transfer(cur realm, path string, to std.Address, amount int64) {
+	if err := GetTokenTeller(path).Transfer(to, amount); err != nil {
+		panic(err)
+	}
+}
+
+// SafeGRC20TransferFrom performs a token transfer from one address to another and panics if it fails.
+func SafeGRC20TransferFrom(cur realm, path string, from, to std.Address, amount int64) {
+	if err := GetTokenTeller(path).TransferFrom(from, to, amount); err != nil {
+		panic(err)
+	}
+}
+
+// SafeGRC20Approve performs a token approval and panics if it fails.
+func SafeGRC20Approve(cur realm, path string, spender std.Address, amount int64) {
+	if err := GetTokenTeller(path).Approve(spender, amount); err != nil {
+		panic(err)
+	}
+}

--- a/contract/r/gnoswap/v1/community_pool/community_pool.gno
+++ b/contract/r/gnoswap/v1/community_pool/community_pool.gno
@@ -32,10 +32,7 @@ func TransferToken(cur realm, tokenPath string, to std.Address, amount int64) {
 
 // transferToken performs actual token transfer.
 func transferToken(tokenPath string, to std.Address, amount int64) error {
-	err := common.Transfer(cross, tokenPath, to, amount)
-	if err != nil {
-		return err
-	}
+	common.SafeGRC20Transfer(cross, tokenPath, to, amount)
 
 	prevRealm := std.PreviousRealm()
 	std.Emit(

--- a/contract/r/gnoswap/v1/gov/staker/staker_reward.gno
+++ b/contract/r/gnoswap/v1/gov/staker/staker_reward.gno
@@ -4,8 +4,8 @@ import (
 	"std"
 	"time"
 
-	"gno.land/p/nt/ufmt"
 	prbac "gno.land/p/gnoswap/rbac"
+	"gno.land/p/nt/ufmt"
 
 	"gno.land/r/gnoland/wugnot"
 	"gno.land/r/gnoswap/access"
@@ -276,5 +276,7 @@ func transferToken(
 	}
 
 	// Handle GRC20 token transfer
-	return common.Transfer(cross, tokenPath, to, amount)
+	common.SafeGRC20Transfer(cross, tokenPath, to, amount)
+
+	return nil
 }

--- a/contract/r/gnoswap/v1/launchpad/launchpad_project.gno
+++ b/contract/r/gnoswap/v1/launchpad/launchpad_project.gno
@@ -287,9 +287,7 @@ func transferLeftFromProject(projectID string, recipient std.Address, currentTim
 	projectLeftReward := project.RemainingAmount()
 
 	if projectLeftReward > 0 {
-		if err := common.Transfer(cross, project.tokenPath, recipient, int64(projectLeftReward)); err != nil {
-			return 0, makeErrorWithDetails(errTransferFailed, ufmt.Sprintf("token(%s), amount(%d)", project.tokenPath, projectLeftReward))
-		}
+		common.SafeGRC20Transfer(cross, project.tokenPath, recipient, int64(projectLeftReward))
 	}
 
 	return projectLeftReward, nil

--- a/contract/r/gnoswap/v1/launchpad/launchpad_project.gno
+++ b/contract/r/gnoswap/v1/launchpad/launchpad_project.gno
@@ -287,7 +287,7 @@ func transferLeftFromProject(projectID string, recipient std.Address, currentTim
 	projectLeftReward := project.RemainingAmount()
 
 	if projectLeftReward > 0 {
-		common.SafeGRC20Transfer(cross, project.tokenPath, recipient, int64(projectLeftReward))
+		common.SafeGRC20Transfer(cross, project.tokenPath, recipient, projectLeftReward)
 	}
 
 	return projectLeftReward, nil

--- a/contract/r/gnoswap/v1/pool/pool.gno
+++ b/contract/r/gnoswap/v1/pool/pool.gno
@@ -337,14 +337,14 @@ func collectProtocol(
 	uAmount0 := safeConvertToInt64(amount0)
 	uAmount1 := safeConvertToInt64(amount1)
 
-	checkTransferError(common.Transfer(cross, pool.token0Path, recipient, uAmount0))
+	common.SafeGRC20Transfer(cross, pool.token0Path, recipient, uAmount0)
 	newBalanceToken0, err := updatePoolBalance(pool.BalanceToken0(), pool.BalanceToken1(), amount0, true)
 	if err != nil {
 		panic(err)
 	}
 	pool.balances.token0 = newBalanceToken0
 
-	checkTransferError(common.Transfer(cross, pool.token1Path, recipient, uAmount1))
+	common.SafeGRC20Transfer(cross, pool.token1Path, recipient, uAmount1)
 	newBalanceToken1, err := updatePoolBalance(pool.BalanceToken0(), pool.BalanceToken1(), amount1, false)
 	if err != nil {
 		panic(err)

--- a/contract/r/gnoswap/v1/pool/pool.gno
+++ b/contract/r/gnoswap/v1/pool/pool.gno
@@ -235,17 +235,12 @@ func Collect(
 
 		position.tokensOwed0 = tokenOwed0
 		pool.balances.token0 = token0Balance
-		if err := common.Approve(cross, pool.token0Path, positionAddr, safeConvertToInt64(amount0)); err != nil {
-			panic(err)
-		}
+		common.SafeGRC20Approve(cross, pool.token0Path, positionAddr, safeConvertToInt64(amount0))
 	}
 	if amount1.Gt(u256.Zero()) {
 		position.tokensOwed1 = u256.Zero().Sub(position.tokensOwed1, amount1)
 		pool.balances.token1 = u256.Zero().Sub(pool.balances.token1, amount1)
-
-		if err := common.Approve(cross, pool.token1Path, positionAddr, safeConvertToInt64(amount1)); err != nil {
-			panic(err)
-		}
+		common.SafeGRC20Approve(cross, pool.token1Path, positionAddr, safeConvertToInt64(amount1))
 	}
 
 	pool.setPosition(positionKey, position)

--- a/contract/r/gnoswap/v1/pool/protocol_fee.gno
+++ b/contract/r/gnoswap/v1/pool/protocol_fee.gno
@@ -3,8 +3,8 @@ package pool
 import (
 	"std"
 
-	"gno.land/p/nt/ufmt"
 	u256 "gno.land/p/gnoswap/uint256"
+	"gno.land/p/nt/ufmt"
 
 	"gno.land/r/gnoswap/access"
 	"gno.land/r/gnoswap/halt"
@@ -71,10 +71,10 @@ func HandleWithdrawalFee(
 	feeAmount0, afterAmount0 := calculateAmountWithFee(u256.MustFromDecimal(amount0), u256.NewUint(fee))
 	feeAmount1, afterAmount1 := calculateAmountWithFee(u256.MustFromDecimal(amount1), u256.NewUint(fee))
 
-	checkTransferError(common.TransferFrom(cross, token0Path, positionCaller, protocolFeeAddr, safeConvertToInt64(feeAmount0)))
 	pf.AddToProtocolFee(cross, token0Path, safeConvertToInt64(feeAmount0))
-	checkTransferError(common.TransferFrom(cross, token1Path, positionCaller, protocolFeeAddr, safeConvertToInt64(feeAmount1)))
+	common.SafeGRC20TransferFrom(cross, token0Path, positionCaller, protocolFeeAddr, safeConvertToInt64(feeAmount0))
 	pf.AddToProtocolFee(cross, token1Path, safeConvertToInt64(feeAmount1))
+	common.SafeGRC20TransferFrom(cross, token1Path, positionCaller, protocolFeeAddr, safeConvertToInt64(feeAmount1))
 
 	previousRealm := std.PreviousRealm()
 	std.Emit(

--- a/contract/r/gnoswap/v1/pool/transfer.gno
+++ b/contract/r/gnoswap/v1/pool/transfer.gno
@@ -55,7 +55,7 @@ func (p *Pool) safeTransfer(
 	}
 	amountInt64 := safeConvertToInt64(absAmount)
 
-	checkTransferError(common.Transfer(cross, tokenPath, to, amountInt64))
+	common.SafeGRC20Transfer(cross, tokenPath, to, amountInt64)
 
 	newBalance, err := updatePoolBalance(token0, token1, absAmount, isToken0)
 	if err != nil {
@@ -112,7 +112,7 @@ func (p *Pool) safeTransferFrom(
 	token := common.GetToken(tokenPath)
 	beforeBalance := token.BalanceOf(to)
 
-	checkTransferError(common.TransferFrom(cross, tokenPath, from, to, amountInt64))
+	common.SafeGRC20TransferFrom(cross, tokenPath, from, to, amountInt64)
 
 	afterBalance := token.BalanceOf(to)
 	if (beforeBalance + amountInt64) != afterBalance {

--- a/contract/r/gnoswap/v1/position/burn.gno
+++ b/contract/r/gnoswap/v1/position/burn.gno
@@ -1,9 +1,9 @@
 package position
 
 import (
-	"gno.land/p/nt/ufmt"
 	prabc "gno.land/p/gnoswap/rbac"
 	u256 "gno.land/p/gnoswap/uint256"
+	"gno.land/p/nt/ufmt"
 
 	"gno.land/r/gnoswap/access"
 	"gno.land/r/gnoswap/v1/common"
@@ -130,13 +130,13 @@ func decreaseLiquidity(params DecreaseLiquidityParams) (uint64, string, string, 
 	if isWrappedToken(pToken0) && params.unwrapResult {
 		unwrapWithTransferFrom(poolAddr, caller, safeConvertToInt64(collectAmount0))
 	} else {
-		common.TransferFrom(cross, pToken0, poolAddr, caller, safeConvertToInt64(collectAmount0))
+		common.SafeGRC20TransferFrom(cross, pToken0, poolAddr, caller, safeConvertToInt64(collectAmount0))
 	}
 
 	if isWrappedToken(pToken1) && params.unwrapResult {
 		unwrapWithTransferFrom(poolAddr, caller, safeConvertToInt64(collectAmount1))
 	} else {
-		common.TransferFrom(cross, pToken1, poolAddr, caller, safeConvertToInt64(collectAmount1))
+		common.SafeGRC20TransferFrom(cross, pToken1, poolAddr, caller, safeConvertToInt64(collectAmount1))
 	}
 
 	// Check for underflow when subtracting collected amounts from tokens owed

--- a/contract/r/gnoswap/v1/position/liquidity_management_test.gno
+++ b/contract/r/gnoswap/v1/position/liquidity_management_test.gno
@@ -128,7 +128,7 @@ func TestAddLiquidity(t *testing.T) {
 			},
 			expectError:     true,
 			errorType:       "abort",
-			expectedMessage: "[GNOSWAP-POOL-021] token transfer failed || insufficient balance",
+			expectedMessage: "insufficient balance",
 		},
 		{
 			name: "add liquidity is failed by same tick range",

--- a/contract/r/gnoswap/v1/position/mint_test.gno
+++ b/contract/r/gnoswap/v1/position/mint_test.gno
@@ -4,9 +4,9 @@ import (
 	"std"
 	"testing"
 
+	u256 "gno.land/p/gnoswap/uint256"
 	"gno.land/p/nt/testutils"
 	"gno.land/p/nt/uassert"
-	u256 "gno.land/p/gnoswap/uint256"
 
 	pl "gno.land/r/gnoswap/v1/pool"
 	"gno.land/r/onbloc/bar"
@@ -105,7 +105,6 @@ func (b *MintBuilder) Caller(caller, mintTo std.Address) *MintBuilder {
 }
 
 func (b *MintBuilder) Params() MintParams { return b.p }
-
 
 // Note: Keep assertions explicit. Only truly regression-critical values
 // are compared exactly; error messages are compared exactly to respect
@@ -249,7 +248,7 @@ func TestMintInternal_PositionMint(t *testing.T) {
 				Caller(alice, alice).
 				Params(),
 			expectPanic: true,
-			expectedMsg: "[GNOSWAP-POOL-021] token transfer failed || insufficient balance",
+			expectedMsg: "insufficient balance",
 		},
 	}
 
@@ -393,7 +392,7 @@ func TestMintInternal_FeeTierEdgeCases(t *testing.T) {
 				WithMins("0", "0").
 				Params(),
 			expectPanic: true,
-			expectedMsg: "[GNOSWAP-POOL-021] token transfer failed || insufficient balance",
+			expectedMsg: "insufficient balance",
 		},
 		// 0.05% pool (tick spacing 10)
 		{

--- a/contract/r/gnoswap/v1/position/native_token_test.gno
+++ b/contract/r/gnoswap/v1/position/native_token_test.gno
@@ -250,7 +250,7 @@ func TestIsWrappedToken(t *testing.T) {
 		},
 		{
 			name:      "isWrappedToken is failed by similar but different tokenPath",
-			tokenPath: "gno.land/r/gnoland/wugnot",
+			tokenPath: "gno.land/r/gnolands/wugnot",
 			expected:  false,
 		},
 	}

--- a/contract/r/gnoswap/v1/position/position.gno
+++ b/contract/r/gnoswap/v1/position/position.gno
@@ -4,9 +4,9 @@ import (
 	"encoding/base64"
 	"std"
 
-	"gno.land/p/nt/ufmt"
 	prabc "gno.land/p/gnoswap/rbac"
 	u256 "gno.land/p/gnoswap/uint256"
+	"gno.land/p/nt/ufmt"
 
 	"gno.land/r/gnoswap/access"
 	"gno.land/r/gnoswap/emission"
@@ -435,13 +435,13 @@ func collectFee(
 	if isWrappedToken(token0) && unwrapResult {
 		unwrapWithTransferFrom(poolAddr, caller, amount0WithoutFee)
 	} else {
-		common.TransferFrom(cross, token0, poolAddr, caller, amount0WithoutFee)
+		common.SafeGRC20TransferFrom(cross, token0, poolAddr, caller, amount0WithoutFee)
 	}
 
 	if isWrappedToken(token1) && unwrapResult {
 		unwrapWithTransferFrom(poolAddr, caller, amount1WithoutFee)
 	} else {
-		common.TransferFrom(cross, token1, poolAddr, caller, amount1WithoutFee)
+		common.SafeGRC20TransferFrom(cross, token1, poolAddr, caller, amount1WithoutFee)
 	}
 
 	protocolFeeAddr, ok := access.GetAddress(prabc.ROLE_PROTOCOL_FEE.String())
@@ -449,8 +449,8 @@ func collectFee(
 		panic("protocol fee address not found")
 	}
 
-	common.TransferFrom(cross, token0, poolAddr, protocolFeeAddr, fee0)
-	common.TransferFrom(cross, token1, poolAddr, protocolFeeAddr, fee1)
+	common.SafeGRC20TransferFrom(cross, token0, poolAddr, protocolFeeAddr, fee0)
+	common.SafeGRC20TransferFrom(cross, token1, poolAddr, protocolFeeAddr, fee1)
 
 	amount0WithoutFeeStr := formatInt(amount0WithoutFee)
 	amount1WithoutFeeStr := formatInt(amount1WithoutFee)

--- a/contract/r/gnoswap/v1/protocol_fee/state.gno
+++ b/contract/r/gnoswap/v1/protocol_fee/state.gno
@@ -66,9 +66,9 @@ func (pfs *ProtocolFeeState) AccuToDevOps() *avl.Tree { return pfs.accuToDevOps 
 func (pfs *ProtocolFeeState) distributeToDevOps(token string, amount int64) error {
 	pfs.addAccuToDevOps(token, amount)
 	pfs.updateDistributedToDevOpsHistory(token, amount)
-	if err := common.Transfer(cross, token, devOpsAddr, amount); err != nil {
-		return ufmt.Errorf("transfer failed: token(%s), amount(%d)", token, amount)
-	}
+
+	common.SafeGRC20Transfer(cross, token, devOpsAddr, amount)
+
 	return nil
 }
 
@@ -77,9 +77,9 @@ func (pfs *ProtocolFeeState) distributeToDevOps(token string, amount int64) erro
 func (pfs *ProtocolFeeState) distributeToGovStaker(token string, amount int64) error {
 	pfs.addAccuToGovStaker(token, amount)
 	pfs.updateDistributedToGovStakerHistory(token, amount)
-	if err := common.Transfer(cross, token, govStakerAddr, amount); err != nil {
-		return ufmt.Errorf("transfer failed: token(%s), amount(%d)", token, amount)
-	}
+
+	common.SafeGRC20Transfer(cross, token, govStakerAddr, amount)
+
 	return nil
 }
 

--- a/contract/r/gnoswap/v1/router/exact_in.gno
+++ b/contract/r/gnoswap/v1/router/exact_in.gno
@@ -90,7 +90,7 @@ func ExactInSwapRoute(cur realm,
 			panic(err)
 		}
 	} else {
-		common.Transfer(cross, outputToken, std.PreviousRealm().Address(), outputAmount.Int64())
+		common.SafeGRC20Transfer(cross, outputToken, std.PreviousRealm().Address(), outputAmount.Int64())
 	}
 
 	// handle referral registration

--- a/contract/r/gnoswap/v1/router/exact_out.gno
+++ b/contract/r/gnoswap/v1/router/exact_out.gno
@@ -93,7 +93,7 @@ func ExactOutSwapRoute(
 			panic(err)
 		}
 	} else {
-		common.Transfer(cross, outputToken, std.PreviousRealm().Address(), outputAmount.Int64())
+		common.SafeGRC20Transfer(cross, outputToken, std.PreviousRealm().Address(), outputAmount.Int64())
 	}
 
 	// handle referral registration

--- a/contract/r/gnoswap/v1/router/protocol_fee_swap.gno
+++ b/contract/r/gnoswap/v1/router/protocol_fee_swap.gno
@@ -82,7 +82,7 @@ func handleSwapFee(
 		outputToken = wugnotPath
 	}
 
-	common.Transfer(cross, outputToken, protocolFeeAddr, feeAmountInt64)
+	common.SafeGRC20Transfer(cross, outputToken, protocolFeeAddr, feeAmountInt64)
 
 	pf.AddToProtocolFee(cross, outputToken, feeAmountInt64)
 

--- a/contract/r/gnoswap/v1/router/protocol_fee_swap_test.gno
+++ b/contract/r/gnoswap/v1/router/protocol_fee_swap_test.gno
@@ -1,9 +1,11 @@
 package router
 
 import (
+	"std"
 	"testing"
 
 	u256 "gno.land/p/gnoswap/uint256"
+	"gno.land/r/onbloc/bar"
 )
 
 func TestHandleSwapFee(t *testing.T) {
@@ -47,11 +49,18 @@ func TestHandleSwapFee(t *testing.T) {
 				swapFee = originalSwapFee
 			}()
 
-			result := handleSwapFee(barPath, tt.amount)
+			testing.SetRealm(std.NewUserRealm(adminAddr))
+			bar.Transfer(cross, routerAddr, tt.amount.Int64())
 
-			if !result.Eq(tt.expectedAmount) {
-				t.Errorf("handleSwapFee() = %v, want %v", result, tt.expectedAmount)
-			}
+			testing.SetRealm(routerRealm)
+
+			func(cur realm) {
+				result := handleSwapFee(barPath, tt.amount)
+
+				if !result.Eq(tt.expectedAmount) {
+					t.Errorf("handleSwapFee() = %v, want %v", result, tt.expectedAmount)
+				}
+			}(cross)
 		})
 	}
 }

--- a/contract/r/gnoswap/v1/router/swap_inner.gno
+++ b/contract/r/gnoswap/v1/router/swap_inner.gno
@@ -52,7 +52,7 @@ func swapInner(
 
 	// approves pool as spender
 	if data.hasNext {
-		common.Approve(cross, data.tokenOut, poolAddr, poolOut.Int64())
+		common.SafeGRC20Approve(cross, data.tokenOut, poolAddr, poolOut.Int64())
 	}
 
 	return poolRecv, poolOut

--- a/contract/r/gnoswap/v1/staker/external_incentive.gno
+++ b/contract/r/gnoswap/v1/staker/external_incentive.gno
@@ -4,8 +4,8 @@ import (
 	"std"
 	"time"
 
-	"gno.land/p/nt/ufmt"
 	prbac "gno.land/p/gnoswap/rbac"
+	"gno.land/p/nt/ufmt"
 
 	"gno.land/r/gnoswap/access"
 	en "gno.land/r/gnoswap/emission"
@@ -53,10 +53,7 @@ func CreateExternalIncentive(
 			panic(err)
 		}
 	} else {
-		err := common.TransferFrom(cross, rewardToken, caller, stakerAddr, rewardAmount)
-		if err != nil {
-			panic(err)
-		}
+		common.SafeGRC20TransferFrom(cross, rewardToken, caller, stakerAddr, rewardAmount)
 	}
 
 	// deposit gns amount
@@ -155,13 +152,12 @@ func EndExternalIncentive(cur realm, targetPoolPath, incentiveId string) {
 	// unwrap if wugnot
 	isUnwrap := incentive.rewardToken == WUGNOT_PATH
 	if isUnwrap {
-		err = unwrapWithTransfer(incentive.refundee, refund)
+		transferErr := unwrapWithTransfer(incentive.refundee, refund)
+		if transferErr != nil {
+			panic(transferErr)
+		}
 	} else {
-		err = common.Transfer(cross, incentive.rewardToken, incentive.refundee, refund)
-	}
-
-	if err != nil {
-		panic(err)
+		common.SafeGRC20Transfer(cross, incentive.rewardToken, incentive.refundee, refund)
 	}
 
 	// also refund deposit gns amount

--- a/contract/r/gnoswap/v1/staker/protocol_fee_unstaking.gno
+++ b/contract/r/gnoswap/v1/staker/protocol_fee_unstaking.gno
@@ -48,7 +48,7 @@ func handleUnStakingFee(
 	}
 
 	// external contract has fee
-	common.Transfer(cross, tokenPath, protocolFeeAddr, feeAmount)
+	common.SafeGRC20Transfer(cross, tokenPath, protocolFeeAddr, feeAmount)
 	pf.AddToProtocolFee(cross, tokenPath, feeAmount)
 
 	return amount - feeAmount, feeAmount, nil

--- a/contract/r/gnoswap/v1/staker/protocol_fee_unstaking_test.gno
+++ b/contract/r/gnoswap/v1/staker/protocol_fee_unstaking_test.gno
@@ -3,44 +3,80 @@ package staker
 import (
 	"math"
 	"testing"
+
+	"gno.land/p/nt/uassert"
+	"gno.land/r/gnoswap/gns"
 )
 
 func TestHandleUnstakingFee(t *testing.T) {
 	tests := []struct {
-		name        string
-		tokenPath   string
-		amount      int64
-		internal    bool
-		positionId  uint64
-		poolPath    string
-		expectedFee int64
-		expectedNet int64
+		name             string
+		tokenPath        string
+		amount           int64
+		stakerBalance    int64
+		internal         bool
+		positionId       uint64
+		poolPath         string
+		expectedFee      int64
+		expectedNet      int64
+		expectedHasPanic bool
+		expectedPanicMsg string
 	}{
 		{
-			name:        "No fee configured",
-			tokenPath:   gnsPath,
-			amount:      10000,
-			internal:    true,
-			positionId:  1,
-			poolPath:    "pool1",
-			expectedFee: 0,
-			expectedNet: 10000,
+			name:          "No fee configured",
+			tokenPath:     gnsPath,
+			amount:        10000,
+			stakerBalance: 0,
+			internal:      true,
+			positionId:    1,
+			poolPath:      "pool1",
+			expectedFee:   0,
+			expectedNet:   10000,
 		},
 		{
-			name:        "Standard fee",
-			tokenPath:   gnsPath,
-			amount:      10000,
-			internal:    false,
-			positionId:  1,
-			poolPath:    "pool1",
-			expectedFee: 100,
-			expectedNet: 9900,
+			name:          "Standard fee",
+			tokenPath:     gnsPath,
+			amount:        10000,
+			stakerBalance: 100,
+			internal:      false,
+			positionId:    1,
+			poolPath:      "pool1",
+			expectedFee:   100,
+			expectedNet:   9900,
+		},
+		{
+			name:             "Standard fee but staker balance is insufficient",
+			tokenPath:        gnsPath,
+			amount:           10000,
+			stakerBalance:    0,
+			internal:         false,
+			positionId:       1,
+			poolPath:         "pool1",
+			expectedFee:      100,
+			expectedNet:      9900,
+			expectedHasPanic: true,
+			expectedPanicMsg: "insufficient balance",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			unstakingFee = tc.expectedFee // Set the fee globally for the test
+
+			if tc.stakerBalance > 0 {
+				testing.SetRealm(adminRealm)
+				gns.Transfer(cross, stakerAddr, tc.stakerBalance)
+			}
+
+			testing.SetRealm(stakerRealm)
+
+			if tc.expectedHasPanic {
+				uassert.AbortsWithMessage(t, tc.expectedPanicMsg, func() {
+					handleUnStakingFee(tc.tokenPath, tc.amount, tc.internal, tc.positionId, tc.poolPath)
+				})
+
+				return
+			}
 
 			netAmount, _, err := handleUnStakingFee(tc.tokenPath, tc.amount, tc.internal, tc.positionId, tc.poolPath)
 			if err != nil {

--- a/contract/r/gnoswap/v1/staker/staker.gno
+++ b/contract/r/gnoswap/v1/staker/staker.gno
@@ -536,7 +536,7 @@ func CollectReward(cur realm, positionId uint64, unwrapResult bool) (string, str
 					panic(tErr)
 				}
 			} else {
-				common.Transfer(cross, rewardToken, deposit.owner, toUser)
+				common.SafeGRC20Transfer(cross, rewardToken, deposit.owner, toUser)
 			}
 		}
 


### PR DESCRIPTION
## Descriptions

This PR addresses critical security vulnerabilities identified in the audit regarding unchecked GRC20 token transfers throughout the codebase. The implementation introduces Safe
  transfer functions that validate transfer operations and revert on failure, ensuring atomicity and preventing state inconsistencies.

  ### What Changed
  - **Added SafeGRC20 Helper Functions**: Introduced `SafeGRC20Transfer`, `SafeGRC20TransferFrom`, and `SafeGRC20Approve` in `grc20reg_helper.gno` that panic on transfer failures
  - **Replaced All Unchecked Transfers**: Systematically replaced all `common.Transfer()` and `common.TransferFrom()` calls with their Safe counterparts across 16 contract files
  - **Ensured State Consistency**: All token transfer operations now guarantee atomicity - either complete successfully or revert entirely

  ### Security Issues Resolved
  The audit identified critical vulnerabilities where token transfers could fail silently. This PR addresses all instances:

  **Protocol Components:**
  - **Pool Operations** (pool.gno:340,347): Protocol fee collection now validates transfers
  - **Pool Transfers** (transfer.gno:58,115): All pool token movements validate success
  - **Pool Protocol Fees** (protocol_fee.gno:74,76,77): Withdrawal fee handling now atomic

  **Position Management:**
  - **Position Burns** (burn.gno:133,139): Token returns during liquidity decrease are validated
  - **Position Collections** (position.gno:438,444,452,453): Fee collections and transfers are checked

  **Reward & Incentive Systems:**
  - **Staker Rewards** (staker.gno:539): CollectReward validates reward distribution
  - **External Incentives** (external_incentive.gno:56,160): Deposit and refund transfers are atomic
  - **Gov Staker Rewards** (staker_reward.gno:279): All reward transfers are validated

  **Fee Distribution:**
  - **Protocol Fee State** (state.gno:70,81): DevOps and GovStaker distributions are atomic
  - **Unstaking Fees** (protocol_fee_unstaking.gno:51): Protocol fee transfers validated
  - **Swap Fees** (protocol_fee_swap.gno:85): Router swap fee transfers are checked
