### PR TITLE
refactor(p/fuzzutils): separate fuzz utils with runner

### DIFF
--- a/contract/p/gnoswap/fuzzutils/gnomod.toml
+++ b/contract/p/gnoswap/fuzzutils/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/p/gnoswap/fuzzutils"
+gno = "0.9"

--- a/contract/p/gnoswap/fuzzutils/result.gno
+++ b/contract/p/gnoswap/fuzzutils/result.gno
@@ -1,11 +1,6 @@
-package fuzz
+package fuzzutils
 
-import (
-	"testing"
-
-	_ "gno.land/r/onbloc/bar"
-	_ "gno.land/r/onbloc/foo"
-)
+import "testing"
 
 type Params interface {
 	IsValid() bool

--- a/contract/p/gnoswap/fuzzutils/runner.gno
+++ b/contract/p/gnoswap/fuzzutils/runner.gno
@@ -1,0 +1,112 @@
+package fuzzutils
+
+import (
+	"strings"
+	"testing"
+
+	"gno.land/p/gnoswap/fuzz"
+	"gno.land/p/nt/ufmt"
+)
+
+func RunFuzzTestWithPanic(t *testing.T, iterations int, fn func(*fuzz.T, *Result, int)) {
+	result := NewFuzzResult(fuzz.BASE_SEED)
+	index := 0
+
+	// Use CheckN instead of CheckWithConfig
+	fuzz.CheckN(t, iterations, func(ft *fuzz.T) {
+		index++
+
+		errorMessage, isPanic := handlePanic(func() {
+			fn(ft, result, index)
+		})
+
+		if isPanic {
+			message := strings.TrimSpace(errorMessage)
+			result.AddErrorMessage(index, message)
+		}
+
+		if result.IsValidState(index) == isPanic {
+			result.AddUnexpectedResult(index)
+		}
+	})
+
+	printResultLog(t, iterations, result)
+}
+
+func RunFuzzTestWithCrossPanic(t *testing.T, iterations int, fn func(*fuzz.T, *Result, int)) {
+	result := NewFuzzResult(fuzz.BASE_SEED)
+	index := 0
+
+	// Use CheckN instead of CheckWithConfig
+	fuzz.CheckN(t, iterations, func(ft *fuzz.T) {
+		index++
+
+		errorMessage, isCrossPanic := handleCrossPanic(func() {
+			fn(ft, result, index)
+		})
+
+		if isCrossPanic {
+			message := strings.TrimSpace(errorMessage)
+			result.AddErrorMessage(index, message)
+		}
+
+		if result.IsValidState(index) == isCrossPanic {
+			result.AddUnexpectedResult(index)
+		}
+	})
+
+	printResultLog(t, iterations, result)
+}
+
+func printResultLog(t *testing.T, iterations int, result *Result) {
+	result.PrintLog(t)
+
+	if result.UnexpectedResultsCount() > 0 {
+		panic(ufmt.Sprintf("Fuzz test failed with %d unexpected results", result.UnexpectedResultsCount()))
+	} else {
+		t.Logf("\n=== RESULT: Fuzz test passed %d iterations (success: %d, errors: %d)", iterations, result.SuccessCount(), result.ErrorMessagesCount())
+	}
+}
+
+func handlePanic(fn func()) (msg string, panicked bool) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			return
+		}
+
+		panicked = true
+
+		if err, ok := r.(error); ok {
+			msg = err.Error()
+			return
+		}
+
+		if s, ok := r.(string); ok {
+			msg = s
+			return
+		}
+
+		msg = "unsupported panic type"
+	}()
+
+	fn()
+	return
+}
+
+func handleCrossPanic(fn func()) (string, bool) {
+	r := revive(fn)
+	if r == nil {
+		return "", false
+	}
+
+	if err, ok := r.(error); ok {
+		return err.Error(), true
+	}
+
+	if s, ok := r.(string); ok {
+		return s, true
+	}
+
+	return "unsupported panic type", true
+}

--- a/contract/r/gnoswap/test/fuzz/_helper_test.gno
+++ b/contract/r/gnoswap/test/fuzz/_helper_test.gno
@@ -1,12 +1,9 @@
 package fuzz
 
 import (
-	"strings"
 	"testing"
 
-	"gno.land/p/gnoswap/fuzz"
 	prabc "gno.land/p/gnoswap/rbac"
-	"gno.land/p/nt/ufmt"
 
 	"gno.land/r/gnoswap/access"
 	"gno.land/r/gnoswap/pool"
@@ -28,41 +25,6 @@ var (
 	initializedPosition = false
 	initializedRouter   = false
 )
-
-func runFuzzTest(t *testing.T, iterations int, fn func(*fuzz.T, *Result, int)) {
-	result := NewFuzzResult(fuzz.BASE_SEED)
-	index := 0
-
-	// Use CheckN instead of CheckWithConfig
-	fuzz.CheckN(t, iterations, func(ft *fuzz.T) {
-		index++
-
-		isAborted := false
-
-		r := revive(func() {
-			fn(ft, result, index)
-		})
-
-		if r != nil {
-			isAborted = true
-
-			abortStr := strings.TrimSpace(ufmt.Sprintf("%v", r))
-			result.AddErrorMessage(index, abortStr)
-		}
-
-		if result.IsValidState(index) == isAborted {
-			result.AddUnexpectedResult(index)
-		}
-	})
-
-	result.PrintLog(t)
-
-	if result.UnexpectedResultsCount() > 0 {
-		panic(ufmt.Sprintf("Fuzz test failed with %d unexpected results", result.UnexpectedResultsCount()))
-	} else {
-		t.Logf("\n=== RESULT: Fuzz test passed %d iterations (success: %d, errors: %d)", iterations, result.SuccessCount(), result.ErrorMessagesCount())
-	}
-}
 
 // initStates initializes the states for the fuzz test
 func initStates(t *testing.T) {

--- a/contract/r/gnoswap/test/fuzz/exact_in_swap_route_test.gno
+++ b/contract/r/gnoswap/test/fuzz/exact_in_swap_route_test.gno
@@ -8,6 +8,7 @@ import (
 	prabc "gno.land/p/gnoswap/rbac"
 
 	"gno.land/p/gnoswap/fuzz"
+	"gno.land/p/gnoswap/fuzzutils"
 
 	"gno.land/r/gnoswap/access"
 	"gno.land/r/gnoswap/pool"
@@ -23,7 +24,7 @@ func TestFuzzExactInSwapRoute_ValidParams_Stateless(t *testing.T) {
 	poolAddr, _ := access.GetAddress(prabc.ROLE_POOL.String())
 	routerAddr, _ := access.GetAddress(prabc.ROLE_ROUTER.String())
 
-	runFuzzTest(t, 100, func(ft *fuzz.T, fuzzResult *Result, index int) {
+	fuzzutils.RunFuzzTestWithCrossPanic(t, 100, func(ft *fuzz.T, fuzzResult *fuzzutils.Result, index int) {
 		// initialize the states for the fuzz test
 		initStates(t)
 
@@ -87,7 +88,7 @@ func TestFuzzExactInSwapRoute_RandomizedParams_Stateless(t *testing.T) {
 	poolAddr, _ := access.GetAddress(prabc.ROLE_POOL.String())
 	routerAddr, _ := access.GetAddress(prabc.ROLE_ROUTER.String())
 
-	runFuzzTest(t, 100, func(ft *fuzz.T, fuzzResult *Result, index int) {
+	fuzzutils.RunFuzzTestWithCrossPanic(t, 100, func(ft *fuzz.T, fuzzResult *fuzzutils.Result, index int) {
 		// initialize the states for the fuzz test
 		initStates(t)
 


### PR DESCRIPTION
## Summary

This PR refactors the fuzz testing utilities by extracting them into a separate reusable package (`p/gnoswap/fuzzutils`). The refactoring improves code organization, reusability, and maintainability of fuzz testing infrastructure.

## Changes

### New Package: `p/gnoswap/fuzzutils`

- **Created `runner.gno`**: Provides centralized fuzz test execution logic with two panic handling strategies:
  - `RunFuzzTestWithPanic`: Handles standard panic recovery using Go's `recover()` mechanism
  - `RunFuzzTestWithCrossPanic`: Handles cross-realm panics using the `revive()` function
- **Moved `result.gno`**: Relocated from `r/gnoswap/test/fuzz/` to `p/gnoswap/fuzzutils/` to make it a shared utility
  - Removed test-specific imports and dependencies
  - Made the `Result` type and related functions available as a reusable component

### Refactored Test Files

- **Updated `_helper_test.gno`**: Removed the `runFuzzTest` function, which is now replaced by the centralized runner functions
- **Updated `exact_in_swap_route_test.gno`**: Migrated to use `fuzzutils.RunFuzzTestWithCrossPanic` instead of the local helper function
