### PR TITLE
fix(pool): relax `DrySwap` validation to match Swap function behavior

### DIFF
--- a/contract/r/gnoswap/v1/pool/swap.gno
+++ b/contract/r/gnoswap/v1/pool/swap.gno
@@ -278,8 +278,9 @@ func DrySwap(
 		}
 	}
 
-	// Validate non-zero amounts
-	if result.Amount0.IsZero() || result.Amount1.IsZero() {
+	// Validate that at least one amount is non-zero
+	// Both amounts being zero indicates a failed swap
+	if result.Amount0.IsZero() && result.Amount1.IsZero() {
 		return "0", "0", false
 	}
 


### PR DESCRIPTION
## Descriptions

This PR fixes an overly restrictive validation in the `DrySwap` function that was causing legitimate swaps to be incorrectly rejected during simulation.

  ## Problem
  The `DrySwap` function had a validation check that required **both** `result.Amount0` and `result.Amount1` to be non-zero:
  ```go
  // Previous implementation
  if result.Amount0.IsZero() || result.Amount1.IsZero() {
      return "0", "0", false
  }

  This validation was inconsistent with the actual Swap function, which does not enforce this restriction and successfully executes swaps where one amount might be zero.

  Valid Edge Cases Being Rejected

  1. Very small swap amounts: Rounding can cause one token amount to become zero while the other remains positive
  2. Extreme price ratios: When the price difference between tokens is extreme, legitimate swaps could result in one amount being zero
  3. Multi-hop swaps: Exact-out swaps relying on DrySwap for pre-flight validation were incorrectly rejecting valid transactions