### PR TITLE
fix(staker): preserve zero-stake reward backlog

### DIFF
--- a/contract/r/gnoswap/gov/staker/v1/emission_reward_manager_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/emission_reward_manager_test.gno
@@ -674,7 +674,7 @@ func TestEmissionRewardManager_DistributeWithZeroTotalStake(t *testing.T) {
 		manager := staker.NewEmissionRewardManager()
 		resolver := NewEmissionRewardManagerResolver(manager)
 
-		// Distribute with zero stakes (should be no-op)
+		// Distribute with zero stakes (baseline is preserved for future backlog release)
 		_, err := resolver.calculateAccumulatedRewardX128PerStake(1000, 0)
 		uassert.NoError(t, err)
 
@@ -686,11 +686,33 @@ func TestEmissionRewardManager_DistributeWithZeroTotalStake(t *testing.T) {
 		accumulatedReward, err := resolver.calculateAccumulatedRewardX128PerStake(2000, 500)
 		uassert.NoError(t, err)
 
-		// then - Should calculate rewards correctly for new distribution only
-		// Delta = 2000 - 1000 = 1000 (previous distribution at zero stake doesn't count)
-		// But since distributed amount tracks cumulative, delta considers last update
-		// Reward per stake = 1000 * 2^128 / 500
+		// then - The preserved zero-stake backlog plus new distribution is considered.
 		uassert.NotEqual(t, accumulatedReward.ToString(), "0")
+	})
+
+	t.Run("pre-stake emission backlog becomes claimable after first stake", func(t *testing.T) {
+		manager := staker.NewEmissionRewardManager()
+		resolver := NewEmissionRewardManagerResolver(manager)
+
+		err := resolver.updateAccumulatedRewardX128PerStake(1000, 100)
+		uassert.NoError(t, err)
+		uassert.Equal(t, resolver.GetDistributedAmount(), int64(0))
+		uassert.Equal(t, resolver.GetAccumulatedTimestamp(), int64(0))
+		uassert.Equal(t, resolver.GetAccumulatedRewardX128PerStake().ToString(), "0")
+
+		err = resolver.addStake("user1", 500, 100)
+		uassert.NoError(t, err)
+
+		claimableBeforeRefresh, err := resolver.GetClaimableRewardAmount(1000, "user1", 100)
+		uassert.NoError(t, err)
+		uassert.Equal(t, claimableBeforeRefresh, int64(1000))
+
+		err = resolver.updateAccumulatedRewardX128PerStake(1500, 150)
+		uassert.NoError(t, err)
+
+		claimableAfterNewEmission, err := resolver.GetClaimableRewardAmount(1500, "user1", 150)
+		uassert.NoError(t, err)
+		uassert.Equal(t, claimableAfterNewEmission, int64(1500))
 	})
 }
 

--- a/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_manager.gno
+++ b/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_manager.gno
@@ -134,6 +134,11 @@ func (self *ProtocolFeeRewardManagerResolver) updateAccumulatedProtocolFeeX128Pe
 		return nil
 	}
 
+	// Preserve backlog while there are no active stakers.
+	if self.GetTotalStakedAmount() == 0 {
+		return nil
+	}
+
 	accumulatedProtocolFeeX128PerStake, changedProtocolFeeAmounts, err := self.calculateAccumulatedRewardX128PerStake(
 		protocolFeeAmounts,
 		currentTimestamp,

--- a/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_manager_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_manager_test.gno
@@ -614,6 +614,19 @@ func TestProtocolFeeRewardManager_updateAccumulatedProtocolFeeX128PerStake(t *te
 			shouldUpdate:     true,
 		},
 		{
+			name: "Should not update when no staked amount",
+			setupManager: func(m *ProtocolFeeRewardManagerResolver) {
+				m.SetAccumulatedTimestamp(50)
+				m.SetTotalStakedAmount(0)
+				m.SetProtocolFeeAmounts(map[string]int64{"token1": 500})
+			},
+			protocolFeeAmounts: map[string]int64{
+				"token1": 1000,
+			},
+			currentTimestamp: 100,
+			shouldUpdate:     false,
+		},
+		{
 			name: "Update with past timestamp preserves state",
 			setupManager: func(m *ProtocolFeeRewardManagerResolver) {
 				m.SetAccumulatedTimestamp(100)
@@ -633,6 +646,7 @@ func TestProtocolFeeRewardManager_updateAccumulatedProtocolFeeX128PerStake(t *te
 			resolver := NewProtocolFeeRewardManagerResolver(manager)
 			tt.setupManager(resolver)
 			initialTimestamp := resolver.GetAccumulatedTimestamp()
+			initialProtocolFeeAmounts := resolver.GetProtocolFeeAmounts()
 
 			// When: Update accumulated protocol fee X128 per stake
 			resolver.updateAccumulatedProtocolFeeX128PerStake(
@@ -645,9 +659,40 @@ func TestProtocolFeeRewardManager_updateAccumulatedProtocolFeeX128PerStake(t *te
 				uassert.Equal(t, resolver.GetAccumulatedTimestamp(), tt.currentTimestamp)
 			} else {
 				uassert.Equal(t, resolver.GetAccumulatedTimestamp(), initialTimestamp)
+				uassert.Equal(t, len(resolver.GetProtocolFeeAmounts()), len(initialProtocolFeeAmounts))
+				for token, amount := range initialProtocolFeeAmounts {
+					uassert.Equal(t, resolver.GetProtocolFeeAmount(token), amount)
+				}
 			}
 		})
 	}
+}
+
+func TestProtocolFeeRewardManager_ZeroStakeBacklogPreserved(t *testing.T) {
+	t.Run("pre-stake protocol fee backlog becomes claimable after first stake", func(t *testing.T) {
+		manager := staker.NewProtocolFeeRewardManager()
+		resolver := NewProtocolFeeRewardManagerResolver(manager)
+
+		protocolFeeAmounts := map[string]int64{"token1": 1000}
+		err := resolver.updateAccumulatedProtocolFeeX128PerStake(protocolFeeAmounts, 100)
+		uassert.NoError(t, err)
+		uassert.Equal(t, resolver.GetAccumulatedTimestamp(), int64(0))
+		uassert.Equal(t, len(resolver.GetProtocolFeeAmounts()), 0)
+
+		err = resolver.addStake("user1", 500, 100)
+		uassert.NoError(t, err)
+
+		claimableBeforeRefresh, err := resolver.GetClaimableRewardAmounts(protocolFeeAmounts, "user1", 100)
+		uassert.NoError(t, err)
+		uassert.Equal(t, claimableBeforeRefresh["token1"], int64(0))
+
+		err = resolver.updateAccumulatedProtocolFeeX128PerStake(map[string]int64{"token1": 1500}, 150)
+		uassert.NoError(t, err)
+
+		claimableAfterNewFees, err := resolver.GetClaimableRewardAmounts(map[string]int64{"token1": 1500}, "user1", 150)
+		uassert.NoError(t, err)
+		uassert.Equal(t, claimableAfterNewFees["token1"], int64(1500))
+	})
 }
 
 func TestProtocolFeeRewardManager_EdgeCases(t *testing.T) {

--- a/contract/r/gnoswap/gov/staker/v1/staker_reward_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/staker_reward_test.gno
@@ -678,7 +678,7 @@ func TestStakerReward_RewardCalculationAccuracy(t *testing.T) {
 			},
 			expectedEmission: 0,
 			expectedProtocol: map[string]int64{
-				GNS_PATH: 0,
+				GNS_PATH: 1_999_999_999,
 			},
 		},
 		{

--- a/contract/r/scenario/getter/gov_staker_getter_filetest.gno
+++ b/contract/r/scenario/getter/gov_staker_getter_filetest.gno
@@ -306,7 +306,7 @@ func testGovStakerGetters(delegationId1 int64) {
 //
 // [EXPECTED] Protocol Fee Accumulated X128 Per Stake: 0
 // [EXPECTED] Protocol Fee Amounts: 0
-// [EXPECTED] Protocol Fee Accumulated Timestamp: 1234567890
+// [EXPECTED] Protocol Fee Accumulated Timestamp: 0
 //
 // [EXPECTED] Emission Accumulated X128 Per Stake: 0
 // [EXPECTED] Emission Distributed Amount: 0


### PR DESCRIPTION
## Summary
- stop gov staker protocol fee accounting from consuming zero-stake backlog so queued fees remain claimable after staking resumes
- restore emission backlog expectations and align reward accuracy coverage with the preserved-backlog policy
- add regression tests for zero-stake protocol fee backlog and verify `make test PKG=gno.land/r/gnoswap/gov/staker/v1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reward handling to preserve emission and protocol-fee rewards accumulated during periods when no stakes are active. These preserved rewards now become claimable once the first stake is added to the pool.

* **Tests**
  * Added and expanded test coverage to verify zero-stake reward backlog preservation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->