### PR TITLE
fix(launchpad): remove current height param

### DIFF
--- a/contract/r/gnoswap/launchpad/_mock_test.gno
+++ b/contract/r/gnoswap/launchpad/_mock_test.gno
@@ -589,17 +589,6 @@ func (m *MockLaunchpad) GetProjectTierRewardAccumulatedDistributeAmount(projectT
 	return res[0].(int64), res[1].(error)
 }
 
-func (m *MockLaunchpad) GetProjectTierRewardAccumulatedHeight(projectTierId string) (int64, error) {
-	res, ok := m.Response.Get("GetProjectTierRewardAccumulatedHeight")
-	if !ok {
-		return 0, nil
-	}
-	if len(res) < 2 || res[1] == nil {
-		return res[0].(int64), nil
-	}
-	return res[0].(int64), res[1].(error)
-}
-
 func (m *MockLaunchpad) GetProjectTierRewardAccumulatedTime(projectTierId string) (int64, error) {
 	res, ok := m.Response.Get("GetProjectTierRewardAccumulatedTime")
 	if !ok {

--- a/contract/r/gnoswap/launchpad/getter.gno
+++ b/contract/r/gnoswap/launchpad/getter.gno
@@ -289,11 +289,6 @@ func GetProjectTierRewardAccumulatedDistributeAmount(projectTierId string) (int6
 	return getImplementation().GetProjectTierRewardAccumulatedDistributeAmount(projectTierId)
 }
 
-// GetProjectTierRewardAccumulatedHeight returns the accumulated height of a reward manager.
-func GetProjectTierRewardAccumulatedHeight(projectTierId string) (int64, error) {
-	return getImplementation().GetProjectTierRewardAccumulatedHeight(projectTierId)
-}
-
 // GetProjectTierRewardAccumulatedTime returns the accumulated time of a reward manager.
 func GetProjectTierRewardAccumulatedTime(projectTierId string) (int64, error) {
 	return getImplementation().GetProjectTierRewardAccumulatedTime(projectTierId)

--- a/contract/r/gnoswap/launchpad/getter_test.gno
+++ b/contract/r/gnoswap/launchpad/getter_test.gno
@@ -15,7 +15,7 @@ func newLaunchpadDeposit() *Deposit {
 }
 
 func newLaunchpadRewardManager() *RewardManager {
-	manager := NewRewardManager(1000, 10, 20, 30, 50)
+	manager := NewRewardManager(1000, 10, 20, 30)
 	manager.SetDistributeAmountPerSecondX128(u256.MustFromDecimal("100"))
 	manager.SetAccumulatedRewardPerDepositX128(u256.MustFromDecimal("200"))
 	manager.SetTotalClaimedAmount(300)

--- a/contract/r/gnoswap/launchpad/getter_test.gno
+++ b/contract/r/gnoswap/launchpad/getter_test.gno
@@ -15,12 +15,11 @@ func newLaunchpadDeposit() *Deposit {
 }
 
 func newLaunchpadRewardManager() *RewardManager {
-	manager := NewRewardManager(1000, 10, 20, 30, 40, 50)
+	manager := NewRewardManager(1000, 10, 20, 30, 50)
 	manager.SetDistributeAmountPerSecondX128(u256.MustFromDecimal("100"))
 	manager.SetAccumulatedRewardPerDepositX128(u256.MustFromDecimal("200"))
 	manager.SetTotalClaimedAmount(300)
 	manager.SetAccumulatedDistributeAmount(400)
-	manager.SetAccumulatedHeight(500)
 	manager.SetAccumulatedTime(600)
 	rewards := avl.NewTree()
 	rewards.Set("deposit-1", NewRewardState(u256.MustFromDecimal("700"), 800, 900, 1000, 1100))
@@ -259,7 +258,6 @@ func TestMutableLaunchpadGetterIsolation(t *testing.T) {
 				rewardState.SetDistributeStartTime(1011)
 				rewardState.SetDistributeEndTime(1012)
 				rewardState.SetAccumulatedRewardAmount(1013)
-				rewardState.SetAccumulatedHeight(1014)
 				rewardState.SetAccumulatedTime(1015)
 				rewardState.SetClaimedAmount(1016)
 			},
@@ -271,7 +269,6 @@ func TestMutableLaunchpadGetterIsolation(t *testing.T) {
 				uassert.Equal(t, int64(900), rewardState.DistributeStartTime())
 				uassert.Equal(t, int64(1000), rewardState.DistributeEndTime())
 				uassert.Equal(t, int64(0), rewardState.AccumulatedRewardAmount())
-				uassert.Equal(t, int64(0), rewardState.AccumulatedHeight())
 				uassert.Equal(t, int64(0), rewardState.AccumulatedTime())
 				uassert.Equal(t, int64(0), rewardState.ClaimedAmount())
 			},
@@ -293,7 +290,6 @@ func TestMutableLaunchpadGetterIsolation(t *testing.T) {
 				manager.SetDistributeStartTime(1003)
 				manager.SetDistributeEndTime(1004)
 				manager.SetAccumulatedDistributeAmount(1005)
-				manager.SetAccumulatedHeight(1006)
 				manager.SetAccumulatedTime(1007)
 				manager.SetRewardClaimableDuration(1008)
 				rewardState := firstRewardState(t, manager.Rewards())
@@ -303,7 +299,6 @@ func TestMutableLaunchpadGetterIsolation(t *testing.T) {
 				rewardState.SetDistributeStartTime(1011)
 				rewardState.SetDistributeEndTime(1012)
 				rewardState.SetAccumulatedRewardAmount(1013)
-				rewardState.SetAccumulatedHeight(1014)
 				rewardState.SetAccumulatedTime(1015)
 				rewardState.SetClaimedAmount(1016)
 			},
@@ -316,7 +311,6 @@ func TestMutableLaunchpadGetterIsolation(t *testing.T) {
 				uassert.Equal(t, int64(10), manager.DistributeStartTime())
 				uassert.Equal(t, int64(20), manager.DistributeEndTime())
 				uassert.Equal(t, int64(400), manager.AccumulatedDistributeAmount())
-				uassert.Equal(t, int64(500), manager.AccumulatedHeight())
 				uassert.Equal(t, int64(600), manager.AccumulatedTime())
 				uassert.Equal(t, int64(30), manager.RewardClaimableDuration())
 				rewardState := firstRewardState(t, manager.Rewards())
@@ -326,7 +320,6 @@ func TestMutableLaunchpadGetterIsolation(t *testing.T) {
 				uassert.Equal(t, int64(900), rewardState.DistributeStartTime())
 				uassert.Equal(t, int64(1000), rewardState.DistributeEndTime())
 				uassert.Equal(t, int64(0), rewardState.AccumulatedRewardAmount())
-				uassert.Equal(t, int64(0), rewardState.AccumulatedHeight())
 				uassert.Equal(t, int64(0), rewardState.AccumulatedTime())
 				uassert.Equal(t, int64(0), rewardState.ClaimedAmount())
 			},

--- a/contract/r/gnoswap/launchpad/reward_manager.gno
+++ b/contract/r/gnoswap/launchpad/reward_manager.gno
@@ -167,7 +167,6 @@ func NewRewardManager(
 	distributeStartTime int64,
 	distributeEndTime int64,
 	rewardCollectableDuration int64,
-	currentTime int64,
 ) *RewardManager {
 	return &RewardManager{
 		totalDistributeAmount:           totalDistributeAmount,

--- a/contract/r/gnoswap/launchpad/reward_manager.gno
+++ b/contract/r/gnoswap/launchpad/reward_manager.gno
@@ -20,7 +20,6 @@ import (
 // - distributeStartTime (int64): The start time of the reward calculation.
 // - distributeEndTime (int64): The end time of the reward calculation.
 // - accumulatedDistributeAmount (int64): The accumulated amount of tokens distributed.
-// - accumulatedHeight (int64): The last height when reward was calculated.
 // - rewardClaimableDuration (int64): The duration of reward claimable.
 type RewardManager struct {
 	rewards *avl.Tree // depositId -> RewardState
@@ -33,7 +32,6 @@ type RewardManager struct {
 	distributeStartTime         int64 // start time of reward calculation
 	distributeEndTime           int64 // end time of reward calculation
 	accumulatedDistributeAmount int64 // accumulated distribute amount
-	accumulatedHeight           int64 // last height when reward was calculated
 	accumulatedTime             int64 // last time when reward was calculated
 	rewardClaimableDuration     int64 // duration of reward claimable
 }
@@ -118,16 +116,6 @@ func (rm *RewardManager) SetAccumulatedDistributeAmount(amount int64) {
 	rm.accumulatedDistributeAmount = amount
 }
 
-// AccumulatedHeight returns the accumulated height of the reward manager.
-func (rm *RewardManager) AccumulatedHeight() int64 {
-	return rm.accumulatedHeight
-}
-
-// SetAccumulatedHeight sets the accumulated height of the reward manager.
-func (rm *RewardManager) SetAccumulatedHeight(height int64) {
-	rm.accumulatedHeight = height
-}
-
 // AccumulatedTime returns the accumulated time of the reward manager.
 func (rm *RewardManager) AccumulatedTime() int64 {
 	return rm.accumulatedTime
@@ -168,7 +156,6 @@ func (rm RewardManager) Clone() *RewardManager {
 		distributeStartTime:             rm.distributeStartTime,
 		distributeEndTime:               rm.distributeEndTime,
 		accumulatedDistributeAmount:     rm.accumulatedDistributeAmount,
-		accumulatedHeight:               rm.accumulatedHeight,
 		accumulatedTime:                 rm.accumulatedTime,
 		rewardClaimableDuration:         rm.rewardClaimableDuration,
 	}
@@ -180,7 +167,6 @@ func NewRewardManager(
 	distributeStartTime int64,
 	distributeEndTime int64,
 	rewardCollectableDuration int64,
-	currentHeight int64,
 	currentTime int64,
 ) *RewardManager {
 	return &RewardManager{
@@ -189,7 +175,6 @@ func NewRewardManager(
 		distributeEndTime:               distributeEndTime,
 		totalClaimedAmount:              0,
 		accumulatedDistributeAmount:     0,
-		accumulatedHeight:               0,
 		accumulatedTime:                 0,
 		accumulatedRewardPerDepositX128: u256.Zero(),
 		distributeAmountPerSecondX128:   u256.Zero(),

--- a/contract/r/gnoswap/launchpad/reward_state.gno
+++ b/contract/r/gnoswap/launchpad/reward_state.gno
@@ -14,7 +14,6 @@ type RewardState struct {
 	distributeStartTime     int64 // time when launchpad started staking
 	distributeEndTime       int64 // end time of reward calculation
 	accumulatedRewardAmount int64 // calculated, not collected
-	accumulatedHeight       int64 // last height when reward was calculated
 	accumulatedTime         int64 // last time when reward was calculated
 	claimedAmount           int64 // amount of reward claimed so far
 }
@@ -35,7 +34,6 @@ func NewRewardState(
 		claimableTime:           claimableTime,
 		accumulatedRewardAmount: 0,
 		claimedAmount:           0,
-		accumulatedHeight:       0,
 	}
 }
 
@@ -99,16 +97,6 @@ func (rs *RewardState) SetAccumulatedRewardAmount(amount int64) {
 	rs.accumulatedRewardAmount = amount
 }
 
-// AccumulatedHeight returns the accumulated height of the reward state.
-func (rs *RewardState) AccumulatedHeight() int64 {
-	return rs.accumulatedHeight
-}
-
-// SetAccumulatedHeight sets the accumulated height of the reward state.
-func (rs *RewardState) SetAccumulatedHeight(height int64) {
-	rs.accumulatedHeight = height
-}
-
 // AccumulatedTime returns the accumulated time of the reward state.
 func (rs *RewardState) AccumulatedTime() int64 {
 	return rs.accumulatedTime
@@ -137,7 +125,6 @@ func (rs RewardState) Clone() *RewardState {
 		distributeStartTime:     rs.distributeStartTime,
 		distributeEndTime:       rs.distributeEndTime,
 		accumulatedRewardAmount: rs.accumulatedRewardAmount,
-		accumulatedHeight:       rs.accumulatedHeight,
 		accumulatedTime:         rs.accumulatedTime,
 		claimedAmount:           rs.claimedAmount,
 	}

--- a/contract/r/gnoswap/launchpad/types.gno
+++ b/contract/r/gnoswap/launchpad/types.gno
@@ -83,7 +83,6 @@ type ILaunchpadGetter interface {
 	GetProjectTierRewardDistributeStartTime(projectTierId string) (int64, error)
 	GetProjectTierRewardDistributeEndTime(projectTierId string) (int64, error)
 	GetProjectTierRewardAccumulatedDistributeAmount(projectTierId string) (int64, error)
-	GetProjectTierRewardAccumulatedHeight(projectTierId string) (int64, error)
 	GetProjectTierRewardAccumulatedTime(projectTierId string) (int64, error)
 	GetProjectTierRewardClaimableDuration(projectTierId string) (int64, error)
 

--- a/contract/r/gnoswap/launchpad/v1/getter.gno
+++ b/contract/r/gnoswap/launchpad/v1/getter.gno
@@ -577,17 +577,6 @@ func (lp *launchpadV1) GetProjectTierRewardAccumulatedDistributeAmount(projectTi
 	return manager.AccumulatedDistributeAmount(), nil
 }
 
-// GetProjectTierRewardAccumulatedHeight returns the accumulated height of a reward manager.
-// Returns 0 and error if reward manager not found.
-func (lp *launchpadV1) GetProjectTierRewardAccumulatedHeight(projectTierId string) (int64, error) {
-	manager, err := lp.GetProjectTierRewardManager(projectTierId)
-	if err != nil {
-		return 0, err
-	}
-
-	return manager.AccumulatedHeight(), nil
-}
-
 // GetProjectTierRewardAccumulatedTime returns the accumulated time of a reward manager.
 // Returns 0 and error if reward manager not found.
 func (lp *launchpadV1) GetProjectTierRewardAccumulatedTime(projectTierId string) (int64, error) {

--- a/contract/r/gnoswap/launchpad/v1/getter_test.gno
+++ b/contract/r/gnoswap/launchpad/v1/getter_test.gno
@@ -1591,33 +1591,6 @@ func TestGetProjectTierRewardAccumulatedDistributeAmount(t *testing.T) {
 	})
 }
 
-func TestGetProjectTierRewardAccumulatedHeight(t *testing.T) {
-	t.Run("get reward manager accumulated height", func(t *testing.T) {
-		setupTestEnvironment(t, testEnvConfig{})
-		lp := getTestImplementation()
-		launchpadAddr := chain.PackageAddress(testLaunchpadPkgPath)
-		_, adminRealm := setupTestEnvironment(t, testEnvConfig{})
-
-		projectID := createTestProject(t, lp, launchpadAddr, adminRealm, testProjectConfig{
-			name:            "Test Project",
-			rewardAmount:    1000000,
-			tier30Pct:       25,
-			tier90Pct:       50,
-			tier180Pct:      25,
-			recipientSuffix: "recipient",
-		})
-
-		projectTierID := projectID + ":" + formatInt(projectTier30)
-
-		// Execute
-		height, err := lp.GetProjectTierRewardAccumulatedHeight(projectTierID)
-
-		// Verify
-		uassert.NoError(t, err)
-		uassert.True(t, height >= 0)
-	})
-}
-
 func TestGetProjectTierRewardAccumulatedTime(t *testing.T) {
 	t.Run("get reward manager accumulated time", func(t *testing.T) {
 		setupTestEnvironment(t, testEnvConfig{})

--- a/contract/r/gnoswap/launchpad/v1/launchpad_deposit.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_deposit.gno
@@ -145,7 +145,7 @@ func (lp *launchpadV1) depositGns(
 	isFirstDeposit := !isRewardManagerInitialized(rewardManager)
 
 	// update rewards before adding deposit to reward manager
-	err = updateRewardPerDepositX128(rewardManager, getTierCurrentDepositAmount(projectTier), currentHeight, currentTime)
+	err = updateRewardPerDepositX128(rewardManager, getTierCurrentDepositAmount(projectTier), currentTime)
 	if err != nil {
 		return nil, nil, false, "", err
 	}

--- a/contract/r/gnoswap/launchpad/v1/launchpad_project.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_project.gno
@@ -212,7 +212,6 @@ func (lp *launchpadV1) createProject(params *createProjectParams) (*launchpad.Pr
 			projectTier.StartTime(),
 			projectTier.EndTime(),
 			rewardCollectableDuration,
-			params.currentTime,
 		))
 	}
 

--- a/contract/r/gnoswap/launchpad/v1/launchpad_project.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_project.gno
@@ -305,10 +305,6 @@ func (lp *launchpadV1) transferLeftFromProject(project *launchpad.Project, recip
 	accumCollectableReward := int64(0)
 
 	for _, tier := range project.Tiers() {
-		if !tier.IsEnded(currentTime) {
-			return 0, ufmt.Errorf("tier(%s) is not ended", tier.ID())
-		}
-
 		// Calculate pending rewards for remaining depositors
 		currentDepositCount := getTierCurrentDepositCount(tier)
 

--- a/contract/r/gnoswap/launchpad/v1/launchpad_project.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_project.gno
@@ -212,7 +212,7 @@ func (lp *launchpadV1) createProject(params *createProjectParams) (*launchpad.Pr
 			projectTier.StartTime(),
 			projectTier.EndTime(),
 			rewardCollectableDuration,
-			params.startTime,
+			params.currentTime,
 		))
 	}
 

--- a/contract/r/gnoswap/launchpad/v1/launchpad_project.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_project.gno
@@ -213,7 +213,6 @@ func (lp *launchpadV1) createProject(params *createProjectParams) (*launchpad.Pr
 			projectTier.EndTime(),
 			rewardCollectableDuration,
 			params.startTime,
-			params.startTime+tierDurationTime,
 		))
 	}
 
@@ -248,7 +247,7 @@ func (lp *launchpadV1) TransferLeftFromProjectByAdmin(projectID string, recipien
 		panic(err)
 	}
 
-	projectLeftReward, err := lp.transferLeftFromProject(project, recipient, currentHeight, currentTime)
+	projectLeftReward, err := lp.transferLeftFromProject(project, recipient, currentTime)
 	if err != nil {
 		panic(err)
 	}
@@ -293,7 +292,7 @@ func (lp *launchpadV1) TransferLeftFromProjectByAdmin(projectID string, recipien
 // This function is called by an admin to transfer any unclaimed rewards from a project to a recipient address.
 // It validates the project ID, checks the recipient conditions, calculates the remaining rewards, and performs the transfer.
 // Returns the amount of rewards transferred to the recipient and any error.
-func (lp *launchpadV1) transferLeftFromProject(project *launchpad.Project, recipient address, currentHeight, currentTime int64) (int64, error) {
+func (lp *launchpadV1) transferLeftFromProject(project *launchpad.Project, recipient address, currentTime int64) (int64, error) {
 	if err := validateRefundProject(project, recipient, currentTime); err != nil {
 		return 0, err
 	}
@@ -314,7 +313,7 @@ func (lp *launchpadV1) transferLeftFromProject(project *launchpad.Project, recip
 		currentDepositCount := getTierCurrentDepositCount(tier)
 
 		if currentDepositCount > 0 {
-			claimableReward, err := lp.applyTierRewardGrowthWithRewards(tier, currentHeight, currentTime)
+			claimableReward, err := lp.applyTierRewardGrowthWithRewards(tier, currentTime)
 			if err != nil {
 				return 0, err
 			}
@@ -354,14 +353,14 @@ func (lp *launchpadV1) transferLeftFromProject(project *launchpad.Project, recip
 
 // applyTierRewardGrowthWithRewards calculates the total claimable rewards
 // for all active deposits in a specific tier.
-func (lp *launchpadV1) applyTierRewardGrowthWithRewards(tier *launchpad.ProjectTier, currentHeight, currentTime int64) (int64, error) {
+func (lp *launchpadV1) applyTierRewardGrowthWithRewards(tier *launchpad.ProjectTier, currentTime int64) (int64, error) {
 	rewardManager, err := lp.getProjectTierRewardManager(tier.ID())
 	if err != nil {
 		return 0, err
 	}
 
 	// Update reward accumulation to current time before calculating claimable.
-	err = updateRewardPerDepositX128(rewardManager, getTierCurrentDepositAmount(tier), currentHeight, currentTime)
+	err = updateRewardPerDepositX128(rewardManager, getTierCurrentDepositAmount(tier), currentTime)
 	if err != nil {
 		return 0, err
 	}

--- a/contract/r/gnoswap/launchpad/v1/launchpad_project_test.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_project_test.gno
@@ -904,7 +904,7 @@ func TestLaunchpadProject_validateRefundProject(t *testing.T) {
 func TestLaunchpadProject_calculateClaimableRewardsForActiveDeposits(t *testing.T) {
 	t.Run("calculate claimable rewards with active deposits", func(t *testing.T) {
 		// Create reward manager with accumulated rewards
-		rm := newRewardManager(100_000, 1000, 2000, 0, 100, 1000)
+		rm := newRewardManager(100_000, 1000, 2000, 0, 1000)
 		rm.SetAccumulatedRewardPerDepositX128(q128.Clone()) // 1.0 reward per deposit
 
 		// Add reward state for deposit with priceDebt = 0.5
@@ -927,7 +927,7 @@ func TestLaunchpadProject_calculateClaimableRewardsForActiveDeposits(t *testing.
 	})
 
 	t.Run("no active deposits returns zero", func(t *testing.T) {
-		rm := newRewardManager(100_000, 1000, 2000, 0, 100, 1000)
+		rm := newRewardManager(100_000, 1000, 2000, 0, 1000)
 		rm.SetAccumulatedRewardPerDepositX128(q128.Clone())
 
 		// No reward states added
@@ -937,7 +937,7 @@ func TestLaunchpadProject_calculateClaimableRewardsForActiveDeposits(t *testing.
 	})
 
 	t.Run("multiple deposits with different claimable rewards", func(t *testing.T) {
-		rm := newRewardManager(100_000, 1000, 2000, 0, 100, 1000)
+		rm := newRewardManager(100_000, 1000, 2000, 0, 1000)
 		rm.SetAccumulatedRewardPerDepositX128(q128.Clone()) // 1.0 reward per deposit
 
 		// Deposit 1: priceDebt = 0.5, amount = 100,000 -> claimable = 50,000
@@ -977,7 +977,7 @@ func TestLaunchpadProject_applyTierRewardGrowthWithRewards(t *testing.T) {
 
 		// Setup reward manager with claimable rewards
 		projectTierRewardManagers := lp.store.GetProjectTierRewardManagers()
-		rm := newRewardManager(100_000, 1000, 2000, 0, 100, 1000)
+		rm := newRewardManager(100_000, 1000, 2000, 0, 1000)
 		rm.SetAccumulatedRewardPerDepositX128(q128.Clone())
 
 		rewardState := launchpad.NewRewardState(
@@ -989,7 +989,7 @@ func TestLaunchpadProject_applyTierRewardGrowthWithRewards(t *testing.T) {
 		lp.store.SetProjectTierRewardManagers(projectTierRewardManagers)
 
 		// Calculate claimable rewards
-		claimableRewards, err := lp.applyTierRewardGrowthWithRewards(tier, int64(1000), int64(2001))
+		claimableRewards, err := lp.applyTierRewardGrowthWithRewards(tier, int64(2001))
 		uassert.NoError(t, err)
 		uassert.Equal(t, int64(50_000), claimableRewards)
 	})
@@ -1102,7 +1102,7 @@ func TestLaunchpadProject_TransferLeftFromProjectWithPendingWithdrawals(t *testi
 
 			// Setup reward manager with pending claimable rewards
 			projectTierRewardManagers := lp.store.GetProjectTierRewardManagers()
-			rm := newRewardManager(tt.totalDistributeAmount, 1000, 2000, 0, 100, 1000)
+			rm := newRewardManager(tt.totalDistributeAmount, 1000, 2000, 0, 1000)
 
 			// Set accumulated reward: Q128 / accumulatedRewardRatio
 			accumulatedReward := u256.Zero().Div(q128.Clone(), u256.NewUint(uint64(tt.accumulatedRewardRatio)))
@@ -1122,10 +1122,9 @@ func TestLaunchpadProject_TransferLeftFromProjectWithPendingWithdrawals(t *testi
 			obl.Transfer(cross, launchpadAddr, tt.totalDistributeAmount)
 
 			// Execute transfer
-			currentHeight := int64(1000)
 			currentTime := int64(2001) // After tier end
 			beforeOblBalance := obl.BalanceOf(recipient)
-			refundedAmount, err := lp.transferLeftFromProject(project, recipient, currentHeight, currentTime)
+			refundedAmount, err := lp.transferLeftFromProject(project, recipient, currentTime)
 			afterOblBalance := obl.BalanceOf(recipient)
 			balanceChange := afterOblBalance - beforeOblBalance
 
@@ -1224,7 +1223,7 @@ func TestLaunchpadProject_TransferLeftFromProjectWithMultiplePendingDeposits(t *
 
 			// Setup reward manager with multiple deposits
 			projectTierRewardManagers := lp.store.GetProjectTierRewardManagers()
-			rm := newRewardManager(tt.totalDistributeAmount, 1000, 2000, 0, 100, 1000)
+			rm := newRewardManager(tt.totalDistributeAmount, 1000, 2000, 0, 1000)
 			rm.SetAccumulatedRewardPerDepositX128(q128.Clone()) // 1.0 accumulated
 
 			for i, dep := range tt.deposits {
@@ -1242,9 +1241,8 @@ func TestLaunchpadProject_TransferLeftFromProjectWithMultiplePendingDeposits(t *
 			obl.Transfer(cross, launchpadAddr, tt.totalDistributeAmount)
 
 			// Execute transfer
-			currentHeight := int64(1000)
 			currentTime := int64(2001)
-			refundedAmount, err := lp.transferLeftFromProject(project, recipient, currentHeight, currentTime)
+			refundedAmount, err := lp.transferLeftFromProject(project, recipient, currentTime)
 
 			uassert.NoError(t, err)
 
@@ -1316,7 +1314,7 @@ func TestLaunchpadProject_TransferLeftFromProjectNoDepositors(t *testing.T) {
 
 			// Setup empty reward manager
 			projectTierRewardManagers := lp.store.GetProjectTierRewardManagers()
-			rm := newRewardManager(tt.totalDistributeAmount, 1000, 2000, 0, 100, 1000)
+			rm := newRewardManager(tt.totalDistributeAmount, 1000, 2000, 0, 1000)
 			rm.SetAccumulatedRewardPerDepositX128(q128.Clone())
 			// No reward states added
 
@@ -1329,9 +1327,8 @@ func TestLaunchpadProject_TransferLeftFromProjectNoDepositors(t *testing.T) {
 			obl.Transfer(cross, launchpadAddr, tt.totalDistributeAmount)
 
 			// Execute transfer
-			currentHeight := int64(1000)
 			currentTime := int64(2001)
-			refundedAmount, err := lp.transferLeftFromProject(project, recipient, currentHeight, currentTime)
+			refundedAmount, err := lp.transferLeftFromProject(project, recipient, currentTime)
 
 			if tt.expectError {
 				uassert.Error(t, err)

--- a/contract/r/gnoswap/launchpad/v1/launchpad_project_test.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_project_test.gno
@@ -904,7 +904,7 @@ func TestLaunchpadProject_validateRefundProject(t *testing.T) {
 func TestLaunchpadProject_calculateClaimableRewardsForActiveDeposits(t *testing.T) {
 	t.Run("calculate claimable rewards with active deposits", func(t *testing.T) {
 		// Create reward manager with accumulated rewards
-		rm := newRewardManager(100_000, 1000, 2000, 0, 1000)
+		rm := newRewardManager(100_000, 1000, 2000, 0)
 		rm.SetAccumulatedRewardPerDepositX128(q128.Clone()) // 1.0 reward per deposit
 
 		// Add reward state for deposit with priceDebt = 0.5
@@ -927,7 +927,7 @@ func TestLaunchpadProject_calculateClaimableRewardsForActiveDeposits(t *testing.
 	})
 
 	t.Run("no active deposits returns zero", func(t *testing.T) {
-		rm := newRewardManager(100_000, 1000, 2000, 0, 1000)
+		rm := newRewardManager(100_000, 1000, 2000, 0)
 		rm.SetAccumulatedRewardPerDepositX128(q128.Clone())
 
 		// No reward states added
@@ -937,7 +937,7 @@ func TestLaunchpadProject_calculateClaimableRewardsForActiveDeposits(t *testing.
 	})
 
 	t.Run("multiple deposits with different claimable rewards", func(t *testing.T) {
-		rm := newRewardManager(100_000, 1000, 2000, 0, 1000)
+		rm := newRewardManager(100_000, 1000, 2000, 0)
 		rm.SetAccumulatedRewardPerDepositX128(q128.Clone()) // 1.0 reward per deposit
 
 		// Deposit 1: priceDebt = 0.5, amount = 100,000 -> claimable = 50,000
@@ -977,7 +977,7 @@ func TestLaunchpadProject_applyTierRewardGrowthWithRewards(t *testing.T) {
 
 		// Setup reward manager with claimable rewards
 		projectTierRewardManagers := lp.store.GetProjectTierRewardManagers()
-		rm := newRewardManager(100_000, 1000, 2000, 0, 1000)
+		rm := newRewardManager(100_000, 1000, 2000, 0)
 		rm.SetAccumulatedRewardPerDepositX128(q128.Clone())
 
 		rewardState := launchpad.NewRewardState(
@@ -1102,7 +1102,7 @@ func TestLaunchpadProject_TransferLeftFromProjectWithPendingWithdrawals(t *testi
 
 			// Setup reward manager with pending claimable rewards
 			projectTierRewardManagers := lp.store.GetProjectTierRewardManagers()
-			rm := newRewardManager(tt.totalDistributeAmount, 1000, 2000, 0, 1000)
+			rm := newRewardManager(tt.totalDistributeAmount, 1000, 2000, 0)
 
 			// Set accumulated reward: Q128 / accumulatedRewardRatio
 			accumulatedReward := u256.Zero().Div(q128.Clone(), u256.NewUint(uint64(tt.accumulatedRewardRatio)))
@@ -1223,7 +1223,7 @@ func TestLaunchpadProject_TransferLeftFromProjectWithMultiplePendingDeposits(t *
 
 			// Setup reward manager with multiple deposits
 			projectTierRewardManagers := lp.store.GetProjectTierRewardManagers()
-			rm := newRewardManager(tt.totalDistributeAmount, 1000, 2000, 0, 1000)
+			rm := newRewardManager(tt.totalDistributeAmount, 1000, 2000, 0)
 			rm.SetAccumulatedRewardPerDepositX128(q128.Clone()) // 1.0 accumulated
 
 			for i, dep := range tt.deposits {
@@ -1314,7 +1314,7 @@ func TestLaunchpadProject_TransferLeftFromProjectNoDepositors(t *testing.T) {
 
 			// Setup empty reward manager
 			projectTierRewardManagers := lp.store.GetProjectTierRewardManagers()
-			rm := newRewardManager(tt.totalDistributeAmount, 1000, 2000, 0, 1000)
+			rm := newRewardManager(tt.totalDistributeAmount, 1000, 2000, 0)
 			rm.SetAccumulatedRewardPerDepositX128(q128.Clone())
 			// No reward states added
 

--- a/contract/r/gnoswap/launchpad/v1/launchpad_reward.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_reward.gno
@@ -77,7 +77,7 @@ func (lp *launchpadV1) collectDepositReward(deposit *launchpad.Deposit, currentH
 	}
 
 	// Update reward state before collection
-	err = updateRewardPerDepositX128(rewardManager, getTierCurrentDepositAmount(projectTier), currentHeight, currentTime)
+	err = updateRewardPerDepositX128(rewardManager, getTierCurrentDepositAmount(projectTier), currentTime)
 	if err != nil {
 		return "", 0, err
 	}

--- a/contract/r/gnoswap/launchpad/v1/launchpad_reward_test.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_reward_test.gno
@@ -92,7 +92,7 @@ func TestLaunchpadReward_CollectDepositReward(t *testing.T) {
 			// Setup reward manager if needed
 			if tt.setupManager {
 				rewardManagers := getTestProjectTierRewardManagers()
-				rewardManager := launchpad.NewRewardManager(1000, 40, 200, 0, 50)
+				rewardManager := launchpad.NewRewardManager(1000, 40, 200, 0)
 				rewardManager.SetRewards(avl.NewTree())
 				rewardManager.SetAccumulatedRewardPerDepositX128(u256.Zero())
 				rewardManager.SetDistributeAmountPerSecondX128(u256.NewUintFromInt64(1))

--- a/contract/r/gnoswap/launchpad/v1/launchpad_reward_test.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_reward_test.gno
@@ -92,7 +92,7 @@ func TestLaunchpadReward_CollectDepositReward(t *testing.T) {
 			// Setup reward manager if needed
 			if tt.setupManager {
 				rewardManagers := getTestProjectTierRewardManagers()
-				rewardManager := launchpad.NewRewardManager(1000, 40, 200, 0, 50, 50)
+				rewardManager := launchpad.NewRewardManager(1000, 40, 200, 0, 50)
 				rewardManager.SetRewards(avl.NewTree())
 				rewardManager.SetAccumulatedRewardPerDepositX128(u256.Zero())
 				rewardManager.SetDistributeAmountPerSecondX128(u256.NewUintFromInt64(1))

--- a/contract/r/gnoswap/launchpad/v1/launchpad_withdraw.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_withdraw.gno
@@ -118,7 +118,7 @@ func (lp *launchpadV1) withdrawDeposit(deposit *launchpad.Deposit, currentHeight
 	}
 
 	// Update rewards with current deposit amount
-	err = updateRewardPerDepositX128(rewardManager, getTierCurrentDepositAmount(projectTier), currentHeight, currentTime)
+	err = updateRewardPerDepositX128(rewardManager, getTierCurrentDepositAmount(projectTier), currentTime)
 	if err != nil {
 		return "", 0, err
 	}

--- a/contract/r/gnoswap/launchpad/v1/reward_manager.gno
+++ b/contract/r/gnoswap/launchpad/v1/reward_manager.gno
@@ -117,7 +117,7 @@ func removeRewardState(r *launchpad.RewardManager, depositId string) {
 	r.SetRewards(rewards)
 }
 
-func addRewardPerDepositX128(r *launchpad.RewardManager, rewardPerDepositX128 *u256.Uint, currentHeight, currentTime int64) error {
+func addRewardPerDepositX128(r *launchpad.RewardManager, rewardPerDepositX128 *u256.Uint, currentTime int64) error {
 	if rewardPerDepositX128.IsZero() {
 		return nil
 	}
@@ -132,7 +132,6 @@ func addRewardPerDepositX128(r *launchpad.RewardManager, rewardPerDepositX128 *u
 
 	accumulated := u256.Zero().Add(r.AccumulatedRewardPerDepositX128(), rewardPerDepositX128)
 	r.SetAccumulatedRewardPerDepositX128(accumulated)
-	r.SetAccumulatedHeight(currentHeight)
 	r.SetAccumulatedTime(currentTime)
 
 	return nil
@@ -140,16 +139,15 @@ func addRewardPerDepositX128(r *launchpad.RewardManager, rewardPerDepositX128 *u
 
 // updateRewardPerDepositX128 updates the reward per deposit state.
 // This function calculates and updates the accumulated reward per deposit
-// based on the current total deposit amount and height.
+// based on the current total deposit amount and time.
 //
 // Parameters:
 // - totalDepositAmount (int64): Current total deposit amount
-// - height (int64): Current blockchain height
 // - time (int64): Current timestamp
 //
 // Returns:
 // - error: If the update fails
-func updateRewardPerDepositX128(r *launchpad.RewardManager, totalDepositAmount int64, currentHeight, currentTime int64) error {
+func updateRewardPerDepositX128(r *launchpad.RewardManager, totalDepositAmount int64, currentTime int64) error {
 	if currentTime <= 0 {
 		return makeErrorWithDetails(errInvalidTime, "time must be positive")
 	}
@@ -165,7 +163,7 @@ func updateRewardPerDepositX128(r *launchpad.RewardManager, totalDepositAmount i
 		return err
 	}
 
-	err = addRewardPerDepositX128(r, rewardPerDepositX128, currentHeight, currentTime)
+	err = addRewardPerDepositX128(r, rewardPerDepositX128, currentTime)
 	if err != nil {
 		return err
 	}
@@ -254,13 +252,12 @@ func newRewardManager(
 	distributeStartTime int64,
 	distributeEndTime int64,
 	rewardCollectableDuration int64,
-	currentHeight int64,
 	currentTime int64,
 ) *launchpad.RewardManager {
-	manager := launchpad.NewRewardManager(totalDistributeAmount, distributeStartTime, distributeEndTime, rewardCollectableDuration, currentHeight, currentTime)
+	manager := launchpad.NewRewardManager(totalDistributeAmount, distributeStartTime, distributeEndTime, rewardCollectableDuration, currentTime)
 
 	updateDistributeAmountPerSecondX128(manager, totalDistributeAmount, distributeStartTime, distributeEndTime)
-	updateRewardPerDepositX128(manager, 0, currentHeight, currentTime)
+	updateRewardPerDepositX128(manager, 0, currentTime)
 
 	return manager
 }

--- a/contract/r/gnoswap/launchpad/v1/reward_manager.gno
+++ b/contract/r/gnoswap/launchpad/v1/reward_manager.gno
@@ -252,12 +252,10 @@ func newRewardManager(
 	distributeStartTime int64,
 	distributeEndTime int64,
 	rewardCollectableDuration int64,
-	currentTime int64,
 ) *launchpad.RewardManager {
 	manager := launchpad.NewRewardManager(totalDistributeAmount, distributeStartTime, distributeEndTime, rewardCollectableDuration)
 
 	updateDistributeAmountPerSecondX128(manager, totalDistributeAmount, distributeStartTime, distributeEndTime)
-	updateRewardPerDepositX128(manager, 0, currentTime)
 
 	return manager
 }

--- a/contract/r/gnoswap/launchpad/v1/reward_manager.gno
+++ b/contract/r/gnoswap/launchpad/v1/reward_manager.gno
@@ -254,7 +254,7 @@ func newRewardManager(
 	rewardCollectableDuration int64,
 	currentTime int64,
 ) *launchpad.RewardManager {
-	manager := launchpad.NewRewardManager(totalDistributeAmount, distributeStartTime, distributeEndTime, rewardCollectableDuration, currentTime)
+	manager := launchpad.NewRewardManager(totalDistributeAmount, distributeStartTime, distributeEndTime, rewardCollectableDuration)
 
 	updateDistributeAmountPerSecondX128(manager, totalDistributeAmount, distributeStartTime, distributeEndTime)
 	updateRewardPerDepositX128(manager, 0, currentTime)

--- a/contract/r/gnoswap/launchpad/v1/reward_manager_test.gno
+++ b/contract/r/gnoswap/launchpad/v1/reward_manager_test.gno
@@ -96,13 +96,12 @@ func TestRewardManager_UpdateRewardPerDepositX128(t *testing.T) {
 			now := time.Now().Unix()
 			distributeStartTime := now - 1000 + tt.distributeStartHeight // Start in the past
 			distributeEndTime := now - 1000 + tt.distributeEndHeight
-			currentTime := now - 1000 + tt.currentHeight
 			manager := newRewardManager(
 				tt.totalDistributeAmount,
 				distributeStartTime,
 				distributeEndTime,
 				0,
-				currentTime,
+				distributeStartTime,
 			)
 
 			// Execute
@@ -354,13 +353,12 @@ func TestnewRewardManager(t *testing.T) {
 			now := time.Now().Unix()
 			distributeStartTime := now - 1000 + tt.distributeStartTime
 			distributeEndTime := now - 1000 + tt.distributeEndTime
-			currentTime := now - 1000 + tt.currentHeight
 			manager := newRewardManager(
 				tt.totalDistributeAmount,
 				distributeStartTime,
 				distributeEndTime,
 				0,
-				currentTime,
+				distributeStartTime,
 			)
 
 			// Verify
@@ -378,14 +376,13 @@ func TestTimestampBasedRewardCalculation_ConstantTime(t *testing.T) {
 	baseTime := time.Now().Unix()
 	distributeStartTime := baseTime + 100
 	distributeEndTime := baseTime + 200 // 100 seconds later
-	currentTime := baseTime
 
 	manager := newRewardManager(
 		totalDistributeAmount,
 		distributeStartTime,
 		distributeEndTime,
 		0,
-		currentTime,
+		distributeStartTime,
 	)
 
 	// Create two deposits to test reward distribution
@@ -462,14 +459,13 @@ func TestTimestampBasedRewardCalculation_VariableBlockTime(t *testing.T) {
 	currentHeight := int64(1)
 	distributeStartTime := baseTime
 	distributeEndTime := baseTime + 100 // 100 seconds for just 10 blocks
-	currentTime := baseTime
 
 	manager := newRewardManager(
 		totalDistributeAmount,
 		distributeStartTime,
 		distributeEndTime,
 		0,
-		currentTime,
+		distributeStartTime,
 	)
 
 	// Create first deposit at start
@@ -544,14 +540,13 @@ func TestRewardManager_VaryingBlockTime_FastBlocks(t *testing.T) {
 	distributeStartTime := int64(1000)
 	distributeEndTime := int64(1100) // 100 seconds duration
 	currentHeight := int64(100)
-	currentTime := int64(1000)
 
 	manager := newRewardManager(
 		totalDistributeAmount,
 		distributeStartTime,
 		distributeEndTime,
 		0,
-		currentTime,
+		distributeStartTime,
 	)
 
 	// Add deposit at start
@@ -592,14 +587,13 @@ func TestRewardManager_VaryingBlockTime_SlowBlocks(t *testing.T) {
 	distributeStartTime := int64(1000)
 	distributeEndTime := int64(1100) // 100 seconds duration
 	currentHeight := int64(100)
-	currentTime := int64(1000)
 
 	manager := newRewardManager(
 		totalDistributeAmount,
 		distributeStartTime,
 		distributeEndTime,
 		0,
-		currentTime,
+		distributeStartTime,
 	)
 
 	// Add deposit at start
@@ -640,14 +634,13 @@ func TestRewardManager_VaryingBlockTime_IrregularBlocks(t *testing.T) {
 	distributeStartTime := int64(1000)
 	distributeEndTime := int64(1100) // 100 seconds duration
 	currentHeight := int64(100)
-	currentTime := int64(1000)
 
 	manager := newRewardManager(
 		totalDistributeAmount,
 		distributeStartTime,
 		distributeEndTime,
 		0,
-		currentTime,
+		distributeStartTime,
 	)
 
 	// Add deposit at start
@@ -684,14 +677,13 @@ func TestRewardManager_EdgeCase_ZeroDuration(t *testing.T) {
 	totalDistributeAmount := int64(1000)
 	distributeStartTime := int64(1000)
 	distributeEndTime := int64(1000) // Same as start (zero duration)
-	currentTime := int64(1000)
 
 	manager := newRewardManager(
 		totalDistributeAmount,
 		distributeStartTime,
 		distributeEndTime,
 		0,
-		currentTime,
+		distributeStartTime,
 	)
 
 	// Should have zero distribute amount per second
@@ -705,14 +697,13 @@ func TestRewardManager_EdgeCase_TimeGoesBackward(t *testing.T) {
 	distributeStartTime := int64(1000)
 	distributeEndTime := int64(2000)
 	currentHeight := int64(100)
-	currentTime := int64(1000)
 
 	manager := newRewardManager(
 		totalDistributeAmount,
 		distributeStartTime,
 		distributeEndTime,
 		0,
-		currentTime,
+		distributeStartTime,
 	)
 
 	// Add deposit
@@ -746,14 +737,13 @@ func TestRewardManager_EdgeCase_RewardAfterEnd(t *testing.T) {
 	distributeStartTime := int64(1000)
 	distributeEndTime := int64(2000)
 	currentHeight := int64(100)
-	currentTime := int64(1000)
 
 	manager := newRewardManager(
 		totalDistributeAmount,
 		distributeStartTime,
 		distributeEndTime,
 		0,
-		currentTime,
+		distributeStartTime,
 	)
 
 	// Add deposit
@@ -788,14 +778,13 @@ func TestRewardManager_MultipleDeposits_DifferentTimings(t *testing.T) {
 	distributeStartTime := int64(1000)
 	distributeEndTime := int64(2000) // 1000 seconds duration
 	currentHeight := int64(100)
-	currentTime := int64(1000)
 
 	manager := newRewardManager(
 		totalDistributeAmount,
 		distributeStartTime,
 		distributeEndTime,
 		0,
-		currentTime,
+		distributeStartTime,
 	)
 
 	// Deposit 1: Joins at start
@@ -913,12 +902,13 @@ func TestRewardManager_ClaimableTimeOverflow(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// given
+			now := time.Now().Unix()
 			manager := newRewardManager(
 				1000000,
-				time.Now().Unix(),
+				now,
 				tt.distributeEndTime,
 				0,
-				time.Now().Unix(),
+				now,
 			)
 			manager.SetRewardClaimableDuration(tt.claimableDuration)
 
@@ -984,7 +974,7 @@ func TestRewardManager_ClaimedAmountOverflow(t *testing.T) {
 				distributeStart,
 				distributeEnd,
 				0,
-				currentTime,
+				distributeStart,
 			)
 			manager.SetRewardClaimableDuration(100)
 
@@ -1075,7 +1065,7 @@ func TestRewardManager_TotalClaimedAmountOverflow(t *testing.T) {
 				distributeStart,
 				distributeEnd,
 				0,
-				currentTime,
+				distributeStart,
 			)
 			manager.SetRewardClaimableDuration(100)
 			manager.SetTotalClaimedAmount(tt.initialTotal)
@@ -1685,7 +1675,7 @@ func TestRewardManager_updateDistributeAmountPerSecondX128(t *testing.T) {
 				tt.distributeStartTime,
 				tt.distributeEndTime,
 				0,
-				1000,
+				tt.distributeStartTime,
 			)
 
 			// Store initial state
@@ -1908,7 +1898,7 @@ func TestRewardManager_addRewardPerDepositX128(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// given
-			manager := launchpad.NewRewardManager(0, 0, 0, 0, 0)
+			manager := launchpad.NewRewardManager(0, 0, 0, 0)
 			manager.SetAccumulatedRewardPerDepositX128(tt.managerValues.accumulatedRewardPerDepositX128)
 			manager.SetAccumulatedTime(tt.managerValues.accumulatedTime)
 			manager.SetDistributeStartTime(tt.managerValues.distributeStartTime)
@@ -1974,7 +1964,7 @@ func TestRewardManager_addRewardState(t *testing.T) {
 				900,
 				2000,
 				0,
-				1000,
+				900,
 			)
 
 			deposit := launchpad.NewDeposit(

--- a/contract/r/gnoswap/launchpad/v1/reward_manager_test.gno
+++ b/contract/r/gnoswap/launchpad/v1/reward_manager_test.gno
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	"chain/runtime"
 	"math"
 	"testing"
 	"time"
@@ -44,7 +43,7 @@ func TestRewardManager_IsInitialized(t *testing.T) {
 			for k, v := range tt.rewardStates {
 				tree.Set(k, v)
 			}
-			manager := newRewardManager(1000000, 100, 200, 0, 100, 100)
+			manager := newRewardManager(1000000, 100, 200, 0, 100)
 			manager.SetRewards(tree)
 
 			// Execute
@@ -103,14 +102,13 @@ func TestRewardManager_UpdateRewardPerDepositX128(t *testing.T) {
 				distributeStartTime,
 				distributeEndTime,
 				0,
-				tt.currentHeight,
 				currentTime,
 			)
 
 			// Execute
 			// Use timestamp based on height offset from start
 			rewardTime := now - 1000 + tt.rewardHeight
-			err := updateRewardPerDepositX128(manager, tt.totalDistributeAmount, tt.rewardHeight, rewardTime)
+			err := updateRewardPerDepositX128(manager, tt.totalDistributeAmount, rewardTime)
 
 			// Verify
 			if tt.expectedHasError {
@@ -194,15 +192,12 @@ func TestRewardManager_AddRewardStateByDeposit(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Setup
-			currentHeight := runtime.ChainHeight()
-
 			// Use current time as base and simulate timing
 			manager := newRewardManager(
 				tt.totalDistributeAmount,
 				tt.distributeStart,
 				tt.distributeEnd,
 				0,
-				currentHeight,
 				tt.distributeStart,
 			)
 
@@ -211,18 +206,18 @@ func TestRewardManager_AddRewardStateByDeposit(t *testing.T) {
 			for _, deposit := range tt.existingDeposits {
 				totalDepositAmount += int64(deposit.DepositAmount())
 				// Use timestamp based on deposit height offset
-				updateRewardPerDepositX128(manager, totalDepositAmount, deposit.CreatedHeight(), deposit.CreatedAt())
+				updateRewardPerDepositX128(manager, totalDepositAmount, deposit.CreatedAt())
 				addRewardStateByDeposit(manager, deposit)
 			}
 
 			// Execute
 			totalDepositAmount += tt.deposit.DepositAmount()
 			// Use timestamp based on deposit height offset
-			updateRewardPerDepositX128(manager, totalDepositAmount, tt.deposit.CreatedHeight(), tt.deposit.CreatedAt())
+			updateRewardPerDepositX128(manager, totalDepositAmount, tt.deposit.CreatedAt())
 			rewardState := addRewardStateByDeposit(manager, tt.deposit)
 
 			// Use timestamp based on collection height offset
-			updateRewardPerDepositX128(manager, totalDepositAmount, tt.collectHeight, tt.collectHeight)
+			updateRewardPerDepositX128(manager, totalDepositAmount, tt.collectHeight)
 			reward, err := collectReward(manager, tt.deposit.ID(), tt.collectHeight)
 			if err != nil {
 				uassert.NoError(t, err)
@@ -301,23 +296,22 @@ func TestRewardManager_CollectReward(t *testing.T) {
 				tt.distributeStartTime,
 				tt.distributeEndTime,
 				0,
-				tt.currentHeight,
 				tt.distributeStartTime,
 			)
 
 			for _, deposit := range tt.existingDeposits {
 				// Use timestamp based on deposit height offset
-				updateRewardPerDepositX128(manager, tt.totalDistributeAmount, deposit.CreatedHeight(), deposit.CreatedAt())
+				updateRewardPerDepositX128(manager, tt.totalDistributeAmount, deposit.CreatedAt())
 				addRewardStateByDeposit(manager, deposit)
 			}
 
 			// Use timestamp based on deposit height offset
-			updateRewardPerDepositX128(manager, tt.totalDistributeAmount, tt.deposit.CreatedHeight(), tt.deposit.CreatedAt())
+			updateRewardPerDepositX128(manager, tt.totalDistributeAmount, tt.deposit.CreatedAt())
 			addRewardStateByDeposit(manager, tt.deposit)
 
 			// Execute
 			// Use timestamp based on collection height offset
-			updateRewardPerDepositX128(manager, tt.totalDistributeAmount, tt.collectHeight, tt.collectHeight)
+			updateRewardPerDepositX128(manager, tt.totalDistributeAmount, tt.collectHeight)
 			amount, err := collectReward(manager, tt.depositId, tt.collectHeight)
 
 			// Verify
@@ -366,7 +360,6 @@ func TestnewRewardManager(t *testing.T) {
 				distributeStartTime,
 				distributeEndTime,
 				0,
-				tt.currentHeight,
 				currentTime,
 			)
 
@@ -381,8 +374,6 @@ func TestTimestampBasedRewardCalculation_ConstantTime(t *testing.T) {
 	// Scenario: 100 seconds duration should distribute rewards evenly per second
 
 	totalDistributeAmount := int64(1000)
-	currentHeight := int64(100)
-
 	// Set up timestamps: 100 seconds duration
 	baseTime := time.Now().Unix()
 	distributeStartTime := baseTime + 100
@@ -394,7 +385,6 @@ func TestTimestampBasedRewardCalculation_ConstantTime(t *testing.T) {
 		distributeStartTime,
 		distributeEndTime,
 		0,
-		currentHeight,
 		currentTime,
 	)
 
@@ -422,17 +412,17 @@ func TestTimestampBasedRewardCalculation_ConstantTime(t *testing.T) {
 	)
 
 	// Add both deposits at start time
-	err := updateRewardPerDepositX128(manager, 1000, distributeStartTime, distributeStartTime)
+	err := updateRewardPerDepositX128(manager, 1000, distributeStartTime)
 	uassert.NoError(t, err)
 	addRewardStateByDeposit(manager, deposit1)
 
-	err = updateRewardPerDepositX128(manager, 2000, distributeStartTime, distributeStartTime)
+	err = updateRewardPerDepositX128(manager, 2000, distributeStartTime)
 	uassert.NoError(t, err)
 	addRewardStateByDeposit(manager, deposit2)
 
 	// Move time forward by 50 seconds (half way through)
 	halfwayTime := distributeStartTime + 50
-	err = updateRewardPerDepositX128(manager, 2000, halfwayTime, halfwayTime)
+	err = updateRewardPerDepositX128(manager, 2000, halfwayTime)
 	uassert.NoError(t, err)
 
 	// Collect reward for deposit1 after 50 seconds
@@ -444,7 +434,7 @@ func TestTimestampBasedRewardCalculation_ConstantTime(t *testing.T) {
 	uassert.Equal(t, true, reward1 >= 245 && reward1 <= 255, "reward1 should be ~250")
 
 	// Move to end of distribution period
-	err = updateRewardPerDepositX128(manager, 2000, distributeEndTime, distributeEndTime)
+	err = updateRewardPerDepositX128(manager, 2000, distributeEndTime)
 	uassert.NoError(t, err)
 
 	// Collect reward for deposit2 after 100 seconds
@@ -479,7 +469,6 @@ func TestTimestampBasedRewardCalculation_VariableBlockTime(t *testing.T) {
 		distributeStartTime,
 		distributeEndTime,
 		0,
-		currentHeight,
 		currentTime,
 	)
 
@@ -495,14 +484,14 @@ func TestTimestampBasedRewardCalculation_VariableBlockTime(t *testing.T) {
 		distributeEndTime,
 	)
 
-	err := updateRewardPerDepositX128(manager, 1000, distributeStartTime, distributeStartTime)
+	err := updateRewardPerDepositX128(manager, 1000, distributeStartTime)
 	uassert.NoError(t, err)
 	addRewardStateByDeposit(manager, deposit1)
 
 	// Simulate irregular block times:
 	// Block 101 comes after 30 seconds (normally would be 1 second)
 	time1 := baseTime + 30
-	err = updateRewardPerDepositX128(manager, 1000, time1, time1)
+	err = updateRewardPerDepositX128(manager, 1000, time1)
 	uassert.NoError(t, err)
 
 	// Add second deposit
@@ -518,13 +507,13 @@ func TestTimestampBasedRewardCalculation_VariableBlockTime(t *testing.T) {
 	)
 
 	totalDeposits := int64(2000)
-	err = updateRewardPerDepositX128(manager, totalDeposits, time1, time1)
+	err = updateRewardPerDepositX128(manager, totalDeposits, time1)
 	uassert.NoError(t, err)
 	addRewardStateByDeposit(manager, deposit2)
 
 	// Block 105 comes after 80 seconds total (another 50 seconds gap)
 	time2 := baseTime + 80
-	err = updateRewardPerDepositX128(manager, totalDeposits, time2, time2)
+	err = updateRewardPerDepositX128(manager, totalDeposits, time2)
 	uassert.NoError(t, err)
 
 	// Check rewards for deposit1 (active for 80 seconds)
@@ -562,7 +551,6 @@ func TestRewardManager_VaryingBlockTime_FastBlocks(t *testing.T) {
 		distributeStartTime,
 		distributeEndTime,
 		0,
-		currentHeight,
 		currentTime,
 	)
 
@@ -580,11 +568,10 @@ func TestRewardManager_VaryingBlockTime_FastBlocks(t *testing.T) {
 	addRewardStateByDeposit(manager, deposit)
 
 	// Simulate fast blocks: 50 blocks in 50 seconds (1 block/second)
-	midHeight := distributeStartTime + 50
 	midTime := distributeStartTime + 50
 
 	// Update reward state
-	err := updateRewardPerDepositX128(manager, 1000000, midHeight, midTime)
+	err := updateRewardPerDepositX128(manager, 1000000, midTime)
 	uassert.NoError(t, err)
 
 	// Collect rewards after 50 seconds
@@ -612,7 +599,6 @@ func TestRewardManager_VaryingBlockTime_SlowBlocks(t *testing.T) {
 		distributeStartTime,
 		distributeEndTime,
 		0,
-		currentHeight,
 		currentTime,
 	)
 
@@ -630,11 +616,10 @@ func TestRewardManager_VaryingBlockTime_SlowBlocks(t *testing.T) {
 	addRewardStateByDeposit(manager, deposit)
 
 	// Simulate slow blocks: only 3 blocks in 60 seconds (20 seconds/block)
-	midHeight := distributeStartTime + 3
 	midTime := distributeStartTime + 60
 
 	// Update reward state
-	err := updateRewardPerDepositX128(manager, 1000000, midHeight, midTime)
+	err := updateRewardPerDepositX128(manager, 1000000, midTime)
 	uassert.NoError(t, err)
 
 	// Collect rewards after 60 seconds
@@ -662,7 +647,6 @@ func TestRewardManager_VaryingBlockTime_IrregularBlocks(t *testing.T) {
 		distributeStartTime,
 		distributeEndTime,
 		0,
-		currentHeight,
 		currentTime,
 	)
 
@@ -680,11 +664,10 @@ func TestRewardManager_VaryingBlockTime_IrregularBlocks(t *testing.T) {
 	addRewardStateByDeposit(manager, deposit)
 
 	// Simulate irregular blocks over 70 seconds
-	irregularHeight := distributeStartTime + 10
 	irregularTime := distributeStartTime + 70
 
 	// Update reward state
-	err := updateRewardPerDepositX128(manager, 1000000, irregularHeight, irregularTime)
+	err := updateRewardPerDepositX128(manager, 1000000, irregularTime)
 	uassert.NoError(t, err)
 
 	// Collect rewards after 70 seconds
@@ -701,7 +684,6 @@ func TestRewardManager_EdgeCase_ZeroDuration(t *testing.T) {
 	totalDistributeAmount := int64(1000)
 	distributeStartTime := int64(1000)
 	distributeEndTime := int64(1000) // Same as start (zero duration)
-	currentHeight := int64(100)
 	currentTime := int64(1000)
 
 	manager := newRewardManager(
@@ -709,7 +691,6 @@ func TestRewardManager_EdgeCase_ZeroDuration(t *testing.T) {
 		distributeStartTime,
 		distributeEndTime,
 		0,
-		currentHeight,
 		currentTime,
 	)
 
@@ -731,7 +712,6 @@ func TestRewardManager_EdgeCase_TimeGoesBackward(t *testing.T) {
 		distributeStartTime,
 		distributeEndTime,
 		0,
-		currentHeight,
 		currentTime,
 	)
 
@@ -749,11 +729,11 @@ func TestRewardManager_EdgeCase_TimeGoesBackward(t *testing.T) {
 	addRewardStateByDeposit(manager, deposit)
 
 	// First update at time 1500
-	err := updateRewardPerDepositX128(manager, 1000000, 150, 1500)
+	err := updateRewardPerDepositX128(manager, 1000000, 1500)
 	uassert.NoError(t, err)
 
 	// Try to update with earlier time (should not affect accumulated time)
-	addRewardPerDepositX128(manager, u256.Zero(), 140, 1400)
+	addRewardPerDepositX128(manager, u256.Zero(), 1400)
 
 	// Accumulated time should still be 1500
 	uassert.Equal(t, int64(1500), manager.AccumulatedTime(),
@@ -773,7 +753,6 @@ func TestRewardManager_EdgeCase_RewardAfterEnd(t *testing.T) {
 		distributeStartTime,
 		distributeEndTime,
 		0,
-		currentHeight,
 		currentTime,
 	)
 
@@ -791,7 +770,7 @@ func TestRewardManager_EdgeCase_RewardAfterEnd(t *testing.T) {
 	addRewardStateByDeposit(manager, deposit)
 
 	// Update past end time
-	err := updateRewardPerDepositX128(manager, 1000000, distributeEndTime, distributeEndTime)
+	err := updateRewardPerDepositX128(manager, 1000000, distributeEndTime)
 	uassert.NoError(t, err)
 
 	// Collect rewards
@@ -816,7 +795,6 @@ func TestRewardManager_MultipleDeposits_DifferentTimings(t *testing.T) {
 		distributeStartTime,
 		distributeEndTime,
 		0,
-		currentHeight,
 		currentTime,
 	)
 
@@ -835,7 +813,7 @@ func TestRewardManager_MultipleDeposits_DifferentTimings(t *testing.T) {
 
 	// Update after 250 seconds (deposit1 alone)
 	timeAfter250s := distributeStartTime + 250
-	err := updateRewardPerDepositX128(manager, 1000000, timeAfter250s, timeAfter250s)
+	err := updateRewardPerDepositX128(manager, 1000000, timeAfter250s)
 	uassert.NoError(t, err)
 
 	// Deposit 2: Joins after 250 seconds
@@ -853,7 +831,7 @@ func TestRewardManager_MultipleDeposits_DifferentTimings(t *testing.T) {
 
 	// Update after 500 seconds total (250 seconds shared)
 	timeAfter500s := distributeStartTime + 500
-	err = updateRewardPerDepositX128(manager, 2000000, timeAfter500s, timeAfter500s)
+	err = updateRewardPerDepositX128(manager, 2000000, timeAfter500s)
 	uassert.NoError(t, err)
 
 	// Deposit 3: Joins after 500 seconds
@@ -870,7 +848,7 @@ func TestRewardManager_MultipleDeposits_DifferentTimings(t *testing.T) {
 	addRewardStateByDeposit(manager, deposit3)
 
 	// Final update at end (500 seconds with 3 deposits)
-	err = updateRewardPerDepositX128(manager, 4000000, distributeEndTime, distributeEndTime)
+	err = updateRewardPerDepositX128(manager, 4000000, distributeEndTime)
 	uassert.NoError(t, err)
 
 	// Collect all rewards
@@ -940,7 +918,6 @@ func TestRewardManager_ClaimableTimeOverflow(t *testing.T) {
 				time.Now().Unix(),
 				tt.distributeEndTime,
 				0,
-				100,
 				time.Now().Unix(),
 			)
 			manager.SetRewardClaimableDuration(tt.claimableDuration)
@@ -1007,7 +984,6 @@ func TestRewardManager_ClaimedAmountOverflow(t *testing.T) {
 				distributeStart,
 				distributeEnd,
 				0,
-				100,
 				currentTime,
 			)
 			manager.SetRewardClaimableDuration(100)
@@ -1099,7 +1075,6 @@ func TestRewardManager_TotalClaimedAmountOverflow(t *testing.T) {
 				distributeStart,
 				distributeEnd,
 				0,
-				100,
 				currentTime,
 			)
 			manager.SetRewardClaimableDuration(100)
@@ -1165,7 +1140,6 @@ func TestRewardManager_calculateRewardPerDepositX128(t *testing.T) {
 					1000,
 					2000,
 					0,
-					100,
 					1000,
 				)
 				return manager
@@ -1195,7 +1169,6 @@ func TestRewardManager_calculateRewardPerDepositX128(t *testing.T) {
 					1000,
 					2000,
 					0,
-					100,
 					1000,
 				)
 
@@ -1229,7 +1202,6 @@ func TestRewardManager_calculateRewardPerDepositX128(t *testing.T) {
 					1000,
 					2000,
 					0,
-					100,
 					1000,
 				)
 				manager.SetAccumulatedTime(1000)
@@ -1251,7 +1223,6 @@ func TestRewardManager_calculateRewardPerDepositX128(t *testing.T) {
 					1000,
 					2000,
 					0,
-					100,
 					1000,
 				)
 				manager.SetAccumulatedTime(1000)
@@ -1277,7 +1248,6 @@ func TestRewardManager_calculateRewardPerDepositX128(t *testing.T) {
 					1000,
 					2000,
 					0,
-					100,
 					1000,
 				)
 				manager.SetAccumulatedTime(2100)
@@ -1299,7 +1269,6 @@ func TestRewardManager_calculateRewardPerDepositX128(t *testing.T) {
 					1000,
 					2000,
 					0,
-					100,
 					1000,
 				)
 				manager.SetAccumulatedTime(2000)
@@ -1321,7 +1290,6 @@ func TestRewardManager_calculateRewardPerDepositX128(t *testing.T) {
 					1000,
 					2000,
 					0,
-					100,
 					1000,
 				)
 				manager.SetAccumulatedTime(1000)
@@ -1353,7 +1321,6 @@ func TestRewardManager_calculateRewardPerDepositX128(t *testing.T) {
 					1000,
 					2000,
 					0,
-					100,
 					1000,
 				)
 				manager.SetAccumulatedTime(1000)
@@ -1384,7 +1351,6 @@ func TestRewardManager_calculateRewardPerDepositX128(t *testing.T) {
 					1000,
 					2000,
 					0,
-					100,
 					1000,
 				)
 				manager.SetAccumulatedTime(1000)
@@ -1406,7 +1372,6 @@ func TestRewardManager_calculateRewardPerDepositX128(t *testing.T) {
 					1000,
 					2000,
 					0,
-					100,
 					1000,
 				)
 				manager.SetAccumulatedTime(1000)
@@ -1428,7 +1393,6 @@ func TestRewardManager_calculateRewardPerDepositX128(t *testing.T) {
 					1000,
 					2000,
 					0,
-					100,
 					1000,
 				)
 				manager.SetAccumulatedTime(1000)
@@ -1459,7 +1423,6 @@ func TestRewardManager_calculateRewardPerDepositX128(t *testing.T) {
 					1000,
 					2000,
 					0,
-					100,
 					1000,
 				)
 				manager.SetAccumulatedTime(1000)
@@ -1491,7 +1454,6 @@ func TestRewardManager_calculateRewardPerDepositX128(t *testing.T) {
 					1000,
 					2000,
 					0,
-					100,
 					1000,
 				)
 				manager.SetAccumulatedTime(1000)
@@ -1723,7 +1685,6 @@ func TestRewardManager_updateDistributeAmountPerSecondX128(t *testing.T) {
 				tt.distributeStartTime,
 				tt.distributeEndTime,
 				0,
-				100,
 				1000,
 			)
 
@@ -1762,7 +1723,6 @@ func TestRewardManager_addRewardPerDepositX128(t *testing.T) {
 	// Define the manager values type for test cases
 	type managerTestValues struct {
 		accumulatedRewardPerDepositX128 *u256.Uint
-		accumulatedHeight               int64
 		accumulatedTime                 int64
 		distributeStartTime             int64
 		distributeEndTime               int64
@@ -1772,10 +1732,8 @@ func TestRewardManager_addRewardPerDepositX128(t *testing.T) {
 		name                      string
 		managerValues             managerTestValues
 		rewardPerDepositX128      *u256.Uint
-		currentHeight             int64
 		currentTime               int64
 		expectedAccumulatedReward string
-		expectedAccumulatedHeight int64
 		expectedAccumulatedTime   int64
 		expectNoUpdate            bool
 	}{
@@ -1783,16 +1741,13 @@ func TestRewardManager_addRewardPerDepositX128(t *testing.T) {
 			name: "normal addition - first reward",
 			managerValues: managerTestValues{
 				accumulatedRewardPerDepositX128: u256.Zero(),
-				accumulatedHeight:               0,
 				accumulatedTime:                 1000,
 				distributeStartTime:             900,
 				distributeEndTime:               2000,
 			},
 			rewardPerDepositX128:      u256.NewUint(1000),
-			currentHeight:             150,
 			currentTime:               1100,
 			expectedAccumulatedReward: "1000",
-			expectedAccumulatedHeight: 150,
 			expectedAccumulatedTime:   1100,
 			expectNoUpdate:            false,
 		},
@@ -1800,16 +1755,13 @@ func TestRewardManager_addRewardPerDepositX128(t *testing.T) {
 			name: "normal addition - accumulating rewards",
 			managerValues: managerTestValues{
 				accumulatedRewardPerDepositX128: u256.NewUint(5000),
-				accumulatedHeight:               100,
 				accumulatedTime:                 1000,
 				distributeStartTime:             900,
 				distributeEndTime:               2000,
 			},
 			rewardPerDepositX128:      u256.NewUint(3000),
-			currentHeight:             150,
 			currentTime:               1100,
 			expectedAccumulatedReward: "8000",
-			expectedAccumulatedHeight: 150,
 			expectedAccumulatedTime:   1100,
 			expectNoUpdate:            false,
 		},
@@ -1817,13 +1769,11 @@ func TestRewardManager_addRewardPerDepositX128(t *testing.T) {
 			name: "reward is zero - no update",
 			managerValues: managerTestValues{
 				accumulatedRewardPerDepositX128: u256.NewUint(5000),
-				accumulatedHeight:               100,
 				accumulatedTime:                 1000,
 				distributeStartTime:             900,
 				distributeEndTime:               2000,
 			},
 			rewardPerDepositX128: u256.Zero(),
-			currentHeight:        150,
 			currentTime:          1100,
 			expectNoUpdate:       true,
 		},
@@ -1831,13 +1781,11 @@ func TestRewardManager_addRewardPerDepositX128(t *testing.T) {
 			name: "accumulated time greater than current time - no update",
 			managerValues: managerTestValues{
 				accumulatedRewardPerDepositX128: u256.NewUint(5000),
-				accumulatedHeight:               100,
 				accumulatedTime:                 1200,
 				distributeStartTime:             900,
 				distributeEndTime:               2000,
 			},
 			rewardPerDepositX128: u256.NewUint(1000),
-			currentHeight:        150,
 			currentTime:          1100,
 			expectNoUpdate:       true,
 		},
@@ -1845,16 +1793,13 @@ func TestRewardManager_addRewardPerDepositX128(t *testing.T) {
 			name: "accumulated time equals current time - boundary",
 			managerValues: managerTestValues{
 				accumulatedRewardPerDepositX128: u256.NewUint(5000),
-				accumulatedHeight:               100,
 				accumulatedTime:                 1100,
 				distributeStartTime:             900,
 				distributeEndTime:               2000,
 			},
 			rewardPerDepositX128:      u256.NewUint(1000),
-			currentHeight:             150,
 			currentTime:               1100,
 			expectedAccumulatedReward: "6000",
-			expectedAccumulatedHeight: 150,
 			expectedAccumulatedTime:   1100,
 			expectNoUpdate:            false,
 		},
@@ -1862,13 +1807,11 @@ func TestRewardManager_addRewardPerDepositX128(t *testing.T) {
 			name: "distribute start time greater than current time - no update",
 			managerValues: managerTestValues{
 				accumulatedRewardPerDepositX128: u256.NewUint(5000),
-				accumulatedHeight:               100,
 				accumulatedTime:                 900,
 				distributeStartTime:             1200,
 				distributeEndTime:               2000,
 			},
 			rewardPerDepositX128: u256.NewUint(1000),
-			currentHeight:        150,
 			currentTime:          1100,
 			expectNoUpdate:       true,
 		},
@@ -1876,16 +1819,13 @@ func TestRewardManager_addRewardPerDepositX128(t *testing.T) {
 			name: "distribute start time equals current time - boundary",
 			managerValues: managerTestValues{
 				accumulatedRewardPerDepositX128: u256.NewUint(5000),
-				accumulatedHeight:               100,
 				accumulatedTime:                 900,
 				distributeStartTime:             1100,
 				distributeEndTime:               2000,
 			},
 			rewardPerDepositX128:      u256.NewUint(1000),
-			currentHeight:             150,
 			currentTime:               1100,
 			expectedAccumulatedReward: "6000",
-			expectedAccumulatedHeight: 150,
 			expectedAccumulatedTime:   1100,
 			expectNoUpdate:            false,
 		},
@@ -1893,16 +1833,13 @@ func TestRewardManager_addRewardPerDepositX128(t *testing.T) {
 			name: "current time past distribute end time - capped",
 			managerValues: managerTestValues{
 				accumulatedRewardPerDepositX128: u256.NewUint(5000),
-				accumulatedHeight:               100,
 				accumulatedTime:                 1000,
 				distributeStartTime:             900,
 				distributeEndTime:               1500,
 			},
 			rewardPerDepositX128:      u256.NewUint(1000),
-			currentHeight:             200,
 			currentTime:               2000,
 			expectedAccumulatedReward: "6000",
-			expectedAccumulatedHeight: 200,
 			expectedAccumulatedTime:   1500,
 			expectNoUpdate:            false,
 		},
@@ -1910,16 +1847,13 @@ func TestRewardManager_addRewardPerDepositX128(t *testing.T) {
 			name: "current time equals distribute end time - boundary",
 			managerValues: managerTestValues{
 				accumulatedRewardPerDepositX128: u256.NewUint(5000),
-				accumulatedHeight:               100,
 				accumulatedTime:                 1000,
 				distributeStartTime:             900,
 				distributeEndTime:               1500,
 			},
 			rewardPerDepositX128:      u256.NewUint(1000),
-			currentHeight:             150,
 			currentTime:               1500,
 			expectedAccumulatedReward: "6000",
-			expectedAccumulatedHeight: 150,
 			expectedAccumulatedTime:   1500,
 			expectNoUpdate:            false,
 		},
@@ -1927,20 +1861,17 @@ func TestRewardManager_addRewardPerDepositX128(t *testing.T) {
 			name: "very large accumulated reward",
 			managerValues: managerTestValues{
 				accumulatedRewardPerDepositX128: u256.Zero().Sub(u256.MustFromDecimal("340282366920938463463374607431768211455"), u256.NewUint(1000)),
-				accumulatedHeight:               100,
 				accumulatedTime:                 1000,
 				distributeStartTime:             900,
 				distributeEndTime:               2000,
 			},
 			rewardPerDepositX128: u256.NewUint(500),
-			currentHeight:        150,
 			currentTime:          1100,
 			expectedAccumulatedReward: func() string {
 				maxUint128 := u256.MustFromDecimal("340282366920938463463374607431768211455")
 				result := u256.Zero().Sub(maxUint128, u256.NewUint(500))
 				return result.ToString()
 			}(),
-			expectedAccumulatedHeight: 150,
 			expectedAccumulatedTime:   1100,
 			expectNoUpdate:            false,
 		},
@@ -1948,16 +1879,13 @@ func TestRewardManager_addRewardPerDepositX128(t *testing.T) {
 			name: "very small reward addition",
 			managerValues: managerTestValues{
 				accumulatedRewardPerDepositX128: u256.NewUint(1000000),
-				accumulatedHeight:               100,
 				accumulatedTime:                 1000,
 				distributeStartTime:             900,
 				distributeEndTime:               2000,
 			},
 			rewardPerDepositX128:      u256.NewUint(1),
-			currentHeight:             150,
 			currentTime:               1100,
 			expectedAccumulatedReward: "1000001",
-			expectedAccumulatedHeight: 150,
 			expectedAccumulatedTime:   1100,
 			expectNoUpdate:            false,
 		},
@@ -1965,16 +1893,13 @@ func TestRewardManager_addRewardPerDepositX128(t *testing.T) {
 			name: "multiple conditions - both time checks pass",
 			managerValues: managerTestValues{
 				accumulatedRewardPerDepositX128: u256.NewUint(1000),
-				accumulatedHeight:               100,
 				accumulatedTime:                 1000,
 				distributeStartTime:             1000,
 				distributeEndTime:               2000,
 			},
 			rewardPerDepositX128:      u256.NewUint(500),
-			currentHeight:             150,
 			currentTime:               1500,
 			expectedAccumulatedReward: "1500",
-			expectedAccumulatedHeight: 150,
 			expectedAccumulatedTime:   1500,
 			expectNoUpdate:            false,
 		},
@@ -1983,23 +1908,20 @@ func TestRewardManager_addRewardPerDepositX128(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// given
-			manager := launchpad.NewRewardManager(0, 0, 0, 0, 0, 0)
+			manager := launchpad.NewRewardManager(0, 0, 0, 0, 0)
 			manager.SetAccumulatedRewardPerDepositX128(tt.managerValues.accumulatedRewardPerDepositX128)
-			manager.SetAccumulatedHeight(tt.managerValues.accumulatedHeight)
 			manager.SetAccumulatedTime(tt.managerValues.accumulatedTime)
 			manager.SetDistributeStartTime(tt.managerValues.distributeStartTime)
 			manager.SetDistributeEndTime(tt.managerValues.distributeEndTime)
 
 			// Store initial state
 			initialReward := manager.AccumulatedRewardPerDepositX128().ToString()
-			initialHeight := manager.AccumulatedHeight()
 			initialTime := manager.AccumulatedTime()
 
 			// when
 			err := addRewardPerDepositX128(
 				manager,
 				tt.rewardPerDepositX128,
-				tt.currentHeight,
 				tt.currentTime,
 			)
 
@@ -2009,12 +1931,10 @@ func TestRewardManager_addRewardPerDepositX128(t *testing.T) {
 			if tt.expectNoUpdate {
 				// Verify no update occurred
 				uassert.Equal(t, initialReward, manager.AccumulatedRewardPerDepositX128().ToString())
-				uassert.Equal(t, initialHeight, manager.AccumulatedHeight())
 				uassert.Equal(t, initialTime, manager.AccumulatedTime())
 			} else {
 				// Verify update occurred with correct values
 				uassert.Equal(t, tt.expectedAccumulatedReward, manager.AccumulatedRewardPerDepositX128().ToString())
-				uassert.Equal(t, tt.expectedAccumulatedHeight, manager.AccumulatedHeight())
 				uassert.Equal(t, tt.expectedAccumulatedTime, manager.AccumulatedTime())
 			}
 		})
@@ -2054,7 +1974,6 @@ func TestRewardManager_addRewardState(t *testing.T) {
 				900,
 				2000,
 				0,
-				100,
 				1000,
 			)
 

--- a/contract/r/gnoswap/launchpad/v1/reward_manager_test.gno
+++ b/contract/r/gnoswap/launchpad/v1/reward_manager_test.gno
@@ -43,7 +43,7 @@ func TestRewardManager_IsInitialized(t *testing.T) {
 			for k, v := range tt.rewardStates {
 				tree.Set(k, v)
 			}
-			manager := newRewardManager(1000000, 100, 200, 0, 100)
+			manager := newRewardManager(1000000, 100, 200, 0)
 			manager.SetRewards(tree)
 
 			// Execute
@@ -101,7 +101,6 @@ func TestRewardManager_UpdateRewardPerDepositX128(t *testing.T) {
 				distributeStartTime,
 				distributeEndTime,
 				0,
-				distributeStartTime,
 			)
 
 			// Execute
@@ -197,7 +196,6 @@ func TestRewardManager_AddRewardStateByDeposit(t *testing.T) {
 				tt.distributeStart,
 				tt.distributeEnd,
 				0,
-				tt.distributeStart,
 			)
 
 			totalDepositAmount := int64(0)
@@ -295,7 +293,6 @@ func TestRewardManager_CollectReward(t *testing.T) {
 				tt.distributeStartTime,
 				tt.distributeEndTime,
 				0,
-				tt.distributeStartTime,
 			)
 
 			for _, deposit := range tt.existingDeposits {
@@ -358,7 +355,6 @@ func TestnewRewardManager(t *testing.T) {
 				distributeStartTime,
 				distributeEndTime,
 				0,
-				distributeStartTime,
 			)
 
 			// Verify
@@ -382,7 +378,6 @@ func TestTimestampBasedRewardCalculation_ConstantTime(t *testing.T) {
 		distributeStartTime,
 		distributeEndTime,
 		0,
-		distributeStartTime,
 	)
 
 	// Create two deposits to test reward distribution
@@ -465,7 +460,6 @@ func TestTimestampBasedRewardCalculation_VariableBlockTime(t *testing.T) {
 		distributeStartTime,
 		distributeEndTime,
 		0,
-		distributeStartTime,
 	)
 
 	// Create first deposit at start
@@ -546,7 +540,6 @@ func TestRewardManager_VaryingBlockTime_FastBlocks(t *testing.T) {
 		distributeStartTime,
 		distributeEndTime,
 		0,
-		distributeStartTime,
 	)
 
 	// Add deposit at start
@@ -593,7 +586,6 @@ func TestRewardManager_VaryingBlockTime_SlowBlocks(t *testing.T) {
 		distributeStartTime,
 		distributeEndTime,
 		0,
-		distributeStartTime,
 	)
 
 	// Add deposit at start
@@ -640,7 +632,6 @@ func TestRewardManager_VaryingBlockTime_IrregularBlocks(t *testing.T) {
 		distributeStartTime,
 		distributeEndTime,
 		0,
-		distributeStartTime,
 	)
 
 	// Add deposit at start
@@ -683,7 +674,6 @@ func TestRewardManager_EdgeCase_ZeroDuration(t *testing.T) {
 		distributeStartTime,
 		distributeEndTime,
 		0,
-		distributeStartTime,
 	)
 
 	// Should have zero distribute amount per second
@@ -703,7 +693,6 @@ func TestRewardManager_EdgeCase_TimeGoesBackward(t *testing.T) {
 		distributeStartTime,
 		distributeEndTime,
 		0,
-		distributeStartTime,
 	)
 
 	// Add deposit
@@ -743,7 +732,6 @@ func TestRewardManager_EdgeCase_RewardAfterEnd(t *testing.T) {
 		distributeStartTime,
 		distributeEndTime,
 		0,
-		distributeStartTime,
 	)
 
 	// Add deposit
@@ -784,7 +772,6 @@ func TestRewardManager_MultipleDeposits_DifferentTimings(t *testing.T) {
 		distributeStartTime,
 		distributeEndTime,
 		0,
-		distributeStartTime,
 	)
 
 	// Deposit 1: Joins at start
@@ -908,7 +895,6 @@ func TestRewardManager_ClaimableTimeOverflow(t *testing.T) {
 				now,
 				tt.distributeEndTime,
 				0,
-				now,
 			)
 			manager.SetRewardClaimableDuration(tt.claimableDuration)
 
@@ -974,7 +960,6 @@ func TestRewardManager_ClaimedAmountOverflow(t *testing.T) {
 				distributeStart,
 				distributeEnd,
 				0,
-				distributeStart,
 			)
 			manager.SetRewardClaimableDuration(100)
 
@@ -1065,7 +1050,6 @@ func TestRewardManager_TotalClaimedAmountOverflow(t *testing.T) {
 				distributeStart,
 				distributeEnd,
 				0,
-				distributeStart,
 			)
 			manager.SetRewardClaimableDuration(100)
 			manager.SetTotalClaimedAmount(tt.initialTotal)
@@ -1130,7 +1114,6 @@ func TestRewardManager_calculateRewardPerDepositX128(t *testing.T) {
 					1000,
 					2000,
 					0,
-					1000,
 				)
 				return manager
 			},
@@ -1159,7 +1142,6 @@ func TestRewardManager_calculateRewardPerDepositX128(t *testing.T) {
 					1000,
 					2000,
 					0,
-					1000,
 				)
 
 				manager.SetAccumulatedTime(800)
@@ -1192,7 +1174,6 @@ func TestRewardManager_calculateRewardPerDepositX128(t *testing.T) {
 					1000,
 					2000,
 					0,
-					1000,
 				)
 				manager.SetAccumulatedTime(1000)
 				manager.SetDistributeStartTime(900)
@@ -1213,7 +1194,6 @@ func TestRewardManager_calculateRewardPerDepositX128(t *testing.T) {
 					1000,
 					2000,
 					0,
-					1000,
 				)
 				manager.SetAccumulatedTime(1000)
 				manager.SetDistributeStartTime(900)
@@ -1238,7 +1218,6 @@ func TestRewardManager_calculateRewardPerDepositX128(t *testing.T) {
 					1000,
 					2000,
 					0,
-					1000,
 				)
 				manager.SetAccumulatedTime(2100)
 				manager.SetDistributeStartTime(1000)
@@ -1259,7 +1238,6 @@ func TestRewardManager_calculateRewardPerDepositX128(t *testing.T) {
 					1000,
 					2000,
 					0,
-					1000,
 				)
 				manager.SetAccumulatedTime(2000)
 				manager.SetDistributeStartTime(1000)
@@ -1280,7 +1258,6 @@ func TestRewardManager_calculateRewardPerDepositX128(t *testing.T) {
 					1000,
 					2000,
 					0,
-					1000,
 				)
 				manager.SetAccumulatedTime(1000)
 				manager.SetDistributeStartTime(900)
@@ -1311,7 +1288,6 @@ func TestRewardManager_calculateRewardPerDepositX128(t *testing.T) {
 					1000,
 					2000,
 					0,
-					1000,
 				)
 				manager.SetAccumulatedTime(1000)
 				manager.SetDistributeStartTime(900)
@@ -1341,7 +1317,6 @@ func TestRewardManager_calculateRewardPerDepositX128(t *testing.T) {
 					1000,
 					2000,
 					0,
-					1000,
 				)
 				manager.SetAccumulatedTime(1000)
 				manager.SetDistributeStartTime(900)
@@ -1362,7 +1337,6 @@ func TestRewardManager_calculateRewardPerDepositX128(t *testing.T) {
 					1000,
 					2000,
 					0,
-					1000,
 				)
 				manager.SetAccumulatedTime(1000)
 				manager.SetDistributeStartTime(900)
@@ -1383,7 +1357,6 @@ func TestRewardManager_calculateRewardPerDepositX128(t *testing.T) {
 					1000,
 					2000,
 					0,
-					1000,
 				)
 				manager.SetAccumulatedTime(1000)
 				manager.SetDistributeStartTime(900)
@@ -1413,7 +1386,6 @@ func TestRewardManager_calculateRewardPerDepositX128(t *testing.T) {
 					1000,
 					2000,
 					0,
-					1000,
 				)
 				manager.SetAccumulatedTime(1000)
 				manager.SetDistributeStartTime(900)
@@ -1444,7 +1416,6 @@ func TestRewardManager_calculateRewardPerDepositX128(t *testing.T) {
 					1000,
 					2000,
 					0,
-					1000,
 				)
 				manager.SetAccumulatedTime(1000)
 				manager.SetDistributeStartTime(900)
@@ -1675,7 +1646,6 @@ func TestRewardManager_updateDistributeAmountPerSecondX128(t *testing.T) {
 				tt.distributeStartTime,
 				tt.distributeEndTime,
 				0,
-				tt.distributeStartTime,
 			)
 
 			// Store initial state
@@ -1964,7 +1934,6 @@ func TestRewardManager_addRewardState(t *testing.T) {
 				900,
 				2000,
 				0,
-				900,
 			)
 
 			deposit := launchpad.NewDeposit(

--- a/contract/r/scenario/getter/launchpad_getter_filetest.gno
+++ b/contract/r/scenario/getter/launchpad_getter_filetest.gno
@@ -500,13 +500,6 @@ func testRewardManagerGetters(projectTier30Id, projectTier90Id, projectTier180Id
 	}
 	println("[EXPECTED] Accumulated distribute amount:", accDistributeAmount)
 
-	// GetProjectTierRewardAccumulatedHeight
-	accHeight, err := launchpad.GetProjectTierRewardAccumulatedHeight(projectTier30Id)
-	if err != nil {
-		panic(err)
-	}
-	println("[EXPECTED] Accumulated height:", accHeight)
-
 	// GetProjectTierRewardAccumulatedTime
 	accTime, err := launchpad.GetProjectTierRewardAccumulatedTime(projectTier30Id)
 	if err != nil {
@@ -663,7 +656,6 @@ func testRewardStateGetters(projectTierId, depositId string) {
 // [EXPECTED] Distribute start time: 1235172690
 // [EXPECTED] Distribute end time: 1237764690
 // [EXPECTED] Accumulated distribute amount: 0
-// [EXPECTED] Accumulated height: 0
 // [EXPECTED] Accumulated time: 0
 // [EXPECTED] Reward claimable duration: 86400
 //

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/getter.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/getter.gno
@@ -514,16 +514,6 @@ func (lp *launchpadV1) GetProjectTierRewardAccumulatedDistributeAmount(projectTi
 	return manager.AccumulatedDistributeAmount(), nil
 }
 
-// GetProjectTierRewardAccumulatedHeight returns the accumulated height of a reward manager.
-// Returns 0 and error if reward manager not found.
-func (lp *launchpadV1) GetProjectTierRewardAccumulatedHeight(projectTierId string) (int64, error) {
-	manager, err := lp.GetProjectTierRewardManager(projectTierId)
-	if err != nil {
-		return 0, err
-	}
-
-	return manager.AccumulatedHeight(), nil
-}
 
 // GetProjectTierRewardAccumulatedTime returns the accumulated time of a reward manager.
 // Returns 0 and error if reward manager not found.

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_deposit.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_deposit.gno
@@ -148,7 +148,7 @@ func (lp *launchpadV1) depositGns(
 
 	rewardState := addRewardStateByDeposit(rewardManager, deposit)
 
-	err = updateRewardPerDepositX128(rewardManager, getTierCurrentDepositAmount(projectTier), currentHeight, currentTime)
+	err = updateRewardPerDepositX128(rewardManager, getTierCurrentDepositAmount(projectTier), currentTime)
 	if err != nil {
 		return nil, nil, false, "", err
 	}

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_project.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_project.gno
@@ -194,7 +194,6 @@ func (lp *launchpadV1) createProject(params *createProjectParams) (*launchpad.Pr
 			projectTier.StartTime(),
 			projectTier.EndTime(),
 			rewardCollectableDuration,
-			params.startTime,
 			params.startTime+tierDurationTime,
 		))
 	}

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_project.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_project.gno
@@ -194,7 +194,7 @@ func (lp *launchpadV1) createProject(params *createProjectParams) (*launchpad.Pr
 			projectTier.StartTime(),
 			projectTier.EndTime(),
 			rewardCollectableDuration,
-			params.startTime+tierDurationTime,
+			params.currentTime,
 		))
 	}
 

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_project.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_project.gno
@@ -194,7 +194,6 @@ func (lp *launchpadV1) createProject(params *createProjectParams) (*launchpad.Pr
 			projectTier.StartTime(),
 			projectTier.EndTime(),
 			rewardCollectableDuration,
-			params.currentTime,
 		))
 	}
 

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_reward.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_reward.gno
@@ -64,7 +64,7 @@ func (lp *launchpadV1) collectDepositReward(deposit *launchpad.Deposit, currentH
 	}
 
 	// Update reward state before collection
-	err = updateRewardPerDepositX128(rewardManager, getTierCurrentDepositAmount(projectTier), currentHeight, currentTime)
+	err = updateRewardPerDepositX128(rewardManager, getTierCurrentDepositAmount(projectTier), currentTime)
 	if err != nil {
 		return 0, err
 	}

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_withdraw.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_withdraw.gno
@@ -96,7 +96,7 @@ func (lp *launchpadV1) withdrawDeposit(deposit *launchpad.Deposit, currentHeight
 	}
 
 	// Update rewards with current deposit amount
-	err = updateRewardPerDepositX128(rewardManager, getTierCurrentDepositAmount(projectTier), currentHeight, currentTime)
+	err = updateRewardPerDepositX128(rewardManager, getTierCurrentDepositAmount(projectTier), currentTime)
 	if err != nil {
 		return "", 0, err
 	}
@@ -105,7 +105,7 @@ func (lp *launchpadV1) withdrawDeposit(deposit *launchpad.Deposit, currentHeight
 	withdrawToTier(projectTier, deposit)
 
 	// Update rewards with new deposit amount after withdrawal
-	err = updateRewardPerDepositX128(rewardManager, getTierCurrentDepositAmount(projectTier), currentHeight, currentTime)
+	err = updateRewardPerDepositX128(rewardManager, getTierCurrentDepositAmount(projectTier), currentTime)
 	if err != nil {
 		return "", 0, err
 	}

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/reward_manager.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/reward_manager.gno
@@ -106,7 +106,7 @@ func addRewardState(r *launchpad.RewardManager, deposit *launchpad.Deposit, rewa
 	return rewardState
 }
 
-func addRewardPerDepositX128(r *launchpad.RewardManager, rewardPerDepositX128 *u256.Uint, currentHeight, currentTime int64) error {
+func addRewardPerDepositX128(r *launchpad.RewardManager, rewardPerDepositX128 *u256.Uint, currentTime int64) error {
 	if rewardPerDepositX128.IsZero() {
 		return nil
 	}
@@ -121,7 +121,6 @@ func addRewardPerDepositX128(r *launchpad.RewardManager, rewardPerDepositX128 *u
 
 	accumulated := u256.Zero().Add(r.AccumulatedRewardPerDepositX128(), rewardPerDepositX128)
 	r.SetAccumulatedRewardPerDepositX128(accumulated)
-	r.SetAccumulatedHeight(currentHeight)
 	r.SetAccumulatedTime(currentTime)
 
 	return nil
@@ -129,16 +128,15 @@ func addRewardPerDepositX128(r *launchpad.RewardManager, rewardPerDepositX128 *u
 
 // updateRewardPerDepositX128 updates the reward per deposit state.
 // This function calculates and updates the accumulated reward per deposit
-// based on the current total deposit amount and height.
+// based on the current total deposit amount.
 //
 // Parameters:
 // - totalDepositAmount (int64): Current total deposit amount
-// - height (int64): Current blockchain height
 // - time (int64): Current timestamp
 //
 // Returns:
 // - error: If the update fails
-func updateRewardPerDepositX128(r *launchpad.RewardManager, totalDepositAmount int64, currentHeight, currentTime int64) error {
+func updateRewardPerDepositX128(r *launchpad.RewardManager, totalDepositAmount int64, currentTime int64) error {
 	if currentTime <= 0 {
 		return makeErrorWithDetails(errInvalidTime, "time must be positive")
 	}
@@ -154,7 +152,7 @@ func updateRewardPerDepositX128(r *launchpad.RewardManager, totalDepositAmount i
 		return err
 	}
 
-	err = addRewardPerDepositX128(r, rewardPerDepositX128, currentHeight, currentTime)
+	err = addRewardPerDepositX128(r, rewardPerDepositX128, currentTime)
 	if err != nil {
 		return err
 	}
@@ -243,13 +241,12 @@ func newRewardManager(
 	distributeStartTime int64,
 	distributeEndTime int64,
 	rewardCollectableDuration int64,
-	currentHeight int64,
 	currentTime int64,
 ) *launchpad.RewardManager {
-	manager := launchpad.NewRewardManager(totalDistributeAmount, distributeStartTime, distributeEndTime, rewardCollectableDuration, currentHeight, currentTime)
+	manager := launchpad.NewRewardManager(totalDistributeAmount, distributeStartTime, distributeEndTime, rewardCollectableDuration, currentTime)
 
 	updateDistributeAmountPerSecondX128(manager, totalDistributeAmount, distributeStartTime, distributeEndTime)
-	updateRewardPerDepositX128(manager, 0, currentHeight, currentTime)
+	updateRewardPerDepositX128(manager, 0, currentTime)
 
 	return manager
 }

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/reward_manager.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/reward_manager.gno
@@ -243,7 +243,7 @@ func newRewardManager(
 	rewardCollectableDuration int64,
 	currentTime int64,
 ) *launchpad.RewardManager {
-	manager := launchpad.NewRewardManager(totalDistributeAmount, distributeStartTime, distributeEndTime, rewardCollectableDuration, currentTime)
+	manager := launchpad.NewRewardManager(totalDistributeAmount, distributeStartTime, distributeEndTime, rewardCollectableDuration)
 
 	updateDistributeAmountPerSecondX128(manager, totalDistributeAmount, distributeStartTime, distributeEndTime)
 	updateRewardPerDepositX128(manager, 0, currentTime)

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/reward_manager.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/reward_manager.gno
@@ -241,12 +241,10 @@ func newRewardManager(
 	distributeStartTime int64,
 	distributeEndTime int64,
 	rewardCollectableDuration int64,
-	currentTime int64,
 ) *launchpad.RewardManager {
 	manager := launchpad.NewRewardManager(totalDistributeAmount, distributeStartTime, distributeEndTime, rewardCollectableDuration)
 
 	updateDistributeAmountPerSecondX128(manager, totalDistributeAmount, distributeStartTime, distributeEndTime)
-	updateRewardPerDepositX128(manager, 0, currentTime)
 
 	return manager
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed accumulated-height tracking from the launchpad reward system.
  * Removed the public getter for project-tier accumulated height.

* **Refactoring**
  * Reward accumulation and update logic now use timestamps only (height removed).
  * Internal APIs and call sites simplified accordingly.
  * Tests updated to reflect time-only semantics and updated constructors/calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->