### PR TITLE
fix(pool): Adjust max bps value

### DIFF
--- a/contract/r/gnoswap/v1/pool/protocol_fee.gno
+++ b/contract/r/gnoswap/v1/pool/protocol_fee.gno
@@ -26,7 +26,7 @@ var (
 )
 
 const (
-	MaxBpsValue = uint64(10000)
+	MaxBpsValue = uint64(1000) // 10%
 	ZeroBps     = uint64(0)
 )
 
@@ -164,7 +164,7 @@ func calculateAmountWithFee(amount, fee *u256.Uint) (feeAmount, afterAmount *u25
 	feeAmount = u256.Zero().Mul(amount, fee)
 	feeAmount = u256.Zero().Div(feeAmount, u256.NewUint(MaxBpsValue))
 	afterAmount = u256.Zero().Sub(amount, feeAmount)
-	return
+	return feeAmount, afterAmount
 }
 
 // setPoolCreationFee this function is internal function called by SetPoolCreationFee
@@ -189,7 +189,7 @@ func setWithdrawalFee(fee uint64) error {
 	if fee > MaxBpsValue {
 		return makeErrorWithDetails(
 			errInvalidWithdrawalFeePct,
-			ufmt.Sprintf("fee(%d) must be in range 0 ~ 10000", fee),
+			ufmt.Sprintf("fee(%d) must be in range 0 ~ %d", fee, MaxBpsValue),
 		)
 	}
 

--- a/contract/r/gnoswap/v1/pool/protocol_fee_test.gno
+++ b/contract/r/gnoswap/v1/pool/protocol_fee_test.gno
@@ -190,7 +190,7 @@ func TestHandleWithdrawalFee(t *testing.T) {
 				poolPath := GetPoolPath(wugnotPath, gnsPath, fee3000)
 				return HandleWithdrawalFee(cross, 2, wugnotPath, "1000", gnsPath, "1000", poolPath, alice)
 			},
-			expected:    "990,990",
+			expected:    "900,900",
 			shouldPanic: false,
 		},
 	}
@@ -259,6 +259,18 @@ func TestSetWithdrawalFee(t *testing.T) {
 			expected:    strconv.FormatUint(200, 10),
 			shouldPanic: false,
 		},
+		{
+			name: "exceed max fee, should panic",
+			action: func(t *testing.T) {
+				const newFee = uint64(MaxBpsValue + 1)
+				govRealm := std.NewUserRealm(govAddr)
+				testing.SetRealm(govRealm)
+				SetWithdrawalFee(cross, newFee)
+			},
+			verify:      nil,
+			expected:    "must be in range 0 ~ 1000",
+			shouldPanic: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -270,7 +282,7 @@ func TestSetWithdrawalFee(t *testing.T) {
 					uassert.Equal(t, gotWithdrawalFee, tc.expected)
 				}
 			} else {
-				uassert.AbortsWithMessage(t, tc.expected, func() {
+				uassert.AbortsContains(t, tc.expected, func() {
 					tc.action(t)
 				})
 			}
@@ -290,8 +302,8 @@ func TestCalculateAmountWithFee(t *testing.T) {
 			name:         "normal case",
 			amount:       u256.NewUint(1000),
 			fee:          u256.NewUint(100), // 1%
-			expectedFee:  u256.NewUint(10),
-			expectedRest: u256.NewUint(990),
+			expectedFee:  u256.NewUint(100),
+			expectedRest: u256.NewUint(900),
 		},
 		{
 			name:         "zero amount",
@@ -310,7 +322,7 @@ func TestCalculateAmountWithFee(t *testing.T) {
 		{
 			name:         "max fee",
 			amount:       u256.NewUint(1000),
-			fee:          u256.NewUint(10000), // 100%
+			fee:          u256.NewUint(MaxBpsValue),
 			expectedFee:  u256.NewUint(1000),
 			expectedRest: u256.NewUint(0),
 		},
@@ -318,8 +330,8 @@ func TestCalculateAmountWithFee(t *testing.T) {
 			name:         "large amount",
 			amount:       u256.MustFromDecimal("1000000000000000000"),
 			fee:          u256.NewUint(100),
-			expectedFee:  u256.MustFromDecimal("10000000000000000"),
-			expectedRest: u256.MustFromDecimal("990000000000000000"),
+			expectedFee:  u256.MustFromDecimal("100000000000000000"),
+			expectedRest: u256.MustFromDecimal("900000000000000000"),
 		},
 	}
 


### PR DESCRIPTION
## Description

Previously, max bps could be set up to 100%, but this has been modified to cap it at 10% (1000bps). Related tests have also been added