### PR TITLE
fix(governance): flatten nested AVL tree for voting info storage

### DIFF
--- a/contract/r/gnoswap/gov/governance/proposal.gno
+++ b/contract/r/gnoswap/gov/governance/proposal.gno
@@ -10,8 +10,6 @@ type Proposal struct {
 	metadata      *ProposalMetadata // Title and description
 	data          *ProposalData     // Type-specific proposal data
 	snapshotTime  int64             // Timestamp for voting weight snapshot lookup
-	createdAt     int64             // Creation timestamp
-	createdHeight int64             // Block height at creation
 }
 
 // ID returns the unique identifier of the proposal.
@@ -117,8 +115,6 @@ func (p *Proposal) IsProposer(addr address) bool {
 //   - proposerAddress: address of the proposal creator
 //   - configVersion: governance configuration version
 //   - snapshotTime: timestamp for voting weight snapshot lookup
-//   - createdAt: creation timestamp
-//   - createdHeight: creation block height
 //
 // Returns:
 //   - *Proposal: newly created proposal instance
@@ -130,8 +126,6 @@ func NewProposal(
 	proposerAddress address,
 	configVersion int64,
 	snapshotTime int64,
-	createdAt int64,
-	createdHeight int64,
 ) *Proposal {
 	return &Proposal{
 		id:            proposalID,
@@ -141,7 +135,5 @@ func NewProposal(
 		data:          data,
 		configVersion: configVersion,
 		snapshotTime:  snapshotTime,
-		createdAt:     createdAt,
-		createdHeight: createdHeight,
 	}
 }

--- a/contract/r/gnoswap/gov/governance/proposal_vote_status.gno
+++ b/contract/r/gnoswap/gov/governance/proposal_vote_status.gno
@@ -59,7 +59,6 @@ func NewProposalVoteStatus(
 	maxVotingWeight int64,
 	quorumAmount int64,
 ) *ProposalVoteStatus {
-
 	return &ProposalVoteStatus{
 		yea:             0,               // Start with no "yes" votes
 		nay:             0,               // Start with no "no" votes

--- a/contract/r/gnoswap/gov/governance/store.gno
+++ b/contract/r/gnoswap/gov/governance/store.gno
@@ -102,7 +102,7 @@ func (s *governanceStore) SetConfigs(configs *avl.Tree) error {
 
 func (s *governanceStore) GetConfig(version int64) (Config, bool) {
 	configs := s.GetConfigs()
-	result, ok := configs.Get(int64ToString(version))
+	result, ok := configs.Get(FormatInt64Key(version))
 	if !ok {
 		return Config{}, false
 	}
@@ -121,7 +121,7 @@ func (s *governanceStore) SetConfig(version int64, config Config) error {
 	}
 
 	configs := s.GetConfigs()
-	configs.Set(int64ToString(version), config)
+	configs.Set(FormatInt64Key(version), config)
 
 	return s.kvStore.Set(StoreKeyConfigs.String(), configs)
 }
@@ -151,7 +151,7 @@ func (s *governanceStore) SetProposals(proposals *avl.Tree) error {
 
 func (s *governanceStore) GetProposal(proposalID int64) (*Proposal, bool) {
 	proposals := s.GetProposals()
-	result, ok := proposals.Get(int64ToString(proposalID))
+	result, ok := proposals.Get(FormatInt64Key(proposalID))
 	if !ok {
 		return nil, false
 	}
@@ -169,7 +169,7 @@ func (s *governanceStore) SetProposal(proposalID int64, proposal *Proposal) erro
 	}
 
 	proposals := s.GetProposals()
-	proposals.Set(int64ToString(proposalID), proposal)
+	proposals.Set(FormatInt64Key(proposalID), proposal)
 
 	return s.kvStore.Set(StoreKeyProposals.String(), proposals)
 }
@@ -199,7 +199,7 @@ func (s *governanceStore) SetProposalUserVotingInfos(votingInfos *avl.Tree) erro
 
 func (s *governanceStore) GetProposalVotingInfos(proposalID int64) (*avl.Tree, bool) {
 	votingInfos := s.GetProposalUserVotingInfos()
-	votingInfo, ok := votingInfos.Get(int64ToString(proposalID))
+	votingInfo, ok := votingInfos.Get(FormatInt64Key(proposalID))
 	if !ok {
 		return nil, false
 	}
@@ -218,7 +218,7 @@ func (s *governanceStore) SetProposalVotingInfos(proposalID int64, votingInfos *
 	}
 
 	allVotingInfos := s.GetProposalUserVotingInfos()
-	allVotingInfos.Set(int64ToString(proposalID), votingInfos)
+	allVotingInfos.Set(FormatInt64Key(proposalID), votingInfos)
 
 	return s.kvStore.Set(StoreKeyProposalUserVotingInfos.String(), allVotingInfos)
 }
@@ -330,6 +330,7 @@ func NewGovernanceStore(kvStore store.KVStore) IGovernanceStore {
 	}
 }
 
-func int64ToString(id int64) string {
+// FormatInt64Key formats int64 identifiers for storage keys.
+func FormatInt64Key(id int64) string {
 	return strconv.FormatInt(id, 10)
 }

--- a/contract/r/gnoswap/gov/governance/store.gno
+++ b/contract/r/gnoswap/gov/governance/store.gno
@@ -197,28 +197,28 @@ func (s *governanceStore) SetProposalUserVotingInfos(votingInfos *avl.Tree) erro
 	return s.kvStore.Set(StoreKeyProposalUserVotingInfos.String(), votingInfos)
 }
 
-func (s *governanceStore) GetProposalVotingInfos(proposalID int64) (*avl.Tree, bool) {
+func (s *governanceStore) GetProposalVotingInfo(proposalID int64, voter string) (*VotingInfo, bool) {
 	votingInfos := s.GetProposalUserVotingInfos()
-	votingInfo, ok := votingInfos.Get(FormatInt64Key(proposalID))
+	votingInfo, ok := votingInfos.Get(FormatProposalVotingInfoKey(proposalID, voter))
 	if !ok {
 		return nil, false
 	}
 
-	votingInfoTree, ok := votingInfo.(*avl.Tree)
+	info, ok := votingInfo.(*VotingInfo)
 	if !ok {
 		return nil, false
 	}
 
-	return votingInfoTree, true
+	return info, true
 }
 
-func (s *governanceStore) SetProposalVotingInfos(proposalID int64, votingInfos *avl.Tree) error {
+func (s *governanceStore) SetProposalVotingInfo(proposalID int64, voter string, votingInfo *VotingInfo) error {
 	if !s.HasProposalUserVotingInfosStoreKey() {
 		return errors.New("proposal user voting infos store key not found")
 	}
 
 	allVotingInfos := s.GetProposalUserVotingInfos()
-	allVotingInfos.Set(FormatInt64Key(proposalID), votingInfos)
+	allVotingInfos.Set(FormatProposalVotingInfoKey(proposalID, voter), votingInfo)
 
 	return s.kvStore.Set(StoreKeyProposalUserVotingInfos.String(), allVotingInfos)
 }
@@ -333,4 +333,9 @@ func NewGovernanceStore(kvStore store.KVStore) IGovernanceStore {
 // FormatInt64Key formats int64 identifiers for storage keys.
 func FormatInt64Key(id int64) string {
 	return strconv.FormatInt(id, 10)
+}
+
+// FormatProposalVotingInfoKey formats the key for proposal voting info storage.
+func FormatProposalVotingInfoKey(proposalID int64, voter string) string {
+	return FormatInt64Key(proposalID) + ":" + voter
 }

--- a/contract/r/gnoswap/gov/governance/store_test.gno
+++ b/contract/r/gnoswap/gov/governance/store_test.gno
@@ -529,7 +529,7 @@ func TestStoreSetAndGetProposalUserVotingInfos(t *testing.T) {
 	}
 }
 
-func TestStoreSetAndGetProposalVotingInfos(t *testing.T) {
+func TestStoreSetAndGetProposalVotingInfo(t *testing.T) {
 	testCases := []struct {
 		name     string
 		verifyFn func(*testing.T)
@@ -544,22 +544,18 @@ func TestStoreSetAndGetProposalVotingInfos(t *testing.T) {
 				err := gs.SetProposalUserVotingInfos(votingInfos)
 				uassert.NoError(t, err)
 
-				_, exists := gs.GetProposalVotingInfos(1)
-				uassert.False(t, exists, "proposal voting infos for proposal 1 should not exist")
+				_, exists := gs.GetProposalVotingInfo(1, "user1")
+				uassert.False(t, exists, "proposal voting info for user1 should not exist")
 
-				proposalVotingInfo := avl.NewTree()
-				proposalVotingInfo.Set("user1", "vote_data")
-
-				err = gs.SetProposalVotingInfos(1, proposalVotingInfo)
+				votingInfo := NewVotingInfo(1000)
+				err = gs.SetProposalVotingInfo(1, "user1", votingInfo)
 				uassert.NoError(t, err)
 
-				retrieved, exists := gs.GetProposalVotingInfos(1)
-				uassert.True(t, exists, "proposal voting infos for proposal 1 should exist")
+				retrieved, exists := gs.GetProposalVotingInfo(1, "user1")
+				uassert.True(t, exists, "proposal voting info for user1 should exist")
 				uassert.NotEqual(t, nil, retrieved)
 
-				val, ok := retrieved.Get("user1")
-				uassert.True(t, ok, "user1 voting info should exist")
-				uassert.Equal(t, "vote_data", val)
+				uassert.Equal(t, int64(1000), retrieved.AvailableVoteWeight())
 			},
 		},
 		{
@@ -568,8 +564,8 @@ func TestStoreSetAndGetProposalVotingInfos(t *testing.T) {
 				resetTestState(t)
 				gs := NewGovernanceStore(kvStore)
 
-				votingInfo := avl.NewTree()
-				err := gs.SetProposalVotingInfos(1, votingInfo)
+				votingInfo := NewVotingInfo(1000)
+				err := gs.SetProposalVotingInfo(1, "user1", votingInfo)
 				uassert.ErrorContains(t, err, "proposal user voting infos store key not found")
 			},
 		},

--- a/contract/r/gnoswap/gov/governance/types.gno
+++ b/contract/r/gnoswap/gov/governance/types.gno
@@ -118,8 +118,8 @@ type IGovernanceStore interface {
 	HasProposalUserVotingInfosStoreKey() bool
 	GetProposalUserVotingInfos() *avl.Tree
 	SetProposalUserVotingInfos(votingInfos *avl.Tree) error
-	GetProposalVotingInfos(proposalID int64) (*avl.Tree, bool)
-	SetProposalVotingInfos(proposalID int64, votingInfos *avl.Tree) error
+	GetProposalVotingInfo(proposalID int64, voter string) (*VotingInfo, bool)
+	SetProposalVotingInfo(proposalID int64, voter string, votingInfo *VotingInfo) error
 
 	// User proposals methods
 	HasUserProposalsStoreKey() bool

--- a/contract/r/gnoswap/gov/governance/v1/_helper_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/_helper_test.gno
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"chain/banker"
+	"chain/runtime"
 	"testing"
 
 	"gno.land/p/nt/avl"
@@ -85,4 +86,27 @@ func createMockGovernanceStore() *mockGovernanceStore {
 		proposalUserVotingInfos: avl.NewTree(),
 		userProposals:           avl.NewTree(),
 	}
+}
+
+func newTestProposal(
+	id int64,
+	status *governance.ProposalStatus,
+	metadata *governance.ProposalMetadata,
+	data *governance.ProposalData,
+	proposer address,
+	configVersion int64,
+	snapshotTime int64,
+	createdAt int64,
+) *governance.Proposal {
+	return governance.NewProposal(
+		id,
+		status,
+		metadata,
+		data,
+		proposer,
+		configVersion,
+		snapshotTime,
+		createdAt,
+		runtime.ChainHeight(),
+	)
 }

--- a/contract/r/gnoswap/gov/governance/v1/_helper_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/_helper_test.gno
@@ -2,7 +2,6 @@ package v1
 
 import (
 	"chain/banker"
-	"chain/runtime"
 	"testing"
 
 	"gno.land/p/nt/avl"
@@ -96,7 +95,6 @@ func newTestProposal(
 	proposer address,
 	configVersion int64,
 	snapshotTime int64,
-	createdAt int64,
 ) *governance.Proposal {
 	return governance.NewProposal(
 		id,
@@ -106,7 +104,5 @@ func newTestProposal(
 		proposer,
 		configVersion,
 		snapshotTime,
-		createdAt,
-		runtime.ChainHeight(),
 	)
 }

--- a/contract/r/gnoswap/gov/governance/v1/_mock_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/_mock_test.gno
@@ -13,7 +13,7 @@ type mockGovernanceStore struct {
 	proposals                 *avl.Tree
 	proposalUserVotingInfos   *avl.Tree
 	userProposals             *avl.Tree
-	setProposalVotingInfosErr error
+	setProposalVotingInfoErr error
 }
 
 // Counter methods
@@ -102,33 +102,35 @@ func (m *mockGovernanceStore) SetProposals(proposals *avl.Tree) error {
 }
 
 // Proposal voting info methods
-func (m *mockGovernanceStore) HasProposalVotingInfosStoreKey() bool {
-	return true
-}
-
 func (m *mockGovernanceStore) GetProposalUserVotingInfos() *avl.Tree {
 	return m.proposalUserVotingInfos
 }
 
-func (m *mockGovernanceStore) GetProposalVotingInfos(proposalID int64) (*avl.Tree, bool) {
+func (m *mockGovernanceStore) GetProposalVotingInfo(proposalID int64, voter string) (*governance.VotingInfo, bool) {
 	if m.proposalUserVotingInfos == nil {
 		return nil, false
 	}
-	result, exists := m.proposalUserVotingInfos.Get(governance.FormatInt64Key(proposalID))
+	result, exists := m.proposalUserVotingInfos.Get(governance.FormatProposalVotingInfoKey(proposalID, voter))
 	if !exists {
 		return nil, false
 	}
-	return result.(*avl.Tree), true
+
+	votingInfo, ok := result.(*governance.VotingInfo)
+	if !ok {
+		return nil, false
+	}
+
+	return votingInfo, true
 }
 
-func (m *mockGovernanceStore) SetProposalVotingInfos(proposalID int64, votingInfos *avl.Tree) error {
-	if m.setProposalVotingInfosErr != nil {
-		return m.setProposalVotingInfosErr
+func (m *mockGovernanceStore) SetProposalVotingInfo(proposalID int64, voter string, votingInfo *governance.VotingInfo) error {
+	if m.setProposalVotingInfoErr != nil {
+		return m.setProposalVotingInfoErr
 	}
 	if m.proposalUserVotingInfos == nil {
 		m.proposalUserVotingInfos = avl.NewTree()
 	}
-	m.proposalUserVotingInfos.Set(governance.FormatInt64Key(proposalID), votingInfos)
+	m.proposalUserVotingInfos.Set(governance.FormatProposalVotingInfoKey(proposalID, voter), votingInfo)
 	return nil
 }
 

--- a/contract/r/gnoswap/gov/governance/v1/_mock_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/_mock_test.gno
@@ -57,7 +57,7 @@ func (m *mockGovernanceStore) GetConfig(version int64) (governance.Config, bool)
 	if m.configs == nil {
 		return governance.Config{}, false
 	}
-	result, exists := m.configs.Get(formatInt(version))
+	result, exists := m.configs.Get(governance.FormatInt64Key(version))
 	if !exists {
 		return governance.Config{}, false
 	}
@@ -68,7 +68,7 @@ func (m *mockGovernanceStore) SetConfig(version int64, config governance.Config)
 	if m.configs == nil {
 		m.configs = avl.NewTree()
 	}
-	m.configs.Set(formatInt(version), config)
+	m.configs.Set(governance.FormatInt64Key(version), config)
 	return nil
 }
 
@@ -81,7 +81,7 @@ func (m *mockGovernanceStore) GetProposal(proposalID int64) (*governance.Proposa
 	if m.proposals == nil {
 		return nil, false
 	}
-	proposal, exists := m.proposals.Get(formatInt(proposalID))
+	proposal, exists := m.proposals.Get(governance.FormatInt64Key(proposalID))
 	if !exists {
 		return nil, false
 	}
@@ -92,7 +92,7 @@ func (m *mockGovernanceStore) SetProposal(proposalID int64, proposal *governance
 	if m.proposals == nil {
 		m.proposals = avl.NewTree()
 	}
-	m.proposals.Set(formatInt(proposalID), proposal)
+	m.proposals.Set(governance.FormatInt64Key(proposalID), proposal)
 	return nil
 }
 
@@ -114,7 +114,7 @@ func (m *mockGovernanceStore) GetProposalVotingInfos(proposalID int64) (*avl.Tre
 	if m.proposalUserVotingInfos == nil {
 		return nil, false
 	}
-	result, exists := m.proposalUserVotingInfos.Get(formatInt(proposalID))
+	result, exists := m.proposalUserVotingInfos.Get(governance.FormatInt64Key(proposalID))
 	if !exists {
 		return nil, false
 	}
@@ -128,7 +128,7 @@ func (m *mockGovernanceStore) SetProposalVotingInfos(proposalID int64, votingInf
 	if m.proposalUserVotingInfos == nil {
 		m.proposalUserVotingInfos = avl.NewTree()
 	}
-	m.proposalUserVotingInfos.Set(formatInt(proposalID), votingInfos)
+	m.proposalUserVotingInfos.Set(governance.FormatInt64Key(proposalID), votingInfos)
 	return nil
 }
 

--- a/contract/r/gnoswap/gov/governance/v1/_mock_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/_mock_test.gno
@@ -6,13 +6,14 @@ import (
 )
 
 type mockGovernanceStore struct {
-	configCounter           *governance.Counter
-	proposalCounter         *governance.Counter
-	configs                 *avl.Tree
-	config                  governance.Config
-	proposals               *avl.Tree
-	proposalUserVotingInfos *avl.Tree
-	userProposals           *avl.Tree
+	configCounter             *governance.Counter
+	proposalCounter           *governance.Counter
+	config                    governance.Config
+	configs                   *avl.Tree
+	proposals                 *avl.Tree
+	proposalUserVotingInfos   *avl.Tree
+	userProposals             *avl.Tree
+	setProposalVotingInfosErr error
 }
 
 // Counter methods
@@ -121,6 +122,9 @@ func (m *mockGovernanceStore) GetProposalVotingInfos(proposalID int64) (*avl.Tre
 }
 
 func (m *mockGovernanceStore) SetProposalVotingInfos(proposalID int64, votingInfos *avl.Tree) error {
+	if m.setProposalVotingInfosErr != nil {
+		return m.setProposalVotingInfosErr
+	}
 	if m.proposalUserVotingInfos == nil {
 		m.proposalUserVotingInfos = avl.NewTree()
 	}

--- a/contract/r/gnoswap/gov/governance/v1/api_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/api_test.gno
@@ -26,7 +26,7 @@ func TestAPI_createVoteJsonNode(t *testing.T) {
 			addr:       testutils.TestAddress("voter1"),
 			proposalId: 1,
 			setupVotingInfo: func() *governance.VotingInfo {
-				vote := governance.NewVotingInfo(1000, testutils.TestAddress("voter1"))
+				vote := governance.NewVotingInfo(1000)
 				resolver := NewVotingInfoResolver(vote)
 				resolver.vote(true, 1000, 100, 1234567890)
 				return vote
@@ -39,7 +39,7 @@ func TestAPI_createVoteJsonNode(t *testing.T) {
 			addr:       testutils.TestAddress("voter2"),
 			proposalId: 2,
 			setupVotingInfo: func() *governance.VotingInfo {
-				vote := governance.NewVotingInfo(500, testutils.TestAddress("voter2"))
+				vote := governance.NewVotingInfo(500)
 				resolver := NewVotingInfoResolver(vote)
 				resolver.vote(false, 500, 200, 1234567900)
 				return vote
@@ -52,7 +52,7 @@ func TestAPI_createVoteJsonNode(t *testing.T) {
 			addr:       testutils.TestAddress("voter3"),
 			proposalId: 3,
 			setupVotingInfo: func() *governance.VotingInfo {
-				return governance.NewVotingInfo(2000, testutils.TestAddress("voter3"))
+				return governance.NewVotingInfo(2000)
 			},
 			expectedProposalId: "3",
 			expectedVoteYes:    "false",
@@ -62,7 +62,7 @@ func TestAPI_createVoteJsonNode(t *testing.T) {
 			addr:       testutils.TestAddress("voter4"),
 			proposalId: 4,
 			setupVotingInfo: func() *governance.VotingInfo {
-				vote := governance.NewVotingInfo(0, testutils.TestAddress("voter4"))
+				vote := governance.NewVotingInfo(0)
 				resolver := NewVotingInfoResolver(vote)
 				resolver.vote(true, 0, 150, 1234567950)
 				return vote

--- a/contract/r/gnoswap/gov/governance/v1/assert_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/assert_test.gno
@@ -31,10 +31,7 @@ func TestAssert_assertCallerIsProposer(t *testing.T) {
 					NewProposalTextData(),
 					proposer,
 					1, // configVersion
-					time.Now().Unix(),
-					time.Now().Unix(),
-					100,
-				)
+					time.Now().Unix())
 				gv.addProposal(proposal)
 				return 1
 			},
@@ -63,10 +60,7 @@ func TestAssert_assertCallerIsProposer(t *testing.T) {
 					NewProposalTextData(),
 					proposer,
 					1, // configVersion
-					time.Now().Unix(),
-					time.Now().Unix(),
-					100,
-				)
+					time.Now().Unix())
 				gv.addProposal(proposal)
 				return 2
 			},
@@ -86,10 +80,7 @@ func TestAssert_assertCallerIsProposer(t *testing.T) {
 					NewProposalTextData(),
 					proposer,
 					1, // configVersion
-					time.Now().Unix(),
-					time.Now().Unix(),
-					100,
-				)
+					time.Now().Unix())
 				gv.addProposal(proposal)
 				return 3
 			},

--- a/contract/r/gnoswap/gov/governance/v1/config.gno
+++ b/contract/r/gnoswap/gov/governance/v1/config.gno
@@ -51,7 +51,8 @@ func (gv *governanceV1) Reconfigure(
 	// Check if system is halted before proceeding
 	halt.AssertIsNotHaltedGovernance()
 
-	caller := runtime.PreviousRealm().Address()
+	previousRealm := runtime.PreviousRealm()
+	caller := previousRealm.Address()
 	access.AssertIsAdminOrGovernance(caller)
 
 	assertIsValidSmoothingPeriod(votingWeightSmoothingDuration)
@@ -82,11 +83,9 @@ func (gv *governanceV1) Reconfigure(
 	// Apply the new configuration
 	nextVersion := gv.reconfigure(newCfg)
 
-	// Emit configuration change event with all parameters
-	previousRealm := runtime.PreviousRealm()
 	chain.Emit(
 		"Reconfigure",
-		"prevAddr", previousRealm.Address().String(),
+		"prevAddr", caller.String(),
 		"prevRealm", previousRealm.PkgPath(),
 		"votingStartDelay", formatInt(newCfg.VotingStartDelay),
 		"votingPeriod", formatInt(newCfg.VotingPeriod),

--- a/contract/r/gnoswap/gov/governance/v1/getter_proposal_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/getter_proposal_test.gno
@@ -37,9 +37,8 @@ func TestGetterProposal_All(t *testing.T) {
 				address("g1proposer"),
 				42, // configVersion
 				time.Now().Unix(),
-				time.Now().Unix(),
 			),
-			getterFunc:    func(gv *governanceV1, id int64) any {
+			getterFunc: func(gv *governanceV1, id int64) any {
 				return gv.GetProposerByProposalId(id)
 			},
 			expectedValue: "g1proposer",
@@ -61,18 +60,17 @@ func TestGetterProposal_All(t *testing.T) {
 				address("g1proposer"),
 				42, // configVersion
 				time.Now().Unix(),
-				time.Now().Unix(),
 			),
-			getterFunc:    func(gv *governanceV1, id int64) any {
+			getterFunc: func(gv *governanceV1, id int64) any {
 				return gv.GetProposalTypeByProposalId(id)
 			},
 			expectedValue: "Text",
 		},
 		{
-			name:          "Get non-existent proposal",
-			proposalId:    999,
-			proposal:      nil,
-			getterFunc:    func(gv *governanceV1, id int64) any {
+			name:       "Get non-existent proposal",
+			proposalId: 999,
+			proposal:   nil,
+			getterFunc: func(gv *governanceV1, id int64) any {
 				return gv.GetProposerByProposalId(id)
 			},
 			expectedPanic: true,
@@ -107,9 +105,9 @@ func TestGetOldestActiveProposalSnapshotTime(t *testing.T) {
 	baseTime := time.Now().Unix()
 
 	tests := []struct {
-		name                   string
-		setupProposals         func(gv *governanceV1)
-		expectedSnapshotTime   int64
+		name                      string
+		setupProposals            func(gv *governanceV1)
+		expectedSnapshotTime      int64
 		expectedHasActiveProposal bool
 	}{
 		{
@@ -117,7 +115,7 @@ func TestGetOldestActiveProposalSnapshotTime(t *testing.T) {
 			setupProposals: func(gv *governanceV1) {
 				// No proposals added
 			},
-			expectedSnapshotTime:   0,
+			expectedSnapshotTime:      0,
 			expectedHasActiveProposal: false,
 		},
 		{
@@ -140,13 +138,10 @@ func TestGetOldestActiveProposalSnapshotTime(t *testing.T) {
 					governance.NewProposalData(governance.Text, nil, nil),
 					address("g1proposer"),
 					1,
-					baseTime-1000, // snapshotTime: 1000 seconds ago
-					baseTime,
-					100,
-				)
+					baseTime-1000)
 				gv.addProposal(proposal)
 			},
-			expectedSnapshotTime:   baseTime - 1000,
+			expectedSnapshotTime:      baseTime - 1000,
 			expectedHasActiveProposal: true,
 		},
 		{
@@ -170,10 +165,7 @@ func TestGetOldestActiveProposalSnapshotTime(t *testing.T) {
 					governance.NewProposalData(governance.Text, nil, nil),
 					address("g1proposer1"),
 					1,
-					baseTime-2000, // oldest snapshotTime
-					baseTime,
-					100,
-				)
+					baseTime-2000)
 				gv.addProposal(proposal1)
 
 				// Proposal 2: snapshotTime = baseTime - 500 (newer)
@@ -186,13 +178,10 @@ func TestGetOldestActiveProposalSnapshotTime(t *testing.T) {
 					governance.NewProposalData(governance.Text, nil, nil),
 					address("g1proposer2"),
 					1,
-					baseTime-500, // newer snapshotTime
-					baseTime,
-					101,
-				)
+					baseTime-500)
 				gv.addProposal(proposal2)
 			},
-			expectedSnapshotTime:   baseTime - 2000, // should return oldest
+			expectedSnapshotTime:      baseTime - 2000, // should return oldest
 			expectedHasActiveProposal: true,
 		},
 	}

--- a/contract/r/gnoswap/gov/governance/v1/getter_proposal_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/getter_proposal_test.gno
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	"chain/runtime"
 	"testing"
 	"time"
 
@@ -24,7 +23,7 @@ func TestGetterProposal_All(t *testing.T) {
 		{
 			name:       "Get proposer address",
 			proposalId: 1,
-			proposal: governance.NewProposal(
+			proposal: newTestProposal(
 				1,
 				NewProposalStatus(governance.Config{
 					VotingStartDelay: 100,
@@ -39,7 +38,6 @@ func TestGetterProposal_All(t *testing.T) {
 				42, // configVersion
 				time.Now().Unix(),
 				time.Now().Unix(),
-				runtime.ChainHeight(),
 			),
 			getterFunc:    func(gv *governanceV1, id int64) any {
 				return gv.GetProposerByProposalId(id)
@@ -49,7 +47,7 @@ func TestGetterProposal_All(t *testing.T) {
 		{
 			name:       "Get proposal type",
 			proposalId: 1,
-			proposal: governance.NewProposal(
+			proposal: newTestProposal(
 				1,
 				NewProposalStatus(governance.Config{
 					VotingStartDelay: 100,
@@ -64,7 +62,6 @@ func TestGetterProposal_All(t *testing.T) {
 				42, // configVersion
 				time.Now().Unix(),
 				time.Now().Unix(),
-				runtime.ChainHeight(),
 			),
 			getterFunc:    func(gv *governanceV1, id int64) any {
 				return gv.GetProposalTypeByProposalId(id)

--- a/contract/r/gnoswap/gov/governance/v1/governance_execute_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_execute_test.gno
@@ -679,6 +679,31 @@ func TestGovernanceExecute_ExecutionValidation(t *testing.T) {
 			shouldFail:    true,
 		},
 		{
+			name:       "fail - quorum met but no majority",
+			proposalId: 1,
+			setupProposal: func() *governance.Proposal {
+				config := testConfig
+				config.Quorum = 40
+				proposal := governance.NewProposal(
+					1,
+					NewProposalStatus(config, 100, true, time.Now().Add(-time.Hour*24*10).Unix()),
+					governance.NewProposalMetadata("Parameter Change", "Description"),
+					NewProposalExecutionData(1, "test*EXE*function*EXE*param"),
+					testutils.TestAddress("proposer"),
+					1,
+					time.Now().Add(-time.Hour*24*10).Unix(),
+					time.Now().Add(-time.Hour*24*10).Unix(),
+					100,
+				)
+				statusResolver := NewProposalStatusResolver(proposal.Status())
+				statusResolver.vote(true, 40)
+				statusResolver.vote(false, 41)
+				return proposal
+			},
+			expectedError: "[GNOSWAP-GOVERNANCE-021] proposal not executable",
+			shouldFail:    true,
+		},
+		{
 			name:       "fail - already executed proposal",
 			proposalId: 1,
 			setupProposal: func() *governance.Proposal {

--- a/contract/r/gnoswap/gov/governance/v1/governance_execute_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_execute_test.gno
@@ -54,10 +54,7 @@ func TestGovernanceExecute_Execute(t *testing.T) {
 					NewProposalExecutionData(1, "gno.land/r/gnoswap/staker*EXE*SetUnStakingFee*EXE*0"),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Add(-time.Hour*24*10).Unix(),
-					time.Now().Add(-time.Hour*24*10).Unix(),
-					100,
-				)
+					time.Now().Add(-time.Hour*24*10).Unix())
 				// Mark as passed
 				resolver := NewProposalStatusResolver(proposal.Status())
 				// proposal.Status().Vote(true, 6_000_000_000) // 60% yes votes
@@ -88,10 +85,7 @@ func TestGovernanceExecute_Execute(t *testing.T) {
 					),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Add(-time.Hour*24*10).Unix(),
-					time.Now().Add(-time.Hour*24*10).Unix(),
-					100,
-				)
+					time.Now().Add(-time.Hour*24*10).Unix())
 				statusResolver := NewProposalStatusResolver(proposal.Status())
 				statusResolver.vote(true, 6_000_000_000)
 				return proposal
@@ -121,10 +115,7 @@ func TestGovernanceExecute_Execute(t *testing.T) {
 				NewProposalTextData(),
 				testutils.TestAddress("proposer"),
 				1,
-				time.Now().Add(-time.Hour*24*10).Unix(),
-				time.Now().Add(-time.Hour*24*10).Unix(),
-				100,
-			),
+				time.Now().Add(-time.Hour*24*10).Unix()),
 			expectedHasAbort: true,
 			expectedAbortMsg: "[GNOSWAP-GOVERNANCE-011] cannot execute text proposal",
 		},
@@ -145,10 +136,7 @@ func TestGovernanceExecute_Execute(t *testing.T) {
 					NewProposalExecutionData(1, "gno.land/r/gnoswap/staker*EXE*SetUnStakingFee*EXE*0"),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Unix(),
-					time.Now().Unix(),
-					100,
-				)
+					time.Now().Unix())
 				statusResolver := NewProposalStatusResolver(proposal.Status())
 				statusResolver.vote(true, 6_000_000_000)
 				return proposal
@@ -173,10 +161,7 @@ func TestGovernanceExecute_Execute(t *testing.T) {
 					NewProposalExecutionData(1, "gno.land/r/gnoswap/staker*EXE*SetUnStakingFee*EXE*0"),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Add(-time.Second*86400).Unix(),
-					time.Now().Add(-time.Second*86400).Unix(),
-					100,
-				)
+					time.Now().Add(-time.Second*86400).Unix())
 				// Don't add votes, so it doesn't pass
 				return proposal
 			}(),
@@ -255,10 +240,7 @@ func TestGovernanceExecute_ExecuteProposalPrivate(t *testing.T) {
 					NewProposalExecutionData(1, "gno.land/r/gnoswap/staker*EXE*SetUnStakingFee*EXE*0"),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Add(-time.Hour*24*10).Unix(),
-					time.Now().Add(-time.Hour*24*10).Unix(),
-					100,
-				)
+					time.Now().Add(-time.Hour*24*10).Unix())
 				statusResolver := NewProposalStatusResolver(proposal.Status())
 				statusResolver.vote(true, 6_000_000_000)
 				return proposal
@@ -289,10 +271,7 @@ func TestGovernanceExecute_ExecuteProposalPrivate(t *testing.T) {
 					),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Add(-time.Hour*24*10).Unix(),
-					time.Now().Add(-time.Hour*24*10).Unix(),
-					100,
-				)
+					time.Now().Add(-time.Hour*24*10).Unix())
 				statusResolver := NewProposalStatusResolver(proposal.Status())
 				statusResolver.vote(true, 6_000_000_000)
 				return proposal
@@ -326,10 +305,7 @@ func TestGovernanceExecute_ExecuteProposalPrivate(t *testing.T) {
 				NewProposalTextData(),
 				testutils.TestAddress("proposer"),
 				1,
-				time.Now().Unix(),
-				time.Now().Unix(),
-				100,
-			),
+				time.Now().Unix()),
 			expectedHasError:     true,
 			expectedErrorMessage: "[GNOSWAP-GOVERNANCE-011] cannot execute text proposal",
 		},
@@ -352,10 +328,7 @@ func TestGovernanceExecute_ExecuteProposalPrivate(t *testing.T) {
 					NewProposalExecutionData(1, "gno.land/r/gnoswap/staker*EXE*SetUnStakingFee*EXE*0"),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Unix(),
-					time.Now().Unix(),
-					100,
-				)
+					time.Now().Unix())
 				statusResolver := NewProposalStatusResolver(proposal.Status())
 				statusResolver.vote(true, 6_000_000_000)
 				return proposal
@@ -434,10 +407,7 @@ func TestGovernanceExecute_Cancel(t *testing.T) {
 				),
 				testutils.TestAddress("proposer"),
 				1,
-				time.Now().Unix()-executableDelay,
-				time.Now().Unix()-executableDelay,
-				100,
-			),
+				time.Now().Unix()-executableDelay),
 			expectedProposalId: 1,
 		},
 		{
@@ -461,10 +431,7 @@ func TestGovernanceExecute_Cancel(t *testing.T) {
 				),
 				testutils.TestAddress("proposer"),
 				1,
-				time.Now().Unix()-executableDelay,
-				time.Now().Unix()-executableDelay,
-				100,
-			),
+				time.Now().Unix()-executableDelay),
 			expectedHasAbort: true,
 			expectedAbortMsg: "[GNOSWAP-GOVERNANCE-022] not proposer",
 		},
@@ -492,10 +459,7 @@ func TestGovernanceExecute_Cancel(t *testing.T) {
 					NewProposalExecutionData(1, "gno.land/r/gnoswap/staker*EXE*SetUnStakingFee*EXE*0"),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Add(-time.Hour*24*10).Unix(),
-					time.Now().Add(-time.Hour*24*10).Unix(),
-					100,
-				)
+					time.Now().Add(-time.Hour*24*10).Unix())
 				// Mark as executed
 				statusResolver := NewProposalStatusResolver(proposal.Status())
 				statusResolver.execute(time.Now().Unix(), 1000, testutils.TestAddress("executor"))
@@ -521,10 +485,7 @@ func TestGovernanceExecute_Cancel(t *testing.T) {
 					NewProposalTextData(),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Unix(),
-					time.Now().Unix(),
-					100,
-				)
+					time.Now().Unix())
 				// Mark as canceled
 				statusResolver := NewProposalStatusResolver(proposal.Status())
 				statusResolver.cancel(time.Now().Unix(), 1000, testutils.TestAddress("canceler"))
@@ -606,10 +567,7 @@ func TestGovernanceExecute_ExecutionValidation(t *testing.T) {
 					NewProposalTextData(),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Add(-time.Hour*24*10).Unix(),
-					time.Now().Add(-time.Hour*24*10).Unix(),
-					100,
-				)
+					time.Now().Add(-time.Hour*24*10).Unix())
 
 				statusResolver := NewProposalStatusResolver(proposal.Status())
 				statusResolver.vote(true, 6_000_000_000)
@@ -629,10 +587,7 @@ func TestGovernanceExecute_ExecutionValidation(t *testing.T) {
 					NewProposalExecutionData(1, "test*EXE*function*EXE*param"),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Unix(),
-					time.Now().Unix(),
-					100,
-				)
+					time.Now().Unix())
 			},
 			expectedError: "[GNOSWAP-GOVERNANCE-021] proposal not executable",
 			shouldFail:    true,
@@ -648,10 +603,7 @@ func TestGovernanceExecute_ExecutionValidation(t *testing.T) {
 					NewProposalExecutionData(1, "test*EXE*function*EXE*param"),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Add(-time.Hour*25).Unix(),
-					time.Now().Add(-time.Hour*25).Unix(),
-					100,
-				)
+					time.Now().Add(-time.Hour*25).Unix())
 			},
 			expectedError: "[GNOSWAP-GOVERNANCE-021] proposal not executable",
 			shouldFail:    true,
@@ -667,10 +619,7 @@ func TestGovernanceExecute_ExecutionValidation(t *testing.T) {
 					NewProposalExecutionData(1, "test*EXE*function*EXE*param"),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Add(-time.Hour*24*10).Unix(),
-					time.Now().Add(-time.Hour*24*10).Unix(),
-					100,
-				)
+					time.Now().Add(-time.Hour*24*10).Unix())
 				statusResolver := NewProposalStatusResolver(proposal.Status())
 				statusResolver.vote(false, 6_000_000_000) // Majority no votes
 				return proposal
@@ -691,10 +640,7 @@ func TestGovernanceExecute_ExecutionValidation(t *testing.T) {
 					NewProposalExecutionData(1, "test*EXE*function*EXE*param"),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Add(-time.Hour*24*10).Unix(),
-					time.Now().Add(-time.Hour*24*10).Unix(),
-					100,
-				)
+					time.Now().Add(-time.Hour*24*10).Unix())
 				statusResolver := NewProposalStatusResolver(proposal.Status())
 				statusResolver.vote(true, 40)
 				statusResolver.vote(false, 41)
@@ -714,10 +660,7 @@ func TestGovernanceExecute_ExecutionValidation(t *testing.T) {
 					NewProposalExecutionData(1, "test*EXE*function*EXE*param"),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Add(-time.Hour*24*15).Unix(),
-					time.Now().Add(-time.Hour*24*15).Unix(),
-					100,
-				)
+					time.Now().Add(-time.Hour*24*15).Unix())
 				statusResolver := NewProposalStatusResolver(proposal.Status())
 				statusResolver.vote(true, 6_000_000_000)
 				statusResolver.execute(time.Now().Unix(), 100, testutils.TestAddress("executor"))
@@ -737,10 +680,7 @@ func TestGovernanceExecute_ExecutionValidation(t *testing.T) {
 					NewProposalExecutionData(1, "test*EXE*function*EXE*param"),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Add(-time.Hour*24*40).Unix(),
-					time.Now().Add(-time.Hour*24*40).Unix(),
-					100,
-				)
+					time.Now().Add(-time.Hour*24*40).Unix())
 			},
 			expectedError: "[GNOSWAP-GOVERNANCE-021] proposal not executable",
 			shouldFail:    true,
@@ -756,10 +696,7 @@ func TestGovernanceExecute_ExecutionValidation(t *testing.T) {
 					NewProposalExecutionData(1, "test*EXE*function*EXE*param"),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Unix(),
-					time.Now().Unix(),
-					100,
-				)
+					time.Now().Unix())
 				statusResolver := NewProposalStatusResolver(proposal.Status())
 				statusResolver.cancel(time.Now().Unix(), 100, testutils.TestAddress("proposer"))
 				return proposal
@@ -862,10 +799,7 @@ func TestGovernanceExecute_ExecutionTiming(t *testing.T) {
 				NewProposalCommunityPoolSpendData("gno.land/r/gnoswap/gns", testutils.TestAddress("recipient"), 100, "gno.land/r/gnoswap/community_pool"),
 				testutils.TestAddress("proposer"),
 				1,
-				tt.proposalTime.Unix(),
-				tt.proposalTime.Unix(),
-				100,
-			)
+				tt.proposalTime.Unix())
 			statusResolver := NewProposalStatusResolver(proposal.Status())
 			statusResolver.vote(true, 6_000_000_000)
 			setupExecuteTestProposal(t, gov, proposal)
@@ -967,10 +901,7 @@ func TestGovernanceExecute_CommunityPoolSpendExecution(t *testing.T) {
 				),
 				testutils.TestAddress("proposer"),
 				1,
-				time.Now().Add(-time.Hour*24*15).Unix(),
-				time.Now().Add(-time.Hour*24*15).Unix(),
-				100,
-			)
+				time.Now().Add(-time.Hour*24*15).Unix())
 			statusResolver := NewProposalStatusResolver(proposal.Status())
 			statusResolver.vote(true, 6_000_000_000)
 			setupExecuteTestProposal(t, gov, proposal)
@@ -1080,10 +1011,7 @@ func TestGovernanceExecute_ParameterChangeExecution(t *testing.T) {
 				NewProposalExecutionData(tt.numToExecute, tt.executions),
 				testutils.TestAddress("proposer"),
 				1,
-				time.Now().Add(-time.Hour*24*15).Unix(),
-				time.Now().Add(-time.Hour*24*15).Unix(),
-				100,
-			)
+				time.Now().Add(-time.Hour*24*15).Unix())
 			statusResolver := NewProposalStatusResolver(proposal.Status())
 			statusResolver.vote(true, 6_000_000_000)
 			setupExecuteTestProposal(t, gov, proposal)
@@ -1197,10 +1125,7 @@ func TestGovernanceExecute_CancellationScenarios(t *testing.T) {
 					NewProposalCommunityPoolSpendData("gno.land/r/gnoswap/gns", tt.proposer, 100, "gno.land/r/gnoswap/community_pool"),
 					tt.proposer,
 					1,
-					tt.cancellationTime.Unix(),
-					tt.cancellationTime.Unix(),
-					100,
-				)
+					tt.cancellationTime.Unix())
 				setupExecuteTestProposal(t, gov, proposal)
 			}
 
@@ -1245,10 +1170,7 @@ func TestGovernanceExecute_ReExecutionPrevention(t *testing.T) {
 			NewProposalExecutionData(1, "gno.land/r/gnoswap/staker*EXE*SetUnStakingFee*EXE*-1"),
 			testutils.TestAddress("proposer"),
 			1,
-			time.Now().Add(-time.Hour*24*15).Unix(),
-			time.Now().Add(-time.Hour*24*15).Unix(),
-			100,
-		)
+			time.Now().Add(-time.Hour*24*15).Unix())
 		resolver := NewProposalStatusResolver(proposal.Status())
 		resolver.vote(true, 6_000_000_000)
 		setupExecuteTestProposal(t, gov, proposal)
@@ -1302,10 +1224,7 @@ func TestGovernanceExecute_executeCommunityPoolSpend(t *testing.T) {
 					),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Unix(),
-					time.Now().Unix(),
-					100,
-				)
+					time.Now().Unix())
 			},
 			setupRegistry: func() *ParameterRegistry {
 				return CreateParameterHandlers()
@@ -1370,10 +1289,7 @@ func TestGovernanceExecute_executeParameterChange(t *testing.T) {
 					NewProposalExecutionData(1, "gno.land/r/gnoswap/staker*EXE*SetUnStakingFee*EXE*100"),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Unix(),
-					time.Now().Unix(),
-					100,
-				)
+					time.Now().Unix())
 			},
 			setupRegistry: func() *ParameterRegistry {
 				return CreateParameterHandlers()
@@ -1393,10 +1309,7 @@ func TestGovernanceExecute_executeParameterChange(t *testing.T) {
 					NewProposalExecutionData(0, ""),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Unix(),
-					time.Now().Unix(),
-					100,
-				)
+					time.Now().Unix())
 			},
 			setupRegistry: func() *ParameterRegistry {
 				return NewParameterRegistry()
@@ -1416,10 +1329,7 @@ func TestGovernanceExecute_executeParameterChange(t *testing.T) {
 					NewProposalExecutionData(1, "gno.land/r/nonexistent/package*EXE*NonExistentFunction*EXE*123"),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Unix(),
-					time.Now().Unix(),
-					100,
-				)
+					time.Now().Unix())
 			},
 			setupRegistry: func() *ParameterRegistry {
 				return NewParameterRegistry()

--- a/contract/r/gnoswap/gov/governance/v1/governance_propose.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_propose.gno
@@ -43,7 +43,6 @@ func (gv *governanceV1) ProposeText(
 	callerAddress := runtime.PreviousRealm().Address()
 
 	createdAt := time.Now().Unix()
-	createdHeight := runtime.ChainHeight()
 	gnsBalance := gns.BalanceOf(callerAddress)
 
 	config, ok := gv.getCurrentConfig()
@@ -82,7 +81,6 @@ func (gv *governanceV1) ProposeText(
 		callerAddress,
 		gnsBalance,
 		createdAt,
-		createdHeight,
 	)
 	if err != nil {
 		panic(err)
@@ -150,7 +148,6 @@ func (gv *governanceV1) ProposeCommunityPoolSpend(
 	assertIsValidToken(tokenPath)
 
 	createdAt := time.Now().Unix()
-	createdHeight := runtime.ChainHeight()
 
 	callerAddress := runtime.PreviousRealm().Address()
 	gnsBalance := gns.BalanceOf(callerAddress)
@@ -191,7 +188,6 @@ func (gv *governanceV1) ProposeCommunityPoolSpend(
 		callerAddress,
 		gnsBalance,
 		createdAt,
-		createdHeight,
 	)
 	if err != nil {
 		panic(err)
@@ -265,7 +261,6 @@ func (gv *governanceV1) ProposeParameterChange(
 	callerAddress := runtime.PreviousRealm().Address()
 
 	createdAt := time.Now().Unix()
-	createdHeight := runtime.ChainHeight()
 	gnsBalance := gns.BalanceOf(callerAddress)
 
 	config, ok := gv.getCurrentConfig()
@@ -309,7 +304,6 @@ func (gv *governanceV1) ProposeParameterChange(
 		callerAddress,
 		gnsBalance,
 		createdAt,
-		createdHeight,
 	)
 	if err != nil {
 		panic(err)
@@ -353,7 +347,6 @@ func (gv *governanceV1) createProposal(
 	proposerAddress address,
 	proposerGnsBalance int64,
 	createdAt int64,
-	createdHeight int64,
 ) (*governance.Proposal, error) {
 	// Validate proposal metadata (title and description)
 	metadataResolver := NewProposalMetadataResolver(proposalMetadata)
@@ -397,8 +390,6 @@ func (gv *governanceV1) createProposal(
 		proposerAddress,
 		configVersion,
 		snapshotTime,
-		createdAt,
-		createdHeight,
 	)
 
 	// Store the proposal in state

--- a/contract/r/gnoswap/gov/governance/v1/governance_propose_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_propose_test.gno
@@ -832,10 +832,7 @@ func TestGovernancePropose_ProposalStateValidation(t *testing.T) {
 					NewProposalTextData(),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Unix()-testConfig.VotingWeightSmoothingDuration,
-					time.Now().Unix(),
-					100,
-				)
+					time.Now().Unix()-testConfig.VotingWeightSmoothingDuration)
 			},
 			expectedError: "[GNOSWAP-GOVERNANCE-019] already active proposal",
 			shouldFail:    true,
@@ -852,10 +849,7 @@ func TestGovernancePropose_ProposalStateValidation(t *testing.T) {
 					NewProposalTextData(),
 					testutils.TestAddress("proposer"),
 					1,
-					createTime-testConfig.VotingWeightSmoothingDuration,
-					createTime,
-					100,
-				)
+					createTime-testConfig.VotingWeightSmoothingDuration)
 			},
 			expectedError: "[GNOSWAP-GOVERNANCE-019] already active proposal",
 			shouldFail:    true,
@@ -872,10 +866,7 @@ func TestGovernancePropose_ProposalStateValidation(t *testing.T) {
 					NewProposalExecutionData(1, "test*EXE*func*EXE*param"),
 					testutils.TestAddress("proposer"),
 					1,
-					createTime-testConfig.VotingWeightSmoothingDuration,
-					createTime,
-					100,
-				)
+					createTime-testConfig.VotingWeightSmoothingDuration)
 				statusResolver := NewProposalStatusResolver(proposal.Status())
 				statusResolver.vote(true, 6_000_000_000)
 				return proposal
@@ -894,10 +885,7 @@ func TestGovernancePropose_ProposalStateValidation(t *testing.T) {
 					NewProposalExecutionData(1, "test*EXE*func*EXE*param"),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Add(-time.Hour*24*12).Unix()-testConfig.VotingWeightSmoothingDuration,
-					time.Now().Add(-time.Hour*24*12).Unix(),
-					100,
-				)
+					time.Now().Add(-time.Hour*24*12).Unix()-testConfig.VotingWeightSmoothingDuration)
 				statusResolver := NewProposalStatusResolver(proposal.Status())
 				statusResolver.vote(true, 6_000_000_000)
 				return proposal
@@ -916,10 +904,7 @@ func TestGovernancePropose_ProposalStateValidation(t *testing.T) {
 					NewProposalExecutionData(1, "test*EXE*func*EXE*param"),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Add(-time.Hour*24*20).Unix()-testConfig.VotingWeightSmoothingDuration,
-					time.Now().Add(-time.Hour*24*20).Unix(),
-					100,
-				)
+					time.Now().Add(-time.Hour*24*20).Unix()-testConfig.VotingWeightSmoothingDuration)
 				statusResolver := NewProposalStatusResolver(proposal.Status())
 				statusResolver.vote(true, 6_000_000_000)
 				statusResolver.execute(time.Now().Unix(), 100, testutils.TestAddress("executor"))
@@ -938,10 +923,7 @@ func TestGovernancePropose_ProposalStateValidation(t *testing.T) {
 					NewProposalTextData(),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Unix()-testConfig.VotingWeightSmoothingDuration,
-					time.Now().Unix(),
-					100,
-				)
+					time.Now().Unix()-testConfig.VotingWeightSmoothingDuration)
 				statusResolver := NewProposalStatusResolver(proposal.Status())
 				statusResolver.cancel(time.Now().Unix(), 100, testutils.TestAddress("proposer"))
 				return proposal
@@ -959,10 +941,7 @@ func TestGovernancePropose_ProposalStateValidation(t *testing.T) {
 					NewProposalExecutionData(1, "test*EXE*func*EXE*param"),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Add(-time.Hour*24*40).Unix()-testConfig.VotingWeightSmoothingDuration,
-					time.Now().Add(-time.Hour*24*40).Unix(),
-					100,
-				)
+					time.Now().Add(-time.Hour*24*40).Unix()-testConfig.VotingWeightSmoothingDuration)
 			},
 			shouldFail:  false,
 			description: "Expired status allows new proposal",
@@ -977,10 +956,7 @@ func TestGovernancePropose_ProposalStateValidation(t *testing.T) {
 					NewProposalTextData(),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Add(-time.Hour*24*10).Unix()-testConfig.VotingWeightSmoothingDuration,
-					time.Now().Add(-time.Hour*24*10).Unix(),
-					100,
-				)
+					time.Now().Add(-time.Hour*24*10).Unix()-testConfig.VotingWeightSmoothingDuration)
 				statusResolver := NewProposalStatusResolver(proposal.Status())
 				statusResolver.vote(false, 6_000_000_000) // Majority no votes
 				return proposal
@@ -1396,10 +1372,7 @@ func setupTestActiveProposal(t *testing.T, gov *governanceV1, proposerAddress ad
 		NewProposalTextData(),
 		proposerAddress,
 		gov.getCurrentConfigVersion(),
-		time.Now().Unix()-testConfig.VotingWeightSmoothingDuration,
-		time.Now().Unix(),
-		100,
-	)
+		time.Now().Unix()-testConfig.VotingWeightSmoothingDuration)
 
 	gov.addProposal(proposal)
 }

--- a/contract/r/gnoswap/gov/governance/v1/governance_propose_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_propose_test.gno
@@ -48,8 +48,8 @@ func TestGovernancePropose_ProposeText(t *testing.T) {
 			setupGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
-				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000, testutils.TestAddress("proposer")),
-				testutils.TestAddress("voter1").String():   governance.NewVotingInfo(3_000_000_000, testutils.TestAddress("voter1")),
+				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
+				testutils.TestAddress("voter1").String():   governance.NewVotingInfo(3_000_000_000),
 			},
 			maxVotingWeight:    8_000_000_000,
 			expectedProposalId: 1,
@@ -71,7 +71,7 @@ func TestGovernancePropose_ProposeText(t *testing.T) {
 			setupGnsBalance:     500_000_000, // Less than threshold
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
-				testutils.TestAddress("poor_proposer").String(): governance.NewVotingInfo(5_000_000_000, testutils.TestAddress("poor_proposer")),
+				testutils.TestAddress("poor_proposer").String(): governance.NewVotingInfo(5_000_000_000),
 			},
 			maxVotingWeight:  5_000_000_000,
 			expectedHasAbort: true,
@@ -94,7 +94,7 @@ func TestGovernancePropose_ProposeText(t *testing.T) {
 			setupGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
-				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000, testutils.TestAddress("proposer")),
+				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
 			},
 			maxVotingWeight:  5_000_000_000,
 			expectedHasAbort: true,
@@ -117,7 +117,7 @@ func TestGovernancePropose_ProposeText(t *testing.T) {
 			setupGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
-				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000, testutils.TestAddress("proposer")),
+				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
 			},
 			maxVotingWeight:  5_000_000_000,
 			expectedHasAbort: true,
@@ -140,7 +140,7 @@ func TestGovernancePropose_ProposeText(t *testing.T) {
 			setupGnsBalance:     10_000_000_000,
 			setupActiveProposal: true,
 			setupUserVotes: map[string]*governance.VotingInfo{
-				testutils.TestAddress("active_proposer").String(): governance.NewVotingInfo(5_000_000_000, testutils.TestAddress("active_proposer")),
+				testutils.TestAddress("active_proposer").String(): governance.NewVotingInfo(5_000_000_000),
 			},
 			maxVotingWeight:  5_000_000_000,
 			expectedHasAbort: true,
@@ -257,8 +257,8 @@ func TestGovernancePropose_ProposeCommunityPoolSpend(t *testing.T) {
 			setupGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
-				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000, testutils.TestAddress("proposer")),
-				testutils.TestAddress("voter1").String():   governance.NewVotingInfo(3_000_000_000, testutils.TestAddress("voter1")),
+				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
+				testutils.TestAddress("voter1").String():   governance.NewVotingInfo(3_000_000_000),
 			},
 			maxVotingWeight:    8_000_000_000,
 			expectedProposalId: 1,
@@ -283,7 +283,7 @@ func TestGovernancePropose_ProposeCommunityPoolSpend(t *testing.T) {
 			setupGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
-				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000, testutils.TestAddress("proposer")),
+				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
 			},
 			maxVotingWeight:  5_000_000_000,
 			expectedHasAbort: true,
@@ -309,7 +309,7 @@ func TestGovernancePropose_ProposeCommunityPoolSpend(t *testing.T) {
 			setupGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
-				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000, testutils.TestAddress("proposer")),
+				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
 			},
 			maxVotingWeight:  5_000_000_000,
 			expectedHasAbort: true,
@@ -335,7 +335,7 @@ func TestGovernancePropose_ProposeCommunityPoolSpend(t *testing.T) {
 			setupGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
-				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000, testutils.TestAddress("proposer")),
+				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
 			},
 			maxVotingWeight:  5_000_000_000,
 			expectedHasAbort: true,
@@ -361,7 +361,7 @@ func TestGovernancePropose_ProposeCommunityPoolSpend(t *testing.T) {
 			setupGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
-				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000, testutils.TestAddress("proposer")),
+				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
 			},
 			maxVotingWeight:  5_000_000_000,
 			expectedHasAbort: true,
@@ -451,8 +451,8 @@ func TestGovernancePropose_ProposeParameterChange(t *testing.T) {
 			setupGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
-				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000, testutils.TestAddress("proposer")),
-				testutils.TestAddress("voter1").String():   governance.NewVotingInfo(3_000_000_000, testutils.TestAddress("voter1")),
+				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
+				testutils.TestAddress("voter1").String():   governance.NewVotingInfo(3_000_000_000),
 			},
 			maxVotingWeight:    8_000_000_000,
 			expectedProposalId: 1,
@@ -476,7 +476,7 @@ func TestGovernancePropose_ProposeParameterChange(t *testing.T) {
 			setupGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
-				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000, testutils.TestAddress("proposer")),
+				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
 			},
 			maxVotingWeight:  5_000_000_000,
 			expectedHasAbort: true,
@@ -501,7 +501,7 @@ func TestGovernancePropose_ProposeParameterChange(t *testing.T) {
 			setupGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
-				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000, testutils.TestAddress("proposer")),
+				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
 			},
 			maxVotingWeight:  5_000_000_000,
 			expectedHasAbort: true,
@@ -526,7 +526,7 @@ func TestGovernancePropose_ProposeParameterChange(t *testing.T) {
 			setupGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
-				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000, testutils.TestAddress("proposer")),
+				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
 			},
 			maxVotingWeight:  5_000_000_000,
 			expectedHasAbort: true,
@@ -551,7 +551,7 @@ func TestGovernancePropose_ProposeParameterChange(t *testing.T) {
 			setupGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
-				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000, testutils.TestAddress("proposer")),
+				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
 			},
 			maxVotingWeight:  5_000_000_000,
 			expectedHasAbort: true,
@@ -576,7 +576,7 @@ func TestGovernancePropose_ProposeParameterChange(t *testing.T) {
 			setupGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
-				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000, testutils.TestAddress("proposer")),
+				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
 			},
 			maxVotingWeight:  5_000_000_000,
 			expectedHasAbort: true,
@@ -601,7 +601,7 @@ func TestGovernancePropose_ProposeParameterChange(t *testing.T) {
 			setupGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
-				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000, testutils.TestAddress("proposer")),
+				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
 			},
 			maxVotingWeight:  5_000_000_000,
 			expectedHasAbort: true,
@@ -626,7 +626,7 @@ func TestGovernancePropose_ProposeParameterChange(t *testing.T) {
 			setupGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
-				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000, testutils.TestAddress("proposer")),
+				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
 			},
 			maxVotingWeight:  5_000_000_000,
 			expectedHasAbort: true,
@@ -651,7 +651,7 @@ func TestGovernancePropose_ProposeParameterChange(t *testing.T) {
 			setupGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
-				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000, testutils.TestAddress("proposer")),
+				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
 			},
 			maxVotingWeight:  5_000_000_000,
 			expectedHasAbort: true,
@@ -782,7 +782,7 @@ func TestGovernancePropose_ProposeTextInputValidation(t *testing.T) {
 			caller := testutils.TestAddress("proposer")
 			setupTestGnsBalance(t, caller, 10_000_000_000)
 			setupTestUserVotesWithDelegation(t, gov, map[string]*governance.VotingInfo{
-				caller.String(): governance.NewVotingInfo(5_000_000_000, caller),
+				caller.String(): governance.NewVotingInfo(5_000_000_000),
 			}, 5_000_000_000)
 
 			testing.SetRealm(testing.NewUserRealm(caller))
@@ -1008,7 +1008,7 @@ func TestGovernancePropose_ProposalStateValidation(t *testing.T) {
 			caller := testutils.TestAddress("proposer")
 			setupTestGnsBalance(t, caller, 10_000_000_000)
 			setupTestUserVotesWithDelegation(t, gov, map[string]*governance.VotingInfo{
-				caller.String(): governance.NewVotingInfo(5_000_000_000, caller),
+				caller.String(): governance.NewVotingInfo(5_000_000_000),
 			}, 5_000_000_000)
 
 			if tt.setupActiveProposal != nil {
@@ -1123,7 +1123,7 @@ func TestGovernancePropose_CommunityPoolSpendValidation(t *testing.T) {
 			caller := testutils.TestAddress("proposer")
 			setupTestGnsBalance(t, caller, 10_000_000_000)
 			setupTestUserVotesWithDelegation(t, gov, map[string]*governance.VotingInfo{
-				caller.String(): governance.NewVotingInfo(5_000_000_000, caller),
+				caller.String(): governance.NewVotingInfo(5_000_000_000),
 			}, 5_000_000_000)
 
 			testing.SetRealm(testing.NewUserRealm(caller))
@@ -1259,7 +1259,7 @@ func TestGovernancePropose_ParameterChangeValidation(t *testing.T) {
 			caller := testutils.TestAddress("proposer")
 			setupTestGnsBalance(t, caller, 10_000_000_000)
 			setupTestUserVotesWithDelegation(t, gov, map[string]*governance.VotingInfo{
-				caller.String(): governance.NewVotingInfo(5_000_000_000, caller),
+				caller.String(): governance.NewVotingInfo(5_000_000_000),
 			}, 5_000_000_000)
 
 			testing.SetRealm(testing.NewUserRealm(caller))
@@ -1312,8 +1312,8 @@ func TestGovernancePropose_ProposalIDGeneration(t *testing.T) {
 		setupTestGnsBalance(t, caller2, 10_000_000_000)
 		setupTestGnsBalance(t, caller3, 10_000_000_000)
 		setupTestUserVotesWithDelegation(t, gov, map[string]*governance.VotingInfo{
-			caller1.String(): governance.NewVotingInfo(5_000_000_000, caller1),
-			caller2.String(): governance.NewVotingInfo(5_000_000_000, caller2),
+			caller1.String(): governance.NewVotingInfo(5_000_000_000),
+			caller2.String(): governance.NewVotingInfo(5_000_000_000),
 		}, 10_000_000_000)
 
 		var proposalId1 int64

--- a/contract/r/gnoswap/gov/governance/v1/governance_snapshot_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_snapshot_test.gno
@@ -249,8 +249,5 @@ func createTestProposal(id int64) *governance.Proposal {
 		governance.NewProposalData(governance.Text, nil, nil),
 		address("g1proposer"),
 		1,
-		createdAt-config.VotingWeightSmoothingDuration,
-		createdAt,
-		100,
-	)
+		createdAt-config.VotingWeightSmoothingDuration)
 }

--- a/contract/r/gnoswap/gov/governance/v1/governance_snapshot_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_snapshot_test.gno
@@ -103,7 +103,7 @@ func TestGetProposalUserVotingInfo(t *testing.T) {
 			setupVotingInfos: func() *mockGovernanceStore {
 				store := newMockGovernanceStore()
 				voterAddr := address("g1voter00000000000000000000000000000001")
-				votingInfo := governance.NewVotingInfo(1000, voterAddr)
+				votingInfo := governance.NewVotingInfo(1000)
 				votingInfos := avl.NewTree()
 				votingInfos.Set(voterAddr.String(), votingInfo)
 				store.SetProposalVotingInfos(1, votingInfos)
@@ -139,7 +139,7 @@ func TestGetProposalUserVotingInfo(t *testing.T) {
 			setupVotingInfos: func() *mockGovernanceStore {
 				store := newMockGovernanceStore()
 				otherUser := address("g1other00000000000000000000000000000002")
-				votingInfo := governance.NewVotingInfo(1000, otherUser)
+				votingInfo := governance.NewVotingInfo(1000)
 				votingInfos := avl.NewTree()
 				votingInfos.Set(otherUser.String(), votingInfo)
 				store.SetProposalVotingInfos(1, votingInfos)
@@ -212,7 +212,7 @@ func TestUpdateProposalUserVotes(t *testing.T) {
 			votingInfos := avl.NewTree()
 			for i := 0; i < tt.numVotes; i++ {
 				voterAddr := address("g1voter0000000000000000000000000000000" + formatInt(int64(i)))
-				votingInfo := governance.NewVotingInfo(1000, voterAddr)
+				votingInfo := governance.NewVotingInfo(1000)
 				votingInfos.Set(voterAddr.String(), votingInfo)
 			}
 

--- a/contract/r/gnoswap/gov/governance/v1/governance_snapshot_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_snapshot_test.gno
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"strings"
 	"testing"
 
 	"gno.land/p/nt/avl"
@@ -104,9 +105,7 @@ func TestGetProposalUserVotingInfo(t *testing.T) {
 				store := newMockGovernanceStore()
 				voterAddr := address("g1voter00000000000000000000000000000001")
 				votingInfo := governance.NewVotingInfo(1000)
-				votingInfos := avl.NewTree()
-				votingInfos.Set(voterAddr.String(), votingInfo)
-				store.SetProposalVotingInfos(1, votingInfos)
+				store.SetProposalVotingInfo(1, voterAddr.String(), votingInfo)
 				return store
 			},
 			proposalID:    1,
@@ -117,7 +116,6 @@ func TestGetProposalUserVotingInfo(t *testing.T) {
 			name: "voting info does not exist for user",
 			setupVotingInfos: func() *mockGovernanceStore {
 				store := newMockGovernanceStore()
-				store.SetProposalVotingInfos(1, avl.NewTree())
 				return store
 			},
 			proposalID:    1,
@@ -140,9 +138,7 @@ func TestGetProposalUserVotingInfo(t *testing.T) {
 				store := newMockGovernanceStore()
 				otherUser := address("g1other00000000000000000000000000000002")
 				votingInfo := governance.NewVotingInfo(1000)
-				votingInfos := avl.NewTree()
-				votingInfos.Set(otherUser.String(), votingInfo)
-				store.SetProposalVotingInfos(1, votingInfos)
+				store.SetProposalVotingInfo(1, otherUser.String(), votingInfo)
 				return store
 			},
 			proposalID:    1,
@@ -222,9 +218,16 @@ func TestUpdateProposalUserVotes(t *testing.T) {
 			uassert.NoError(t, err)
 
 			// Verify stored votes
-			storedVotes, exists := store.GetProposalVotingInfos(tt.proposalID)
-			uassert.True(t, exists)
-			uassert.Equal(t, tt.expectedCount, storedVotes.Size())
+			storedVotes := store.GetProposalUserVotingInfos()
+			prefix := governance.FormatProposalVotingInfoKey(tt.proposalID, "")
+			count := 0
+			storedVotes.Iterate("", "", func(key string, _ interface{}) bool {
+				if strings.HasPrefix(key, prefix) {
+					count++
+				}
+				return false
+			})
+			uassert.Equal(t, tt.expectedCount, count)
 		})
 	}
 }

--- a/contract/r/gnoswap/gov/governance/v1/governance_vote.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_vote.gno
@@ -131,7 +131,10 @@ func (gv *governanceV1) vote(
 	votingInfosTree, _ := gv.getProposalUserVotingInfos(proposalID)
 	if votingInfosTree != nil {
 		votingInfosTree.Set(voterAddress.String(), userVote)
-		gv.store.SetProposalVotingInfos(proposalID, votingInfosTree)
+		err := gv.store.SetProposalVotingInfos(proposalID, votingInfosTree)
+		if err != nil {
+			return nil, 0, 0, err
+		}
 	}
 
 	// Update proposal vote tallies

--- a/contract/r/gnoswap/gov/governance/v1/governance_vote.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_vote.gno
@@ -128,13 +128,9 @@ func (gv *governanceV1) vote(
 	}
 
 	// Store the user's vote in the proposal voting infos
-	votingInfosTree, _ := gv.getProposalUserVotingInfos(proposalID)
-	if votingInfosTree != nil {
-		votingInfosTree.Set(voterAddress.String(), userVote)
-		err := gv.store.SetProposalVotingInfos(proposalID, votingInfosTree)
-		if err != nil {
-			return nil, 0, 0, err
-		}
+	err = gv.store.SetProposalVotingInfo(proposalID, voterAddress.String(), userVote)
+	if err != nil {
+		return nil, 0, 0, err
 	}
 
 	// Update proposal vote tallies

--- a/contract/r/gnoswap/gov/governance/v1/governance_vote.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_vote.gno
@@ -117,7 +117,7 @@ func (gv *governanceV1) vote(
 
 	// Create or update voting info for this user
 	if userVote == nil {
-		userVote = governance.NewVotingInfo(votingWeight, voterAddress)
+		userVote = governance.NewVotingInfo(votingWeight)
 	}
 
 	userVoteResolver := NewVotingInfoResolver(userVote)

--- a/contract/r/gnoswap/gov/governance/v1/governance_vote_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_vote_test.gno
@@ -49,7 +49,7 @@ func TestGovernanceVote_Vote(t *testing.T) {
 				100,
 			),
 			setupVotingInfos: map[string]*governance.VotingInfo{
-				testutils.TestAddress("voter").String(): governance.NewVotingInfo(5_000_000_000, testutils.TestAddress("voter")),
+				testutils.TestAddress("voter").String(): governance.NewVotingInfo(5_000_000_000),
 			},
 			expectedWeight: "5000000000",
 		},
@@ -75,7 +75,7 @@ func TestGovernanceVote_Vote(t *testing.T) {
 				100,
 			),
 			setupVotingInfos: map[string]*governance.VotingInfo{
-				testutils.TestAddress("voter").String(): governance.NewVotingInfo(3_000_000_000, testutils.TestAddress("voter")),
+				testutils.TestAddress("voter").String(): governance.NewVotingInfo(3_000_000_000),
 			},
 			expectedWeight: "3000000000",
 		},
@@ -109,7 +109,7 @@ func TestGovernanceVote_Vote(t *testing.T) {
 				100,
 			),
 			setupVotingInfos: map[string]*governance.VotingInfo{
-				testutils.TestAddress("voter_no_weight").String(): governance.NewVotingInfo(0, testutils.TestAddress("voter_no_weight")),
+				testutils.TestAddress("voter_no_weight").String(): governance.NewVotingInfo(0),
 			},
 			expectedHasAbort: true,
 			expectedAbortMsg: "[GNOSWAP-GOVERNANCE-007] not enough voting power || no voting weight at snapshot time",
@@ -136,7 +136,7 @@ func TestGovernanceVote_Vote(t *testing.T) {
 				100,
 			),
 			setupVotingInfos: map[string]*governance.VotingInfo{
-				testutils.TestAddress("voter").String(): governance.NewVotingInfo(5_000_000_000, testutils.TestAddress("voter")),
+				testutils.TestAddress("voter").String(): governance.NewVotingInfo(5_000_000_000),
 			},
 			expectedHasAbort: true,
 			expectedAbortMsg: "[GNOSWAP-GOVERNANCE-014] unable to vote out of voting period || cannot vote out of voting period",
@@ -164,7 +164,7 @@ func TestGovernanceVote_Vote(t *testing.T) {
 			),
 			setupVotingInfos: map[string]*governance.VotingInfo{
 				testutils.TestAddress("voter_already").String(): func() *governance.VotingInfo {
-					vi := governance.NewVotingInfo(5_000_000_000, testutils.TestAddress("voter_already"))
+					vi := governance.NewVotingInfo(5_000_000_000)
 					viResolver := NewVotingInfoResolver(vi)
 					viResolver.vote(true, 5_000_000_000, 100, time.Now().Unix()) // Already voted
 					return vi
@@ -260,7 +260,7 @@ func TestGovernanceVote_VotePrivate(t *testing.T) {
 				time.Now().Unix()-testConfig.VotingStartDelay,
 				100,
 			),
-			setupVotingInfo:   governance.NewVotingInfo(5_000_000_000, testutils.TestAddress("voter")),
+			setupVotingInfo:   governance.NewVotingInfo(5_000_000_000),
 			expectedYesWeight: 5_000_000_000,
 			expectedNoWeight:  0,
 		},
@@ -287,7 +287,7 @@ func TestGovernanceVote_VotePrivate(t *testing.T) {
 				time.Now().Unix()-testConfig.VotingStartDelay,
 				100,
 			),
-			setupVotingInfo:   governance.NewVotingInfo(3_000_000_000, testutils.TestAddress("voter")),
+			setupVotingInfo:   governance.NewVotingInfo(3_000_000_000),
 			expectedYesWeight: 0,
 			expectedNoWeight:  3_000_000_000,
 		},
@@ -350,7 +350,7 @@ func TestGovernanceVote_VotePrivate(t *testing.T) {
 				time.Now().Unix()-testConfig.VotingStartDelay,
 				100,
 			),
-			setupVotingInfo:  governance.NewVotingInfo(0, testutils.TestAddress("voter")),
+			setupVotingInfo:  governance.NewVotingInfo(0),
 			expectedHasError: true,
 			expectedError:    "[GNOSWAP-GOVERNANCE-007] not enough voting power || no voting weight",
 		},
@@ -377,7 +377,7 @@ func TestGovernanceVote_VotePrivate(t *testing.T) {
 				time.Now().Unix()-testConfig.VotingStartDelay,
 				100,
 			),
-			setupVotingInfo:  governance.NewVotingInfo(5_000_000_000, testutils.TestAddress("voter")),
+			setupVotingInfo:  governance.NewVotingInfo(5_000_000_000),
 			setVotingInfoErr: errors.New("set proposal voting infos failed"),
 			expectedHasError: true,
 			expectedError:    "set proposal voting infos failed",
@@ -563,7 +563,7 @@ func TestGovernanceVote_VoteValidation(t *testing.T) {
 			}()
 			if tt.setupProposal != nil {
 				setupTestProposal(t, gov, tt.setupProposal())
-				setupTestVotingInfo(t, gov, tt.proposalID, tt.voter.String(), governance.NewVotingInfo(5_000_000_000, tt.voter))
+				setupTestVotingInfo(t, gov, tt.proposalID, tt.voter.String(), governance.NewVotingInfo(5_000_000_000))
 			}
 
 			testing.SetRealm(testing.NewUserRealm(tt.voter))
@@ -640,7 +640,7 @@ func TestGovernanceVote_VotePeriod(t *testing.T) {
 			)
 			setupTestProposal(t, gov, proposal)
 			voter := testutils.TestAddress("voter")
-			setupTestVotingInfo(t, gov, 1, voter.String(), governance.NewVotingInfo(5_000_000_000, voter))
+			setupTestVotingInfo(t, gov, 1, voter.String(), governance.NewVotingInfo(5_000_000_000))
 
 			testing.SetRealm(testing.NewUserRealm(voter))
 
@@ -731,7 +731,7 @@ func TestGovernanceVote_VoteWeightCalculation(t *testing.T) {
 				totalWeight = 0 // Simulate launchpad exclusion
 			}
 
-			setupTestVotingInfo(t, gov, 1, voter.String(), governance.NewVotingInfo(totalWeight, voter))
+			setupTestVotingInfo(t, gov, 1, voter.String(), governance.NewVotingInfo(totalWeight))
 
 			testing.SetRealm(testing.NewUserRealm(voter))
 

--- a/contract/r/gnoswap/gov/governance/v1/governance_vote_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_vote_test.gno
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"gno.land/p/nt/uassert"
 
 	"gno.land/r/gnoswap/gov/governance"
+	"gno.land/r/gnoswap/halt"
 )
 
 func TestGovernanceVote_Vote(t *testing.T) {
@@ -221,13 +223,14 @@ func TestGovernanceVote_VotePrivate(t *testing.T) {
 	tests := []struct {
 		name string
 		// given
-		proposalID      int64
-		voterAddress    address
-		votedYes        bool
-		votedHeight     int64
-		votedAt         int64
-		setupProposal   *governance.Proposal
-		setupVotingInfo *governance.VotingInfo
+		proposalID       int64
+		voterAddress     address
+		votedYes         bool
+		votedHeight      int64
+		votedAt          int64
+		setupProposal    *governance.Proposal
+		setupVotingInfo  *governance.VotingInfo
+		setVotingInfoErr error
 		// then
 		expectedYesWeight int64
 		expectedNoWeight  int64
@@ -351,6 +354,34 @@ func TestGovernanceVote_VotePrivate(t *testing.T) {
 			expectedHasError: true,
 			expectedError:    "[GNOSWAP-GOVERNANCE-007] not enough voting power || no voting weight",
 		},
+		{
+			name:         "fail - voting info store error",
+			proposalID:   1,
+			voterAddress: testutils.TestAddress("voter"),
+			votedYes:     true,
+			votedHeight:  100,
+			votedAt:      time.Now().Unix(),
+			setupProposal: governance.NewProposal(
+				1,
+				NewProposalStatus(
+					testConfig,
+					10_000_000_000,
+					true,
+					time.Now().Unix()-testConfig.VotingStartDelay,
+				),
+				governance.NewProposalMetadata("Test Proposal", "Test Description"),
+				NewProposalTextData(),
+				testutils.TestAddress("proposer"),
+				1,
+				time.Now().Unix()-testConfig.VotingStartDelay-testConfig.VotingWeightSmoothingDuration,
+				time.Now().Unix()-testConfig.VotingStartDelay,
+				100,
+			),
+			setupVotingInfo:  governance.NewVotingInfo(5_000_000_000, testutils.TestAddress("voter")),
+			setVotingInfoErr: errors.New("set proposal voting infos failed"),
+			expectedHasError: true,
+			expectedError:    "set proposal voting infos failed",
+		},
 	}
 
 	for _, tt := range tests {
@@ -363,6 +394,11 @@ func TestGovernanceVote_VotePrivate(t *testing.T) {
 			}
 			if tt.setupVotingInfo != nil {
 				setupTestVotingInfo(t, gov, tt.proposalID, tt.voterAddress.String(), tt.setupVotingInfo)
+			}
+			if tt.setVotingInfoErr != nil {
+				store, ok := gov.store.(*mockGovernanceStore)
+				uassert.True(t, ok)
+				store.setProposalVotingInfosErr = tt.setVotingInfoErr
 			}
 
 			// when
@@ -437,7 +473,7 @@ func TestGovernanceVote_VoteValidation(t *testing.T) {
 				)
 			},
 			setupHalt:     true,
-			expectedError: "[GNOSWAP-GOVERNANCE-014] unable to vote out of voting period || cannot vote out of voting period",
+			expectedError: "halted: governance",
 		},
 		{
 			name:       "fail - canceled proposal voting",
@@ -516,9 +552,15 @@ func TestGovernanceVote_VoteValidation(t *testing.T) {
 			// given
 			gov := newMockGovernance()
 
+			testing.SetRealm(adminRealm)
+			halt.SetHaltLevel(cross, halt.HaltLevelNone)
 			if tt.setupHalt {
-				// Mock halt state setup
+				halt.SetHaltLevel(cross, halt.HaltLevelComplete)
 			}
+			defer func() {
+				testing.SetRealm(adminRealm)
+				halt.SetHaltLevel(cross, halt.HaltLevelNone)
+			}()
 			if tt.setupProposal != nil {
 				setupTestProposal(t, gov, tt.setupProposal())
 				setupTestVotingInfo(t, gov, tt.proposalID, tt.voter.String(), governance.NewVotingInfo(5_000_000_000, tt.voter))

--- a/contract/r/gnoswap/gov/governance/v1/governance_vote_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_vote_test.gno
@@ -44,10 +44,7 @@ func TestGovernanceVote_Vote(t *testing.T) {
 				NewProposalTextData(),
 				testutils.TestAddress("proposer"),
 				1,
-				time.Now().Unix()-testConfig.VotingStartDelay-testConfig.VotingWeightSmoothingDuration,
-				time.Now().Unix()-testConfig.VotingStartDelay,
-				100,
-			),
+				time.Now().Unix()-testConfig.VotingStartDelay-testConfig.VotingWeightSmoothingDuration),
 			setupVotingInfos: map[string]*governance.VotingInfo{
 				testutils.TestAddress("voter").String(): governance.NewVotingInfo(5_000_000_000),
 			},
@@ -70,10 +67,7 @@ func TestGovernanceVote_Vote(t *testing.T) {
 				NewProposalTextData(),
 				testutils.TestAddress("proposer"),
 				1,
-				time.Now().Unix()-testConfig.VotingStartDelay-testConfig.VotingWeightSmoothingDuration,
-				time.Now().Unix()-testConfig.VotingStartDelay,
-				100,
-			),
+				time.Now().Unix()-testConfig.VotingStartDelay-testConfig.VotingWeightSmoothingDuration),
 			setupVotingInfos: map[string]*governance.VotingInfo{
 				testutils.TestAddress("voter").String(): governance.NewVotingInfo(3_000_000_000),
 			},
@@ -104,10 +98,7 @@ func TestGovernanceVote_Vote(t *testing.T) {
 				NewProposalTextData(),
 				testutils.TestAddress("proposer"),
 				1,
-				time.Now().Unix()-testConfig.VotingStartDelay-testConfig.VotingWeightSmoothingDuration,
-				time.Now().Unix()-testConfig.VotingStartDelay,
-				100,
-			),
+				time.Now().Unix()-testConfig.VotingStartDelay-testConfig.VotingWeightSmoothingDuration),
 			setupVotingInfos: map[string]*governance.VotingInfo{
 				testutils.TestAddress("voter_no_weight").String(): governance.NewVotingInfo(0),
 			},
@@ -131,10 +122,7 @@ func TestGovernanceVote_Vote(t *testing.T) {
 				NewProposalTextData(),
 				testutils.TestAddress("proposer"),
 				1,
-				time.Now().Add(-time.Hour*24*8).Unix()-testConfig.VotingWeightSmoothingDuration,
-				time.Now().Add(-time.Hour*24*8).Unix(),
-				100,
-			),
+				time.Now().Add(-time.Hour*24*8).Unix()-testConfig.VotingWeightSmoothingDuration),
 			setupVotingInfos: map[string]*governance.VotingInfo{
 				testutils.TestAddress("voter").String(): governance.NewVotingInfo(5_000_000_000),
 			},
@@ -158,10 +146,7 @@ func TestGovernanceVote_Vote(t *testing.T) {
 				NewProposalTextData(),
 				testutils.TestAddress("proposer"),
 				1,
-				time.Now().Unix()-testConfig.VotingStartDelay-testConfig.VotingWeightSmoothingDuration,
-				time.Now().Unix()-testConfig.VotingStartDelay,
-				100,
-			),
+				time.Now().Unix()-testConfig.VotingStartDelay-testConfig.VotingWeightSmoothingDuration),
 			setupVotingInfos: map[string]*governance.VotingInfo{
 				testutils.TestAddress("voter_already").String(): func() *governance.VotingInfo {
 					vi := governance.NewVotingInfo(5_000_000_000)
@@ -256,10 +241,7 @@ func TestGovernanceVote_VotePrivate(t *testing.T) {
 				NewProposalTextData(),
 				testutils.TestAddress("proposer"),
 				1,
-				time.Now().Unix()-testConfig.VotingStartDelay-testConfig.VotingWeightSmoothingDuration,
-				time.Now().Unix()-testConfig.VotingStartDelay,
-				100,
-			),
+				time.Now().Unix()-testConfig.VotingStartDelay-testConfig.VotingWeightSmoothingDuration),
 			setupVotingInfo:   governance.NewVotingInfo(5_000_000_000),
 			expectedYesWeight: 5_000_000_000,
 			expectedNoWeight:  0,
@@ -283,10 +265,7 @@ func TestGovernanceVote_VotePrivate(t *testing.T) {
 				NewProposalTextData(),
 				testutils.TestAddress("proposer"),
 				1,
-				time.Now().Unix()-testConfig.VotingStartDelay-testConfig.VotingWeightSmoothingDuration,
-				time.Now().Unix()-testConfig.VotingStartDelay,
-				100,
-			),
+				time.Now().Unix()-testConfig.VotingStartDelay-testConfig.VotingWeightSmoothingDuration),
 			setupVotingInfo:   governance.NewVotingInfo(3_000_000_000),
 			expectedYesWeight: 0,
 			expectedNoWeight:  3_000_000_000,
@@ -320,10 +299,7 @@ func TestGovernanceVote_VotePrivate(t *testing.T) {
 				NewProposalTextData(),
 				testutils.TestAddress("proposer"),
 				1,
-				time.Now().Unix()-testConfig.VotingStartDelay-testConfig.VotingWeightSmoothingDuration,
-				time.Now().Unix()-testConfig.VotingStartDelay,
-				100,
-			),
+				time.Now().Unix()-testConfig.VotingStartDelay-testConfig.VotingWeightSmoothingDuration),
 			expectedHasError: true,
 			expectedError:    "[GNOSWAP-GOVERNANCE-007] not enough voting power || no voting weight at snapshot time",
 		},
@@ -346,10 +322,7 @@ func TestGovernanceVote_VotePrivate(t *testing.T) {
 				NewProposalTextData(),
 				testutils.TestAddress("proposer"),
 				1,
-				time.Now().Unix()-testConfig.VotingStartDelay-testConfig.VotingWeightSmoothingDuration,
-				time.Now().Unix()-testConfig.VotingStartDelay,
-				100,
-			),
+				time.Now().Unix()-testConfig.VotingStartDelay-testConfig.VotingWeightSmoothingDuration),
 			setupVotingInfo:  governance.NewVotingInfo(0),
 			expectedHasError: true,
 			expectedError:    "[GNOSWAP-GOVERNANCE-007] not enough voting power || no voting weight",
@@ -373,10 +346,7 @@ func TestGovernanceVote_VotePrivate(t *testing.T) {
 				NewProposalTextData(),
 				testutils.TestAddress("proposer"),
 				1,
-				time.Now().Unix()-testConfig.VotingStartDelay-testConfig.VotingWeightSmoothingDuration,
-				time.Now().Unix()-testConfig.VotingStartDelay,
-				100,
-			),
+				time.Now().Unix()-testConfig.VotingStartDelay-testConfig.VotingWeightSmoothingDuration),
 			setupVotingInfo:  governance.NewVotingInfo(5_000_000_000),
 			setVotingInfoErr: errors.New("set proposal voting infos failed"),
 			expectedHasError: true,
@@ -467,10 +437,7 @@ func TestGovernanceVote_VoteValidation(t *testing.T) {
 					NewProposalTextData(),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Unix()-testConfig.VotingWeightSmoothingDuration,
-					time.Now().Unix(),
-					100,
-				)
+					time.Now().Unix()-testConfig.VotingWeightSmoothingDuration)
 			},
 			setupHalt:     true,
 			expectedError: "halted: governance",
@@ -488,10 +455,7 @@ func TestGovernanceVote_VoteValidation(t *testing.T) {
 					NewProposalTextData(),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Unix()-testConfig.VotingWeightSmoothingDuration,
-					time.Now().Unix(),
-					100,
-				)
+					time.Now().Unix()-testConfig.VotingWeightSmoothingDuration)
 
 				resolver := NewProposalStatusResolver(proposal.Status())
 				resolver.cancel(time.Now().Unix(), 100, testutils.TestAddress("canceler"))
@@ -512,10 +476,7 @@ func TestGovernanceVote_VoteValidation(t *testing.T) {
 					NewProposalExecutionData(1, "test*EXE*function*EXE*param"),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Add(-time.Hour*24*10).Unix()-testConfig.VotingWeightSmoothingDuration,
-					time.Now().Add(-time.Hour*24*10).Unix(),
-					100,
-				)
+					time.Now().Add(-time.Hour*24*10).Unix()-testConfig.VotingWeightSmoothingDuration)
 
 				resolver := NewProposalStatusResolver(proposal.Status())
 				resolver.vote(true, 6_000_000_000)
@@ -537,10 +498,7 @@ func TestGovernanceVote_VoteValidation(t *testing.T) {
 					NewProposalExecutionData(1, "test*EXE*function*EXE*param"),
 					testutils.TestAddress("proposer"),
 					1,
-					time.Now().Add(-time.Hour*24*40).Unix()-testConfig.VotingWeightSmoothingDuration,
-					time.Now().Add(-time.Hour*24*40).Unix(),
-					100,
-				)
+					time.Now().Add(-time.Hour*24*40).Unix()-testConfig.VotingWeightSmoothingDuration)
 				return proposal
 			},
 			expectedError: "[GNOSWAP-GOVERNANCE-014] unable to vote out of voting period || cannot vote out of voting period",
@@ -634,10 +592,7 @@ func TestGovernanceVote_VotePeriod(t *testing.T) {
 				NewProposalTextData(),
 				testutils.TestAddress("proposer"),
 				1,
-				tt.proposalTime-testConfig.VotingWeightSmoothingDuration,
-				tt.proposalTime,
-				100,
-			)
+				tt.proposalTime-testConfig.VotingWeightSmoothingDuration)
 			setupTestProposal(t, gov, proposal)
 			voter := testutils.TestAddress("voter")
 			setupTestVotingInfo(t, gov, 1, voter.String(), governance.NewVotingInfo(5_000_000_000))
@@ -718,10 +673,7 @@ func TestGovernanceVote_VoteWeightCalculation(t *testing.T) {
 				NewProposalTextData(),
 				testutils.TestAddress("proposer"),
 				1,
-				time.Now().Unix()-testConfig.VotingStartDelay,
-				time.Now().Unix(),
-				100,
-			)
+				time.Now().Unix()-testConfig.VotingStartDelay)
 			setupTestProposal(t, gov, proposal)
 
 			voter := testutils.TestAddress("voter")
@@ -805,10 +757,7 @@ func TestGovernanceVote_QuorumCalculation(t *testing.T) {
 				NewProposalTextData(),
 				testutils.TestAddress("proposer"),
 				1,
-				time.Now().Add(-time.Hour*24*10).Unix()-testConfig.VotingWeightSmoothingDuration,
-				time.Now().Add(-time.Hour*24*10).Unix(),
-				100,
-			)
+				time.Now().Add(-time.Hour*24*10).Unix()-testConfig.VotingWeightSmoothingDuration)
 
 			resolver := NewProposalStatusResolver(proposal.Status())
 			// Simulate voting

--- a/contract/r/gnoswap/gov/governance/v1/governance_vote_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_vote_test.gno
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"gno.land/p/nt/avl"
 	"gno.land/p/nt/testutils"
 	"gno.land/p/nt/uassert"
 
@@ -398,7 +397,7 @@ func TestGovernanceVote_VotePrivate(t *testing.T) {
 			if tt.setVotingInfoErr != nil {
 				store, ok := gov.store.(*mockGovernanceStore)
 				uassert.True(t, ok)
-				store.setProposalVotingInfosErr = tt.setVotingInfoErr
+				store.setProposalVotingInfoErr = tt.setVotingInfoErr
 			}
 
 			// when
@@ -831,11 +830,6 @@ func TestGovernanceVote_QuorumCalculation(t *testing.T) {
 
 func setupTestProposal(t *testing.T, gov *governanceV1, proposal *governance.Proposal) {
 	gov.addProposal(proposal)
-
-	// Initialize empty voting info tree for the proposal if not exists
-	if _, exists := gov.getProposalUserVotingInfos(proposal.ID()); !exists {
-		gov.store.SetProposalVotingInfos(proposal.ID(), avl.NewTree())
-	}
 }
 
 func setupVoteTestUserVotesWithDelegation(t *testing.T, gov *governanceV1, proposalID int64, userVotes map[string]*governance.VotingInfo, maxVotingWeight int64) {
@@ -855,16 +849,8 @@ func setupVoteTestUserVotesWithDelegation(t *testing.T, gov *governanceV1, propo
 }
 
 func setupTestVotingInfo(t *testing.T, gov *governanceV1, proposalID int64, voter string, votingInfo *governance.VotingInfo) {
-	// Get existing voting infos or create new ones
-	votingInfos, exists := gov.getProposalUserVotingInfos(proposalID)
-
-	if !exists {
-		votingInfos = avl.NewTree()
-	}
-	votingInfos.Set(voter, votingInfo)
-
 	// Set the voting info for the voter
-	gov.store.SetProposalVotingInfos(proposalID, votingInfos)
+	gov.store.SetProposalVotingInfo(proposalID, voter, votingInfo)
 
 	// Set up mock accessor to return the expected delegation amounts for this voter
 	mockAccessor, ok := gov.stakerAccessor.(*mockGovStakerAccessor)

--- a/contract/r/gnoswap/gov/governance/v1/instance.gno
+++ b/contract/r/gnoswap/gov/governance/v1/instance.gno
@@ -126,12 +126,28 @@ func (g *governanceV1) removeInactiveUserProposals(proposerAddress address, curr
 }
 
 // Proposal voting info methods
-func (g *governanceV1) getProposalUserVotingInfos(proposalID int64) (*avl.Tree, bool) {
-	return g.store.GetProposalVotingInfos(proposalID)
-}
-
 func (g *governanceV1) updateProposalUserVotes(proposal *governance.Proposal, userVotingInfos *avl.Tree) error {
-	return g.store.SetProposalVotingInfos(proposal.ID(), userVotingInfos)
+	if userVotingInfos == nil {
+		return nil
+	}
+
+	var setErr error
+	userVotingInfos.Iterate("", "", func(voter string, value interface{}) bool {
+		votingInfo, ok := value.(*governance.VotingInfo)
+		if !ok {
+			setErr = ufmt.Errorf("invalid voting info type for voter %s", voter)
+			return true
+		}
+
+		if err := g.store.SetProposalVotingInfo(proposal.ID(), voter, votingInfo); err != nil {
+			setErr = err
+			return true
+		}
+
+		return false
+	})
+
+	return setErr
 }
 
 // Helper methods for API
@@ -144,20 +160,5 @@ func (g *governanceV1) mustGetProposal(id int64) *governance.Proposal {
 }
 
 func (g *governanceV1) getProposalUserVotingInfo(proposalID int64, addr address) (*governance.VotingInfo, bool) {
-	votingInfosTree, exists := g.getProposalUserVotingInfos(proposalID)
-	if !exists {
-		return nil, false
-	}
-
-	votingInfoRaw, exists := votingInfosTree.Get(addr.String())
-	if !exists {
-		return nil, false
-	}
-
-	votingInfo, ok := votingInfoRaw.(*governance.VotingInfo)
-	if !ok {
-		return nil, false
-	}
-
-	return votingInfo, true
+	return g.store.GetProposalVotingInfo(proposalID, addr.String())
 }

--- a/contract/r/gnoswap/gov/governance/v1/instance.gno
+++ b/contract/r/gnoswap/gov/governance/v1/instance.gno
@@ -11,9 +11,14 @@ type governanceV1 struct {
 	stakerAccessor governance.GovStakerAccessor
 }
 
-func NewGovernanceV1(governanceStore governance.IGovernanceStore, stakerAccessor governance.GovStakerAccessor) governance.IGovernance {
-	gv := &governanceV1{store: governanceStore, stakerAccessor: stakerAccessor}
-	return gv
+func NewGovernanceV1(
+    governanceStore governance.IGovernanceStore,
+    stakerAccessor governance.GovStakerAccessor,
+) governance.IGovernance {
+	return &governanceV1{
+		store:          governanceStore,
+		stakerAccessor: stakerAccessor,
+	}
 }
 
 // Config version methods

--- a/contract/r/gnoswap/gov/governance/v1/instance.gno
+++ b/contract/r/gnoswap/gov/governance/v1/instance.gno
@@ -12,8 +12,8 @@ type governanceV1 struct {
 }
 
 func NewGovernanceV1(
-    governanceStore governance.IGovernanceStore,
-    stakerAccessor governance.GovStakerAccessor,
+	governanceStore governance.IGovernanceStore,
+	stakerAccessor governance.GovStakerAccessor,
 ) governance.IGovernance {
 	return &governanceV1{
 		store:          governanceStore,

--- a/contract/r/gnoswap/gov/governance/v1/instance_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/instance_test.gno
@@ -69,8 +69,7 @@ func TestInstance_RemoveInactiveUserProposals(t *testing.T) {
 					NewProposalStatus(config, 1000, false, baseCreatedAt),
 					governance.NewProposalMetadata("Test Title", "Test Description"),
 					NewProposalTextData(),
-					proposerAddr, 1, baseCreatedAt, baseCreatedAt, 100,
-				)
+					proposerAddr, 1, baseCreatedAt)
 				gv.addProposal(proposal)
 			},
 			currentTime:            baseCreatedAt + config.VotingStartDelay + 50, // during voting period
@@ -85,8 +84,7 @@ func TestInstance_RemoveInactiveUserProposals(t *testing.T) {
 					NewProposalStatus(config, 1000, false, baseCreatedAt),
 					governance.NewProposalMetadata("Test Title", "Test Description"),
 					NewProposalTextData(),
-					proposerAddr, 1, baseCreatedAt, baseCreatedAt, 100,
-				)
+					proposerAddr, 1, baseCreatedAt)
 				gv.addProposal(proposal)
 			},
 			currentTime:            expiredTime + 100, // after expired
@@ -102,8 +100,7 @@ func TestInstance_RemoveInactiveUserProposals(t *testing.T) {
 					NewProposalStatus(config, 1000, false, baseCreatedAt),
 					governance.NewProposalMetadata("Old Title", "Old Description"),
 					NewProposalTextData(),
-					proposerAddr, 1, baseCreatedAt, baseCreatedAt, 100,
-				)
+					proposerAddr, 1, baseCreatedAt)
 				gv.addProposal(oldProposal)
 
 				// Active proposal (created after first one expired)
@@ -113,8 +110,7 @@ func TestInstance_RemoveInactiveUserProposals(t *testing.T) {
 					NewProposalStatus(config, 1000, false, newCreatedAt),
 					governance.NewProposalMetadata("New Title", "New Description"),
 					NewProposalTextData(),
-					proposerAddr, 1, newCreatedAt, newCreatedAt, 200,
-				)
+					proposerAddr, 1, newCreatedAt)
 				gv.addProposal(newProposal)
 			},
 			currentTime:            expiredTime + 50 + config.VotingStartDelay + 50, // during new proposal's voting period
@@ -129,8 +125,7 @@ func TestInstance_RemoveInactiveUserProposals(t *testing.T) {
 					NewProposalStatus(config, 1000, true, baseCreatedAt),
 					governance.NewProposalMetadata("Test Title", "Test Description"),
 					NewProposalTextData(),
-					proposerAddr, 1, baseCreatedAt, baseCreatedAt, 100,
-				)
+					proposerAddr, 1, baseCreatedAt)
 				gv.addProposal(proposal)
 
 				// Cancel the proposal
@@ -150,8 +145,7 @@ func TestInstance_RemoveInactiveUserProposals(t *testing.T) {
 						NewProposalStatus(config, 1000, false, baseCreatedAt),
 						governance.NewProposalMetadata("Test Title", "Test Description"),
 						NewProposalTextData(),
-						proposerAddr, 1, baseCreatedAt, baseCreatedAt, 100,
-					)
+						proposerAddr, 1, baseCreatedAt)
 					gv.addProposal(proposal)
 				}
 			},
@@ -168,8 +162,7 @@ func TestInstance_RemoveInactiveUserProposals(t *testing.T) {
 						NewProposalStatus(config, 1000, false, baseCreatedAt),
 						governance.NewProposalMetadata("Test Title", "Test Description"),
 						NewProposalTextData(),
-						proposerAddr, 1, baseCreatedAt, baseCreatedAt, 100,
-					)
+						proposerAddr, 1, baseCreatedAt)
 					gv.addProposal(proposal)
 				}
 			},

--- a/contract/r/gnoswap/gov/governance/v1/proposal.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal.gno
@@ -98,7 +98,12 @@ func (r *ProposalResolver) CommunityPoolSpendTokenPath() string {
 		return ""
 	}
 
-	return r.dataResolver.CommunityPoolSpend().TokenPath()
+	communityPoolSpend := r.dataResolver.CommunityPoolSpend()
+	if communityPoolSpend == nil {
+		return ""
+	}
+
+	return communityPoolSpend.TokenPath()
 }
 
 // vote records a vote for this proposal and updates vote tallies.

--- a/contract/r/gnoswap/gov/governance/v1/proposal.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal.gno
@@ -110,8 +110,7 @@ func (r *ProposalResolver) Vote(votedYes bool, weight int64) error {
 // execute marks the proposal as executed and records execution details.
 // This method validates execution conditions before proceeding.
 func (r *ProposalResolver) execute(
-	executedAt int64,
-	executedHeight int64,
+	executedAt, executedHeight int64,
 	executedBy address,
 ) error {
 	// Verify proposal is in executable state
@@ -126,8 +125,7 @@ func (r *ProposalResolver) execute(
 // cancel marks the proposal as canceled and records cancellation details.
 // This method validates cancellation conditions before proceeding.
 func (r *ProposalResolver) cancel(
-	canceledAt int64,
-	canceledHeight int64,
+	canceledAt, canceledHeight int64,
 	canceledBy address,
 ) error {
 	if r.statusResolver.IsCanceled(canceledAt) {

--- a/contract/r/gnoswap/gov/governance/v1/proposal_action_status.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal_action_status.gno
@@ -22,7 +22,10 @@ func NewProposalActionStatusResolver(status *governance.ProposalActionStatus) *P
 //
 // Returns:
 //   - error: already canceled error if proposal action status is already canceled
-func (p *ProposalActionStatusResolver) cancel(canceledAt int64, canceledHeight int64, canceledBy address) error {
+func (p *ProposalActionStatusResolver) cancel(
+	canceledAt, canceledHeight int64,
+	canceledBy address,
+) error {
 	if p.Canceled() {
 		return errAlreadyCanceledProposal
 	}
@@ -46,7 +49,10 @@ func (p *ProposalActionStatusResolver) cancel(canceledAt int64, canceledHeight i
 //
 // Returns:
 //   - error: already canceled error if proposal action status is already canceled
-func (p *ProposalActionStatusResolver) Execute(executedAt int64, executedHeight int64, executedBy address) error {
+func (p *ProposalActionStatusResolver) Execute(
+	executedAt, executedHeight int64,
+	executedBy address,
+) error {
 	// Only executable proposals can be executed (text proposals cannot)
 	if !p.IsExecutable() {
 		return errProposalNotExecutable

--- a/contract/r/gnoswap/gov/governance/v1/proposal_data.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal_data.gno
@@ -225,7 +225,8 @@ func (r *ProposalDataResolver) ParameterChangesInfos() []governance.ParameterCha
 		// Split message into components: pkgPath, function, params
 		params := strings.Split(msg, parameterSeparator)
 		if len(params) != 3 {
-			continue // Skip malformed messages
+			// validation rejects mismatched counts upstream.
+			continue
 		}
 
 		pkgPath := params[0]

--- a/contract/r/gnoswap/gov/governance/v1/proposal_data.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal_data.gno
@@ -136,6 +136,10 @@ func (r *ProposalDataResolver) validateText() error {
 func (r *ProposalDataResolver) validateCommunityPoolSpend() error {
 	// Validate recipient address
 	communityPoolSpend := r.ProposalData.CommunityPoolSpend()
+	if communityPoolSpend == nil {
+		return makeErrorWithDetails(
+			errInvalidInput, "community pool spend info is missing")
+	}
 
 	if !communityPoolSpend.To().IsValid() {
 		return makeErrorWithDetails(
@@ -160,6 +164,12 @@ func (r *ProposalDataResolver) validateCommunityPoolSpend() error {
 //   - error: validation error if parameter change data structure is invalid
 func (r *ProposalDataResolver) validateParameterChange() error {
 	execution := r.Execution()
+	if execution == nil {
+		return makeErrorWithDetails(
+			errInvalidInput,
+			"execution info is missing",
+		)
+	}
 	num := execution.Num()
 	msgs := execution.Msgs()
 
@@ -167,7 +177,7 @@ func (r *ProposalDataResolver) validateParameterChange() error {
 	if num <= 0 {
 		return makeErrorWithDetails(
 			errInvalidInput,
-			ufmt.Sprintf("numToExecute is less than or equal to 0"),
+			"numToExecute is less than or equal to 0",
 		)
 	}
 
@@ -175,7 +185,7 @@ func (r *ProposalDataResolver) validateParameterChange() error {
 	if len(msgs) == 0 {
 		return makeErrorWithDetails(
 			errInvalidInput,
-			ufmt.Sprintf("executions is empty"),
+			"executions is empty",
 		)
 	}
 
@@ -183,7 +193,7 @@ func (r *ProposalDataResolver) validateParameterChange() error {
 	if len(msgs) != int(num) {
 		return makeErrorWithDetails(
 			errInvalidInput,
-			ufmt.Sprintf("executions is not equal to numToExecute"),
+			"executions is not equal to numToExecute",
 		)
 	}
 
@@ -200,7 +210,7 @@ func (r *ProposalDataResolver) validateParameterChange() error {
 	if len(parameterChangesInfos) != int(num) {
 		return makeErrorWithDetails(
 			errInvalidInput,
-			ufmt.Sprintf("invalid parameter change info"),
+			"invalid parameter change info",
 		)
 	}
 
@@ -216,12 +226,13 @@ func (r *ProposalDataResolver) ParameterChangesInfos() []governance.ParameterCha
 	infos := make([]governance.ParameterChangeInfo, 0)
 
 	// Return empty slice if no executions
-	if r.Execution().Num() <= 0 {
+	execution := r.Execution()
+	if execution == nil || execution.Num() <= 0 {
 		return infos
 	}
 
 	// Parse each execution message
-	for _, msg := range r.Execution().Msgs() {
+	for _, msg := range execution.Msgs() {
 		// Split message into components: pkgPath, function, params
 		params := strings.Split(msg, parameterSeparator)
 		if len(params) != 3 {
@@ -247,11 +258,7 @@ func (r *ProposalDataResolver) ParameterChangesInfos() []governance.ParameterCha
 // Returns:
 //   - *ProposalData: proposal data configured for text proposal
 func NewProposalTextData() *governance.ProposalData {
-	return governance.NewProposalData(
-		governance.Text,
-		&governance.CommunityPoolSpendInfo{},
-		&governance.ExecutionInfo{},
-	)
+	return governance.NewProposalData(governance.Text, nil, nil)
 }
 
 // NewProposalCommunityPoolSpendData creates proposal data for a community pool spend proposal.
@@ -300,7 +307,7 @@ func NewProposalExecutionData(numToExecute int64, executions string) *governance
 
 	return governance.NewProposalData(
 		governance.ParameterChange,
-		governance.NewCommunityPoolSpendInfo(address(""), "", 0),
+		nil,
 		governance.NewExecutionInfo(numToExecute, msgs),
 	)
 }

--- a/contract/r/gnoswap/gov/governance/v1/proposal_status.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal_status.gno
@@ -48,8 +48,6 @@ func (p *ProposalStatusResolver) StatusType(current int64) governance.ProposalSt
 		return governance.StatusCanceled
 	}
 
-	// schedule := p.Schedule()
-
 	// Check time-based statuses
 	if !p.scheduleResolver.IsPassedActiveAt(current) {
 		return governance.StatusUpcoming
@@ -59,8 +57,8 @@ func (p *ProposalStatusResolver) StatusType(current int64) governance.ProposalSt
 		return governance.StatusActive
 	}
 
-	// Check voting outcome
-	if p.voteStatusResolver.IsRejected() {
+	// Check voting outcome after voting period ends
+	if !p.voteStatusResolver.IsPassed() {
 		return governance.StatusRejected
 	}
 

--- a/contract/r/gnoswap/gov/governance/v1/proposal_status_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal_status_test.gno
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	"chain/runtime"
 	"testing"
 	"time"
 
@@ -159,7 +158,7 @@ func TestProposalStatus_StatusType_NoMajorityWithQuorum(t *testing.T) {
 		Quorum:           40,
 	}
 
-	proposal := governance.NewProposal(
+	proposal := newTestProposal(
 		1,
 		NewProposalStatus(config, 100, true, baseTime.Unix()),
 		governance.NewProposalMetadata("Test", "Test"),
@@ -168,7 +167,6 @@ func TestProposalStatus_StatusType_NoMajorityWithQuorum(t *testing.T) {
 		1,
 		baseTime.Unix(),
 		baseTime.Unix(),
-		runtime.ChainHeight(),
 	)
 
 	resolver := NewProposalStatusResolver(proposal.Status())

--- a/contract/r/gnoswap/gov/governance/v1/proposal_status_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal_status_test.gno
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"chain/runtime"
 	"testing"
 	"time"
 
@@ -146,6 +147,36 @@ func TestProposalStatus_StatusType(t *testing.T) {
 			uassert.Equal(t, statusType.String(), tc.expectedStatus.String())
 		})
 	}
+}
+
+func TestProposalStatus_StatusType_NoMajorityWithQuorum(t *testing.T) {
+	baseTime := time.Unix(1000, 0)
+	config := governance.Config{
+		VotingStartDelay: 100,
+		VotingPeriod:     200,
+		ExecutionDelay:   100,
+		ExecutionWindow:  200,
+		Quorum:           40,
+	}
+
+	proposal := governance.NewProposal(
+		1,
+		NewProposalStatus(config, 100, true, baseTime.Unix()),
+		governance.NewProposalMetadata("Test", "Test"),
+		NewProposalTextData(),
+		address("g1proposer"),
+		1,
+		baseTime.Unix(),
+		baseTime.Unix(),
+		runtime.ChainHeight(),
+	)
+
+	resolver := NewProposalStatusResolver(proposal.Status())
+	resolver.vote(true, 40)  // meets quorum
+	resolver.vote(false, 41) // no majority
+
+	status := resolver.StatusType(baseTime.Add(time.Duration(350) * time.Second).Unix())
+	uassert.True(t, status == governance.StatusRejected)
 }
 
 // TestProposalStatus_VotingOperations tests voting operations

--- a/contract/r/gnoswap/gov/governance/v1/proposal_status_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal_status_test.gno
@@ -166,7 +166,6 @@ func TestProposalStatus_StatusType_NoMajorityWithQuorum(t *testing.T) {
 		address("g1proposer"),
 		1,
 		baseTime.Unix(),
-		baseTime.Unix(),
 	)
 
 	resolver := NewProposalStatusResolver(proposal.Status())

--- a/contract/r/gnoswap/gov/governance/v1/proposal_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal_test.gno
@@ -99,7 +99,6 @@ func TestProposal_Validation(t *testing.T) {
 				address("g1proposer"),
 				1, // configVersion
 				baseTime,
-				baseTime,
 			)
 
 			// when
@@ -166,7 +165,6 @@ func TestProposal_StatusOperations(t *testing.T) {
 				governance.NewProposalData(tc.proposalType, nil, nil),
 				address("g1proposer"),
 				1, // configVersion
-				baseTime.Unix(),
 				baseTime.Unix(),
 			)
 
@@ -463,7 +461,6 @@ func TestProposal_IsActive_StatusTypeCaching(t *testing.T) {
 				address("g1proposer"),
 				1,
 				baseTime,
-				baseTime,
 			)
 
 			currentTime := baseTime + tc.currentTimeOffset
@@ -530,7 +527,6 @@ func TestNewProposal(t *testing.T) {
 				governance.NewProposalData(tc.proposalType, nil, nil),
 				tc.proposer,
 				1, // configVersion
-				baseTime,
 				baseTime,
 			)
 

--- a/contract/r/gnoswap/gov/governance/v1/proposal_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal_test.gno
@@ -62,21 +62,21 @@ func TestProposal_Validation(t *testing.T) {
 		expectedError bool
 	}{
 		{
-			name: "Valid Text proposal",
-			metadata: governance.NewProposalMetadata("Valid Title", "Valid Description"),
-			data: governance.NewProposalData(governance.Text, nil, nil),
+			name:          "Valid Text proposal",
+			metadata:      governance.NewProposalMetadata("Valid Title", "Valid Description"),
+			data:          governance.NewProposalData(governance.Text, nil, nil),
 			expectedError: false,
 		},
 		{
-			name: "Invalid metadata",
-			metadata: governance.NewProposalMetadata("", "Valid Description"),
-			data: governance.NewProposalData(governance.Text, nil, nil),
+			name:          "Invalid metadata",
+			metadata:      governance.NewProposalMetadata("", "Valid Description"),
+			data:          governance.NewProposalData(governance.Text, nil, nil),
 			expectedError: true,
 		},
 		{
-			name: "Invalid CommunityPoolSpend proposal",
-			metadata: governance.NewProposalMetadata("Valid Title", "Valid Description"),
-			data: governance.NewProposalData(governance.CommunityPoolSpend, governance.NewCommunityPoolSpendInfo(address(""), "", 0), nil),
+			name:          "Invalid CommunityPoolSpend proposal",
+			metadata:      governance.NewProposalMetadata("Valid Title", "Valid Description"),
+			data:          governance.NewProposalData(governance.CommunityPoolSpend, governance.NewCommunityPoolSpendInfo(address(""), "", 0), nil),
 			expectedError: true,
 		},
 	}
@@ -174,7 +174,11 @@ func TestProposal_StatusOperations(t *testing.T) {
 			)
 
 			if tc.isExecuted {
-				err := NewProposalResolver(proposal).execute(tc.currentTime.Unix(), 100, address("g1executor"))
+				resolver := NewProposalResolver(proposal)
+				err := resolver.Vote(true, 600)
+				uassert.NoError(t, err)
+
+				err = NewProposalResolver(proposal).execute(tc.currentTime.Unix(), 100, address("g1executor"))
 				uassert.NoError(t, err)
 			}
 			if tc.isCanceled {
@@ -272,16 +276,16 @@ func TestProposal_IsActive_StatusTypeCaching(t *testing.T) {
 		},
 		// Passed status tests (Text vs non-Text)
 		{
-			name:               "StatusPassed: Text proposal becomes inactive",
-			description:        "Text proposal becomes inactive after passing (no execution needed)",
-			proposalType:       governance.Text,
-			votingStartDelay:   100,
-			votingPeriod:       200,
-			executionDelay:     100,
-			executionWindow:    200,
-			quorum:             50,
-			maxVotingWeight:    1000,
-			currentTimeOffset:  350, // after voting ends
+			name:              "StatusPassed: Text proposal becomes inactive",
+			description:       "Text proposal becomes inactive after passing (no execution needed)",
+			proposalType:      governance.Text,
+			votingStartDelay:  100,
+			votingPeriod:      200,
+			executionDelay:    100,
+			executionWindow:   200,
+			quorum:            50,
+			maxVotingWeight:   1000,
+			currentTimeOffset: 350, // after voting ends
 			setupFunc: func(proposal *governance.Proposal, current int64) {
 				// Add enough yes votes to pass
 				resolver := NewProposalResolver(proposal)
@@ -291,16 +295,16 @@ func TestProposal_IsActive_StatusTypeCaching(t *testing.T) {
 			expectedStatusType: governance.StatusPassed,
 		},
 		{
-			name:               "StatusPassed: CommunityPoolSpend stays active",
-			description:        "CommunityPoolSpend proposal stays active after passing (awaiting execution)",
-			proposalType:       governance.CommunityPoolSpend,
-			votingStartDelay:   100,
-			votingPeriod:       200,
-			executionDelay:     100,
-			executionWindow:    200,
-			quorum:             50,
-			maxVotingWeight:    1000,
-			currentTimeOffset:  350, // after voting ends, before executable
+			name:              "StatusPassed: CommunityPoolSpend stays active",
+			description:       "CommunityPoolSpend proposal stays active after passing (awaiting execution)",
+			proposalType:      governance.CommunityPoolSpend,
+			votingStartDelay:  100,
+			votingPeriod:      200,
+			executionDelay:    100,
+			executionWindow:   200,
+			quorum:            50,
+			maxVotingWeight:   1000,
+			currentTimeOffset: 350, // after voting ends, before executable
 			setupFunc: func(proposal *governance.Proposal, current int64) {
 				resolver := NewProposalResolver(proposal)
 				resolver.Vote(true, 600) // 60% yes
@@ -309,16 +313,16 @@ func TestProposal_IsActive_StatusTypeCaching(t *testing.T) {
 			expectedStatusType: governance.StatusPassed,
 		},
 		{
-			name:               "StatusPassed: ParameterChange stays active",
-			description:        "ParameterChange proposal stays active after passing",
-			proposalType:       governance.ParameterChange,
-			votingStartDelay:   100,
-			votingPeriod:       200,
-			executionDelay:     100,
-			executionWindow:    200,
-			quorum:             50,
-			maxVotingWeight:    1000,
-			currentTimeOffset:  350,
+			name:              "StatusPassed: ParameterChange stays active",
+			description:       "ParameterChange proposal stays active after passing",
+			proposalType:      governance.ParameterChange,
+			votingStartDelay:  100,
+			votingPeriod:      200,
+			executionDelay:    100,
+			executionWindow:   200,
+			quorum:            50,
+			maxVotingWeight:   1000,
+			currentTimeOffset: 350,
 			setupFunc: func(proposal *governance.Proposal, current int64) {
 				resolver := NewProposalResolver(proposal)
 				resolver.Vote(true, 600)
@@ -328,16 +332,16 @@ func TestProposal_IsActive_StatusTypeCaching(t *testing.T) {
 		},
 		// Executable status tests
 		{
-			name:               "StatusExecutable: proposal can be executed",
-			description:        "Proposal is in executable window",
-			proposalType:       governance.CommunityPoolSpend,
-			votingStartDelay:   100,
-			votingPeriod:       200,
-			executionDelay:     100,
-			executionWindow:    200,
-			quorum:             50,
-			maxVotingWeight:    1000,
-			currentTimeOffset:  450, // after execution delay
+			name:              "StatusExecutable: proposal can be executed",
+			description:       "Proposal is in executable window",
+			proposalType:      governance.CommunityPoolSpend,
+			votingStartDelay:  100,
+			votingPeriod:      200,
+			executionDelay:    100,
+			executionWindow:   200,
+			quorum:            50,
+			maxVotingWeight:   1000,
+			currentTimeOffset: 450, // after execution delay
 			setupFunc: func(proposal *governance.Proposal, current int64) {
 				resolver := NewProposalResolver(proposal)
 				resolver.Vote(true, 600)
@@ -347,16 +351,16 @@ func TestProposal_IsActive_StatusTypeCaching(t *testing.T) {
 		},
 		// Rejected status tests
 		{
-			name:               "StatusRejected: majority no votes",
-			description:        "Proposal rejected by majority no votes",
-			proposalType:       governance.Text,
-			votingStartDelay:   100,
-			votingPeriod:       200,
-			executionDelay:     100,
-			executionWindow:    200,
-			quorum:             50,
-			maxVotingWeight:    1000,
-			currentTimeOffset:  350,
+			name:              "StatusRejected: majority no votes",
+			description:       "Proposal rejected by majority no votes",
+			proposalType:      governance.Text,
+			votingStartDelay:  100,
+			votingPeriod:      200,
+			executionDelay:    100,
+			executionWindow:   200,
+			quorum:            50,
+			maxVotingWeight:   1000,
+			currentTimeOffset: 350,
 			setupFunc: func(proposal *governance.Proposal, current int64) {
 				resolver := NewProposalResolver(proposal)
 				resolver.Vote(false, 600) // 60% no
@@ -365,19 +369,19 @@ func TestProposal_IsActive_StatusTypeCaching(t *testing.T) {
 			expectedStatusType: governance.StatusRejected,
 		},
 		{
-			name:               "StatusRejected: insufficient yes votes for quorum",
-			description:        "Proposal rejected due to not reaching quorum of yes votes",
-			proposalType:       governance.CommunityPoolSpend,
-			votingStartDelay:   100,
-			votingPeriod:       200,
-			executionDelay:     100,
-			executionWindow:    200,
-			quorum:             50,
-			maxVotingWeight:    1000,
-			currentTimeOffset:  350,
+			name:              "StatusRejected: insufficient yes votes for quorum",
+			description:       "Proposal rejected due to not reaching quorum of yes votes",
+			proposalType:      governance.CommunityPoolSpend,
+			votingStartDelay:  100,
+			votingPeriod:      200,
+			executionDelay:    100,
+			executionWindow:   200,
+			quorum:            50,
+			maxVotingWeight:   1000,
+			currentTimeOffset: 350,
 			setupFunc: func(proposal *governance.Proposal, current int64) {
 				resolver := NewProposalResolver(proposal)
-				resolver.Vote(true, 400) // 40% yes - not enough
+				resolver.Vote(true, 400)  // 40% yes - not enough
 				resolver.Vote(false, 500) // 50% no
 			},
 			expectedActive:     false,
@@ -385,16 +389,16 @@ func TestProposal_IsActive_StatusTypeCaching(t *testing.T) {
 		},
 		// Executed status tests
 		{
-			name:               "StatusExecuted: proposal has been executed",
-			description:        "Proposal is inactive after execution",
-			proposalType:       governance.CommunityPoolSpend,
-			votingStartDelay:   100,
-			votingPeriod:       200,
-			executionDelay:     100,
-			executionWindow:    200,
-			quorum:             50,
-			maxVotingWeight:    1000,
-			currentTimeOffset:  450,
+			name:              "StatusExecuted: proposal has been executed",
+			description:       "Proposal is inactive after execution",
+			proposalType:      governance.CommunityPoolSpend,
+			votingStartDelay:  100,
+			votingPeriod:      200,
+			executionDelay:    100,
+			executionWindow:   200,
+			quorum:            50,
+			maxVotingWeight:   1000,
+			currentTimeOffset: 450,
 			setupFunc: func(proposal *governance.Proposal, current int64) {
 				resolver := NewProposalResolver(proposal)
 				resolver.Vote(true, 600)
@@ -405,16 +409,16 @@ func TestProposal_IsActive_StatusTypeCaching(t *testing.T) {
 		},
 		// Canceled status tests
 		{
-			name:               "StatusCanceled: proposal canceled before voting",
-			description:        "Proposal is inactive after cancellation",
-			proposalType:       governance.ParameterChange,
-			votingStartDelay:   100,
-			votingPeriod:       200,
-			executionDelay:     100,
-			executionWindow:    200,
-			quorum:             50,
-			maxVotingWeight:    1000,
-			currentTimeOffset:  50,
+			name:              "StatusCanceled: proposal canceled before voting",
+			description:       "Proposal is inactive after cancellation",
+			proposalType:      governance.ParameterChange,
+			votingStartDelay:  100,
+			votingPeriod:      200,
+			executionDelay:    100,
+			executionWindow:   200,
+			quorum:            50,
+			maxVotingWeight:   1000,
+			currentTimeOffset: 50,
 			setupFunc: func(proposal *governance.Proposal, current int64) {
 				resolver := NewProposalResolver(proposal)
 				resolver.cancel(current, 100, address("g1proposer"))
@@ -424,16 +428,16 @@ func TestProposal_IsActive_StatusTypeCaching(t *testing.T) {
 		},
 		// Expired status tests
 		{
-			name:               "StatusExpired: execution window passed",
-			description:        "Proposal is inactive after execution window expires",
-			proposalType:       governance.CommunityPoolSpend,
-			votingStartDelay:   100,
-			votingPeriod:       200,
-			executionDelay:     100,
-			executionWindow:    200,
-			quorum:             50,
-			maxVotingWeight:    1000,
-			currentTimeOffset:  700, // after execution window
+			name:              "StatusExpired: execution window passed",
+			description:       "Proposal is inactive after execution window expires",
+			proposalType:      governance.CommunityPoolSpend,
+			votingStartDelay:  100,
+			votingPeriod:      200,
+			executionDelay:    100,
+			executionWindow:   200,
+			quorum:            50,
+			maxVotingWeight:   1000,
+			currentTimeOffset: 700, // after execution window
 			setupFunc: func(proposal *governance.Proposal, current int64) {
 				resolver := NewProposalResolver(proposal)
 				resolver.Vote(true, 600)

--- a/contract/r/gnoswap/gov/governance/v1/proposal_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal_test.gno
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	"chain/runtime"
 	"testing"
 	"time"
 
@@ -92,7 +91,7 @@ func TestProposal_Validation(t *testing.T) {
 				ExecutionWindow:  200,
 				Quorum:           50,
 			}
-			proposal := governance.NewProposal(
+			proposal := newTestProposal(
 				1,
 				NewProposalStatus(config, 1000, governance.Text.IsExecutable(), baseTime),
 				tc.metadata,
@@ -101,7 +100,6 @@ func TestProposal_Validation(t *testing.T) {
 				1, // configVersion
 				baseTime,
 				baseTime,
-				runtime.ChainHeight(),
 			)
 
 			// when
@@ -161,7 +159,7 @@ func TestProposal_StatusOperations(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// given
-			proposal := governance.NewProposal(
+			proposal := newTestProposal(
 				1,
 				NewProposalStatus(config, 1000, tc.proposalType.IsExecutable(), baseTime.Unix()),
 				governance.NewProposalMetadata("Test", "Test"),
@@ -170,7 +168,6 @@ func TestProposal_StatusOperations(t *testing.T) {
 				1, // configVersion
 				baseTime.Unix(),
 				baseTime.Unix(),
-				runtime.ChainHeight(),
 			)
 
 			if tc.isExecuted {
@@ -458,7 +455,7 @@ func TestProposal_IsActive_StatusTypeCaching(t *testing.T) {
 				Quorum:           tc.quorum,
 			}
 
-			proposal := governance.NewProposal(
+			proposal := newTestProposal(
 				1,
 				NewProposalStatus(config, tc.maxVotingWeight, tc.proposalType.IsExecutable(), baseTime),
 				governance.NewProposalMetadata("Test Title", "Test Description"),
@@ -467,7 +464,6 @@ func TestProposal_IsActive_StatusTypeCaching(t *testing.T) {
 				1,
 				baseTime,
 				baseTime,
-				runtime.ChainHeight(),
 			)
 
 			currentTime := baseTime + tc.currentTimeOffset
@@ -527,7 +523,7 @@ func TestNewProposal(t *testing.T) {
 			}
 
 			// when
-			proposal := governance.NewProposal(
+			proposal := newTestProposal(
 				1,
 				NewProposalStatus(config, 1000, tc.proposalType.IsExecutable(), baseTime),
 				governance.NewProposalMetadata(tc.title, tc.description),
@@ -536,7 +532,6 @@ func TestNewProposal(t *testing.T) {
 				1, // configVersion
 				baseTime,
 				baseTime,
-				runtime.ChainHeight(),
 			)
 
 			// then

--- a/contract/r/gnoswap/gov/governance/v1/proposal_vote_status.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal_vote_status.gno
@@ -72,12 +72,14 @@ func (p *ProposalVoteStatusResolver) IsRejected() bool {
 }
 
 // IsPassed determines if the proposal has passed the voting requirements.
-// A proposal passes if it receives at least the quorum amount of "yes" votes.
+// A proposal passes if "yes" votes meet quorum and exceed "no" votes.
 //
 // Returns:
 //   - bool: true if proposal has passed
 func (p *ProposalVoteStatusResolver) IsPassed() bool {
-	return p.YesWeight() >= p.QuorumAmount()
+	yesMeetsQuorum := p.YesWeight() >= p.QuorumAmount()
+	yesBeatsNo := p.YesWeight() > p.NoWeight()
+	return yesMeetsQuorum && yesBeatsNo
 }
 
 // addYesVoteWeight adds the specified weight to the "yes" vote tally.

--- a/contract/r/gnoswap/gov/governance/v1/proposal_vote_status_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal_vote_status_test.gno
@@ -60,6 +60,16 @@ func TestProposalVoteStatus_VotingOperations(t *testing.T) {
 			expectedRejected: false,
 			expectedPassed:   false,
 		},
+		{
+			name:             "Quorum met but no leads",
+			maxVotingWeight:  5000,
+			quorum:           40,
+			yesVotes:         2000,
+			noVotes:          2500,
+			expectedFinished: true,
+			expectedRejected: true,
+			expectedPassed:   false,
+		},
 	}
 
 	for _, tc := range tests {

--- a/contract/r/gnoswap/gov/governance/v1/voting_info_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/voting_info_test.gno
@@ -12,31 +12,27 @@ func TestVotingInfo_NewVotingInfo(t *testing.T) {
 	tests := []struct {
 		name               string
 		availableWeight    int64
-		voterAddress       address
 		expectedVotingInfo *governance.VotingInfo
 	}{
 		{
 			name:            "Create new voting info with positive weight",
 			availableWeight: 100,
-			voterAddress:    address("g1voter"),
-			expectedVotingInfo: governance.NewVotingInfo(100, address("g1voter")),
+			expectedVotingInfo: governance.NewVotingInfo(100),
 		},
 		{
 			name:            "Create new voting info with zero weight",
 			availableWeight: 0,
-			voterAddress:    address("g1voter2"),
-			expectedVotingInfo: governance.NewVotingInfo(0, address("g1voter2")),
+			expectedVotingInfo: governance.NewVotingInfo(0),
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// when
-			result := governance.NewVotingInfo(tc.availableWeight, tc.voterAddress)
+			result := governance.NewVotingInfo(tc.availableWeight)
 
 			// then
 			uassert.Equal(t, result.AvailableVoteWeight(), tc.expectedVotingInfo.AvailableVoteWeight())
-			uassert.Equal(t, result.VoterAddress(), tc.expectedVotingInfo.VoterAddress())
 			uassert.Equal(t, result.VotedWeight(), tc.expectedVotingInfo.VotedWeight())
 			uassert.Equal(t, result.VotedHeight(), tc.expectedVotingInfo.VotedHeight())
 			uassert.Equal(t, result.VotedAt(), tc.expectedVotingInfo.VotedAt())
@@ -61,7 +57,7 @@ func TestVotingInfo_VoteExecution(t *testing.T) {
 	}{
 		{
 			name: "Vote yes successfully",
-			votingInfo: governance.NewVotingInfo(100, address("g1voter")),
+			votingInfo: governance.NewVotingInfo(100),
 			voteYes:         true,
 			weight:          50,
 			height:          1000,
@@ -72,7 +68,7 @@ func TestVotingInfo_VoteExecution(t *testing.T) {
 		},
 		{
 			name: "Vote no successfully",
-			votingInfo: governance.NewVotingInfo(100, address("g1voter")),
+			votingInfo: governance.NewVotingInfo(100),
 			voteYes:         false,
 			weight:          50,
 			height:          1000,
@@ -83,7 +79,7 @@ func TestVotingInfo_VoteExecution(t *testing.T) {
 		},
 		{
 			name: "Cannot vote twice",
-			votingInfo: governance.NewVotingInfo(100, address("g1voter")),
+			votingInfo: governance.NewVotingInfo(100),
 			voteYes:         true,
 			weight:          50,
 			height:          1000,
@@ -127,7 +123,7 @@ func TestVotingInfo_VotingTypeAndStatus(t *testing.T) {
 		{
 			name: "Yes vote status",
 			votingInfo: func() *governance.VotingInfo {
-				vi := governance.NewVotingInfo(100, address("g1voter"))
+				vi := governance.NewVotingInfo(100)
 				vi.SetVoted(true)
 				vi.SetVotedYes(true)
 				return vi
@@ -140,7 +136,7 @@ func TestVotingInfo_VotingTypeAndStatus(t *testing.T) {
 		{
 			name: "No vote status",
 			votingInfo: func() *governance.VotingInfo {
-				vi := governance.NewVotingInfo(100, address("g1voter"))
+				vi := governance.NewVotingInfo(100)
 				vi.SetVoted(true)
 				vi.SetVotedYes(false)
 				return vi
@@ -153,7 +149,7 @@ func TestVotingInfo_VotingTypeAndStatus(t *testing.T) {
 		{
 			name: "Not voted status",
 			votingInfo: func() *governance.VotingInfo {
-				vi := governance.NewVotingInfo(100, address("g1voter"))
+				vi := governance.NewVotingInfo(100)
 				return vi
 			},
 			expectedVotingType: "no",
@@ -176,7 +172,6 @@ func TestVotingInfo_VotingTypeAndStatus(t *testing.T) {
 
 // TestVotingInfo_VoteWeights tests the vote weight getters
 func TestVotingInfo_VoteWeights(t *testing.T) {
-	voterAddr := address("g1voter")
 	tests := []struct {
 		name                    string
 		votingInfo              func() *governance.VotingInfo
@@ -186,7 +181,7 @@ func TestVotingInfo_VoteWeights(t *testing.T) {
 		{
 			name: "Get weights before voting",
 			votingInfo: func() *governance.VotingInfo {
-				vi := governance.NewVotingInfo(100, voterAddr)
+				vi := governance.NewVotingInfo(100)
 				return vi
 			},
 			expectedAvailableWeight: 100,
@@ -195,7 +190,7 @@ func TestVotingInfo_VoteWeights(t *testing.T) {
 		{
 			name: "Get weights after voting",
 			votingInfo: func() *governance.VotingInfo {
-				vi := governance.NewVotingInfo(100, voterAddr)
+				vi := governance.NewVotingInfo(100)
 				vi.SetVoted(true)
 				vi.SetVotedWeight(50)
 				return vi
@@ -206,7 +201,7 @@ func TestVotingInfo_VoteWeights(t *testing.T) {
 		{
 			name: "Get weights with zero available weight",
 			votingInfo: func() *governance.VotingInfo {
-				vi := governance.NewVotingInfo(0, voterAddr)
+				vi := governance.NewVotingInfo(0)
 				return vi
 			},
 			expectedAvailableWeight: 0,

--- a/contract/r/gnoswap/gov/governance/voting_info.gno
+++ b/contract/r/gnoswap/gov/governance/voting_info.gno
@@ -3,7 +3,6 @@ package governance
 // VotingInfo tracks voting-related information for a specific user on a specific proposal.
 // This structure maintains the user's voting eligibility, voting history, and voting power.
 type VotingInfo struct {
-	voterAddress        address // Address of the voter
 	availableVoteWeight int64   // Total voting weight available to this user for this proposal
 	votedWeight         int64   // Actual weight used when voting (0 if not voted)
 	votedHeight         int64   // Block height when vote was cast
@@ -17,21 +16,15 @@ type VotingInfo struct {
 //
 // Parameters:
 //   - availableVoteWeight: total voting weight available to this user
-//   - voterAddress: address of the voter
 //
 // Returns:
 //   - *VotingInfo: newly created voting information structure
-func NewVotingInfo(availableVoteWeight int64, voterAddress address) *VotingInfo {
+func NewVotingInfo(availableVoteWeight int64) *VotingInfo {
 	return &VotingInfo{
 		availableVoteWeight: availableVoteWeight,
-		voterAddress:        voterAddress,
 		// Other fields are initialized to zero values (false, 0)
 		// voted starts as false, indicating no vote has been cast
 	}
-}
-
-func (v *VotingInfo) VoterAddress() address {
-	return v.voterAddress
 }
 
 // VotingType returns a human-readable string representation of the vote choice.
@@ -123,10 +116,6 @@ func (v *VotingInfo) VotedAt() int64 {
 /* Setter methods */
 func (v *VotingInfo) SetAvailableVoteWeight(availableVoteWeight int64) {
 	v.availableVoteWeight = availableVoteWeight
-}
-
-func (v *VotingInfo) SetVoterAddress(voterAddress address) {
-	v.voterAddress = voterAddress
 }
 
 func (v *VotingInfo) SetVotedWeight(votedWeight int64) {

--- a/contract/r/scenario/halt/emission_halt_does_not_block_governance_filetest.gno
+++ b/contract/r/scenario/halt/emission_halt_does_not_block_governance_filetest.gno
@@ -92,16 +92,17 @@ func initGovernanceAndTokens() {
 	gns.Transfer(cross, bobAddr, defaultTokenAmount)
 
 	// Delegate GNS tokens for voting power (leave some for proposal creation)
-	// Delegate less to ensure enough balance remains for proposal creation
-	delegatedAmount := defaultTokenAmount / 4 // Delegate only 25% instead of 50%
+	// Alice delegates more than Bob to ensure YES > NO when they vote differently
+	aliceDelegateAmount := defaultTokenAmount * 3 / 10 // 30% = 600M
+	bobDelegateAmount := defaultTokenAmount * 2 / 10   // 20% = 400M
 
 	testing.SetRealm(aliceRealm)
 	gns.Approve(cross, govStakerAddr, INT64_MAX)
-	gs.Delegate(cross, aliceAddr, delegatedAmount, "")
+	gs.Delegate(cross, aliceAddr, aliceDelegateAmount, "")
 
 	testing.SetRealm(bobRealm)
 	gns.Approve(cross, govStakerAddr, INT64_MAX)
-	gs.Delegate(cross, bobAddr, delegatedAmount, "")
+	gs.Delegate(cross, bobAddr, bobDelegateAmount, "")
 
 	ufmt.Printf("[INFO] Alice GNS balance: %d\n", gns.BalanceOf(aliceAddr))
 	ufmt.Printf("[INFO] Bob GNS balance: %d\n", gns.BalanceOf(bobAddr))
@@ -275,8 +276,8 @@ func resetProposalVotesWithEmissionHalted() {
 
 // Output:
 // [SCENARIO] 1. Initialize governance and tokens
-// [INFO] Alice GNS balance: 1500000000
-// [INFO] Bob GNS balance: 1500000000
+// [INFO] Alice GNS balance: 1400000000
+// [INFO] Bob GNS balance: 1600000000
 // [INFO] Governance and tokens initialized
 //
 // [SCENARIO] 2. Skip vote weight smoothing duration for create proposal
@@ -304,7 +305,7 @@ func resetProposalVotesWithEmissionHalted() {
 // [INFO] Voting on proposal with emission HALTED...
 // [EXPECTED] Alice voted YES successfully despite emission halt
 // [EXPECTED] Bob voted NO successfully despite emission halt
-// [INFO] Vote status: {"height":"432123","now":"1236727890","proposalId":"2","votes":"eyJxdW9ydW0iOiI1MDAwMDAwMDAiLCJtYXgiOiIxMDAwMDAwMDAwIiwieWVzIjoiNTAwMDAwMDAwIiwibm8iOiI1MDAwMDAwMDAifQ=="}
+// [INFO] Vote status: {"height":"432123","now":"1236727890","proposalId":"2","votes":"eyJxdW9ydW0iOiI1MDAwMDAwMDAiLCJtYXgiOiIxMDAwMDAwMDAwIiwieWVzIjoiNjAwMDAwMDAwIiwibm8iOiI0MDAwMDAwMDAifQ=="}
 // [SUCCESS] Governance voting not blocked by emission halt
 //
 // [SCENARIO] 7. Execute proposal with emission halted
@@ -317,5 +318,5 @@ func resetProposalVotesWithEmissionHalted() {
 // [SCENARIO] 8. Test vote integrity with emission halted
 // [INFO] Testing double voting protection with emission HALTED...
 // [INFO] Vote status: %s
-//  {"height":"777723","now":"1238455890","proposalId":"3","votes":"eyJxdW9ydW0iOiI1MDAwMDAwMDAiLCJtYXgiOiIxMDAwMDAwMDAwIiwieWVzIjoiNTAwMDAwMDAwIiwibm8iOiIwIn0="}
+//  {"height":"777723","now":"1238455890","proposalId":"3","votes":"eyJxdW9ydW0iOiI1MDAwMDAwMDAiLCJtYXgiOiIxMDAwMDAwMDAwIiwieWVzIjoiNjAwMDAwMDAwIiwibm8iOiIwIn0="}
 // [SUCCESS] Double voting protection works with emission halted


### PR DESCRIPTION
## Description

Replace nested AVL tree structure with single tree using composite keys (`proposalID:voter`).

- Eliminate write amplication on vote updates
- Removes need to pre-create empty trees for each proposal
- Simplifies `Get`/`Set` operations to single-item access

| Operation | Before (Nested Tree) | After (Composite Key) |
|-----------|----------------------|-----------------------|
| Vote Storage | O(log P) + O(log V) + full subtree serialization | O(log N) single entry only |
| Vote Lookup | O(log P) + O(log V) two traversals | O(log N) single traversal |
| Per-Proposal Full Iteration | O(V) only votes for that proposal | O(N) full iteration + prefix filter |

- P = number of proposals, V = votes per proposal, N = total votes