### PR TITLE
feat: apply random seed in fuzz test CI environment

### DIFF
--- a/.github/scripts/update_fuzz_seed.sh
+++ b/.github/scripts/update_fuzz_seed.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Update BASE_SEED in p/gnoswap/fuzz/seed.gno with current Unix timestamp
+# This ensures each CI run uses a different random seed for fuzz testing
+
+set -e
+
+SEED_FILE="contract/p/gnoswap/fuzz/seed.gno"
+TIMESTAMP=$(date +%s)
+
+if [ ! -f "$SEED_FILE" ]; then
+    echo "Error: seed.gno not found at $SEED_FILE"
+    exit 1
+fi
+
+echo "Updating BASE_SEED to Unix timestamp: $TIMESTAMP"
+
+# Use sed to replace the BASE_SEED value
+# macOS and Linux have different sed syntax, so we handle both
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS
+    sed -i '' "s/const BASE_SEED = [0-9]*/const BASE_SEED = $TIMESTAMP/" "$SEED_FILE"
+else
+    # Linux
+    sed -i "s/const BASE_SEED = [0-9]*/const BASE_SEED = $TIMESTAMP/" "$SEED_FILE"
+fi
+
+echo "BASE_SEED updated successfully"
+cat "$SEED_FILE"

--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -58,6 +58,11 @@ jobs:
           cd gno
           make install.gno
 
+      - name: Update fuzz test seed
+        run: |
+          chmod +x .github/scripts/update_fuzz_seed.sh
+          .github/scripts/update_fuzz_seed.sh
+
       - name: "Run tests for ${{ matrix.name }}"
         run: |
           chmod +x .github/scripts/run_tests.rb


### PR DESCRIPTION
## Summary
 Add automatic seed randomization for fuzz tests in CI environment to improve test coverage by using different random       seeds for each CI run.

 ## Changes

 ### 1. New Script: `.github/scripts/update_fuzz_seed.sh`
 - Automatically updates `BASE_SEED` in `p/gnoswap/fuzz/seed.gno` with current Unix timestamp
 - Supports both macOS and Linux (handles different sed syntax)
 - Ensures each CI run uses a different random seed

 ### 2. GitHub Actions Update: `.github/workflows/run_test.yml`
 - Added "Update fuzz test seed" step before running tests
 - Executes the seed update script automatically in CI environment

 ## Benefits
 - **Improved Coverage**: Each CI run tests with different random inputs
 - **Bug Detection**: Increased chance of discovering edge cases
 - **Reproducibility**: Failed test cases can be reproduced using the logged seed value
 - **Zero Maintenance**: Fully automated with no manual intervention required