### PR TITLE
fix(staker): WUGNOT Unwrapping Asymmetry in External Incentive Refunds

### DIFF
--- a/contract/r/gnoswap/v1/staker/external_incentive.gno
+++ b/contract/r/gnoswap/v1/staker/external_incentive.gno
@@ -48,7 +48,9 @@ func CreateExternalIncentive(
 	en.MintAndDistributeGns(cross)
 
 	// transfer reward token from user to staker
+	wasNativeGnot := false
 	if rewardToken == GNOT {
+		wasNativeGnot = true
 		rewardToken = WUGNOT_PATH
 		err := wrapWithTransfer(stakerAddr, rewardAmount)
 		if err != nil {
@@ -77,6 +79,7 @@ func CreateExternalIncentive(
 		currentHeight,
 		depositGnsAmount,
 		currentTime,
+		wasNativeGnot,
 	)
 
 	if externalIncentives.Has(incentiveId) {
@@ -170,14 +173,15 @@ func EndExternalIncentive(cur realm, targetPoolPath, incentiveId string) {
 		refund = poolLeftExternalRewardAmount
 	}
 
-	// unwrap if wugnot
-	isUnwrap := incentive.rewardToken == WUGNOT_PATH
-	if isUnwrap {
+	// handle refund based on original token type
+	if incentive.wasNativeGnot {
+		// unwrap to GNOT if originally deposited as native GNOT
 		transferErr := unwrapWithTransfer(incentive.refundee, refund)
 		if transferErr != nil {
 			panic(transferErr)
 		}
 	} else {
+		// keep as WUGNOT or other token if originally deposited as wrapped token
 		common.SafeGRC20Transfer(cross, incentive.rewardToken, incentive.refundee, refund)
 	}
 
@@ -202,7 +206,7 @@ func EndExternalIncentive(cur realm, targetPoolPath, incentiveId string) {
 		"refundToken", incentive.rewardToken,
 		"refundAmount", formatInt(refund),
 		"refundGnsAmount", formatInt(incentive.depositGnsAmount),
-		"isRequestUnwrap", formatBool(isUnwrap),
+		"wasNativeGnot", formatBool(incentive.wasNativeGnot),
 		"externalIncentiveEndBy", previousRealm.Address().String(),
 	)
 }

--- a/contract/r/gnoswap/v1/staker/type.gno
+++ b/contract/r/gnoswap/v1/staker/type.gno
@@ -22,6 +22,7 @@ type ExternalIncentive struct {
 	refundee         std.Address // refundee address
 
 	refunded bool // whether incentive has been refunded (includes GNS deposit and unclaimed rewards)
+	wasNativeGnot bool // whether the original deposit was native GNOT (needs unwrap on refund)
 }
 
 func (e ExternalIncentive) IsStarted(currentTimestamp int64) bool {
@@ -177,6 +178,7 @@ func NewExternalIncentive(
 	createdHeight int64,
 	depositGnsAmount int64,
 	currentTime int64, // current time in unix time(seconds)
+	wasNativeGnot bool, // whether original deposit was native GNOT
 ) *ExternalIncentive {
 	incentiveDuration := endTimestamp - startTimestamp
 	rewardPerSecond := rewardAmount / incentiveDuration
@@ -193,6 +195,7 @@ func NewExternalIncentive(
 		createdHeight:    createdHeight,
 		depositGnsAmount: depositGnsAmount,
 		refunded:         false,
+		wasNativeGnot:    wasNativeGnot,
 	}
 }
 


### PR DESCRIPTION
## Description

This PR fixes an issue where the `EndExternalIncentive` function incorrectly unwraps WUGNOT refunds to native GNOT, violating the principle that refunds should match the original deposited token type.

Previous behaviours:
- Users depositing **WUGNOT** directly would receive **GNOT** refunds
- Users depositing **native GNOT** (wrapped by the contract) would receive **GNOT** refunds

## Changes

1. **Added `wasNativeGnot` flag to `ExternalIncentive` struct** (type.gno):
   - Tracks whether the original deposit was native GNOT
   - Preserves this information throughout the incentive lifecycle

2. **Modified `NewExternalIncentive` constructor** (type.gno):
   - Added `wasNativeGnot` parameter
   - Stores the flag in the incentive struct

3. **Updated `CreateExternalIncentive` function** (external_incentive.gno):
   - Sets `wasNativeGnot = true` when user sends native GNOT
   - Sets `wasNativeGnot = false` when user sends WUGNOT or other tokens
   - Passes the flag to `NewExternalIncentive`

4. **Fixed refund logic in `EndExternalIncentive`** (external_incentive.gno):