### PR TITLE
fix: check underflow when update swap amounts

### DIFF
--- a/contract/r/gnoswap/v1/pool/swap.gno
+++ b/contract/r/gnoswap/v1/pool/swap.gno
@@ -25,7 +25,8 @@ var (
 	fixedPointQ128 = u256.MustFromDecimal(Q128)
 
 	maxInt256 = u256.MustFromDecimal(MAX_INT256)
-	maxInt64  = i256.MustFromDecimal(MAX_INT64)
+	maxInt64  = i256.Zero().SetInt64(INT64_MAX)
+	minInt64  = i256.Zero().SetInt64(INT64_MIN)
 
 	swapStartHook func(poolPath string, timestamp int64)
 	tickCrossHook func(poolPath string, tickId int32, zeroForOne bool, timestamp int64)
@@ -579,8 +580,13 @@ func updateAmounts(step StepComputations, state SwapState, exactInput bool) (Swa
 	}
 
 	// If an overflowed value is stored in state, it may cause problems in the next step
-	if amountCalculated.Gt(maxInt64) {
+	if amountCalculated.Gt(maxInt64) || amountSpecifiedRemaining.Gt(maxInt64) {
 		return state, errOverFlow
+	}
+
+	// If an underflowed value is stored in state, it may cause problems in the next step
+	if amountCalculated.Lt(minInt64) || amountSpecifiedRemaining.Lt(minInt64) {
+		return state, errUnderflow
 	}
 
 	state.amountSpecifiedRemaining = amountSpecifiedRemaining

--- a/contract/r/gnoswap/v1/pool/utils.gno
+++ b/contract/r/gnoswap/v1/pool/utils.gno
@@ -3,9 +3,9 @@ package pool
 import (
 	"strconv"
 
-	"gno.land/p/nt/ufmt"
 	i256 "gno.land/p/gnoswap/int256"
 	u256 "gno.land/p/gnoswap/uint256"
+	"gno.land/p/nt/ufmt"
 )
 
 const (
@@ -14,6 +14,7 @@ const (
 	MAX_INT128  string = "170141183460469231731687303715884105727"
 	MAX_UINT128 string = "340282366920938463463374607431768211455"
 
+	INT64_MIN int64 = -9223372036854775808
 	INT64_MAX int64 = 9223372036854775807
 
 	Q96_RESOLUTION  uint = 96


### PR DESCRIPTION
## Descriptions

This PR adds underflow validation to the swap amount calculation logic to prevent potential issues when storing negative values that exceed the minimum int64 bounds.

  ## Problem
  The previous implementation only checked for overflow conditions when updating swap amounts, but failed to validate underflow scenarios. This could lead to storing invalid negative
  values in the state, potentially causing unexpected behavior in subsequent swap operations.

  ## Solution
  - Added `minInt64` constant definition using `INT64_MIN` (-9223372036854775808)
  - Fixed `maxInt64` initialization to use `INT64_MAX` directly
  - Implemented underflow checks for both `amountCalculated` and `amountSpecifiedRemaining` before storing them in state
  - Returns `errUnderflow` when values fall below the minimum int64 bounds

  ## Changes

  ### contract/r/gnoswap/v1/pool/swap.gno
  - Added `minInt64` constant for underflow boundary checking
  - Fixed `maxInt64` initialization method
  - Added underflow validation in `updateAmounts()` function
