### PR TITLE
fix(staker): replace wrapping `Mul` with `MulDiv` in reward scaling

### DIFF
--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
@@ -408,9 +408,8 @@ func (self *RewardState) rewardPerWarmup(startTime, endTime int64, rewardPerSeco
 				self.deposit.Deposit,
 			)
 
-			rewardAcc = u256.Zero().Mul(rewardAcc, self.deposit.Liquidity())
-			rewardAcc = u256.MulDiv(rewardAcc, u256.NewUintFromInt64(rewardPerSecond), q128)
-			self.rewards[i] = safeAddInt64(self.rewards[i], safeConvertToInt64(rewardAcc))
+			scaled := self.scaleReward(rewardAcc, rewardPerSecond)
+			self.rewards[i] = safeAddInt64(self.rewards[i], safeConvertToInt64(scaled))
 
 			break
 		}
@@ -423,14 +422,23 @@ func (self *RewardState) rewardPerWarmup(startTime, endTime int64, rewardPerSeco
 			self.deposit.Deposit,
 		)
 
-		rewardAcc = u256.Zero().Mul(rewardAcc, self.deposit.Liquidity())
-		rewardAcc = u256.MulDiv(rewardAcc, u256.NewUintFromInt64(rewardPerSecond), q128)
-		self.rewards[i] = safeAddInt64(self.rewards[i], safeConvertToInt64(rewardAcc))
+		scaled := self.scaleReward(rewardAcc, rewardPerSecond)
+		self.rewards[i] = safeAddInt64(self.rewards[i], safeConvertToInt64(scaled))
 
 		startTime = warmup.NextWarmupTime
 	}
 
 	return nil
+}
+
+// scaleReward scales the raw reward accumulation by the deposit's liquidity
+// and rewardPerSecond, returning the descaled result.
+//
+// Uses MulDiv with a 512-bit intermediate to avoid silent wrapping that would
+// occur if rewardAcc were multiplied by liquidity in a plain 256-bit Mul.
+func (self *RewardState) scaleReward(rewardAcc *u256.Uint, rewardPerSecond int64) *u256.Uint {
+	rewardScaler := u256.Zero().Mul(self.deposit.Liquidity(), u256.NewUintFromInt64(rewardPerSecond))
+	return u256.MulDiv(rewardAcc, rewardScaler, q128)
 }
 
 // modifyDeposit updates the pool's staked liquidity and returns the new staked liquidity.

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool_test.gno
@@ -5,8 +5,11 @@ import (
 	"time"
 
 	u256 "gno.land/p/gnoswap/uint256"
-	testutils "gno.land/p/nt/testutils/v0"
-	uassert "gno.land/p/nt/uassert/v0"
+
+	"gno.land/p/nt/testutils/v0"
+	"gno.land/p/nt/uassert/v0"
+	"gno.land/p/nt/ufmt/v0"
+
 	"gno.land/r/gnoswap/staker"
 	sr "gno.land/r/gnoswap/staker"
 )
@@ -879,6 +882,94 @@ func TestPoolsIterateAll(t *testing.T) {
 			})
 
 			uassert.Equal(t, tt.numPools, count)
+		})
+	}
+}
+
+// TestRewardScalerPrecision verifies that using MulDiv with a combined
+// (liquidity * rewardPerSecond) scaler avoids the silent wrapping that
+// occurs when Mul(rewardAcc, liquidity) exceeds 256 bits.
+//
+// Old approach (wraps):
+//
+//	temp = Mul(rewardAcc, liquidity)          // 256-bit, wraps on overflow
+//	result = MulDiv(temp, rewardPerSecond, q128)
+//
+// New approach (512-bit safe):
+//
+//	scaler = Mul(liquidity, rewardPerSecond)  // ≤ 191 bits, never overflows
+//	result = MulDiv(rewardAcc, scaler, q128)  // 512-bit intermediate
+func TestRewardScalerPrecision(t *testing.T) {
+	tests := []struct {
+		name         string
+		rewardAcc    *u256.Uint
+		liquidity    *u256.Uint
+		rewardPerSec int64
+		expected     *u256.Uint
+		// oldWraps indicates that the old Mul-based approach would silently
+		// wrap the intermediate product, producing a wrong result.
+		oldWraps bool
+	}{
+		{
+			// rewardAcc * liquidity = 2^160, fits in 256 bits.
+			// Both approaches yield the same result.
+			name:         "normal range, both approaches agree",
+			rewardAcc:    u256.Zero().Lsh(u256.NewUint(1), 100), // 2^100
+			liquidity:    u256.Zero().Lsh(u256.NewUint(1), 60),  // 2^60
+			rewardPerSec: 100,
+			// (2^100 * 2^60 * 100) / 2^128 = 100 * 2^32 = 429496729600
+			expected: u256.NewUint(429496729600),
+			oldWraps: false,
+		},
+		{
+			// rewardAcc * liquidity = 2^280, exceeds 256 bits.
+			// Old Mul wraps: 2^280 mod 2^256 = 0 → final result 0.
+			// New MulDiv:    floor(2^200 * 2^80 / 2^128) = 2^152.
+			name:         "large accumulation, Mul wraps to zero",
+			rewardAcc:    u256.Zero().Lsh(u256.NewUint(1), 200), // 2^200
+			liquidity:    u256.Zero().Lsh(u256.NewUint(1), 80),  // 2^80
+			rewardPerSec: 1,
+			expected:     u256.Zero().Lsh(u256.NewUint(1), 152), // 2^152
+			oldWraps:     true,
+		},
+		{
+			// (2^200 + 1) * 2^80 = 2^280 + 2^80.
+			// Old Mul wraps: mod 2^256 → 2^80, then MulDiv(2^80, 1, 2^128) = 0.
+			// New MulDiv:    floor((2^280 + 2^80) / 2^128) = 2^152.
+			name:         "large accumulation with residual, Mul loses high bits",
+			rewardAcc:    u256.Zero().Add(u256.Zero().Lsh(u256.NewUint(1), 200), u256.NewUint(1)),
+			liquidity:    u256.Zero().Lsh(u256.NewUint(1), 80),
+			rewardPerSec: 1,
+			expected:     u256.Zero().Lsh(u256.NewUint(1), 152), // 2^152 (residual truncated by floor)
+			oldWraps:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rps := u256.NewUintFromInt64(tt.rewardPerSec)
+
+			// --- new approach (current implementation) ---
+			rewardScaler := u256.Zero().Mul(tt.liquidity.Clone(), rps)
+			newResult := u256.MulDiv(tt.rewardAcc.Clone(), rewardScaler, q128)
+
+			uassert.True(t, tt.expected.Eq(newResult),
+				ufmt.Sprintf("new approach: expected %s, got %s",
+					tt.expected.ToString(), newResult.ToString()))
+
+			// --- old approach (Mul then MulDiv) ---
+			oldIntermediate := u256.Zero().Mul(tt.rewardAcc.Clone(), tt.liquidity.Clone())
+			oldResult := u256.MulDiv(oldIntermediate, rps, q128)
+
+			if tt.oldWraps {
+				uassert.False(t, tt.expected.Eq(oldResult),
+					ufmt.Sprintf("old approach should diverge due to wrapping but got correct result %s",
+						oldResult.ToString()))
+			} else {
+				uassert.True(t, tt.expected.Eq(oldResult),
+					ufmt.Sprintf("old approach: expected %s, got %s",
+						tt.expected.ToString(), oldResult.ToString()))
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Description

- Replace `Mul(rewardAcc, liquidity)` with `MulDiv(rewardAcc, liquidity * rewardPerSecond, q128)` to use a 512 bit intermediate instead of a 256-bit wrapping multiplication

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved precision in reward scaling calculations by optimizing the arithmetic computation path to prevent intermediate overflow issues.

* **Tests**
  * Added test coverage for reward scaler precision validation to ensure calculation accuracy across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->