### PR TITLE
fix(gnsmath): use MustDiv to properly handle division by zero in getNextPriceAmount1Add

### DIFF
--- a/contract/p/gnoswap/gnsmath/sqrt_price_math.gno
+++ b/contract/p/gnoswap/gnsmath/sqrt_price_math.gno
@@ -100,7 +100,7 @@ func getNextPriceAmount1Add(
 	if amount.Lte(max160) {
 		// Use local variables to avoid allocation conflicts
 		shifted := u256.Zero().Lsh(amount, Q96_RESOLUTION)
-		quotient = u256.Zero().Div(shifted, liquidity)
+		quotient = u256.Zero().MustDiv(shifted, liquidity)
 	} else {
 		quotient = u256.MulDiv(amount, q96, liquidity)
 	}


### PR DESCRIPTION
## Problem

  The `getNextPriceAmount1Add` function in `sqrt_price_math.gno` was using `Div` instead of `MustDiv` for division operations. This caused incorrect behavior when `liquidity` is zero:

  - `Div(x, 0)` silently returns `0` without panicking
  - `MustDiv(x, 0)` properly panics with "division by zero" error

  This discrepancy led to fuzz test failures where cases with `liquidity=0` would pass unexpectedly instead of being rejected.

  ### Issue Found
  - **SEED**: 1762705589
  - **Test**: `TestFuzzGetNextPriceAmount1Add_RandomizedParams_Stateless`
  - **Iterations**: 6, 9
  - **Error**: "should be failed but passed" with `liquidity=0`

  ## Solution

  Changed `Div` to `MustDiv` in line 103 of `sqrt_price_math.gno`:

  ```diff
  - quotient = u256.Zero().Div(shifted, liquidity)
  + quotient = u256.Zero().MustDiv(shifted, liquidity)
```

  This ensures consistent behavior across all code paths:
  - Small amounts (≤ max160): now uses MustDiv → panics on division by zero
  - Large amounts (> max160): already uses MulDiv → panics on division by zero