### PR TITLE
fix(access): prevent duplicate entries in GetWhitelistedSwaps

### DIFF
--- a/contract/r/gnoswap/access/swap_whitelist.gno
+++ b/contract/r/gnoswap/access/swap_whitelist.gno
@@ -68,8 +68,11 @@ func GetWhitelistedSwaps() []address {
 		routers = append(routers, officialRouter)
 	}
 
-	// Add whitelisted routers
+	// Add whitelisted routers (skip if already added as official router)
 	for router := range swapWhitelist {
+		if ok && router == officialRouter {
+			continue // Skip duplicate
+		}
 		routers = append(routers, router)
 	}
 

--- a/contract/r/gnoswap/access/swap_whitelist_test.gno
+++ b/contract/r/gnoswap/access/swap_whitelist_test.gno
@@ -169,12 +169,14 @@ func TestGetWhitelistedSwaps(t *testing.T) {
 		officialRouter   address
 		whitelistRouters []address
 		expectedCount    int
+		description      string
 	}{
 		{
 			name:             "only official router",
 			officialRouter:   testutils.TestAddress("official"),
 			whitelistRouters: []address{},
 			expectedCount:    1,
+			description:      "should return 1 when only official router exists",
 		},
 		{
 			name:           "official router plus whitelisted",
@@ -184,12 +186,24 @@ func TestGetWhitelistedSwaps(t *testing.T) {
 				testutils.TestAddress("router2"),
 			},
 			expectedCount: 3,
+			description:   "should return 3 when official + 2 whitelisted routers",
 		},
 		{
 			name:             "no official router",
 			officialRouter:   address(""),
 			whitelistRouters: []address{testutils.TestAddress("router1")},
 			expectedCount:    1,
+			description:      "should return 1 when only whitelisted router exists",
+		},
+		{
+			name:           "official router also in whitelist (no duplication)",
+			officialRouter: testutils.TestAddress("official"),
+			whitelistRouters: []address{
+				testutils.TestAddress("official"), // Same as official router
+				testutils.TestAddress("router1"),
+			},
+			expectedCount: 2,
+			description:   "should return 2 without duplication when official router is also whitelisted",
 		},
 	}
 
@@ -208,7 +222,16 @@ func TestGetWhitelistedSwaps(t *testing.T) {
 			}
 
 			routers := GetWhitelistedSwaps()
-			uassert.Equal(t, len(routers), tt.expectedCount)
+			uassert.Equal(t, len(routers), tt.expectedCount, ufmt.Sprintf("%s: expected %d routers, got %d", tt.description, tt.expectedCount, len(routers)))
+
+			// Verify no duplicates
+			seen := make(map[address]bool)
+			for _, r := range routers {
+				if seen[r] {
+					t.Errorf("Duplicate router found: %s", r.String())
+				}
+				seen[r] = true
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary
Fixed a bug in `GetWhitelistedSwaps` function that returned duplicate router addresses when the official router was also added to the swap whitelist.

## Problem
The `GetWhitelistedSwaps` function previously:
1. Added the official router first
2. Then iterated through all whitelisted routers and added them

This caused duplication when the official router address was also manually added to the whitelist map.

**Example scenario:**
```go
// Official router: 0xAAA
// Whitelist: [0xAAA, 0xBBB]
// Result: [0xAAA, 0xAAA, 0xBBB] ❌ (duplicate)
```

## Solution

Modified the logic to skip whitelisted routers that match the official router address:

```go
// Add whitelisted routers (skip if already added as official router)
for router := range swapWhitelist {
    if ok && router == officialRouter {
        continue // Skip duplicate
    }
    routers = append(routers, router)
}
```

After fix:

```
// Official router: 0xAAA
// Whitelist: [0xAAA, 0xBBB]
// Result: [0xAAA, 0xBBB] ✅ (no duplicate)
```

## Performance Improvement

- Time complexity: O(n) (single pass through whitelist)
- Space complexity: O(1) additional space

## Changes

Modified Files

- swap_whitelist.gno: Fixed GetWhitelistedSwaps to prevent duplicates
- swap_whitelist_test.gno: Added test case for duplication scenario