### PR TITLE
fix(governance): proposal to cancel conditions

### DIFF
--- a/contract/r/gnoswap/gov/governance/v1/proposal_action_status.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal_action_status.gno
@@ -21,11 +21,10 @@ func NewProposalActionStatusResolver(status *governance.ProposalActionStatus) *P
 //   - canceledBy: address performing the cancellation
 //
 // Returns:
-//   - error: cancellation error if proposal cannot be canceled
-func (p *ProposalActionStatusResolver) Cancel(canceledAt int64, canceledHeight int64, canceledBy address) error {
-	// Only executable proposals can be canceled (text proposals cannot)
-	if !p.IsExecutable() {
-		return errProposalNotExecutable
+//   - error: already canceled error if proposal action status is already canceled
+func (p *ProposalActionStatusResolver) cancel(canceledAt int64, canceledHeight int64, canceledBy address) error {
+	if p.Canceled() {
+		return errAlreadyCanceledProposal
 	}
 
 	// Record cancellation details
@@ -46,11 +45,15 @@ func (p *ProposalActionStatusResolver) Cancel(canceledAt int64, canceledHeight i
 //   - executedBy: address performing the execution
 //
 // Returns:
-//   - error: execution error if proposal cannot be executed
+//   - error: already canceled error if proposal action status is already canceled
 func (p *ProposalActionStatusResolver) Execute(executedAt int64, executedHeight int64, executedBy address) error {
 	// Only executable proposals can be executed (text proposals cannot)
 	if !p.IsExecutable() {
 		return errProposalNotExecutable
+	}
+
+	if p.Canceled() {
+		return errAlreadyCanceledProposal
 	}
 
 	// Record execution details

--- a/contract/r/gnoswap/gov/governance/v1/proposal_action_status_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal_action_status_test.gno
@@ -13,6 +13,7 @@ func TestProposalActionStatus_CancelAndExecute(t *testing.T) {
 		name            string
 		executable      bool
 		operation       string // "cancel" or "execute"
+		canceled        bool
 		timestamp       int64
 		height          int64
 		actor           address
@@ -23,6 +24,7 @@ func TestProposalActionStatus_CancelAndExecute(t *testing.T) {
 			name:          "Success - Cancel executable proposal",
 			executable:    true,
 			operation:     "cancel",
+			canceled:      false,
 			timestamp:     1000,
 			height:        100,
 			actor:         address("g1canceler"),
@@ -32,15 +34,17 @@ func TestProposalActionStatus_CancelAndExecute(t *testing.T) {
 			name:          "Success - Execute executable proposal",
 			executable:    true,
 			operation:     "execute",
+			canceled:      false,
 			timestamp:     1000,
 			height:        100,
 			actor:         address("g1executor"),
 			expectedError: false,
 		},
 		{
-			name:          "Failure - Cancel non-executable proposal",
+			name:          "Failure - Cancel already canceled proposal",
 			executable:    false,
 			operation:     "cancel",
+			canceled:      true,
 			timestamp:     1000,
 			height:        100,
 			actor:         address("g1canceler"),
@@ -50,6 +54,17 @@ func TestProposalActionStatus_CancelAndExecute(t *testing.T) {
 			name:          "Failure - Execute non-executable proposal",
 			executable:    false,
 			operation:     "execute",
+			canceled:      false,
+			timestamp:     1000,
+			height:        100,
+			actor:         address("g1executor"),
+			expectedError: true,
+		},
+		{
+			name:          "Failure - Execute already canceled proposal",
+			executable:    true,
+			operation:     "execute",
+			canceled:      true,
 			timestamp:     1000,
 			height:        100,
 			actor:         address("g1executor"),
@@ -62,10 +77,13 @@ func TestProposalActionStatus_CancelAndExecute(t *testing.T) {
 			// given
 			status := governance.NewProposalActionStatus(tc.executable)
 			resolver := NewProposalActionStatusResolver(status)
+			if tc.canceled {
+				resolver.SetCanceled(true)
+			}
 			// when
 			var err error
 			if tc.operation == "cancel" {
-				err = resolver.Cancel(tc.timestamp, tc.height, tc.actor)
+				err = resolver.cancel(tc.timestamp, tc.height, tc.actor)
 			} else {
 				err = resolver.Execute(tc.timestamp, tc.height, tc.actor)
 			}

--- a/contract/r/gnoswap/gov/governance/v1/proposal_status.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal_status.gno
@@ -183,7 +183,7 @@ func (p *ProposalStatusResolver) IsCanceled(current int64) bool {
 // Returns:
 //   - error: cancellation error if operation fails
 func (p *ProposalStatusResolver) cancel(canceledAt int64, canceledHeight int64, canceledBy address) error {
-	return p.actionStatusResolver.Cancel(canceledAt, canceledHeight, canceledBy)
+	return p.actionStatusResolver.cancel(canceledAt, canceledHeight, canceledBy)
 }
 
 // execute marks the proposal as executed with the provided details.

--- a/contract/r/scenario/gov/governance/governance_proposal_cancel_status_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_proposal_cancel_status_filetest.gno
@@ -1,0 +1,135 @@
+// governance proposal text cancel status
+
+// PKGPATH: gno.land/r/gnoswap/v1/main
+
+package main
+
+import (
+	"chain/runtime"
+	"testing"
+
+	"gno.land/p/nt/uassert"
+	"gno.land/p/nt/ufmt"
+
+	prbac "gno.land/p/gnoswap/rbac"
+	_ "gno.land/r/gnoswap/rbac"
+
+	_ "gno.land/r/gnoswap/protocol_fee"
+	_ "gno.land/r/gnoswap/protocol_fee/v1"
+
+	"gno.land/r/gnoswap/access"
+
+	"gno.land/r/gnoswap/gov/governance"
+	_ "gno.land/r/gnoswap/gov/governance/v1"
+
+	gs "gno.land/r/gnoswap/gov/staker"
+	_ "gno.land/r/gnoswap/gov/staker/v1"
+
+	gns "gno.land/r/gnoswap/gns"
+)
+
+var t *testing.T
+
+var (
+	adminAddr        = access.MustGetAddress(prbac.ROLE_ADMIN.String())
+	govStakerAddr    = access.MustGetAddress(prbac.ROLE_GOV_STAKER.String())
+	currentBlockTime = int64(2)
+)
+
+func main() {
+	testing.SetRealm(testing.NewUserRealm(adminAddr))
+	config := governance.GetLatestConfig()
+
+	println("[SCENARIO] 1. Delegate gns to admin")
+	delegateGnsToAdmin()
+	println()
+
+	println("[SCENARIO] 2. Skip vote weight smoothing duration for create proposal")
+	testing.SkipHeights(int64(config.VotingWeightSmoothingDuration) / currentBlockTime)
+	println("[INFO] current height:", runtime.ChainHeight())
+	println()
+
+	println("[SCENARIO] 3. Propose community pool spend")
+	proposalId := proposeTextProposal()
+	println()
+
+	println("[SCENARIO] 4. Cancel Proposal is successful by upcoming proposal")
+	cancelProposalWithError(proposalId, false, "")
+	println()
+
+	println("[SCENARIO] 5. Cancel Proposal is aborted by already canceled proposal")
+	cancelProposalWithError(proposalId, true, "[GNOSWAP-GOVERNANCE-008]")
+	println()
+
+	println("[SCENARIO] 6. Propose community pool spend")
+	proposalId2 := proposeTextProposal()
+	println()
+
+	println("[SCENARIO] 7. Skip heights for active proposal")
+	testing.SkipHeights(int64(config.VotingStartDelay) / currentBlockTime)
+	println("[INFO] current height:", runtime.ChainHeight())
+	println()
+
+	println("[SCENARIO] 8. Cancel Proposal is aborted by active proposal")
+	cancelProposalWithError(proposalId2, true, "[GNOSWAP-GOVERNANCE-009]")
+	println()
+}
+
+func delegateGnsToAdmin() {
+	delegatedAmount := int64(1_000_000_000)
+	testing.SetRealm(testing.NewUserRealm(adminAddr))
+	gns.Approve(cross, govStakerAddr, delegatedAmount)
+	gs.Delegate(cross, adminAddr, int64(delegatedAmount), "")
+	ufmt.Printf("[INFO] gns delegated to %s (amount: %d)\n", adminAddr.String(), delegatedAmount)
+}
+
+func proposeTextProposal() int64 {
+	testing.SetRealm(testing.NewUserRealm(adminAddr))
+	proposalId := governance.ProposeText(cross, "test_title", "test_description")
+	ufmt.Printf("[INFO] created proposal ID: %d\n", proposalId)
+	return proposalId
+}
+
+func voteProposal(proposalId int64) {
+	testing.SetRealm(testing.NewUserRealm(adminAddr))
+	governance.Vote(cross, proposalId, true)
+	state := governance.GetExecutionStateByProposalId(proposalId)
+	ufmt.Printf("[EXPECTED] after voting - %s\n", state)
+}
+
+func cancelProposalWithError(proposalId int64, hasAborted bool, abortMessage string) {
+	testing.SetRealm(testing.NewUserRealm(adminAddr))
+	if hasAborted {
+		uassert.AbortsContains(t, abortMessage, func() {
+			governance.Cancel(cross, proposalId)
+		})
+	} else {
+		governance.Cancel(cross, proposalId)
+	}
+	ufmt.Printf("[EXPECTED] proposal canceled and archived\n")
+}
+
+// Output:
+// [SCENARIO] 1. Delegate gns to admin
+// [INFO] gns delegated to g17290cwvmrapvp869xfnhhawa8sm9edpufzat7d (amount: 1000000000)
+//
+// [SCENARIO] 2. Skip vote weight smoothing duration for create proposal
+// [INFO] current height: 43323
+//
+// [SCENARIO] 3. Propose community pool spend
+// [INFO] created proposal ID: 1
+//
+// [SCENARIO] 4. Cancel Proposal is successful by upcoming proposal
+// [EXPECTED] proposal canceled and archived
+//
+// [SCENARIO] 5. Cancel Proposal is aborted by already canceled proposal
+// [EXPECTED] proposal canceled and archived
+//
+// [SCENARIO] 6. Propose community pool spend
+// [INFO] created proposal ID: 2
+//
+// [SCENARIO] 7. Skip heights for active proposal
+// [INFO] current height: 86523
+//
+// [SCENARIO] 8. Cancel Proposal is aborted by active proposal
+// [EXPECTED] proposal canceled and archived


### PR DESCRIPTION
## Descriptions

The previous implementation had an incorrect condition for canceling proposals. It only allowed executable proposals to be canceled, which prevented text proposals from being canceled. Additionally, there was no check to prevent executing already-canceled proposals.

### Changes

**1. Updated cancel conditions**
- Changed the cancel condition from checking if the proposal is executable to checking if it's already canceled
- This allows both text and executable proposals to be canceled as long as they haven't been canceled before
- Method renamed from `Cancel` to `cancel` (made private)

**2. Added execution safeguard**
- Added a check in the `Execute` method to prevent executing proposals that have already been canceled
- Returns `errAlreadyCanceledProposal` error when attempting to execute a canceled proposal