### PR TITLE
fix(pool): avoid nil panic in balance check

### DIFF
--- a/contract/r/gnoswap/pool/v1/transfer.gno
+++ b/contract/r/gnoswap/pool/v1/transfer.gno
@@ -276,7 +276,10 @@ func validatePoolBalance(token0, token1, amount *u256.Uint, isToken0 bool) error
 	if token0 == nil || token1 == nil || amount == nil {
 		return ufmt.Errorf(
 			"%v. token0(%s) or token1(%s) or amount(%s) is nil",
-			errTransferFailed, token0.ToString(), token1.ToString(), amount.ToString(),
+			errTransferFailed,
+			formatUintOrNil(token0),
+			formatUintOrNil(token1),
+			formatUintOrNil(amount),
 		)
 	}
 
@@ -296,6 +299,14 @@ func validatePoolBalance(token0, token1, amount *u256.Uint, isToken0 bool) error
 		)
 	}
 	return nil
+}
+
+func formatUintOrNil(value *u256.Uint) string {
+	if value == nil {
+		return "<nil>"
+	}
+
+	return value.ToString()
 }
 
 // updatePoolBalance calculates the new balance after a transfer and validate.

--- a/contract/r/gnoswap/pool/v1/transfer_test.gno
+++ b/contract/r/gnoswap/pool/v1/transfer_test.gno
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"strings"
 	"testing"
 
 	i256 "gno.land/p/gnoswap/int256"
@@ -17,6 +18,7 @@ func TestValidatePoolBalance(t *testing.T) {
 		amount        *u256.Uint
 		isToken0      bool
 		expectedError bool
+		expectedMsg   string
 	}{
 		{
 			name:          "successful token0 transfer",
@@ -57,6 +59,7 @@ func TestValidatePoolBalance(t *testing.T) {
 			amount:        u256.NewUint(500),
 			isToken0:      true,
 			expectedError: true,
+			expectedMsg:   "token0(<nil>) or token1(1000) or amount(500) is nil",
 		},
 		{
 			name:          "nil token1",
@@ -65,6 +68,7 @@ func TestValidatePoolBalance(t *testing.T) {
 			amount:        u256.NewUint(500),
 			isToken0:      false,
 			expectedError: true,
+			expectedMsg:   "token0(1000) or token1(<nil>) or amount(500) is nil",
 		},
 		{
 			name:          "nil amount",
@@ -73,15 +77,26 @@ func TestValidatePoolBalance(t *testing.T) {
 			amount:        nil,
 			isToken0:      true,
 			expectedError: true,
+			expectedMsg:   "token0(1000) or token1(1000) or amount(<nil>) is nil",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("validatePoolBalance panicked: %v", r)
+				}
+			}()
+
 			err := validatePoolBalance(tt.token0, tt.token1, tt.amount, tt.isToken0)
 			if tt.expectedError {
 				if err == nil {
 					t.Errorf("expected error but got none")
+					return
+				}
+				if tt.expectedMsg != "" && !strings.Contains(err.Error(), tt.expectedMsg) {
+					t.Errorf("expected error containing %q, got %q", tt.expectedMsg, err.Error())
 				}
 			} else {
 				if err != nil {


### PR DESCRIPTION
## Summary
- Fix nil-guard behavior in `validatePoolBalance` to return a controlled error instead of panicking when `token0`, `token1`, or `amount` is nil.
- Add a nil-safe formatter for `*u256.Uint` values used in the nil validation error path.
- Strengthen `TestValidatePoolBalance` to ensure nil inputs do not panic and return expected error content.

## Why
- The previous nil-check branch still called `.ToString()` on potentially nil pointers while constructing the error message, which could trigger an unexpected panic.
- This change preserves graceful validation failure semantics and hardens the transfer precondition checks.

## Verification
- `make test WORKDIR=tmp PKG=gno.land/r/gnoswap/pool/v1 RUN=TestValidatePoolBalance`
- `make test WORKDIR=tmp PKG=gno.land/r/gnoswap/pool/v1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages in pool balance validation to properly handle edge cases with nil values, ensuring clearer feedback when operations encounter data inconsistencies.

* **Tests**
  * Enhanced test coverage for pool balance validation scenarios, including edge cases with nil values and improved error message verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->