### PR TITLE
test(integration): add missing fee values to measurement tests

### DIFF
--- a/tests/integration/testdata/base/comment_gas_measurement.txtar
+++ b/tests/integration/testdata/base/comment_gas_measurement.txtar
@@ -3,39 +3,63 @@ gnoland start
 
 # Deploy realm without comments
 gnokey maketx addpkg -pkgdir $WORK/nocomment -pkgpath gno.land/r/test/nocomment -gas-fee 100000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   328452'
 
 # Deploy realm with comments (same logic)
 gnokey maketx addpkg -pkgdir $WORK/withcomment -pkgpath gno.land/r/test/withcomment -gas-fee 100000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   343204'
 
 # Deploy realm with heavy comments (lots of comments)
 gnokey maketx addpkg -pkgdir $WORK/heavycomment -pkgpath gno.land/r/test/heavycomment -gas-fee 100000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   390698'
+
+# Deploy caller realm
+gnokey maketx addpkg -pkgdir $WORK/caller -pkgpath gno.land/r/test/caller -gas-fee 100000ugnot -gas-wanted 50000000 -broadcast -chainid=tendermint_test test1
+# stdout 'GAS USED:   754645'
 
 ### Call each realm to check runtime load cost ###
 
-# Call no comment realm
-gnokey maketx call -pkgpath gno.land/r/test/nocomment -func DoAdd -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# Call no comment realm (single)
+gnokey maketx call -pkgpath gno.land/r/test/caller -func CallNoCommentOnce -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
+# stdout 'GAS USED:   308405'
 
-# Call with comment realm
-gnokey maketx call -pkgpath gno.land/r/test/withcomment -func DoAdd -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# Call with comment realm (single)
+gnokey maketx call -pkgpath gno.land/r/test/caller -func CallWithCommentOnce -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
+# stdout 'GAS USED:   309863'
 
-# Call heavy comment realm
-gnokey maketx call -pkgpath gno.land/r/test/heavycomment -func DoAdd -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# Call heavy comment realm (single)
+gnokey maketx call -pkgpath gno.land/r/test/caller -func CallHeavyCommentOnce -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
+# stdout 'GAS USED:   310669'
 
-### Second call (cached) ###
+### Call twice in same transaction (cached) ###
 
-# Call no comment realm again
-gnokey maketx call -pkgpath gno.land/r/test/nocomment -func DoAdd -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# Call no comment realm twice in one tx
+gnokey maketx call -pkgpath gno.land/r/test/caller -func CallNoCommentTwice -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
+# stdout 'GAS USED:   309915'
 
-# Call heavy comment realm again
-gnokey maketx call -pkgpath gno.land/r/test/heavycomment -func DoAdd -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# Call with comment realm twice in one tx
+gnokey maketx call -pkgpath gno.land/r/test/caller -func CallWithCommentTwice -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
+# stdout 'GAS USED:   311367'
+
+# Call heavy comment realm twice in one tx
+gnokey maketx call -pkgpath gno.land/r/test/caller -func CallHeavyCommentTwice -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
+# stdout 'GAS USED:   312173'
+
+### Call 5 times in same transaction ###
+
+# Call no comment realm 5x in one tx
+gnokey maketx call -pkgpath gno.land/r/test/caller -func CallNoComment5x -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
+# stdout 'GAS USED:   314367'
+
+# Call heavy comment realm 5x in one tx
+gnokey maketx call -pkgpath gno.land/r/test/caller -func CallHeavyComment5x -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
+# stdout 'GAS USED:   316625'
+
+### Call with comment and heavy comment ###
+
+# Call with comment and heavy comment realm in one tx
+gnokey maketx call -pkgpath gno.land/r/test/caller -func CallDiffentFunctionTwiceInSameTx -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
+# stdout 'GAS USED:   311488'
 
 -- nocomment/gnomod.toml --
 module = "gno.land/r/test/nocomment"
@@ -60,10 +84,6 @@ func Divide(a, b int) int {
 		panic("division by zero")
 	}
 	return a / b
-}
-
-func DoAdd(cur realm) int {
-	return Add(1, 2)
 }
 
 -- withcomment/gnomod.toml --
@@ -98,11 +118,6 @@ func Divide(a, b int) int {
 		panic("division by zero")
 	}
 	return a / b
-}
-
-// DoAdd is an exported function that calls Add internally.
-func DoAdd(cur realm) int {
-	return Add(1, 2)
 }
 
 -- heavycomment/gnomod.toml --
@@ -214,22 +229,65 @@ func Divide(a, b int) int {
 	return a / b
 }
 
-// DoAdd is an exported function that demonstrates internal function calls.
-//
-// This function serves as an entry point for external callers.
-// It internally calls the Add function with predefined parameters.
-//
-// Parameters:
-//   - cur: The current realm context (required for cross-realm calls)
-//
-// Returns:
-//   - int: The result of Add(1, 2), which is 3
-//
-// Example:
-//   result := DoAdd()  // result = 3
-func DoAdd(cur realm) int {
-	// Call the internal Add function with test values
-	// This demonstrates how internal functions can be wrapped
-	// for external access
-	return Add(1, 2)
+-- caller/gnomod.toml --
+module = "gno.land/r/test/caller"
+gno = "0.9"
+-- caller/caller.gno --
+package caller
+
+import (
+	"gno.land/r/test/nocomment"
+	"gno.land/r/test/withcomment"
+	"gno.land/r/test/heavycomment"
+)
+
+// Single calls
+func CallNoCommentOnce(cur realm) {
+	nocomment.Add(1, 2)
+}
+
+func CallWithCommentOnce(cur realm) {
+	withcomment.Add(1, 2)
+}
+
+func CallHeavyCommentOnce(cur realm) {
+	heavycomment.Add(1, 2)
+}
+
+// Double calls (same tx - test caching)
+func CallNoCommentTwice(cur realm) {
+	nocomment.Add(1, 2)
+	nocomment.Add(3, 4)
+}
+
+func CallWithCommentTwice(cur realm) {
+	withcomment.Add(1, 2)
+	withcomment.Add(3, 4)
+}
+
+func CallHeavyCommentTwice(cur realm) {
+	heavycomment.Add(1, 2)
+	heavycomment.Add(3, 4)
+}
+
+// 5x calls (same tx)
+func CallNoComment5x(cur realm) {
+	nocomment.Add(1, 2)
+	nocomment.Add(2, 3)
+	nocomment.Add(3, 4)
+	nocomment.Add(4, 5)
+	nocomment.Add(5, 6)
+}
+
+func CallHeavyComment5x(cur realm) {
+	heavycomment.Add(1, 2)
+	heavycomment.Add(2, 3)
+	heavycomment.Add(3, 4)
+	heavycomment.Add(4, 5)
+	heavycomment.Add(5, 6)
+}
+
+func CallDiffentFunctionTwiceInSameTx(cur realm) {
+	withcomment.Add(1, 2)
+	withcomment.Multiply(3, 4)
 }

--- a/tests/integration/testdata/base/cross_realm_depth_gas_measurement.txtar
+++ b/tests/integration/testdata/base/cross_realm_depth_gas_measurement.txtar
@@ -24,46 +24,46 @@ gnokey maketx addpkg -pkgdir $WORK/caller -pkgpath gno.land/r/test/caller -gas-f
 ### Baseline ###
 # Direct call (no cross-realm)
 gnokey maketx call -pkgpath gno.land/r/test/caller -func DirectCall -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   209647'
 
 ### Cross-realm depth tests ###
 # Depth 1: Caller -> RealmA
 gnokey maketx call -pkgpath gno.land/r/test/caller -func CallDepth1 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   331870'
 
 # Depth 2: Caller -> RealmA -> RealmB
 gnokey maketx call -pkgpath gno.land/r/test/caller -func CallDepth2 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   441563'
 
 # Depth 3: Caller -> RealmA -> RealmB -> RealmC
 gnokey maketx call -pkgpath gno.land/r/test/caller -func CallDepth3 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   538856'
 
 # Depth 4: Caller -> RealmA -> RealmB -> RealmC -> RealmD
 gnokey maketx call -pkgpath gno.land/r/test/caller -func CallDepth4 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   623797'
 
 # Depth 5: Caller -> RealmA -> RealmB -> RealmC -> RealmD -> RealmE
 gnokey maketx call -pkgpath gno.land/r/test/caller -func CallDepth5 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   693706'
 
-### Second call (check caching) ###
-# Depth 1 again
-gnokey maketx call -pkgpath gno.land/r/test/caller -func CallDepth1 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+### Second call in same TX (check caching) ###
+# Depth 1 twice in same tx
+gnokey maketx call -pkgpath gno.land/r/test/caller -func CallDepth1Twice -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
+# stdout 'GAS USED:   333441'
 
-# Depth 5 again
-gnokey maketx call -pkgpath gno.land/r/test/caller -func CallDepth5 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# Depth 5 twice in same tx
+gnokey maketx call -pkgpath gno.land/r/test/caller -func CallDepth5Twice -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
+# stdout 'GAS USED:   700657'
 
 ### Multiple sequential cross-realm calls ###
 # Call depth 1 x 5 times sequentially
 gnokey maketx call -pkgpath gno.land/r/test/caller -func CallDepth1x5 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   337893'
 
 # Call depth 2 x 5 times sequentially
 gnokey maketx call -pkgpath gno.land/r/test/caller -func CallDepth2x5 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   452996'
 
 -- realma/gnomod.toml --
 module = "gno.land/r/test/realma"
@@ -226,24 +226,32 @@ func CallDepth5(cur realm) int {
 	return realma.CallBtoCtoDtoE(1, 2)
 }
 
+// Depth 1 twice in same tx (caching test)
+func CallDepth1Twice(cur realm) {
+	realma.Add(1, 2)
+	realma.Add(3, 4)
+}
+
+// Depth 5 twice in same tx (caching test)
+func CallDepth5Twice(cur realm) {
+	realma.CallBtoCtoDtoE(1, 2)
+	realma.CallBtoCtoDtoE(3, 4)
+}
+
 // Multiple depth 1 calls
-func CallDepth1x5(cur realm) int {
-	sum := 0
-	sum += realma.Add(1, 2)
-	sum += realma.Add(2, 3)
-	sum += realma.Add(3, 4)
-	sum += realma.Add(4, 5)
-	sum += realma.Add(5, 6)
-	return sum
+func CallDepth1x5(cur realm) {
+	realma.Add(1, 2)
+	realma.Add(2, 3)
+	realma.Add(3, 4)
+	realma.Add(4, 5)
+	realma.Add(5, 6)
 }
 
 // Multiple depth 2 calls
-func CallDepth2x5(cur realm) int {
-	sum := 0
-	sum += realma.CallB(1, 2)
-	sum += realma.CallB(2, 3)
-	sum += realma.CallB(3, 4)
-	sum += realma.CallB(4, 5)
-	sum += realma.CallB(5, 6)
-	return sum
+func CallDepth2x5(cur realm) {
+	realma.CallB(1, 2)
+	realma.CallB(2, 3)
+	realma.CallB(3, 4)
+	realma.CallB(4, 5)
+	realma.CallB(5, 6)
 }

--- a/tests/integration/testdata/base/data_structure_gas_measurement.txtar
+++ b/tests/integration/testdata/base/data_structure_gas_measurement.txtar
@@ -8,148 +8,148 @@ gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/test/datastructgas -gas-f
 ### Baseline ###
 # Empty function (baseline)
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func Empty -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   546366'
 
 ### AVL Tree Operations ###
 ## Insert
 # AVL Insert 10 items
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func AVLInsert10 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   3825697'
 
 # AVL Insert 100 items
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func AVLInsert100 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   29445923'
 
 # AVL Insert 1000 items
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func AVLInsert1000 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   410927833'
 
 ## Get (from pre-populated tree)
 # AVL Get from 10 items (single lookup)
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func AVLGet10 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   3852991'
 
 # AVL Get from 100 items (single lookup)
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func AVLGet100 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   29497570'
 
 # AVL Get from 1000 items (single lookup)
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func AVLGet1000 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   410994369'
 
 ## Iterate
 # AVL Iterate 10 items
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func AVLIterate10 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   4248631'
 
 # AVL Iterate 100 items
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func AVLIterate100 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   33828593'
 
 ### Map Operations ###
 ## Insert
 # Map Insert 10 items
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func MapInsert10 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2303943'
 
 # Map Insert 100 items
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func MapInsert100 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   3037723'
 
 # Map Insert 1000 items
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func MapInsert1000 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   22758533'
 
 ## Get (from pre-populated map)
 # Map Get from 10 items (single lookup)
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func MapGet10 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2304199'
 
 # Map Get from 100 items (single lookup)
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func MapGet100 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   3037979'
 
 # Map Get from 1000 items (single lookup)
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func MapGet1000 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   22758789'
 
 ## Iterate
 # Map Iterate 10 items
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func MapIterate10 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2306892'
 
 # Map Iterate 100 items
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func MapIterate100 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   3059572'
 
 ### Slice Operations ###
 ## Append (no pre-allocation)
 # Slice Append 10 items
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func SliceAppend10 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   575660'
 
 # Slice Append 100 items
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func SliceAppend100 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   1007130'
 
 # Slice Append 1000 items
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func SliceAppend1000 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   23141740'
 
 ## Pre-allocated (make with capacity)
 # Slice PreAlloc 10 items
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func SlicePreAlloc10 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   574078'
 
 # Slice PreAlloc 100 items
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func SlicePreAlloc100 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   790628'
 
 # Slice PreAlloc 1000 items
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func SlicePreAlloc1000 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2956038'
 
 ### Struct Copy vs Pointer ###
 # Small struct copy (3 fields)
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func SmallStructCopy -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   549708'
 
 # Small struct pointer
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func SmallStructPointer -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   549612'
 
 # Large struct copy (10 fields)
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func LargeStructCopy -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   551710'
 
 # Large struct pointer
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func LargeStructPointer -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   551054'
 
 # XLarge struct copy (20 fields)
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func XLargeStructCopy -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   554580'
 
 # XLarge struct pointer
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func XLargeStructPointer -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   553124'
 
 ### Multiple struct operations (100 iterations) ###
 # Small struct copy x100
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func SmallStructCopy100 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   768635'
 
 # Small struct pointer x100
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func SmallStructPointer100 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   738443'
 
 # Large struct copy x100
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func LargeStructCopy100 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   893298'
 
 # Large struct pointer x100
 gnokey maketx call -pkgpath gno.land/r/test/datastructgas -func LargeStructPointer100 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   834826'
 
 -- gnomod.toml --
 module = "gno.land/r/test/datastructgas"

--- a/tests/integration/testdata/base/pkg_realm_call_gas_measurement.txtar
+++ b/tests/integration/testdata/base/pkg_realm_call_gas_measurement.txtar
@@ -13,86 +13,86 @@ gnokey maketx addpkg -pkgdir $WORK/caller -pkgpath gno.land/r/test/caller -gas-f
 ### Baseline ###
 # Empty call
 gnokey maketx call -pkgpath gno.land/r/test/caller -func Empty -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   338646'
 
 ### Simple function (no state) ###
 # Call package function (Add)
 gnokey maketx call -pkgpath gno.land/r/test/caller -func CallPkgAdd -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   407490'
 
 # Call realm function (Add)
 gnokey maketx call -pkgpath gno.land/r/test/caller -func CallRealmAdd -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   475214'
 
 # Inline calculation (Add)
 gnokey maketx call -pkgpath gno.land/r/test/caller -func InlineAdd -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   338763'
 
 ### Complex function (multiple operations) ###
 # Call package function (Complex)
 gnokey maketx call -pkgpath gno.land/r/test/caller -func CallPkgComplex -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   408502'
 
 # Call realm function (Complex)
 gnokey maketx call -pkgpath gno.land/r/test/caller -func CallRealmComplex -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   476226'
 
 # Inline calculation (Complex)
 gnokey maketx call -pkgpath gno.land/r/test/caller -func InlineComplex -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   339705'
 
 ### Loop function ###
 # Call package function (Loop 10)
 gnokey maketx call -pkgpath gno.land/r/test/caller -func CallPkgLoop10 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   411917'
 
 # Call realm function (Loop 10)
 gnokey maketx call -pkgpath gno.land/r/test/caller -func CallRealmLoop10 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   479641'
 
 # Inline loop (10)
 gnokey maketx call -pkgpath gno.land/r/test/caller -func InlineLoop10 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   343365'
 
 ### Loop function (larger) ###
 # Call package function (Loop 100)
 gnokey maketx call -pkgpath gno.land/r/test/caller -func CallPkgLoop100 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   442923'
 
 # Call realm function (Loop 100)
 gnokey maketx call -pkgpath gno.land/r/test/caller -func CallRealmLoop100 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   510647'
 
 # Inline loop (100)
 gnokey maketx call -pkgpath gno.land/r/test/caller -func InlineLoop100 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   374341'
 
 ### String operation ###
 # Call package function (String)
 gnokey maketx call -pkgpath gno.land/r/test/caller -func CallPkgString -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   407770'
 
 # Call realm function (String)
 gnokey maketx call -pkgpath gno.land/r/test/caller -func CallRealmString -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   475494'
 
 # Inline string operation
 gnokey maketx call -pkgpath gno.land/r/test/caller -func InlineString -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   338829'
 
 ### Multiple calls ###
 # Call package 5 times
 gnokey maketx call -pkgpath gno.land/r/test/caller -func CallPkg5Times -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   414248'
 
 # Call realm 5 times
 gnokey maketx call -pkgpath gno.land/r/test/caller -func CallRealm5Times -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   481972'
 
 ### State read (realm only) ###
 # Read realm state
 gnokey maketx call -pkgpath gno.land/r/test/caller -func CallRealmGetCounter -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   475106'
 
 -- pkg/gnomod.toml --
 module = "gno.land/p/test/mathpkg"

--- a/tests/integration/testdata/base/realm_load_cost_measurement.txtar
+++ b/tests/integration/testdata/base/realm_load_cost_measurement.txtar
@@ -25,79 +25,79 @@ gnokey maketx addpkg -pkgdir $WORK/caller -pkgpath gno.land/r/test/caller -gas-f
 ### First call (cold - includes load cost) ###
 # Call small realm
 gnokey maketx call -pkgpath gno.land/r/test/small -func DoAdd -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   124119'
 
 # Call medium realm
 gnokey maketx call -pkgpath gno.land/r/test/medium -func DoAdd -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   205075'
 
 # Call large realm
 gnokey maketx call -pkgpath gno.land/r/test/large -func DoAdd -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   455701'
 
 # Call xlarge realm
 gnokey maketx call -pkgpath gno.land/r/test/xlarge -func DoAdd -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   793163'
 
 ### Second call (warm - cached?) ###
 # Call small realm again
 gnokey maketx call -pkgpath gno.land/r/test/small -func DoAdd -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   124125'
 
 # Call medium realm again
 gnokey maketx call -pkgpath gno.land/r/test/medium -func DoAdd -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   205075'
 
 # Call large realm again
 gnokey maketx call -pkgpath gno.land/r/test/large -func DoAdd -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   455701'
 
 # Call xlarge realm again
 gnokey maketx call -pkgpath gno.land/r/test/xlarge -func DoAdd -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   793163'
 
 ### Third call ###
 # Call small realm 3rd
 gnokey maketx call -pkgpath gno.land/r/test/small -func DoAdd -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   124125'
 
 # Call xlarge realm 3rd
 gnokey maketx call -pkgpath gno.land/r/test/xlarge -func DoAdd -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   793193'
 
 ### Package load vs Realm load comparison ###
 # Call small package (via caller realm)
 gnokey maketx call -pkgpath gno.land/r/test/caller -func CallSmallPkg -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   186890'
 
 # Call xlarge package (via caller realm)
 gnokey maketx call -pkgpath gno.land/r/test/caller -func CallXlargePkg -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   899124'
 
 # Call small realm (via caller realm)
 gnokey maketx call -pkgpath gno.land/r/test/caller -func CallSmallRealm -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   236774'
 
 # Call xlarge realm (via caller realm)
 gnokey maketx call -pkgpath gno.land/r/test/caller -func CallXlargeRealm -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   940900'
 
 ### Second call (package/realm cached?) ###
 # Call small package again
 gnokey maketx call -pkgpath gno.land/r/test/caller -func CallSmallPkg -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   186890'
 
 # Call xlarge package again
 gnokey maketx call -pkgpath gno.land/r/test/caller -func CallXlargePkg -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   899124'
 
 # Call small realm again
 gnokey maketx call -pkgpath gno.land/r/test/caller -func CallSmallRealm -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   236774'
 
 # Call xlarge realm again
 gnokey maketx call -pkgpath gno.land/r/test/caller -func CallXlargeRealm -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   940900'
 
 -- small/gnomod.toml --
 module = "gno.land/r/test/small"

--- a/tests/integration/testdata/base/storage_gas_measurement.txtar
+++ b/tests/integration/testdata/base/storage_gas_measurement.txtar
@@ -7,132 +7,146 @@ gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/test/storagegas -gas-fee 
 ### Baseline ###
 # Empty function (baseline)
 gnokey maketx call -pkgpath gno.land/r/test/storagegas -func Empty -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   484726'
 
 ### Storage Write - Different Value Sizes ###
 # Write small int (single int)
 gnokey maketx call -pkgpath gno.land/r/test/storagegas -func WriteSmallInt -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
-# stdout 'STORAGE'
+# stdout 'GAS USED:   589120'
+# stdout 'STORAGE DELTA:  5 bytes'
+# stdout 'STORAGE FEE:    500ugnot'
 
 # Write large int (int64 max)
 gnokey maketx call -pkgpath gno.land/r/test/storagegas -func WriteLargeInt -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
-# stdout 'STORAGE'
+# stdout 'GAS USED:   589216'
+# stdout 'STORAGE DELTA:  5 bytes'
+# stdout 'STORAGE FEE:    500ugnot'
 
 # Write short string (10 chars)
 gnokey maketx call -pkgpath gno.land/r/test/storagegas -func WriteShortString -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
-# stdout 'STORAGE'
+# stdout 'GAS USED:   589854'
+# stdout 'STORAGE DELTA:  39 bytes'
+# stdout 'STORAGE FEE:    3900ugnot'
 
 # Write medium string (100 chars)
 gnokey maketx call -pkgpath gno.land/r/test/storagegas -func WriteMediumString -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
-# stdout 'STORAGE'
+# stdout 'GAS USED:   591944'
+# stdout 'STORAGE DELTA:  130 bytes'
+# stdout 'STORAGE FEE:    13000ugnot'
 
 # Write long string (1000 chars)
 gnokey maketx call -pkgpath gno.land/r/test/storagegas -func WriteLongString -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
-# stdout 'STORAGE'
+# stdout 'GAS USED:   606708'
+# stdout 'STORAGE DELTA:  924 bytes'
+# stdout 'STORAGE FEE:    92400ugnot'
 
 ### Storage Read vs Write ###
 # Read existing value (after write)
 gnokey maketx call -pkgpath gno.land/r/test/storagegas -func ReadSmallInt -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   502521'
 
 # Read existing string
 gnokey maketx call -pkgpath gno.land/r/test/storagegas -func ReadShortString -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   502551'
 
 # Read long string
 gnokey maketx call -pkgpath gno.land/r/test/storagegas -func ReadLongString -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   502541'
 
 ### New Key vs Update Existing Key ###
 # Create new key (first write to counter1)
 gnokey maketx call -pkgpath gno.land/r/test/storagegas -func CreateNewKey1 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
-# stdout 'STORAGE'
+# stdout 'GAS USED:   606798'
+# stdout 'STORAGE DELTA:  5 bytes'
+# stdout 'STORAGE FEE:    500ugnot'
 
 # Update existing key (second write to counter1)
 gnokey maketx call -pkgpath gno.land/r/test/storagegas -func UpdateExistingKey1 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   506018'
 
 # Create new key (first write to counter2)
 gnokey maketx call -pkgpath gno.land/r/test/storagegas -func CreateNewKey2 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
-# stdout 'STORAGE'
+# stdout 'GAS USED:   606884'
+# stdout 'STORAGE DELTA:  5 bytes'
+# stdout 'STORAGE FEE:    500ugnot'
 
 # Update existing key (second write to counter2)
 gnokey maketx call -pkgpath gno.land/r/test/storagegas -func UpdateExistingKey2 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   506098'
 
 ### Multiple Writes in Single TX ###
 # Write 10 new keys
 gnokey maketx call -pkgpath gno.land/r/test/storagegas -func Write10Keys -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
-# stdout 'STORAGE'
+# stdout 'GAS USED:   627058'
+# stdout 'STORAGE DELTA:  5 bytes'
+# stdout 'STORAGE FEE:    500ugnot'
 
 # Update 10 existing keys
 gnokey maketx call -pkgpath gno.land/r/test/storagegas -func Update10Keys -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   526232'
 
 ### Struct Storage ###
 # Write small struct (3 fields)
 gnokey maketx call -pkgpath gno.land/r/test/storagegas -func WriteSmallStruct -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
-# stdout 'STORAGE'
+# stdout 'GAS USED:   665354'
+# stdout 'STORAGE DELTA:  5 bytes'
+# stdout 'STORAGE FEE:    500ugnot'
 
 # Write large struct (10 fields)
 gnokey maketx call -pkgpath gno.land/r/test/storagegas -func WriteLargeStruct -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
-# stdout 'STORAGE'
+# stdout 'GAS USED:   674989'
+# stdout 'STORAGE DELTA:  5 bytes'
+# stdout 'STORAGE FEE:    500ugnot'
 
 # Read small struct
 gnokey maketx call -pkgpath gno.land/r/test/storagegas -func ReadSmallStruct -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   507898'
 
 # Read large struct
 gnokey maketx call -pkgpath gno.land/r/test/storagegas -func ReadLargeStruct -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   513393'
 
 ### Slice Storage ###
 # Write small slice (10 elements)
 gnokey maketx call -pkgpath gno.land/r/test/storagegas -func WriteSmallSlice -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
-# stdout 'STORAGE'
+# stdout 'GAS USED:   668203'
+# stdout 'STORAGE DELTA:  695 bytes'
+# stdout 'STORAGE FEE:    69500ugnot'
 
 # Write large slice (100 elements)
 gnokey maketx call -pkgpath gno.land/r/test/storagegas -func WriteLargeSlice -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
-# stdout 'STORAGE'
+# stdout 'GAS USED:   764403'
+# stdout 'STORAGE DELTA:  4117 bytes'
+# stdout 'STORAGE FEE:    411700ugnot'
 
 # Read small slice
 gnokey maketx call -pkgpath gno.land/r/test/storagegas -func ReadSmallSlice -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   520624'
 
 # Read large slice
 gnokey maketx call -pkgpath gno.land/r/test/storagegas -func ReadLargeSlice -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   608104'
 
 ### Map Storage ###
 # Write small map (10 entries)
 gnokey maketx call -pkgpath gno.land/r/test/storagegas -func WriteSmallMap -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
-# stdout 'STORAGE'
+# stdout 'GAS USED:   2432689'
+# stdout 'STORAGE DELTA:  1320 bytes'
+# stdout 'STORAGE FEE:    132000ugnot'
 
 # Write large map (100 entries)
 gnokey maketx call -pkgpath gno.land/r/test/storagegas -func WriteLargeMap -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
-# stdout 'STORAGE'
+# stdout 'GAS USED:   3318011'
+# stdout 'STORAGE DELTA:  10680 bytes'
+# stdout 'STORAGE FEE:    1068000ugnot'
 
 # Read from small map
 gnokey maketx call -pkgpath gno.land/r/test/storagegas -func ReadSmallMap -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   531428'
 
 # Read from large map
 gnokey maketx call -pkgpath gno.land/r/test/storagegas -func ReadLargeMap -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   691988'
 
 -- gnomod.toml --
 module = "gno.land/r/test/storagegas"

--- a/tests/integration/testdata/base/strconv_gas_measurement.txtar
+++ b/tests/integration/testdata/base/strconv_gas_measurement.txtar
@@ -5,108 +5,108 @@ gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/gnoswap/strconvgas -gas-f
 
 # Call Empty (baseline)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconvgas -func Empty -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   351612'
 
 ### Itoa Functions ###
 # Itoa (small positive)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconvgas -func Itoa_SmallPositive -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2033707'
 
 # Itoa (large positive)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconvgas -func Itoa_LargePositive -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2060594'
 
 # Itoa (negative)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconvgas -func Itoa_Negative -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2060729'
 
 # Itoa (zero)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconvgas -func Itoa_Zero -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2033459'
 
 ### FormatInt Functions ###
 # FormatInt (base 10)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconvgas -func FormatInt_Base10 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2051350'
 
 # FormatInt (base 16)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconvgas -func FormatInt_Base16 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2750371'
 
 # FormatInt (base 2)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconvgas -func FormatInt_Base2 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2773867'
 
 ### FormatUint Functions ###
 # FormatUint (base 10)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconvgas -func FormatUint_Base10 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2050268'
 
 # FormatUint (max uint64)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconvgas -func FormatUint_MaxUint64 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2058533'
 
 ### Atoi Functions ###
 # Atoi (small number)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconvgas -func Atoi_SmallNumber -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2039295'
 
 # Atoi (large number)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconvgas -func Atoi_LargeNumber -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2199804'
 
 # Atoi (negative)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconvgas -func Atoi_Negative -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2200565'
 
 ### ParseInt Functions ###
 # ParseInt (base 10)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconvgas -func ParseInt_Base10 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2125376'
 
 # ParseInt (base 16)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconvgas -func ParseInt_Base16 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2115249'
 
 # ParseInt (base 2)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconvgas -func ParseInt_Base2 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2286921'
 
 ### ParseUint Functions ###
 # ParseUint (base 10)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconvgas -func ParseUint_Base10 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2114282'
 
 # ParseUint (max uint64)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconvgas -func ParseUint_MaxUint64 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2190920'
 
 ### Quote Functions ###
 # Quote (simple string)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconvgas -func Quote_SimpleString -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2542744'
 
 # Quote (special chars)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconvgas -func Quote_SpecialChars -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2623439'
 
 ### ParseBool Functions ###
 # ParseBool (true)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconvgas -func ParseBool_True -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2028713'
 
 # ParseBool (false)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconvgas -func ParseBool_False -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2029793'
 
 ### FormatBool Functions ###
 # FormatBool (true)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconvgas -func FormatBool_True -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2027966'
 
 # FormatBool (false)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconvgas -func FormatBool_False -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2027979'
 
 -- gnomod.toml --
 module = "gno.land/r/gnoswap/strconvgas"

--- a/tests/integration/testdata/base/string_concat_gas_measurement.txtar
+++ b/tests/integration/testdata/base/string_concat_gas_measurement.txtar
@@ -7,186 +7,186 @@ gnokey maketx addpkg -pkgdir $WORK -pkgpath gno.land/r/gnoswap/strconcatgas -gas
 
 # Call Empty (baseline)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func Empty -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   638314'
 
 ### String Concatenation with + operator ###
 # Plus operator (2 strings)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func PlusOperator_2Strings -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   638760'
 
 # Plus operator (5 strings)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func PlusOperator_5Strings -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   639111'
 
 # Plus operator (10 strings)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func PlusOperator_10Strings -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   639807'
 
 # Plus operator (20 strings)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func PlusOperator_20Strings -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   641529'
 
 ### strings.Builder ###
 # Builder (2 strings)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func Builder_2Strings -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   1983474'
 
 # Builder (5 strings)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func Builder_5Strings -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2014376'
 
 # Builder (10 strings)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func Builder_10Strings -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2065998'
 
 # Builder (20 strings)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func Builder_20Strings -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2169597'
 
 ### ufmt.Sprintf ###
 # Sprintf (2 strings)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func Sprintf_2Strings -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   1143228'
 
 # Sprintf (5 strings)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func Sprintf_5Strings -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   1213335'
 
 # Sprintf (10 strings)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func Sprintf_10Strings -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   1330152'
 
 ### strings.Join ###
 # Join (2 strings)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func Join_2Strings -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2032555'
 
 # Join (5 strings)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func Join_5Strings -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2104502'
 
 # Join (10 strings)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func Join_10Strings -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2224439'
 
 # Join (20 strings)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func Join_20Strings -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2464283'
 
 ### Plus operator in loop (worst case) ###
 # Plus in loop (10 iterations)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func PlusInLoop_10Iterations -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   644463'
 
 # Plus in loop (50 iterations)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func PlusInLoop_50Iterations -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   668083'
 
 ### Builder in loop ###
 # Builder in loop (10 iterations)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func BuilderInLoop_10Iterations -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2068899'
 
 # Builder in loop (50 iterations)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func BuilderInLoop_50Iterations -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2493879'
 
 ### Long strings ###
 # Plus operator (long strings)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func PlusOperator_LongStrings -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   639525'
 
 # Builder (long strings)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func Builder_LongStrings -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   1995236'
 
 # Join (long strings)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func Join_LongStrings -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2057604'
 
 ### Number to string concatenation ###
 # Plus with Itoa (1 number)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func PlusWithItoa -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2338434'
 
 # Sprintf with number (1 number)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func SprintfWithNumber -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   3209925'
 
 # Builder with Itoa (1 number)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func BuilderWithItoa -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   3693421'
 
 ### Multiple numbers ###
 # Plus with Itoa (3 numbers)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func PlusWithItoa_3Numbers -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2378014'
 
 # Sprintf with 3 numbers
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func SprintfWith3Numbers -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   3243120'
 
 # Plus with Itoa (5 numbers)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func PlusWithItoa_5Numbers -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2425690'
 
 # Sprintf with 5 numbers
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func SprintfWith5Numbers -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   3396178'
 
 ### uint64 numbers ###
 # Plus with FormatUint
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func PlusWithFormatUint -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2345776'
 
 # Sprintf with uint64
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func SprintfWithUint64 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   3217295'
 
 ### Number to String Conversion Only ###
 # strconv.Itoa (small int)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func Itoa_Small -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2320437'
 
 # strconv.Itoa (large int)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func Itoa_Large -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2347324'
 
 # strconv.FormatInt (base 10)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func FormatInt_Base10 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2340965'
 
 # strconv.FormatUint (base 10)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func FormatUint_Base10 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2339883'
 
 # strconv.FormatUint (max uint64)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func FormatUint_MaxUint64 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2345313'
 
 # ufmt.Sprintf %d (small int)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func Sprintf_SmallInt -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2800739'
 
 # ufmt.Sprintf %d (large int)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func Sprintf_LargeInt -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2827676'
 
 # ufmt.Sprintf %d (uint64)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func Sprintf_Uint64 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2825770'
 
 # strconv.FormatInt (base 16 hex)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func FormatInt_Base16 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   3040247'
 
 # strconv.FormatBool
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func FormatBool_True -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   2314740'
 
 # ufmt.Sprintf %t (bool)
 gnokey maketx call -pkgpath gno.land/r/gnoswap/strconcatgas -func Sprintf_Bool -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
-# stdout 'GAS USED:'
+# stdout 'GAS USED:   1120782'
 
 -- gnomod.toml --
 module = "gno.land/r/gnoswap/strconcatgas"


### PR DESCRIPTION
## Summary

- Add missing gas values to all 8 gas measurement txtar files
- Add STORAGE DELTA and STORAGE FEE values to storage_gas_measurement.txtar
- Enhance comment_gas_measurement with wrapper functions for same-TX caching tests

## Changes

### Files Updated
- `comment_gas_measurement.txtar` - Add gas values, add caching test wrapper functions
- `cross_realm_depth_gas_measurement.txtar` - Add gas values
- `data_structure_gas_measurement.txtar` - Add gas values
- `pkg_realm_call_gas_measurement.txtar` - Add gas values
- `realm_load_cost_measurement.txtar` - Add gas values
- `storage_gas_measurement.txtar` - Add gas values, add STORAGE DELTA/FEE values
- `strconv_gas_measurement.txtar` - Add gas values
- `string_concat_gas_measurement.txtar` - Add gas values

### Key Improvements
1. **Storage Fee Tracking**: `storage_gas_measurement.txtar` now includes actual storage delta bytes and fee amounts for each write operation
2. **Same-TX Caching Tests**: `comment_gas_measurement.txtar` uses wrapper functions (e.g., `CallNoCommentTwice`, `CallHeavyComment5x`) to test caching behavior within a single transaction
