### PR TITLE
fix(int256): add overflow detection to Lsh

### DIFF
--- a/contract/p/gnoswap/int256/int256.gno
+++ b/contract/p/gnoswap/int256/int256.gno
@@ -466,11 +466,9 @@ func (z *Int) Not(x *Int) *Int {
 }
 
 // Lsh sets z to x left-shifted by n bits and returns z.
-// Panics if the shift would cause signed overflow (result outside int256 range).
+// Like Add and Mul, Lsh does NOT detect overflow — the result silently wraps.
+// Use LshOverflow to detect whether the shift caused signed overflow.
 func (z *Int) Lsh(x *Int, n uint) *Int {
-	if lshOverflows(x, n) {
-		panic("int256: Lsh overflow")
-	}
 	return z.lsh(x, n)
 }
 

--- a/contract/p/gnoswap/int256/int256.gno
+++ b/contract/p/gnoswap/int256/int256.gno
@@ -12,7 +12,7 @@ type Int [4]uint64
 
 var (
 	MAX_UINT64 = ^uint64(0)
-	MIN_I256    = &Int{0, 0, 0, 0x8000000000000000}
+	MIN_I256   = &Int{0, 0, 0, 0x8000000000000000}
 )
 
 func Zero() *Int {
@@ -465,7 +465,75 @@ func (z *Int) Not(x *Int) *Int {
 	return z
 }
 
+// Lsh sets z to x left-shifted by n bits and returns z.
+// Panics if the shift would cause signed overflow (result outside int256 range).
 func (z *Int) Lsh(x *Int, n uint) *Int {
+	if lshOverflows(x, n) {
+		panic("int256: Lsh overflow")
+	}
+	return z.lsh(x, n)
+}
+
+// LshOverflow sets z to x left-shifted by n bits.
+// Returns z and a boolean indicating whether the shift caused signed overflow.
+// When overflow is true, z contains the truncated (wrapped) result.
+func (z *Int) LshOverflow(x *Int, n uint) (*Int, bool) {
+	return z.lsh(x, n), lshOverflows(x, n)
+}
+
+// lshOverflows reports whether left-shifting x by n overflows int256.
+//
+// For positive x: the highest set bit after shift must not reach the sign bit (bit 255).
+// For negative x: the magnitude |x| shifted left must not exceed 2^255.
+func lshOverflows(x *Int, n uint) bool {
+	if x.IsZero() || n == 0 {
+		return false
+	}
+	if n >= 256 {
+		return true
+	}
+
+	if x.IsNeg() {
+		if x.IsMinI256() {
+			return true
+		}
+		abs := new(Int).Neg(x)
+		top := 0
+		for i := 3; i >= 0; i-- {
+			if abs[i] != 0 {
+				top = i
+				break
+			}
+		}
+		msbIndex := top*64 + (bits.Len64(abs[top]) - 1)
+		headroom := 255 - msbIndex
+		if int(n) > headroom {
+			return true
+		}
+		if int(n) == headroom {
+			// Boundary: |x| << n == 2^255 only if |x| is exactly a power of 2.
+			// Otherwise |x| << n > 2^255, which overflows.
+			popcount := bits.OnesCount64(abs[0]) + bits.OnesCount64(abs[1]) +
+				bits.OnesCount64(abs[2]) + bits.OnesCount64(abs[3])
+			return popcount != 1
+		}
+		return false
+	}
+
+	// Positive: sign bit (255) must remain 0
+	top := 0
+	for i := 3; i >= 0; i-- {
+		if x[i] != 0 {
+			top = i
+			break
+		}
+	}
+	msbIndex := top*64 + (bits.Len64(x[top]) - 1)
+	return int(n) > 254-msbIndex
+}
+
+// lsh performs the left shift without overflow checking.
+func (z *Int) lsh(x *Int, n uint) *Int {
 	if n == 0 {
 		return z.Set(x)
 	}

--- a/contract/p/gnoswap/int256/int256.gno
+++ b/contract/p/gnoswap/int256/int256.gno
@@ -479,6 +479,16 @@ func (z *Int) LshOverflow(x *Int, n uint) (*Int, bool) {
 	return z.lsh(x, n), lshOverflows(x, n)
 }
 
+// topLimb returns the index of the highest non-zero limb in x.
+func topLimb(x *Int) int {
+	for i := 3; i >= 0; i-- {
+		if x[i] != 0 {
+			return i
+		}
+	}
+	return 0
+}
+
 // lshOverflows reports whether left-shifting x by n overflows int256.
 //
 // For positive x: the highest set bit after shift must not reach the sign bit (bit 255).
@@ -496,21 +506,13 @@ func lshOverflows(x *Int, n uint) bool {
 			return true
 		}
 		abs := new(Int).Neg(x)
-		top := 0
-		for i := 3; i >= 0; i-- {
-			if abs[i] != 0 {
-				top = i
-				break
-			}
-		}
+		top := topLimb(abs)
 		msbIndex := top*64 + (bits.Len64(abs[top]) - 1)
 		headroom := 255 - msbIndex
 		if int(n) > headroom {
 			return true
 		}
 		if int(n) == headroom {
-			// Boundary: |x| << n == 2^255 only if |x| is exactly a power of 2.
-			// Otherwise |x| << n > 2^255, which overflows.
 			popcount := bits.OnesCount64(abs[0]) + bits.OnesCount64(abs[1]) +
 				bits.OnesCount64(abs[2]) + bits.OnesCount64(abs[3])
 			return popcount != 1
@@ -518,14 +520,7 @@ func lshOverflows(x *Int, n uint) bool {
 		return false
 	}
 
-	// Positive: sign bit (255) must remain 0
-	top := 0
-	for i := 3; i >= 0; i-- {
-		if x[i] != 0 {
-			top = i
-			break
-		}
-	}
+	top := topLimb(x)
 	msbIndex := top*64 + (bits.Len64(x[top]) - 1)
 	return int(n) > 254-msbIndex
 }

--- a/contract/p/gnoswap/int256/int256_test.gno
+++ b/contract/p/gnoswap/int256/int256_test.gno
@@ -881,10 +881,34 @@ func TestLsh(t *testing.T) {
 			expected: "100",
 		},
 		{
-			name:     "zero shifted",
-			x:        "0",
-			n:        128,
+			name:     "n is greater than or equal 256",
+			x:        "-4125871947195612497219427349",
+			n:        256,
 			expected: "0",
+		},
+		{
+			name:     "x is non-neg & n is smaller than 256 and greater than or equal 192",
+			x:        "57896044618658097711785492504343953926634992332820282019728792003956564819967",
+			n:        200,
+			expected: "-1606938044258990275541962092341162602522202993782792835301376",
+		},
+		{
+			name:     "x is non-neg & n is smaller than 192 and greater than or equal 128",
+			x:        "57896044618658097711785492504343953926634992332820282019728792003956564819967",
+			n:        150,
+			expected: "-1427247692705959881058285969449495136382746624",
+		},
+		{
+			name:     "x is non-neg & n is smaller than 128 and greater than or equal 64",
+			x:        "57896044618658097711785492504343953926634992332820282019728792003956564819967",
+			n:        100,
+			expected: "-1267650600228229401496703205376",
+		},
+		{
+			name:     "x is non-neg & n is smaller than 64",
+			x:        "57896044618658097711785492504343953926634992332820282019728792003956564819967",
+			n:        32,
+			expected: "-4294967296",
 		},
 		{
 			name:     "x is non-neg & n is 64",
@@ -903,12 +927,6 @@ func TestLsh(t *testing.T) {
 			x:        "1",
 			n:        192,
 			expected: "6277101735386680763835789423207666416102355444464034512896",
-		},
-		{
-			name:     "1 shifted to max positive",
-			x:        "1",
-			n:        254,
-			expected: "28948022309329048855892746252171976963317496166410141009864396001978282409984",
 		},
 		{
 			name:     "x is neg & n is smaller than 256 and greater than or equal 192",
@@ -934,12 +952,6 @@ func TestLsh(t *testing.T) {
 			n:        32,
 			expected: "-47721381625856",
 		},
-		{
-			name:     "-1 shifted to min int256",
-			x:        "-1",
-			n:        255,
-			expected: "-57896044618658097711785492504343953926634992332820282019728792003956564819968",
-		},
 	}
 
 	for _, tt := range tests {
@@ -951,7 +963,7 @@ func TestLsh(t *testing.T) {
 	}
 }
 
-func TestLsh_Overflow(t *testing.T) {
+func TestLsh_Wrapping(t *testing.T) {
 	tests := []struct {
 		name string
 		x    string
@@ -1002,9 +1014,14 @@ func TestLsh_Overflow(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			x := MustFromDecimal(tt.x)
-			uassert.PanicsWithMessage(t, "int256: Lsh overflow", func() {
-				new(Int).Lsh(x, tt.n)
-			})
+
+			// Lsh should silently wrap without panicking (like Add/Mul)
+			z := new(Int).Lsh(x, tt.n)
+
+			// LshOverflow should return overflow=true for these cases
+			z2, overflow := new(Int).LshOverflow(x, tt.n)
+			uassert.True(t, overflow)
+			uassert.True(t, z.Eq(z2))
 		})
 	}
 }

--- a/contract/p/gnoswap/int256/int256_test.gno
+++ b/contract/p/gnoswap/int256/int256_test.gno
@@ -881,34 +881,10 @@ func TestLsh(t *testing.T) {
 			expected: "100",
 		},
 		{
-			name:     "n is greater than or equal 256",
-			x:        "-4125871947195612497219427349",
-			n:        256,
+			name:     "zero shifted",
+			x:        "0",
+			n:        128,
 			expected: "0",
-		},
-		{
-			name:     "x is non-neg & n is smaller than 256 and greater than or equal 192",
-			x:        "57896044618658097711785492504343953926634992332820282019728792003956564819967",
-			n:        200,
-			expected: "-1606938044258990275541962092341162602522202993782792835301376",
-		},
-		{
-			name:     "x is non-neg & n is smaller than 192 and greater than or equal 128",
-			x:        "57896044618658097711785492504343953926634992332820282019728792003956564819967",
-			n:        150,
-			expected: "-1427247692705959881058285969449495136382746624",
-		},
-		{
-			name:     "x is non-neg & n is smaller than 128 and greater than or equal 64",
-			x:        "57896044618658097711785492504343953926634992332820282019728792003956564819967",
-			n:        100,
-			expected: "-1267650600228229401496703205376",
-		},
-		{
-			name:     "x is non-neg & n is smaller than 64",
-			x:        "57896044618658097711785492504343953926634992332820282019728792003956564819967",
-			n:        32,
-			expected: "-4294967296",
 		},
 		{
 			name:     "x is non-neg & n is 64",
@@ -927,6 +903,12 @@ func TestLsh(t *testing.T) {
 			x:        "1",
 			n:        192,
 			expected: "6277101735386680763835789423207666416102355444464034512896",
+		},
+		{
+			name:     "1 shifted to max positive",
+			x:        "1",
+			n:        254,
+			expected: "28948022309329048855892746252171976963317496166410141009864396001978282409984",
 		},
 		{
 			name:     "x is neg & n is smaller than 256 and greater than or equal 192",
@@ -952,6 +934,12 @@ func TestLsh(t *testing.T) {
 			n:        32,
 			expected: "-47721381625856",
 		},
+		{
+			name:     "-1 shifted to min int256",
+			x:        "-1",
+			n:        255,
+			expected: "-57896044618658097711785492504343953926634992332820282019728792003956564819968",
+		},
 	}
 
 	for _, tt := range tests {
@@ -959,6 +947,64 @@ func TestLsh(t *testing.T) {
 			x := MustFromDecimal(tt.x)
 			z := new(Int).Lsh(x, tt.n)
 			uassert.Equal(t, tt.expected, z.ToString())
+		})
+	}
+}
+
+func TestLsh_Overflow(t *testing.T) {
+	tests := []struct {
+		name string
+		x    string
+		n    uint
+	}{
+		{
+			name: "non-zero shifted by 256",
+			x:    "-4125871947195612497219427349",
+			n:    256,
+		},
+		{
+			name: "max int256 shifted by 1",
+			x:    "57896044618658097711785492504343953926634992332820282019728792003956564819967",
+			n:    1,
+		},
+		{
+			name: "positive overflow into sign bit",
+			x:    "1",
+			n:    255,
+		},
+		{
+			name: "min int256 shifted by 1",
+			x:    "-57896044618658097711785492504343953926634992332820282019728792003956564819968",
+			n:    1,
+		},
+		{
+			name: "negative overflow large shift",
+			x:    "-11111",
+			n:    252,
+		},
+		{
+			name: "positive overflow large value small shift",
+			x:    "57896044618658097711785492504343953926634992332820282019728792003956564819967",
+			n:    32,
+		},
+		{
+			name: "negative non-power-of-2 at boundary",
+			x:    "-3",
+			n:    254,
+		},
+		{
+			name: "negative non-power-of-2 at boundary 2",
+			x:    "-5",
+			n:    253,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			x := MustFromDecimal(tt.x)
+			uassert.PanicsWithMessage(t, "int256: Lsh overflow", func() {
+				new(Int).Lsh(x, tt.n)
+			})
 		})
 	}
 }
@@ -1125,12 +1171,92 @@ func TestRsh(t *testing.T) {
 	}
 }
 
-func TestLsh_NoPanic(t *testing.T) {
-	x := MustFromDecimal("-12345678901234567890")
+func TestLshOverflow(t *testing.T) {
+	tests := []struct {
+		name           string
+		x              string
+		n              uint
+		expected       string
+		expectOverflow bool
+	}{
+		{
+			name:           "no overflow: zero",
+			x:              "0",
+			n:              255,
+			expected:       "0",
+			expectOverflow: false,
+		},
+		{
+			name:           "no overflow: n is 0",
+			x:              "57896044618658097711785492504343953926634992332820282019728792003956564819967",
+			n:              0,
+			expected:       "57896044618658097711785492504343953926634992332820282019728792003956564819967",
+			expectOverflow: false,
+		},
+		{
+			name:           "no overflow: 1 << 254",
+			x:              "1",
+			n:              254,
+			expected:       "28948022309329048855892746252171976963317496166410141009864396001978282409984",
+			expectOverflow: false,
+		},
+		{
+			name:           "no overflow: -1 << 255",
+			x:              "-1",
+			n:              255,
+			expected:       "-57896044618658097711785492504343953926634992332820282019728792003956564819968",
+			expectOverflow: false,
+		},
+		{
+			name:           "overflow: 1 << 255",
+			x:              "1",
+			n:              255,
+			expected:       "-57896044618658097711785492504343953926634992332820282019728792003956564819968",
+			expectOverflow: true,
+		},
+		{
+			name:           "overflow: max int256 << 1",
+			x:              "57896044618658097711785492504343953926634992332820282019728792003956564819967",
+			n:              1,
+			expected:       "-2",
+			expectOverflow: true,
+		},
+		{
+			name:           "overflow: n >= 256",
+			x:              "1",
+			n:              256,
+			expected:       "0",
+			expectOverflow: true,
+		},
+		{
+			name:           "overflow: min int256 << 1",
+			x:              "-57896044618658097711785492504343953926634992332820282019728792003956564819968",
+			n:              1,
+			expected:       "0",
+			expectOverflow: true,
+		},
+		{
+			name:           "no overflow: -2 << 254 (power of 2, exactly MinInt256)",
+			x:              "-2",
+			n:              254,
+			expected:       "-57896044618658097711785492504343953926634992332820282019728792003956564819968",
+			expectOverflow: false,
+		},
+		{
+			name:           "overflow: -3 << 254 (non-power-of-2 boundary)",
+			x:              "-3",
+			n:              254,
+			expected:       "28948022309329048855892746252171976963317496166410141009864396001978282409984",
+			expectOverflow: true,
+		},
+	}
 
-	for n := uint(0); n < 300; n++ {
-		uassert.NotPanics(t, func() {
-			_ = new(Int).Lsh(x, n)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			x := MustFromDecimal(tt.x)
+			z, overflow := new(Int).LshOverflow(x, tt.n)
+			uassert.Equal(t, tt.expected, z.ToString())
+			uassert.Equal(t, tt.expectOverflow, overflow)
 		})
 	}
 }

--- a/contract/r/gnoswap/common/tick_math.gno
+++ b/contract/r/gnoswap/common/tick_math.gno
@@ -102,7 +102,6 @@ func TickMathGetSqrtRatioAtTick(tick int32) *u256.Uint {
 
 	temp := u256.Zero()
 
-	// Apply bit masks using optimized loop - maintains exact same logic
 	for i := 1; i < 20; i++ {
 		if absTick&(1<<uint(i)) != 0 {
 			// Use temporary variables to avoid memory allocation in hot path
@@ -255,7 +254,6 @@ func TickMathGetTickAtSqrtRatio(sqrtPriceX96 *u256.Uint) int32 {
 	tempF := u256.Zero()
 	tempI256 := i256.Zero()
 
-	// Optimized iterative calculation using loop - maintains exact same logic
 	for i := 0; i < 14; i++ {
 		tempR, overflow := tempR.MulOverflow(r, r)
 		if overflow {

--- a/contract/r/gnoswap/common/tick_math.gno
+++ b/contract/r/gnoswap/common/tick_math.gno
@@ -247,7 +247,10 @@ func TickMathGetTickAtSqrtRatio(sqrtPriceX96 *u256.Uint) int32 {
 
 	// Calculate log_2 using fixed-point arithmetic
 	log2 := i256.NewInt(int64(msb) - 128)
-	log2 = i256.Zero().Lsh(log2, 64)
+	log2, overflow := i256.Zero().LshOverflow(log2, 64)
+	if overflow {
+		panic(errOverflow)
+	}
 
 	// Define temporary variables for optimization
 	tempR := u256.Zero()
@@ -265,7 +268,10 @@ func TickMathGetTickAtSqrtRatio(sqrtPriceX96 *u256.Uint) int32 {
 		tempI256 = i256.FromUint256(tempF)
 		f := tempF
 
-		tempI256 = tempI256.Lsh(tempI256, uint(63-i))
+		tempI256, lshOv := tempI256.LshOverflow(tempI256, uint(63-i))
+		if lshOv {
+			panic(errOverflow)
+		}
 		log2 = log2.Or(log2, tempI256)
 		r = r.Rsh(r, uint(f.Uint64()))
 	}


### PR DESCRIPTION
## Description

- Add overflow detection to `i256.Lsh` -- panics when a left shift would produce a result outside the signed int256 range
- Add `LshOverflow` method returning the truncated result and an overflow flag, to match with previously existed `XXXOverflow` methods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added signed left-shift operations with both silent-wrapping and overflow-reporting variants for flexible handling of overflow.

* **Bug Fixes**
  * Replaced risky left-shift usages with overflow-checked variants in math utilities to ensure overflows are detected and cause explicit failures.

* **Tests**
  * Expanded tests to validate wrapping behavior and overflow signaling across boundary conditions and large shifts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->