### PR TITLE
chore: change immutable contract path

### DIFF
--- a/contract/r/gnoswap/pool/v1/manager.gno
+++ b/contract/r/gnoswap/pool/v1/manager.gno
@@ -7,10 +7,10 @@ import (
 	prbac "gno.land/p/gnoswap/rbac"
 
 	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/common"
 	"gno.land/r/gnoswap/emission"
 	"gno.land/r/gnoswap/gns"
 	"gno.land/r/gnoswap/halt"
-	"gno.land/r/gnoswap/v1/common"
 
 	pf "gno.land/r/gnoswap/v1/protocol_fee"
 )

--- a/contract/r/gnoswap/pool/v1/type.gno
+++ b/contract/r/gnoswap/pool/v1/type.gno
@@ -8,7 +8,7 @@ import (
 	i256 "gno.land/p/gnoswap/int256"
 	u256 "gno.land/p/gnoswap/uint256"
 
-	"gno.land/r/gnoswap/v1/common"
+	"gno.land/r/gnoswap/common"
 )
 
 type PositionInfo struct {

--- a/contract/r/gnoswap/v1/launchpad/launchpad_withdraw.gno
+++ b/contract/r/gnoswap/v1/launchpad/launchpad_withdraw.gno
@@ -8,9 +8,9 @@ import (
 	"gno.land/p/nt/ufmt"
 
 	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/common"
 	"gno.land/r/gnoswap/emission"
 	"gno.land/r/gnoswap/halt"
-	"gno.land/r/gnoswap/v1/common"
 
 	gov_staker "gno.land/r/gnoswap/v1/gov/staker"
 )

--- a/contract/r/scenario/audit/initial_tier_unclaimable_period_filetest.gno
+++ b/contract/r/scenario/audit/initial_tier_unclaimable_period_filetest.gno
@@ -11,11 +11,11 @@ import (
 	"gno.land/p/nt/ufmt"
 
 	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/common"
 	"gno.land/r/gnoswap/emission"
-	"gno.land/r/gnoswap/v1/common"
 
+	"gno.land/r/gnoswap/gnft"
 	"gno.land/r/gnoswap/gns"
-	"gno.land/r/gnoswap/v1/gnft"
 
 	pl "gno.land/r/gnoswap/v1/pool"
 	pn "gno.land/r/gnoswap/v1/position"


### PR DESCRIPTION
## Descriptions

- Change immutable contract paths
    - `gno.land/r/gnoswap/v1/common` -> `gno.land/r/gnoswap/common`
    - `gno.land/r/gnoswap/v1/gnft` -> `gno.land/r/gnoswap/gnft`