### PR TITLE
fix(staker): optimize `EndExternalIncentive` refund calculation

### DIFF
--- a/contract/r/gnoswap/staker/v1/external_incentive.gno
+++ b/contract/r/gnoswap/staker/v1/external_incentive.gno
@@ -237,7 +237,17 @@ func (s *stakerV1) endExternalIncentive(resolver *PoolResolver, incentiveResolve
 		)
 	}
 
-	// O(1) refund: unclaimable reward during zero-liquidity periods plus division remainder.
+	// O(1) refund calculation:
+	//   refund = unclaimableReward + remainder + collectedPenalties
+	//
+	// - unclaimableReward: rewards for zero-liquidity periods (no depositors to earn them)
+	// - remainder: integer division truncation from rewardPerSecond (L-14 dust)
+	// - collectedPenalties: warmup penalties retained in staker during CollectReward,
+	//   routed back to creator on incentive end (PR #1221).
+	//   Derived from accounting fields:
+	//     rewardAmount decreases by (reward + penalty) on each collect,
+	//     distributedRewardAmount increases by reward only,
+	//     so collectedPenalties = (totalRewardAmount - rewardAmount) - distributedRewardAmount
 	incentivesResolver := resolver.IncentivesResolver()
 	unclaimableReward := incentivesResolver.calculateUnclaimableReward(incentiveResolver.IncentiveId())
 
@@ -245,7 +255,10 @@ func (s *stakerV1) endExternalIncentive(resolver *PoolResolver, incentiveResolve
 	distributable := safeMulInt64(incentiveResolver.RewardPerSecond(), duration)
 	remainder := safeSubInt64(incentiveResolver.TotalRewardAmount(), distributable)
 
-	refund := safeAddInt64(unclaimableReward, remainder)
+	consumed := safeSubInt64(incentiveResolver.TotalRewardAmount(), incentiveResolver.RewardAmount())
+	collectedPenalties := safeSubInt64(consumed, incentiveResolver.DistributedRewardAmount())
+
+	refund := safeAddInt64(safeAddInt64(unclaimableReward, remainder), collectedPenalties)
 
 	maxRefund := safeSubInt64(incentiveResolver.TotalRewardAmount(), incentiveResolver.DistributedRewardAmount())
 	if refund > maxRefund {

--- a/contract/r/gnoswap/staker/v1/external_incentive.gno
+++ b/contract/r/gnoswap/staker/v1/external_incentive.gno
@@ -3,7 +3,6 @@ package v1
 import (
 	"chain"
 	"chain/runtime"
-	"math"
 	"time"
 
 	prbac "gno.land/p/gnoswap/rbac"
@@ -238,27 +237,23 @@ func (s *stakerV1) endExternalIncentive(resolver *PoolResolver, incentiveResolve
 		)
 	}
 
-	totalReward := int64(0)
+	// O(1) refund: unclaimable reward during zero-liquidity periods plus division remainder.
+	incentivesResolver := resolver.IncentivesResolver()
+	unclaimableReward := incentivesResolver.calculateUnclaimableReward(incentiveResolver.IncentiveId())
 
-	// calculate total external reward for the incentive
-	s.getDeposits().IterateByPoolPath(0, math.MaxUint64, incentiveResolver.TargetPoolPath(), func(positionId uint64, deposit *sr.Deposit) bool {
-		depositResolver := NewDepositResolver(deposit)
-		lastCollectTime := depositResolver.ExternalRewardLastCollectTime(incentiveResolver.IncentiveId())
+	duration := safeSubInt64(incentiveResolver.EndTimestamp(), incentiveResolver.StartTimestamp())
+	distributable := safeMulInt64(incentiveResolver.RewardPerSecond(), duration)
+	remainder := safeSubInt64(incentiveResolver.TotalRewardAmount(), distributable)
 
-		if lastCollectTime > incentiveResolver.EndTimestamp() {
-			return false
-		}
+	refund := safeAddInt64(unclaimableReward, remainder)
 
-		rewardState := resolver.RewardStateOf(deposit)
-		calculatedTotalReward := rewardState.calculateCollectableExternalReward(lastCollectTime, currentTime, incentiveResolver.ExternalIncentive)
-		totalReward = safeAddInt64(totalReward, calculatedTotalReward)
-
-		return false
-	})
-
-	// calculate refund amount is the difference between the incentive reward amount and the total external reward
-	refund := safeSubInt64(incentiveResolver.TotalRewardAmount(), totalReward)
-	refund = safeSubInt64(refund, incentiveResolver.DistributedRewardAmount())
+	maxRefund := safeSubInt64(incentiveResolver.TotalRewardAmount(), incentiveResolver.DistributedRewardAmount())
+	if refund > maxRefund {
+		refund = maxRefund
+	}
+	if refund < 0 {
+		refund = 0
+	}
 
 	return incentiveResolver.ExternalIncentive, refund, nil
 }

--- a/contract/r/gnoswap/staker/v1/external_incentive.gno
+++ b/contract/r/gnoswap/staker/v1/external_incentive.gno
@@ -247,15 +247,21 @@ func (s *stakerV1) endExternalIncentive(resolver *PoolResolver, incentiveResolve
 
 	consumed := safeSubInt64(incentiveResolver.TotalRewardAmount(), incentiveResolver.RewardAmount())
 	collectedPenalties := safeSubInt64(consumed, incentiveResolver.DistributedRewardAmount())
+	if collectedPenalties < 0 {
+		return nil, 0, makeErrorWithDetails(
+			errCannotEndIncentive,
+			ufmt.Sprintf(
+				"invalid incentive accounting: consumed(%d) < distributed(%d)",
+				consumed, incentiveResolver.DistributedRewardAmount(),
+			),
+		)
+	}
 
 	refund := safeAddInt64(safeAddInt64(unclaimableReward, remainder), collectedPenalties)
 
 	maxRefund := safeSubInt64(incentiveResolver.TotalRewardAmount(), incentiveResolver.DistributedRewardAmount())
 	if refund > maxRefund {
 		refund = maxRefund
-	}
-	if refund < 0 {
-		refund = 0
 	}
 
 	return incentiveResolver.ExternalIncentive, refund, nil

--- a/contract/r/gnoswap/staker/v1/external_incentive.gno
+++ b/contract/r/gnoswap/staker/v1/external_incentive.gno
@@ -237,17 +237,7 @@ func (s *stakerV1) endExternalIncentive(resolver *PoolResolver, incentiveResolve
 		)
 	}
 
-	// O(1) refund calculation:
-	//   refund = unclaimableReward + remainder + collectedPenalties
-	//
-	// - unclaimableReward: rewards for zero-liquidity periods (no depositors to earn them)
-	// - remainder: integer division truncation from rewardPerSecond (L-14 dust)
-	// - collectedPenalties: warmup penalties retained in staker during CollectReward,
-	//   routed back to creator on incentive end (PR #1221).
-	//   Derived from accounting fields:
-	//     rewardAmount decreases by (reward + penalty) on each collect,
-	//     distributedRewardAmount increases by reward only,
-	//     so collectedPenalties = (totalRewardAmount - rewardAmount) - distributedRewardAmount
+	// refund = unclaimableReward + remainder + collectedPenalties
 	incentivesResolver := resolver.IncentivesResolver()
 	unclaimableReward := incentivesResolver.calculateUnclaimableReward(incentiveResolver.IncentiveId())
 

--- a/contract/r/gnoswap/staker/v1/external_incentive_test.gno
+++ b/contract/r/gnoswap/staker/v1/external_incentive_test.gno
@@ -1194,13 +1194,14 @@ func TestRefundCalculationWithPartialCollections(t *testing.T) {
 	userA := testutils.TestAddress("userA")
 	userB := testutils.TestAddress("userB")
 
-	currentTime := time.Now().Unix()
-	startTime := currentTime - 86400*10 // 10 days ago
-	endTime := currentTime - 86400      // ended 1 day ago
+	baseTime := time.Now().Unix()
+	poolCreateTime := baseTime
+	startTime := baseTime + 86400
+	endTime := startTime + 86400*9
 	totalRewardAmount := int64(1_000_000_000)
 
 	// Create pool
-	pool := sr.NewPool(poolPath, startTime)
+	pool := sr.NewPool(poolPath, poolCreateTime)
 	s.getPools().set(poolPath, pool)
 
 	// Create incentive
@@ -1215,7 +1216,7 @@ func TestRefundCalculationWithPartialCollections(t *testing.T) {
 		creator,
 		100_000_000,
 		runtime.ChainHeight(),
-		startTime-100,
+		poolCreateTime,
 	)
 
 	poolResolver := NewPoolResolver(pool)
@@ -1244,9 +1245,12 @@ func TestRefundCalculationWithPartialCollections(t *testing.T) {
 		},
 	}
 
+	stakeTimeA := startTime + 100
+	stakeTimeB := startTime + 200
+
 	// Create deposits for User A and User B
-	depositA := sr.NewDeposit(userA, poolPath, u256.NewUint(1000), startTime+100, -10000, 10000, warmups)
-	depositB := sr.NewDeposit(userB, poolPath, u256.NewUint(1000), startTime+200, -10000, 10000, warmups)
+	depositA := sr.NewDeposit(userA, poolPath, u256.NewUint(1000), stakeTimeA, -10000, 10000, warmups)
+	depositB := sr.NewDeposit(userB, poolPath, u256.NewUint(1000), stakeTimeB, -10000, 10000, warmups)
 
 	s.getDeposits().set(1, depositA)
 	s.getDeposits().set(2, depositB)
@@ -1254,10 +1258,10 @@ func TestRefundCalculationWithPartialCollections(t *testing.T) {
 	depositResolverA := NewDepositResolver(depositA)
 	depositResolverB := NewDepositResolver(depositB)
 
-	poolResolver.modifyDeposit(i256.NewInt(1000), startTime+100, 0)
-	poolResolver.HistoricalTick().Set(startTime+100, int32(0))
-	poolResolver.modifyDeposit(i256.NewInt(1000), startTime+200, 0)
-	poolResolver.HistoricalTick().Set(startTime+200, int32(0))
+	poolResolver.modifyDeposit(i256.NewInt(1000), stakeTimeA, 0)
+	poolResolver.HistoricalTick().Set(stakeTimeA, int32(0))
+	poolResolver.modifyDeposit(i256.NewInt(1000), stakeTimeB, 0)
+	poolResolver.HistoricalTick().Set(stakeTimeB, int32(0))
 
 	// User A collects 300
 	collectedA := int64(300)
@@ -1281,21 +1285,31 @@ func TestRefundCalculationWithPartialCollections(t *testing.T) {
 		t.Errorf("Expected DistributedRewardAmount 500, got %d", incentiveResolver.DistributedRewardAmount())
 	}
 
-	// Verify DistributedRewardAmount remains 500 after unstakes
-	if incentiveResolver.DistributedRewardAmount() != 500 {
-		t.Errorf("After unstakes, DistributedRewardAmount should still be 500, got %d", incentiveResolver.DistributedRewardAmount())
-	}
-
-	// Calculate refund
-	// remain deposit A reward: 1286000
-	// remain deposit B reward: 643000
 	_, refund, err := s.endExternalIncentive(poolResolver, incentiveResolver, creator, endTime+100)
 	uassert.NoError(t, err)
 
-	// Verify refund amount
-	expectedRefund := int64(999035000)
-	if refund != expectedRefund {
-		t.Errorf("Expected refund %d, got %d", expectedRefund, refund)
+	duration := endTime - startTime
+	rewardPerSecond := totalRewardAmount / duration
+	remainder := totalRewardAmount - rewardPerSecond*duration
+
+	expectedUnclaimable := rewardPerSecond * (stakeTimeA - startTime)
+	expectedRefund := expectedUnclaimable + remainder
+
+	maxRefund := totalRewardAmount - int64(500)
+	if expectedRefund > maxRefund {
+		expectedRefund = maxRefund
+	}
+
+	numDeposits := int64(2)
+	numWarmups := int64(len(warmups))
+	tolerance := numDeposits * numWarmups * 2
+	diff := refund - expectedRefund
+	if diff < 0 {
+		diff = -diff
+	}
+	if diff > tolerance {
+		t.Errorf("Refund %d deviates from expected %d by %d (tolerance %d = %d deposits * %d warmups * 2)",
+			refund, expectedRefund, diff, tolerance, numDeposits, numWarmups)
 	}
 
 	// Verify refund is not negative

--- a/contract/r/gnoswap/staker/v1/external_incentive_test.gno
+++ b/contract/r/gnoswap/staker/v1/external_incentive_test.gno
@@ -1263,21 +1263,22 @@ func TestRefundCalculationWithPartialCollections(t *testing.T) {
 	poolResolver.modifyDeposit(i256.NewInt(1000), stakeTimeB, 0)
 	poolResolver.HistoricalTick().Set(stakeTimeB, int32(0))
 
-	// User A collects 300
+	// Simulate CollectReward for User A (raw earned = 300)
+	// Production flow: rewardAmount -= raw, distributedRewardAmount += reward only
 	collectedA := int64(300)
 	depositResolverA.addCollectedExternalReward(incentiveId, collectedA)
 	depositResolverA.updateExternalRewardLastCollectTime(incentiveId, endTime-1000)
 
-	// Update DistributedRewardAmount (simulating CollectReward)
 	incentiveResolver := NewExternalIncentiveResolver(incentive)
+	incentive.SetRewardAmount(incentive.RewardAmount() - collectedA)
 	incentiveResolver.addDistributedRewardAmount(collectedA)
 
-	// User B collects 200
+	// Simulate CollectReward for User B (raw earned = 200)
 	collectedB := int64(200)
 	depositResolverB.addCollectedExternalReward(incentiveId, collectedB)
 	depositResolverB.updateExternalRewardLastCollectTime(incentiveId, endTime-500)
 
-	// Update DistributedRewardAmount (simulating CollectReward)
+	incentive.SetRewardAmount(incentive.RewardAmount() - collectedB)
 	incentiveResolver.addDistributedRewardAmount(collectedB)
 
 	// Verify DistributedRewardAmount = 500

--- a/contract/r/gnoswap/staker/v1/reward_calculation_incentives_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_incentives_test.gno
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	i256 "gno.land/p/gnoswap/int256"
 	testutils "gno.land/p/nt/testutils/v0"
 	sr "gno.land/r/gnoswap/staker"
 )
@@ -153,6 +154,54 @@ func TestIncentivesUpdate(t *testing.T) {
 			}
 			tt.verifyFunc(t, retrieved)
 		})
+	}
+}
+
+// Test that zero-liquidity windows are tracked via modifyDeposit and reflected in calculateUnclaimableReward.
+func TestCalculateUnclaimableReward_TracksZeroLiquidityTransitions(t *testing.T) {
+	poolPath := "test_pool_unclaimable_tracking"
+	creator := testutils.TestAddress("creator")
+
+	currentTime := time.Now().Unix()
+	pool := sr.NewPool(poolPath, currentTime)
+	poolResolver := NewPoolResolver(pool)
+	incentives := poolResolver.IncentivesResolver()
+
+	startTime := currentTime + 10
+	endTime := startTime + 100
+	rewardAmount := int64(1000) // rewardPerSecond = 10
+
+	incentive := sr.NewExternalIncentive(
+		"test_incentive_tracking",
+		poolPath,
+		GNS_PATH,
+		rewardAmount,
+		startTime,
+		endTime,
+		creator,
+		100,
+		runtime.ChainHeight(),
+		currentTime,
+	)
+	incentives.create(creator, incentive)
+
+	stakeTimeA := startTime + 20
+	zeroTime := startTime + 60
+	stakeTimeB := startTime + 80
+
+	// zero -> positive: end unclaimable
+	poolResolver.modifyDeposit(i256.NewInt(1000), stakeTimeA, 0)
+	// positive -> zero: start unclaimable
+	poolResolver.modifyDeposit(i256.NewInt(-1000), zeroTime, 0)
+	// zero -> positive: end unclaimable
+	poolResolver.modifyDeposit(i256.NewInt(1000), stakeTimeB, 0)
+
+	expectedDuration := (stakeTimeA - startTime) + (stakeTimeB - zeroTime)
+	expected := expectedDuration * incentive.RewardPerSecond()
+
+	got := incentives.calculateUnclaimableReward(incentive.IncentiveId())
+	if got != expected {
+		t.Fatalf("unclaimable reward mismatch: got %d, want %d", got, expected)
 	}
 }
 

--- a/contract/r/gnoswap/staker/v1/reward_calculation_incentives_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_incentives_test.gno
@@ -183,7 +183,7 @@ func TestCalculateUnclaimableReward_TracksZeroLiquidityTransitions(t *testing.T)
 		runtime.ChainHeight(),
 		currentTime,
 	)
-	incentives.create(creator, incentive)
+	incentives.create(incentive)
 
 	stakeTimeA := startTime + 20
 	zeroTime := startTime + 60

--- a/contract/r/scenario/staker/external_incentive_complete_distribution_filetest.gno
+++ b/contract/r/scenario/staker/external_incentive_complete_distribution_filetest.gno
@@ -398,17 +398,17 @@ func endExternalIncentiveAndVerifyNoDust() {
 	ufmt.Printf("[EXPECTED] creator receives all remaining reward token: %d\n", stakerQuxBefore)
 	ufmt.Printf("[EXPECTED] creator receives fixed GNS deposit: %d\n", depositGnsAmount)
 
-	// Verify total distribution
+	// Total accounting: collected + refunded + staker residual = initial reward
 	ufmt.Printf("[EXPECTED] Total reward distribution:\n")
 	ufmt.Printf("  - Initial reward amount: %d QUX\n", REWARD_AMOUNT)
 	ufmt.Printf("  - Rewards collected by staker: %d QUX\n", totalRewardsCollected)
-	undistributedRewardRefunded := refundQuxAmount
-	ufmt.Printf("  - Undistributed reward refunded: %d QUX\n", undistributedRewardRefunded)
+	ufmt.Printf("  - Reward refunded to creator: %d QUX\n", refundQuxAmount)
+	ufmt.Printf("  - Residual in staker: %d QUX\n", stakerQuxAfter)
 
-	totalDistributed := totalRewardsCollected + undistributedRewardRefunded
-	ufmt.Printf("  - Total accounted for: %d QUX\n", totalDistributed)
+	totalAccounted := totalRewardsCollected + refundQuxAmount + stakerQuxAfter
+	ufmt.Printf("  - Total accounted for: %d QUX\n", totalAccounted)
 
-	if totalDistributed == REWARD_AMOUNT {
+	if totalAccounted == REWARD_AMOUNT {
 		println("[EXPECTED] all rewards accounted for with no loss")
 	}
 }
@@ -497,14 +497,15 @@ func positionIdFrom(positionId int) grc721.TokenID {
 //   - Creator GNS (deposit): 1000000000
 //   - Admin QUX balances: 99998487998997
 // [RESULT] refund breakdown:
-//   - Total refunded reward token (QUX): 1512000003
-//   - Total reduced from staker QUX: 1512000003
+//   - Total refunded reward token (QUX): 1512000000
+//   - Total reduced from staker QUX: 1512000000
 //   - Refunded GNS deposit: 1000000000
 // [EXPECTED] creator receives all remaining reward token: 1512000003
 // [EXPECTED] creator receives fixed GNS deposit: 1000000000
 // [EXPECTED] Total reward distribution:
 //   - Initial reward amount: 7776000000 QUX
 //   - Rewards collected by staker: 6263999997 QUX
-//   - Undistributed reward refunded: 1512000003 QUX
+//   - Reward refunded to creator: 1512000000 QUX
+//   - Residual in staker: 3 QUX
 //   - Total accounted for: 7776000000 QUX
 // [EXPECTED] all rewards accounted for with no loss

--- a/contract/r/scenario/staker/external_incentive_complete_distribution_filetest.gno
+++ b/contract/r/scenario/staker/external_incentive_complete_distribution_filetest.gno
@@ -492,8 +492,8 @@ func positionIdFrom(positionId int) grc721.TokenID {
 //   - Creator GNS (deposit): 0
 //   - Admin total rewards collected (QUX): 6263999997
 // [INFO] after ending incentive:
-//   - Creator QUX: 1512000003
-//   - Staker contract QUX: 0
+//   - Creator QUX: 1512000000
+//   - Staker contract QUX: 3
 //   - Creator GNS (deposit): 1000000000
 //   - Admin QUX balances: 99998487998997
 // [RESULT] refund breakdown:

--- a/contract/r/scenario/staker/external_incentive_drain_filetest.gno
+++ b/contract/r/scenario/staker/external_incentive_drain_filetest.gno
@@ -242,11 +242,14 @@ func endExternalGnsIncentive() {
 	stakerGnsAfterFirstEnd := gns.BalanceOf(stakerAddr)
 	creatorGnsAfterFirstEnd := gns.BalanceOf(externalCreatorUser)
 
+	creatorReceived := creatorGnsAfterFirstEnd - creatorGnsBeforeFirstEnd
+
 	ufmt.Printf("[INFO] FIRST END - Staker GNS balance before: %d\n", stakerGnsBeforeFirstEnd)
 	ufmt.Printf("[INFO] FIRST END - Staker GNS balance after: %d\n", stakerGnsAfterFirstEnd)
 	ufmt.Printf("[INFO] FIRST END - Creator GNS balance before: %d\n", creatorGnsBeforeFirstEnd)
 	ufmt.Printf("[INFO] FIRST END - Creator GNS balance after: %d\n", creatorGnsAfterFirstEnd)
-	ufmt.Printf("[INFO] FIRST END - Creator received: %d GNS\n", creatorGnsAfterFirstEnd-creatorGnsBeforeFirstEnd)
+	ufmt.Printf("[INFO] FIRST END - Creator received: %d GNS\n", creatorReceived)
+	ufmt.Printf("[INFO] FIRST END - Staker residual: %d GNS\n", stakerGnsAfterFirstEnd)
 }
 
 func demonstrateVulnerability() {
@@ -311,10 +314,11 @@ func positionIdFrom(positionId int) grc721.TokenID {
 // [INFO] skip blocks until external incentive ends
 // [INFO] end external incentive FIRST TIME and collect remaining GNS
 // [INFO] FIRST END - Staker GNS balance before: 20000000000
-// [INFO] FIRST END - Staker GNS balance after: 18996826213
+// [INFO] FIRST END - Staker GNS balance after: 18996826215
 // [INFO] FIRST END - Creator GNS balance before: 0
-// [INFO] FIRST END - Creator GNS balance after: 1003173787
-// [INFO] FIRST END - Creator received: 1003173787 GNS
+// [INFO] FIRST END - Creator GNS balance after: 1003173785
+// [INFO] FIRST END - Creator received: 1003173785 GNS
+// [INFO] FIRST END - Staker residual: 18996826215 GNS
 //
 // [SCENARIO] 8. FIX VERIFICATION: Verify EndExternalIncentive cannot be called multiple times
 // [FIX VERIFICATION] Attempting to call EndExternalIncentive multiple times
@@ -322,7 +326,7 @@ func positionIdFrom(positionId int) grc721.TokenID {
 //
 // [SCENARIO] 9. Final verification
 // [RESULT] Final balances after fix:
-//   - Staker GNS balance: 18996826213
-//   - Creator GNS balance: 1003173787
+//   - Staker GNS balance: 18996826215
+//   - Creator GNS balance: 1003173785
 // [VERIFIED] Staker was NOT drained - only one GNS deposit was refunded
 // [VERIFIED] The vulnerability has been successfully fixed

--- a/contract/r/scenario/staker/external_incentive_dust_refund_filetest.gno
+++ b/contract/r/scenario/staker/external_incentive_dust_refund_filetest.gno
@@ -277,22 +277,21 @@ func endExternalIncentiveAndVerifyDustRefund() {
 		panic(ufmt.Sprintf("Expected GNS refund of %d, but got %d", depositGnsAmount, gnsRefunded))
 	}
 
-	// Calculate expected dust
+	// Verify refund = unclaimable reward + division remainder
 	rewardAmount := int64(10000000007)
 	duration := int64(90 * 24 * 60 * 60)
-	expectedDust := rewardAmount - (rewardAmount/duration)*duration
+	rewardPerSecond := rewardAmount / duration
+	remainder := rewardAmount - rewardPerSecond*duration
+	unclaimablePortion := barRefunded - remainder
 
-	// Verify that dust was included in the refund
-	// The refund should be at least the dust amount
-	if barRefunded < expectedDust {
-		panic(ufmt.Sprintf("Expected refund to include at least dust amount of %d, but got %d", expectedDust, barRefunded))
+	ufmt.Printf("[VERIFY] refund: %d = unclaimable(%d) + remainder(%d)\n", barRefunded, unclaimablePortion, remainder)
+
+	if barRefunded < remainder {
+		panic(ufmt.Sprintf("Refund %d is less than division remainder %d", barRefunded, remainder))
 	}
 
-	// Check if the refund amount makes sense (dust + unallocated rewards)
-	if barRefunded > 0 && barRefunded >= expectedDust {
-		ufmt.Printf("[SUCCESS] Dust refund mechanism verified - dust amount (%d) properly included in total refund (%d)!\n", expectedDust, barRefunded)
-	} else {
-		panic(ufmt.Sprintf("Unexpected refund amount: %d (expected dust: %d)", barRefunded, expectedDust))
+	if rewardPerSecond > 0 && unclaimablePortion%rewardPerSecond != 0 {
+		panic(ufmt.Sprintf("Unclaimable portion %d is not a multiple of rewardPerSecond %d", unclaimablePortion, rewardPerSecond))
 	}
 }
 
@@ -334,10 +333,10 @@ func positionIdFrom(tokenId uint64) grc721.TokenID {
 // [INFO] bar balance before ending: 100000000
 // [INFO] gns balance before ending: 0
 // [INFO] end external incentive
-// [INFO] bar balance after ending: 100070440
+// [INFO] bar balance after ending: 100070437
 // [INFO] gns balance after ending: 1000000000
-// [RESULT] bar tokens refunded: 70440
+// [RESULT] bar tokens refunded: 70437
 // [RESULT] gns tokens refunded: 1000000000
-// [SUCCESS] Dust refund mechanism verified - dust amount (64007) properly included in total refund (70440)!
+// [VERIFY] refund: 70437 = unclaimable(6430) + remainder(64007)
 //
 // [SUCCESS] Test completed - rewardDust mechanism works correctly!

--- a/contract/r/scenario/staker/single_gns_external_ends_filetest.gno
+++ b/contract/r/scenario/staker/single_gns_external_ends_filetest.gno
@@ -275,7 +275,6 @@ func endExternalQuxIncentive() {
 	println("[INFO] end external incentive and collect remaining QUX")
 	testing.SetRealm(externalCreatorRealm)
 	quxBalanceBeforeEnds := qux.BalanceOf(externalCreatorUser)
-	stakerQuxBeforeEnds := qux.BalanceOf(stakerAddr)
 	gnsBalanceBeforeEnds := gns.BalanceOf(externalCreatorUser)
 
 	incentiveID := "g1v4u8getjdeskcsmjv4shgmmjta047h6lua7mup:1234567910:1"
@@ -363,9 +362,9 @@ func positionIdFrom(positionId int) grc721.TokenID {
 // [INFO] skip blocks until external incentive ends
 // [INFO] end external incentive and collect remaining QUX
 // [INFO] QUX balance before ending: 0
-// [INFO] QUX balance after ending: 3181889
-// [INFO] staker QUX residual: 5
-// [EXPECTED] creator receives remaining reward token: 3181889
+// [INFO] QUX balance after ending: 3181884
+// [INFO] staker QUX residual: 8996814646
+// [EXPECTED] creator receives remaining reward token: 3181884
 // [EXPECTED] creator receives fixed GNS deposit: 1000000000
 //
 // [SCENARIO] 11. Verify no rewards after external incentive ends

--- a/contract/r/scenario/staker/single_gns_external_ends_filetest.gno
+++ b/contract/r/scenario/staker/single_gns_external_ends_filetest.gno
@@ -291,7 +291,7 @@ func endExternalQuxIncentive() {
 
 	ufmt.Printf("[INFO] QUX balance before ending: %d\n", quxBalanceBeforeEnds)
 	ufmt.Printf("[INFO] QUX balance after ending: %d\n", quxBalanceAfterEnds)
-	ufmt.Printf("[INFO] staker QUX before ending: %d\n", stakerQuxBeforeEnds)
+	ufmt.Printf("[INFO] staker QUX residual: %d\n", qux.BalanceOf(stakerAddr))
 
 	refundedQuxAmount := quxBalanceAfterEnds - quxBalanceBeforeEnds
 	refundedGnsDeposit := gnsBalanceAfterEnds - gnsBalanceBeforeEnds
@@ -364,7 +364,7 @@ func positionIdFrom(positionId int) grc721.TokenID {
 // [INFO] end external incentive and collect remaining QUX
 // [INFO] QUX balance before ending: 0
 // [INFO] QUX balance after ending: 3181889
-// [INFO] staker QUX before ending: 8999996530
+// [INFO] staker QUX residual: 5
 // [EXPECTED] creator receives remaining reward token: 3181889
 // [EXPECTED] creator receives fixed GNS deposit: 1000000000
 //

--- a/contract/r/scenario/staker/staker_native_create_collect_unstake_filetest.gno
+++ b/contract/r/scenario/staker/staker_native_create_collect_unstake_filetest.gno
@@ -464,6 +464,9 @@ func endExternalIncentive() {
 	ufmt.Printf("[EXPECTED] ugnot balance after end: %d\n", ugnotBalanceAfter)
 	ufmt.Printf("[EXPECTED] wugnot change: %d\n", wugnotChange)
 	ufmt.Printf("[EXPECTED] ugnot refund: %d\n", ugnotIncrease)
+
+	stakerWugnot := wugnot.BalanceOf(stakerAddr)
+	ufmt.Printf("[VERIFY] staker wugnot residual: %d\n", stakerWugnot)
 }
 
 func unstakeToken01() {
@@ -605,19 +608,19 @@ func positionIdFrom(positionId any) grc721.TokenID {
 // [INFO] ugnot balance before end: 20050001005
 // [INFO] skip to end of external incentive
 // [INFO] end external incentive
-// [EXPECTED] wugnot balance after end: 55579946
+// [EXPECTED] wugnot balance after end: 55579944
 // [EXPECTED] ugnot balance after end: 20050001005
-// [EXPECTED] wugnot change: 64002
+// [EXPECTED] wugnot change: 64000
 // [EXPECTED] ugnot refund: 0
+// [VERIFY] staker wugnot residual: 9994419061
 //
 // [SCENARIO] 11. Unstake token 01 after external incentive
 // [INFO] skip more blocks
-// [INFO] wugnot balance before unstake: 55579946
+// [INFO] wugnot balance before unstake: 55579944
 // [INFO] ugnot balance before unstake: 20050001005
 // [INFO] unstake token 01 (no unwrap)
 // [EXPECTED] NFT owner after unstaking: g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5
-// [EXPECTED] wugnot balance after unstake: 10049999005
+// [EXPECTED] wugnot balance after unstake: 10049999003
 // [EXPECTED] ugnot balance after unstake: 20050001005
 // [EXPECTED] wugnot increase from unstake: 9994419059
 // [EXPECTED] ugnot change from unstake: 0
-

--- a/contract/r/scenario/staker/staker_native_create_collect_unstake_with_finish_filetest.gno
+++ b/contract/r/scenario/staker/staker_native_create_collect_unstake_with_finish_filetest.gno
@@ -463,6 +463,9 @@ func endExternalIncentive() {
 	ufmt.Printf("[EXPECTED] ugnot balance after end: %d\n", ugnotBalanceAfter)
 	ufmt.Printf("[EXPECTED] wugnot change: %d\n", wugnotChange)
 	ufmt.Printf("[EXPECTED] ugnot refund: %d\n", ugnotIncrease)
+
+	stakerWugnot := wugnot.BalanceOf(stakerAddr)
+	ufmt.Printf("[VERIFY] staker wugnot residual: %d\n", stakerWugnot)
 }
 
 func ugnotBalanceOf(addr address) uint64 {
@@ -584,8 +587,8 @@ func positionIdFrom(positionId any) grc721.TokenID {
 // [INFO] ugnot balance before end: 20050001005
 // [INFO] skip to end of external incentive
 // [INFO] end external incentive
-// [EXPECTED] wugnot balance after end: 10049999005
+// [EXPECTED] wugnot balance after end: 10049999003
 // [EXPECTED] ugnot balance after end: 20050001005
-// [EXPECTED] wugnot change: 9991242342
+// [EXPECTED] wugnot change: 9991242340
 // [EXPECTED] ugnot refund: 0
-
+// [VERIFY] staker wugnot residual: 2


### PR DESCRIPTION
## Description

Replace the O(n) deposit iteration in `endExternalIncentive` with an O(1) refund calculation based on unclaimable period tracking.

### Changes

**Before:** 

`EndExternalIncentive` iterated over every deposit in the pool to compute uncollected rewards. An attacker could create thousands of minimal staked positions, making the transaction prohibitively expensive and blocking the incentive creator from recovering their remaining rewards and GNS deposit.

**After:** 

```
refund = unclaimableReward + remainder + collectedPenalties
```

- `unclaimableReward`: rewards for zero-liquidity periods (via `calculateUnclaimableReward`, already tracked by `modifyDeposit`)
- `remainder`: integer division truncation from `rewardPerSecond` (L-14 dust)
- `collectedPenalties`: warmup penalties retained in staker during `CollectReward`, derived from existing accounting fields without iteration: `(totalRewardAmount - rewardAmount) - distributedRewardAmount`
- A `maxRefund` cap (`totalRewardAmount - distributedRewardAmount`) prevents over-refund

### Trade-off

Per-deposit `MulDiv` floor rounding dust (2–5 units per incentive) now remains in the staker contract instead of being returned to the creator. This is because computing per-deposit rounding requires the iteration we're removing. The amounts are negligible and the direction is conservative (users' collectable rewards are never affected).

### Related Works

- #852: Precision loss in `rewardPerSecond` leading to dust rewards
- #894 fixed this by introducing the deposit iteration
- #1221: Changed external incentive penalty flow — penalties are no longer sent to community pool during `CollectReward`, but retained in staker and returned to creator via `EndExternalIncentive`. `distributedRewardAmount` now tracks rewards only (not penalties), which required adding `collectedPenalties` to the O(1) formula

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More efficient O(1) external-incentive refund calculation with tighter bounds, proper handling of unclaimable amounts, remainders and collected penalties, and clamped refunds.

* **Tests**
  * Converted tests to deterministic forward-looking timelines.
  * Added coverage for zero-liquidity transitions.
  * Relaxed refund assertions to allow realistic tolerances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->