### PR TITLE
fix(pool): json parse error in api method

### DIFF
--- a/contract/r/gnoswap/pool/v1/api.gno
+++ b/contract/r/gnoswap/pool/v1/api.gno
@@ -17,9 +17,11 @@ func (i *poolV1) ApiGetPool(poolPath string) string {
 		return ""
 	}
 
+	pool := i.mustGetPool(poolPath)
+
 	node := json.ObjectNode("", map[string]*json.Node{
 		"stat":     newStatNode().JSON(),
-		"response": newRpcPool(i, poolPath).JSON(),
+		"response": newRpcPool(pool, poolPath).JSON(),
 	})
 
 	return marshal(node)

--- a/contract/r/gnoswap/pool/v1/json.gno
+++ b/contract/r/gnoswap/pool/v1/json.gno
@@ -47,13 +47,10 @@ type RpcPool struct {
 	Ticks RpcTicks `json:"ticks"`
 
 	TickBitmaps RpcTickBitmaps `json:"tickBitmaps"`
-
-	Positions RpcPositions `json:"positions"`
 }
 
-func newRpcPool(i *poolV1, poolPath string) RpcPool {
+func newRpcPool(pool *pl.Pool, poolPath string) RpcPool {
 	rpcPool := RpcPool{}
-	pool := i.mustGetPool(poolPath)
 
 	rpcPool.PoolPath = poolPath
 
@@ -125,28 +122,6 @@ func newRpcPool(i *poolV1, poolPath string) RpcPool {
 		return false
 	})
 
-	rpcPositions := []RpcPosition{}
-	pool.Positions().Iterate("", "", func(posKey string, iPositionInfo any) bool {
-		owner, tickLower, tickUpper := posKeyDivide(posKey)
-		posInfo, ok := iPositionInfo.(pl.PositionInfo)
-		if !ok {
-			panic("failed to cast position info to PositionInfo")
-		}
-
-		rpcPositions = append(rpcPositions, RpcPosition{
-			Owner:      owner,
-			TickLower:  tickLower,
-			TickUpper:  tickUpper,
-			Liquidity:  posInfo.Liquidity().ToString(),
-			Token0Owed: posInfo.TokensOwed0().ToString(),
-			Token1Owed: posInfo.TokensOwed1().ToString(),
-		})
-
-		return false
-	})
-
-	rpcPool.Positions = rpcPositions
-
 	return rpcPool
 }
 
@@ -175,7 +150,6 @@ func makePoolNode(pool RpcPool) *json.Node {
 		"liquidity":            json.StringNode("liquidity", pool.Liquidity),
 		"ticks":                pool.Ticks.JSON(),
 		"tickBitmaps":          pool.TickBitmaps.JSON(),
-		"positions":            pool.Positions.JSON(),
 	})
 }
 


### PR DESCRIPTION
## Descriptions

The `ApiGetPool` method was encountering JSON parsing errors in the VM when attempting to serialize pool data that included position information. This was causing failures when retrieving pool details through the API.

### Changes

**1. Refactored pool retrieval flow**
- Modified `ApiGetPool` to fetch the pool instance first before passing it to `newRpcPool`
- Changed `newRpcPool` function signature to accept `*pl.Pool` directly instead of `*poolV1` instance

**2. Removed position data from pool API response**
- Removed `Positions` field from `RpcPool` struct
- Eliminated the positions iteration logic in `newRpcPool` function
- Removed positions field from JSON node construction in `makePoolNode`