### PR TITLE
perf(gnsmath): Optimize `BitMathMostSignificantBit` / `BitMathLeastSignificantBit`

### DIFF
--- a/contract/p/gnoswap/gnsmath/bit_math.gno
+++ b/contract/p/gnoswap/gnsmath/bit_math.gno
@@ -1,6 +1,8 @@
 package gnsmath
 
 import (
+	"math/bits"
+
 	u256 "gno.land/p/gnoswap/uint256"
 )
 
@@ -42,17 +44,19 @@ func BitMathMostSignificantBit(x *u256.Uint) uint8 {
 		panic(errMSBZeroInput)
 	}
 
-	temp := x.Clone()
-	r := uint8(0)
-
-	for _, s := range msbShifts {
-		if temp.Gte(s.bitPattern) {
-			temp = temp.Rsh(temp, s.shift)
-			r += uint8(s.shift)
-		}
+	if x[3] != 0 {
+		return 192 + uint8(bits.Len64(x[3])-1)
 	}
 
-	return r
+	if x[2] != 0 {
+		return 128 + uint8(bits.Len64(x[2])-1)
+	}
+
+	if x[1] != 0 {
+		return 64 + uint8(bits.Len64(x[1])-1)
+	}
+
+	return uint8(bits.Len64(x[0]) - 1)
 }
 
 // BitMathLeastSignificantBit returns the 0-based position of the least significant bit in x.
@@ -63,18 +67,17 @@ func BitMathLeastSignificantBit(x *u256.Uint) uint8 {
 		panic(errLSBZeroInput)
 	}
 
-	temp := x.Clone()
-	hasSetBits := u256.Zero()
-	r := uint8(255)
+	if x[0] != 0 {
+        return uint8(bits.TrailingZeros64(x[0]))
+    }
 
-	for _, s := range lsbShifts {
-		hasSetBits = hasSetBits.And(temp, s.bitPattern)
-		if !hasSetBits.IsZero() {
-			r -= uint8(s.shift)
-		} else {
-			temp = temp.Rsh(temp, s.shift)
-		}
-	}
+	if x[1] != 0 {
+        return 64 + uint8(bits.TrailingZeros64(x[1]))
+    }
 
-	return r
+	if x[2] != 0 {
+        return 128 + uint8(bits.TrailingZeros64(x[2]))
+    }
+
+    return 192 + uint8(bits.TrailingZeros64(x[3]))
 }

--- a/contract/p/gnoswap/gnsmath/bit_math.gno
+++ b/contract/p/gnoswap/gnsmath/bit_math.gno
@@ -7,23 +7,25 @@ import (
 )
 
 var (
+	oneU256 = u256.One() // readonly
+
 	msbShifts = []bitShift{
-		{u256.Zero().Lsh(u256.One(), 128), 128}, // 2^128
-		{u256.Zero().Lsh(u256.One(), 64), 64},   // 2^64
-		{u256.Zero().Lsh(u256.One(), 32), 32},   // 2^32
-		{u256.Zero().Lsh(u256.One(), 16), 16},   // 2^16
-		{u256.Zero().Lsh(u256.One(), 8), 8},     // 2^8
-		{u256.Zero().Lsh(u256.One(), 4), 4},     // 2^4
-		{u256.Zero().Lsh(u256.One(), 2), 2},     // 2^2
-		{u256.Zero().Lsh(u256.One(), 1), 1},     // 2^1
+		{u256.Zero().Lsh(oneU256, 128), 128}, // 2^128
+		{u256.Zero().Lsh(oneU256, 64), 64},   // 2^64
+		{u256.Zero().Lsh(oneU256, 32), 32},   // 2^32
+		{u256.Zero().Lsh(oneU256, 16), 16},   // 2^16
+		{u256.Zero().Lsh(oneU256, 8), 8},     // 2^8
+		{u256.Zero().Lsh(oneU256, 4), 4},     // 2^4
+		{u256.Zero().Lsh(oneU256, 2), 2},     // 2^2
+		{u256.Zero().Lsh(oneU256, 1), 1},     // 2^1
 	}
 
 	lsbShifts = []bitShift{
-		{u256.Zero().Sub(u256.Zero().Lsh(u256.One(), 128), u256.One()), 128}, // 2^128 - 1
-		{u256.Zero().Sub(u256.Zero().Lsh(u256.One(), 64), u256.One()), 64},   // 2^64 - 1
-		{u256.Zero().Sub(u256.Zero().Lsh(u256.One(), 32), u256.One()), 32},   // 2^32 - 1
-		{u256.Zero().Sub(u256.Zero().Lsh(u256.One(), 16), u256.One()), 16},   // 2^16 - 1
-		{u256.Zero().Sub(u256.Zero().Lsh(u256.One(), 8), u256.One()), 8},     // 2^8 - 1
+		{u256.Zero().Sub(u256.Zero().Lsh(oneU256, 128), oneU256), 128}, // 2^128 - 1
+		{u256.Zero().Sub(u256.Zero().Lsh(oneU256, 64), oneU256), 64},   // 2^64 - 1
+		{u256.Zero().Sub(u256.Zero().Lsh(oneU256, 32), oneU256), 32},   // 2^32 - 1
+		{u256.Zero().Sub(u256.Zero().Lsh(oneU256, 16), oneU256), 16},   // 2^16 - 1
+		{u256.Zero().Sub(u256.Zero().Lsh(oneU256, 8), oneU256), 8},     // 2^8 - 1
 		{u256.NewUint(0xf), 4}, // 2^4 - 1 = 15
 		{u256.NewUint(0x3), 2}, // 2^2 - 1 = 3
 		{u256.NewUint(0x1), 1}, // 2^1 - 1 = 1
@@ -68,16 +70,16 @@ func BitMathLeastSignificantBit(x *u256.Uint) uint8 {
 	}
 
 	if x[0] != 0 {
-        return uint8(bits.TrailingZeros64(x[0]))
-    }
+		return uint8(bits.TrailingZeros64(x[0]))
+	}
 
 	if x[1] != 0 {
-        return 64 + uint8(bits.TrailingZeros64(x[1]))
-    }
+		return 64 + uint8(bits.TrailingZeros64(x[1]))
+	}
 
 	if x[2] != 0 {
-        return 128 + uint8(bits.TrailingZeros64(x[2]))
-    }
+		return 128 + uint8(bits.TrailingZeros64(x[2]))
+	}
 
-    return 192 + uint8(bits.TrailingZeros64(x[3]))
+	return 192 + uint8(bits.TrailingZeros64(x[3]))
 }

--- a/contract/p/gnoswap/gnsmath/sqrt_price_math.gno
+++ b/contract/p/gnoswap/gnsmath/sqrt_price_math.gno
@@ -11,9 +11,9 @@ const (
 )
 
 var (
-	q96       = u256.Zero().Lsh(u256.One(), 96)                               // 2^96
-	max160    = u256.Zero().Sub(u256.Zero().Lsh(u256.One(), 160), u256.One()) // 2^160 - 1
-	maxInt256 = u256.Zero().Sub(u256.Zero().Lsh(u256.One(), 255), u256.One()) // 2^255 - 1
+	q96       = u256.Zero().Lsh(oneU256, 96)                            // 2^96
+	max160    = u256.Zero().Sub(u256.Zero().Lsh(oneU256, 160), oneU256) // 2^160 - 1
+	maxInt256 = u256.Zero().Sub(u256.Zero().Lsh(oneU256, 255), oneU256) // 2^255 - 1
 
 	MIN_SQRT_RATIO = u256.MustFromDecimal("4295128739")
 	MAX_SQRT_RATIO = u256.MustFromDecimal("1461446703485210103287273052203988822378723970342")
@@ -30,15 +30,12 @@ func getNextPriceAmount0Add(
 	quotientCheck := u256.Zero()
 	denominator := u256.Zero()
 
-	// liquidityShifted = liquidity << 96
 	liquidityShifted.Lsh(liquidity, Q96_RESOLUTION)
-	// amountTimesSqrtPrice = amount * sqrtPrice
 	amountTimesSqrtPrice.Mul(amountToAdd, currentSqrtPriceX96)
 
 	// Overflow check: Ensure (amountTimesSqrtPrice / amountToAdd) == currentSqrtPriceX96
 	quotientCheck.Div(amountTimesSqrtPrice, amountToAdd)
 	if quotientCheck.Eq(currentSqrtPriceX96) {
-		// denominator = liquidityShifted + amountTimesSqrtPrice
 		denominator.Add(liquidityShifted, amountTimesSqrtPrice)
 		// only take this path when denominator >= liquidityShifted
 		if denominator.Gte(liquidityShifted) {
@@ -46,7 +43,7 @@ func getNextPriceAmount0Add(
 		}
 	}
 
-	// fallback: liquidityShifted / ((liquidityShifted / sqrtPrice) + amount)
+	// fallback
 	quotientCheck.Div(liquidityShifted, currentSqrtPriceX96)
 	denominator.Add(quotientCheck, amountToAdd)
 
@@ -269,7 +266,6 @@ func GetAmount0Delta(
 	if liquidity.IsNeg() {
 		u := getAmount0DeltaHelper(sqrtRatioAX96, sqrtRatioBX96, liquidity.Abs(), false)
 		if u.Gt(maxInt256) {
-			// if u > (2**255 - 1), cannot cast to int256
 			panic(errAmount0DeltaOverflow)
 		}
 
@@ -279,7 +275,6 @@ func GetAmount0Delta(
 
 	u := getAmount0DeltaHelper(sqrtRatioAX96, sqrtRatioBX96, liquidity.Abs(), true)
 	if u.Gt(maxInt256) {
-		// if u > (2**255 - 1), cannot cast to int256
 		panic(errAmount0DeltaOverflow)
 	}
 
@@ -301,7 +296,6 @@ func GetAmount1Delta(
 	if liquidity.IsNeg() {
 		u := getAmount1DeltaHelper(sqrtRatioAX96, sqrtRatioBX96, liquidity.Abs(), false)
 		if u.Gt(maxInt256) {
-			// if u > (2**255 - 1), cannot cast to int256
 			panic(errAmount1DeltaOverflow)
 		}
 
@@ -311,7 +305,6 @@ func GetAmount1Delta(
 
 	u := getAmount1DeltaHelper(sqrtRatioAX96, sqrtRatioBX96, liquidity.Abs(), true)
 	if u.Gt(maxInt256) {
-		// if u > (2**255 - 1), cannot cast to int256
 		panic(errAmount1DeltaOverflow)
 	}
 

--- a/contract/p/gnoswap/gnsmath/sqrt_price_math.gno
+++ b/contract/p/gnoswap/gnsmath/sqrt_price_math.gno
@@ -25,27 +25,21 @@ var (
 func getNextPriceAmount0Add(
 	currentSqrtPriceX96, liquidity, amountToAdd *u256.Uint,
 ) *u256.Uint {
-	liquidityShifted := u256.Zero()
-	amountTimesSqrtPrice := u256.Zero()
-	quotientCheck := u256.Zero()
-	denominator := u256.Zero()
-
-	liquidityShifted.Lsh(liquidity, Q96_RESOLUTION)
-	amountTimesSqrtPrice.Mul(amountToAdd, currentSqrtPriceX96)
+	liquidityShifted := u256.Zero().Lsh(liquidity, Q96_RESOLUTION)
+	amountTimesSqrtPrice := u256.Zero().Mul(amountToAdd, currentSqrtPriceX96)
 
 	// Overflow check: Ensure (amountTimesSqrtPrice / amountToAdd) == currentSqrtPriceX96
-	quotientCheck.Div(amountTimesSqrtPrice, amountToAdd)
+	quotientCheck := u256.Zero().Div(amountTimesSqrtPrice, amountToAdd)
 	if quotientCheck.Eq(currentSqrtPriceX96) {
-		denominator.Add(liquidityShifted, amountTimesSqrtPrice)
-		// only take this path when denominator >= liquidityShifted
+		denominator := u256.Zero().Add(liquidityShifted, amountTimesSqrtPrice)
 		if denominator.Gte(liquidityShifted) {
 			return u256.MulDivRoundingUp(liquidityShifted, currentSqrtPriceX96, denominator)
 		}
 	}
 
 	// fallback
-	quotientCheck.Div(liquidityShifted, currentSqrtPriceX96)
-	denominator.Add(quotientCheck, amountToAdd)
+	divValue := u256.Zero().Div(liquidityShifted, currentSqrtPriceX96)
+	denominator := u256.Zero().Add(divValue, amountToAdd)
 
 	return u256.DivRoundingUp(liquidityShifted, denominator)
 }

--- a/contract/p/gnoswap/gnsmath/sqrt_price_math.gno
+++ b/contract/p/gnoswap/gnsmath/sqrt_price_math.gno
@@ -25,16 +25,21 @@ var (
 func getNextPriceAmount0Add(
 	currentSqrtPriceX96, liquidity, amountToAdd *u256.Uint,
 ) *u256.Uint {
+	liquidityShifted := u256.Zero()
+	amountTimesSqrtPrice := u256.Zero()
+	quotientCheck := u256.Zero()
+	denominator := u256.Zero()
+
 	// liquidityShifted = liquidity << 96
-	liquidityShifted := u256.Zero().Lsh(liquidity, Q96_RESOLUTION)
+	liquidityShifted.Lsh(liquidity, Q96_RESOLUTION)
 	// amountTimesSqrtPrice = amount * sqrtPrice
-	amountTimesSqrtPrice := u256.Zero().Mul(amountToAdd, currentSqrtPriceX96)
+	amountTimesSqrtPrice.Mul(amountToAdd, currentSqrtPriceX96)
 
 	// Overflow check: Ensure (amountTimesSqrtPrice / amountToAdd) == currentSqrtPriceX96
-	quotientCheck := u256.Zero().Div(amountTimesSqrtPrice, amountToAdd)
+	quotientCheck.Div(amountTimesSqrtPrice, amountToAdd)
 	if quotientCheck.Eq(currentSqrtPriceX96) {
 		// denominator = liquidityShifted + amountTimesSqrtPrice
-		denominator := u256.Zero().Add(liquidityShifted, amountTimesSqrtPrice)
+		denominator.Add(liquidityShifted, amountTimesSqrtPrice)
 		// only take this path when denominator >= liquidityShifted
 		if denominator.Gte(liquidityShifted) {
 			return u256.MulDivRoundingUp(liquidityShifted, currentSqrtPriceX96, denominator)
@@ -42,8 +47,9 @@ func getNextPriceAmount0Add(
 	}
 
 	// fallback: liquidityShifted / ((liquidityShifted / sqrtPrice) + amount)
-	divValue := u256.Zero().Div(liquidityShifted, currentSqrtPriceX96)
-	denominator := u256.Zero().Add(divValue, amountToAdd)
+	quotientCheck.Div(liquidityShifted, currentSqrtPriceX96)
+	denominator.Add(quotientCheck, amountToAdd)
+
 	return u256.DivRoundingUp(liquidityShifted, denominator)
 }
 

--- a/contract/p/gnoswap/gnsmath/sqrt_price_math_fuzz_test.gno
+++ b/contract/p/gnoswap/gnsmath/sqrt_price_math_fuzz_test.gno
@@ -9,7 +9,7 @@ import (
 	u256 "gno.land/p/gnoswap/uint256"
 )
 
-const FUZZ_ITERATIONS = 10
+const FUZZ_ITERATIONS = 100
 
 // TestFuzzGetAmount0Delta_ValidParams_Stateless tests GetAmount0Delta with valid parameters
 func TestFuzzGetAmount0Delta_ValidParams_Stateless(t *testing.T) {

--- a/contract/p/gnoswap/gnsmath/swap_math.gno
+++ b/contract/p/gnoswap/gnsmath/swap_math.gno
@@ -7,6 +7,8 @@ import (
 
 const denominator = uint64(1_000_000)
 
+var denominatorU256 = u256.NewUint(denominator)
+
 // SwapMathComputeSwapStep computes the next sqrt price, amount in, amount out, and fee amount
 // for a swap step within a single tick range.
 //
@@ -160,7 +162,7 @@ func handleExactIn(
 	amountRemainingLessFee := u256.MulDiv(
 		amountRemainingAbs,
 		withoutFeeRateInPips,
-		u256.NewUint(denominator),
+		denominatorU256,
 	)
 
 	// Special case:

--- a/tests/integration/testdata/base/gnsmath_gas_measurement.txtar
+++ b/tests/integration/testdata/base/gnsmath_gas_measurement.txtar
@@ -24,6 +24,13 @@ gnokey maketx call -pkgpath gno.land/r/gnoswap/basic -func TestGetAmount1Delta -
 gnokey maketx call -pkgpath gno.land/r/gnoswap/basic -func TestSwapMathComputeSwapStep -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
 # stdout 'GAS USED:   14430494'
 
+### Bit Math Functions
+# BitMathMostSignificantBit
+gnokey maketx call -pkgpath gno.land/r/gnoswap/basic -func TestBitMathMostSignificantBit -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
+
+# TestBitMathLeastSignificantBit
+gnokey maketx call -pkgpath gno.land/r/gnoswap/basic -func TestBitMathLeastSignificantBit -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 1000000ugnot -gas-wanted 1000000000 -memo "" test1
+
 -- gnomod.toml --
 module = "gno.land/r/gnoswap/basic"
 gno = "0.9"
@@ -73,4 +80,14 @@ func TestSwapMathComputeSwapStep(cur realm) {
 		amountRemaining,
 		feePips,
 	)
+}
+
+func TestBitMathMostSignificantBit(cur realm) {
+	x := uint256.MustFromDecimal("57896044618658097711785492504343953926634992332820282019728792003956564819968")
+	gnsmath.BitMathMostSignificantBit(x)
+}
+
+func TestBitMathLeastSignificantBit(cur realm) {
+	x := uint256.MustFromDecimal("57896044618658097711785492504343953926634992332820282019728792003956564819968")
+	gnsmath.BitMathLeastSignificantBit(x)
 }


### PR DESCRIPTION
## Description

This PR replaces the previous shift-and-mask–based implementations of `BitMathMostSignificantBit` and `BitMathLeastSignificantBit` with a word-based bit scanning algorithm.

The new implementation performs O(1) operations exclusively using `uint64` word checks and built-in `bits` package (`bits.Len64`, `bits.TrailingZeros64`), eliminating all temporary `u256.Uint` allocations and multi-word arithmetic from the previous version.