### PR TITLE
fix(staker): skip CollectReward state update when user reward is zero

### DIFF
--- a/contract/r/gnoswap/staker/v1/staker.gno
+++ b/contract/r/gnoswap/staker/v1/staker.gno
@@ -712,7 +712,7 @@ func (s *stakerV1) CollectReward(positionId uint64) (string, string, map[string]
 			"poolPath", depositResolver.TargetPoolPath(),
 			"recipient", depositResolver.Owner().String(),
 			"rewardToken", GNS_PATH,
-			"rewardAmount", formatAnyInt(internalRewardToUser),
+			"rewardAmount", formatAnyInt(reward.Internal),
 			"rewardToUser", rewardToUser,
 			"rewardToFee", formatAnyInt(internalRewardToFee),
 			"rewardPenalty", rewardPenalty,

--- a/contract/r/gnoswap/staker/v1/staker.gno
+++ b/contract/r/gnoswap/staker/v1/staker.gno
@@ -606,6 +606,7 @@ func (s *stakerV1) CollectReward(positionId uint64) (string, string, map[string]
 		)
 	}
 
+	internalReward := int64(0)
 	internalRewardToUser := int64(0)
 	internalRewardToFee := int64(0)
 	internalRewardPenalty := int64(0)
@@ -622,6 +623,7 @@ func (s *stakerV1) CollectReward(positionId uint64) (string, string, map[string]
 			panic(err.Error())
 		}
 
+		internalReward = reward.Internal
 		internalRewardToUser = toUser
 		internalRewardToFee = feeAmount
 		internalRewardPenalty = reward.InternalPenalty
@@ -712,7 +714,7 @@ func (s *stakerV1) CollectReward(positionId uint64) (string, string, map[string]
 			"poolPath", depositResolver.TargetPoolPath(),
 			"recipient", depositResolver.Owner().String(),
 			"rewardToken", GNS_PATH,
-			"rewardAmount", formatAnyInt(reward.Internal),
+			"rewardAmount", formatAnyInt(internalReward),
 			"rewardToUser", rewardToUser,
 			"rewardToFee", formatAnyInt(internalRewardToFee),
 			"rewardPenalty", rewardPenalty,

--- a/contract/r/gnoswap/staker/v1/staker.gno
+++ b/contract/r/gnoswap/staker/v1/staker.gno
@@ -480,7 +480,10 @@ func (s *stakerV1) CollectReward(positionId uint64) (string, string, map[string]
 	toUserExternalPenalty := make(map[string]int64)
 
 	for incentiveId, rewardAmount := range reward.External {
-		if rewardAmount == 0 && reward.ExternalPenalty[incentiveId] == 0 {
+		// Skip when user reward is zero.
+		// Do not update last collect time so the reward accrues until
+		// the next collection where a non-zero amount can be delivered.
+		if rewardAmount == 0 {
 			continue
 		}
 
@@ -603,10 +606,25 @@ func (s *stakerV1) CollectReward(positionId uint64) (string, string, map[string]
 		)
 	}
 
+	internalRewardToUser := int64(0)
+	internalRewardToFee := int64(0)
+	internalRewardPenalty := int64(0)
+
+	// Skip internal reward state update when user reward is zero (only penalty).
+	// Do not update last collect time so the reward accrues until the next
+	// collection where a non-zero amount can be delivered.
+	skipInternalUpdate := reward.Internal == 0
+
 	// internal reward to user
-	toUser, feeAmount, err := s.handleStakingRewardFee(GNS_PATH, reward.Internal, true)
-	if err != nil {
-		panic(err.Error())
+	if !skipInternalUpdate {
+		toUser, feeAmount, err := s.handleStakingRewardFee(GNS_PATH, reward.Internal, true)
+		if err != nil {
+			panic(err.Error())
+		}
+
+		internalRewardToUser = toUser
+		internalRewardToFee = feeAmount
+		internalRewardPenalty = reward.InternalPenalty
 	}
 
 	chain.Emit(
@@ -616,23 +634,23 @@ func (s *stakerV1) CollectReward(positionId uint64) (string, string, map[string]
 		"fromPositionId", formatUint(positionId),
 		"fromPoolPath", deposit.TargetPoolPath(),
 		"feeTokenPath", GNS_PATH,
-		"feeAmount", formatAnyInt(feeAmount),
+		"feeAmount", formatAnyInt(internalRewardToFee),
 		"currentTime", formatAnyInt(currentTime),
 		"currentHeight", formatAnyInt(blockHeight),
 	)
 
 	totalEmissionSent := s.store.GetTotalEmissionSent()
 
-	if toUser > 0 {
+	if internalRewardToUser > 0 {
 		// internal reward to user
-		totalEmissionSent = safeAddInt64(totalEmissionSent, toUser)
+		totalEmissionSent = safeAddInt64(totalEmissionSent, internalRewardToUser)
 		depositResolver.addCollectedInternalReward(reward.Internal)
 	}
 
-	if reward.InternalPenalty > 0 {
+	if internalRewardPenalty > 0 {
 		// internal penalty to community pool
-		totalEmissionSent = safeAddInt64(totalEmissionSent, reward.InternalPenalty)
-		depositResolver.addCollectedInternalReward(reward.InternalPenalty)
+		totalEmissionSent = safeAddInt64(totalEmissionSent, internalRewardPenalty)
+		depositResolver.addCollectedInternalReward(internalRewardPenalty)
 	}
 
 	// Unclaimable must be processed after regular rewards so that accumulated
@@ -642,34 +660,36 @@ func (s *stakerV1) CollectReward(positionId uint64) (string, string, map[string]
 		totalEmissionSent = safeAddInt64(totalEmissionSent, unClaimableInternal)
 	}
 
-	err = s.store.SetTotalEmissionSent(totalEmissionSent)
+	err := s.store.SetTotalEmissionSent(totalEmissionSent)
 	if err != nil {
 		panic(err)
 	}
 
-	// Update lastCollectTime for internal rewards (GNS emissions)
-	err = depositResolver.updateInternalRewardLastCollectTime(currentTime)
-	if err != nil {
-		panic(err)
+	if !skipInternalUpdate {
+		// Update lastCollectTime for internal rewards (GNS emissions)
+		err = depositResolver.updateInternalRewardLastCollectTime(currentTime)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	deposits := s.getDeposits()
 	deposits.set(positionId, deposit)
 
-	if toUser > 0 {
-		gns.Transfer(cross, deposit.Owner(), toUser)
+	if internalRewardToUser > 0 {
+		gns.Transfer(cross, deposit.Owner(), internalRewardToUser)
 	}
 
-	if reward.InternalPenalty > 0 {
-		gns.Transfer(cross, communityPoolAddr, reward.InternalPenalty)
+	if internalRewardPenalty > 0 {
+		gns.Transfer(cross, communityPoolAddr, internalRewardPenalty)
 	}
 
 	if unClaimableInternal > 0 {
 		gns.Transfer(cross, communityPoolAddr, unClaimableInternal)
 	}
 
-	rewardToUser := formatAnyInt(toUser)
-	rewardPenalty := formatAnyInt(reward.InternalPenalty)
+	rewardToUser := formatAnyInt(internalRewardToUser)
+	rewardPenalty := formatAnyInt(internalRewardPenalty)
 
 	poolPath := depositResolver.TargetPoolPath()
 	pool, _ := s.getPools().Get(poolPath)
@@ -691,9 +711,9 @@ func (s *stakerV1) CollectReward(positionId uint64) (string, string, map[string]
 		"poolPath", depositResolver.TargetPoolPath(),
 		"recipient", depositResolver.Owner().String(),
 		"rewardToken", GNS_PATH,
-		"rewardAmount", formatAnyInt(reward.Internal),
+		"rewardAmount", formatAnyInt(internalRewardToUser),
 		"rewardToUser", rewardToUser,
-		"rewardToFee", formatAnyInt(reward.Internal-toUser),
+		"rewardToFee", formatAnyInt(internalRewardToFee),
 		"rewardPenalty", rewardPenalty,
 		"rewardUnClaimableAmount", formatAnyInt(unClaimableInternal),
 		"currentTime", formatAnyInt(currentTime),

--- a/contract/r/gnoswap/staker/v1/staker.gno
+++ b/contract/r/gnoswap/staker/v1/staker.gno
@@ -625,19 +625,19 @@ func (s *stakerV1) CollectReward(positionId uint64) (string, string, map[string]
 		internalRewardToUser = toUser
 		internalRewardToFee = feeAmount
 		internalRewardPenalty = reward.InternalPenalty
-	}
 
-	chain.Emit(
-		"ProtocolFeeInternalReward",
-		"prevAddr", previousRealm.Address().String(),
-		"prevRealm", previousRealm.PkgPath(),
-		"fromPositionId", formatUint(positionId),
-		"fromPoolPath", deposit.TargetPoolPath(),
-		"feeTokenPath", GNS_PATH,
-		"feeAmount", formatAnyInt(internalRewardToFee),
-		"currentTime", formatAnyInt(currentTime),
-		"currentHeight", formatAnyInt(blockHeight),
-	)
+		chain.Emit(
+			"ProtocolFeeInternalReward",
+			"prevAddr", previousRealm.Address().String(),
+			"prevRealm", previousRealm.PkgPath(),
+			"fromPositionId", formatUint(positionId),
+			"fromPoolPath", deposit.TargetPoolPath(),
+			"feeTokenPath", GNS_PATH,
+			"feeAmount", formatAnyInt(internalRewardToFee),
+			"currentTime", formatAnyInt(currentTime),
+			"currentHeight", formatAnyInt(blockHeight),
+		)
+	}
 
 	totalEmissionSent := s.store.GetTotalEmissionSent()
 
@@ -691,38 +691,40 @@ func (s *stakerV1) CollectReward(positionId uint64) (string, string, map[string]
 	rewardToUser := formatAnyInt(internalRewardToUser)
 	rewardPenalty := formatAnyInt(internalRewardPenalty)
 
-	poolPath := depositResolver.TargetPoolPath()
-	pool, _ := s.getPools().Get(poolPath)
-	poolResolver := NewPoolResolver(pool)
+	if !skipInternalUpdate {
+		poolPath := depositResolver.TargetPoolPath()
+		pool, _ := s.getPools().Get(poolPath)
+		poolResolver := NewPoolResolver(pool)
 
-	// Get accumulator values for reward calculation tracking
-	_, globalAccX128 := poolResolver.CurrentGlobalRewardRatioAccumulation(currentTime)
-	stakedLiquidity := poolResolver.CurrentStakedLiquidity(currentTime)
-	lowerTickResolver := poolResolver.TickResolver(deposit.TickLower())
-	upperTickResolver := poolResolver.TickResolver(deposit.TickUpper())
-	lowerOutsideAccX128 := lowerTickResolver.CurrentOutsideAccumulation(currentTime)
-	upperOutsideAccX128 := upperTickResolver.CurrentOutsideAccumulation(currentTime)
+		// Get accumulator values for reward calculation tracking
+		_, globalAccX128 := poolResolver.CurrentGlobalRewardRatioAccumulation(currentTime)
+		stakedLiquidity := poolResolver.CurrentStakedLiquidity(currentTime)
+		lowerTickResolver := poolResolver.TickResolver(deposit.TickLower())
+		upperTickResolver := poolResolver.TickResolver(deposit.TickUpper())
+		lowerOutsideAccX128 := lowerTickResolver.CurrentOutsideAccumulation(currentTime)
+		upperOutsideAccX128 := upperTickResolver.CurrentOutsideAccumulation(currentTime)
 
-	chain.Emit(
-		"CollectReward",
-		"prevAddr", previousRealm.Address().String(),
-		"prevRealm", previousRealm.PkgPath(),
-		"positionId", formatUint(positionId),
-		"poolPath", depositResolver.TargetPoolPath(),
-		"recipient", depositResolver.Owner().String(),
-		"rewardToken", GNS_PATH,
-		"rewardAmount", formatAnyInt(internalRewardToUser),
-		"rewardToUser", rewardToUser,
-		"rewardToFee", formatAnyInt(internalRewardToFee),
-		"rewardPenalty", rewardPenalty,
-		"rewardUnClaimableAmount", formatAnyInt(unClaimableInternal),
-		"currentTime", formatAnyInt(currentTime),
-		"currentHeight", formatAnyInt(blockHeight),
-		"stakedLiquidity", stakedLiquidity.ToString(),
-		"globalRewardRatioAccX128", globalAccX128,
-		"lowerTickOutsideAccX128", lowerOutsideAccX128.ToString(),
-		"upperTickOutsideAccX128", upperOutsideAccX128.ToString(),
-	)
+		chain.Emit(
+			"CollectReward",
+			"prevAddr", previousRealm.Address().String(),
+			"prevRealm", previousRealm.PkgPath(),
+			"positionId", formatUint(positionId),
+			"poolPath", depositResolver.TargetPoolPath(),
+			"recipient", depositResolver.Owner().String(),
+			"rewardToken", GNS_PATH,
+			"rewardAmount", formatAnyInt(internalRewardToUser),
+			"rewardToUser", rewardToUser,
+			"rewardToFee", formatAnyInt(internalRewardToFee),
+			"rewardPenalty", rewardPenalty,
+			"rewardUnClaimableAmount", formatAnyInt(unClaimableInternal),
+			"currentTime", formatAnyInt(currentTime),
+			"currentHeight", formatAnyInt(blockHeight),
+			"stakedLiquidity", stakedLiquidity.ToString(),
+			"globalRewardRatioAccX128", globalAccX128,
+			"lowerTickOutsideAccX128", lowerOutsideAccX128.ToString(),
+			"upperTickOutsideAccX128", upperOutsideAccX128.ToString(),
+		)
+	}
 
 	return rewardToUser, rewardPenalty, toUserExternalReward, toUserExternalPenalty
 }

--- a/contract/r/scenario/staker/collect_zero_reward_skip_external_filetest.gno
+++ b/contract/r/scenario/staker/collect_zero_reward_skip_external_filetest.gno
@@ -1,0 +1,372 @@
+// PKGPATH: gno.land/r/gnoswap/v1/main
+
+package main
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"gno.land/p/demo/tokens/grc721"
+	testutils "gno.land/p/nt/testutils/v0"
+	ufmt "gno.land/p/nt/ufmt/v0"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/common"
+	"gno.land/r/gnoswap/gnft"
+	"gno.land/r/gnoswap/gns"
+
+	pl "gno.land/r/gnoswap/pool"
+	pn "gno.land/r/gnoswap/position"
+	sr "gno.land/r/gnoswap/staker"
+
+	prabc "gno.land/p/gnoswap/rbac"
+	_ "gno.land/r/gnoswap/rbac"
+
+	_ "gno.land/r/gnoswap/pool/v1"
+	_ "gno.land/r/gnoswap/position/v1"
+	_ "gno.land/r/gnoswap/staker/v1"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/qux"
+)
+
+var (
+	adminAddr, _ = access.GetAddress(prabc.ROLE_ADMIN.String())
+	adminUser    = adminAddr
+	adminRealm   = testing.NewUserRealm(adminAddr)
+
+	// provider: mints 500,000 bar + 500,000 qux → liquidity 100,255,208
+	providerAddr  = testutils.TestAddress("provider")
+	providerUser  = providerAddr
+	providerRealm = testing.NewUserRealm(providerAddr)
+
+	// Target: mints 1,000 bar + 1,000 qux → liquidity 200,510 (share ≈ 0.001996%)
+	user1Addr  = testutils.TestAddress("user1")
+	user1User  = user1Addr
+	user1Realm = testing.NewUserRealm(user1Addr)
+
+	externalCreatorAddr  = testutils.TestAddress("externalCreator")
+	externalCreatorUser  = externalCreatorAddr
+	externalCreatorRealm = testing.NewUserRealm(externalCreatorAddr)
+
+	stakerAddr, _ = access.GetAddress(prabc.ROLE_STAKER.String())
+	poolAddr, _   = access.GetAddress(prabc.ROLE_POOL.String())
+
+	barPath = "gno.land/r/onbloc/bar"
+	quxPath = "gno.land/r/onbloc/qux"
+	gnsPath = "gno.land/r/gnoswap/gns"
+
+	fee100 uint32 = 100
+
+	maxTimeout int64 = 9999999999
+	maxInt64   int64 = 9223372036854775807
+
+	depositGnsAmount int64 = 1_000_000_000
+
+	INCENTIVE_DURATION int64 = 90 * 24 * 60 * 60 // 90 days
+	REWARD_AMOUNT      int64 = 1000000000        // 1,000,000,000 bar tokens (~128 bar/sec)
+
+	actualIncentiveID string
+)
+
+func main() {
+	println("[SCENARIO] Testing zero-reward skip behavior on CollectReward")
+	println()
+
+	println("[SCENARIO] 1. Initialize")
+	initialize()
+	println()
+
+	println("[SCENARIO] 2. Create pool (no internal tier, external-only)")
+	createPool()
+	println()
+
+	println("[SCENARIO] 3. Create and start 90-day external incentive (bar token)")
+	createAndStartIncentive()
+	println()
+
+	println("[SCENARIO] 4. provider mints 100255208 liquidity position and stakes")
+	providerMintAndStake()
+	println()
+
+	println("[SCENARIO] 5. User mints 200510 liquidity position and stakes (0.001996% share)")
+	userMintAndStake()
+	println()
+
+	println("[SCENARIO] 6. Collect at 5 sec (skip: 5 sec) → expect 0 bar (zero-reward skip)")
+	collectAfter5Sec(0)
+	println()
+
+	println("[SCENARIO] 7. Collect at 10 sec (skip: 5 sec) → expect 0 bar (zero-reward skip)")
+	collectAfter5Sec(0)
+	println()
+
+	println("[SCENARIO] 8. Collect at 15 sec (skip: 5 sec) → expect 0 bar (zero-reward skip)")
+	collectAfter5Sec(0)
+	println()
+
+	println("[SCENARIO] 9. Collect at 20 sec (skip: 5 sec) → expect 1 bar (first non-zero reward)")
+	collectAfter5Sec(1)
+	println()
+
+	println("[SCENARIO] 10. Collect at 25 sec (skip: 5 sec) → expect 0 bar (cycle resets after collect)")
+	collectAfter5Sec(0)
+	println()
+
+	println("[SCENARIO] 11. Collect at 30 sec (skip: 5 sec) → expect 0 bar (still accumulating)")
+	collectAfter5Sec(0)
+	println()
+
+	println("[SCENARIO] 12. Collect at 35 sec (skip: 5 sec) → expect 0 bar (still accumulating)")
+	collectAfter5Sec(0)
+	println()
+
+	println("[SCENARIO] 13. Collect at 40 sec (skip: 5 sec) → expect 1 bar (second non-zero reward)")
+	collectAfter5Sec(1)
+	println()
+
+	println("[SCENARIO] 14. Collect after 86,400 sec (1 day) → expect accumulated bar reward")
+	collectAfterOneDay()
+	println()
+}
+
+func initialize() {
+	testing.SetRealm(adminRealm)
+
+	sr.SetUnStakingFee(cross, 0)
+	pl.SetPoolCreationFee(cross, 0)
+	testing.SkipHeights(1)
+
+	bar.Transfer(cross, providerUser, 5000000)
+	qux.Transfer(cross, providerUser, 5000000)
+
+	bar.Transfer(cross, user1User, 5000000)
+	qux.Transfer(cross, user1User, 5000000)
+
+	// External creator gets bar tokens for reward + GNS for deposit
+	bar.Transfer(cross, externalCreatorUser, REWARD_AMOUNT)
+	gns.Transfer(cross, externalCreatorUser, depositGnsAmount)
+
+	println("[INFO] initialized accounts")
+}
+
+func createPool() {
+	testing.SetRealm(adminRealm)
+
+	testing.SkipHeights(1)
+	pl.CreatePool(
+		cross,
+		barPath,
+		quxPath,
+		fee100,
+		common.TickMathGetSqrtRatioAtTick(0).ToString(),
+	)
+
+	// NOTE: No SetPoolTier call — pool has no internal tier.
+	// External incentive alone makes it stakeable.
+	println("[INFO] created pool (external-only, no internal tier)")
+}
+
+func createAndStartIncentive() {
+	testing.SetRealm(externalCreatorRealm)
+
+	bar.Approve(cross, stakerAddr, maxInt64)
+	gns.Approve(cross, stakerAddr, maxInt64)
+
+	startTime := int64(1234569600) // +1 day midnight
+	endTime := startTime + INCENTIVE_DURATION
+
+	actualIncentiveID = ufmt.Sprintf("%s:%d:%d", externalCreatorAddr, time.Now().Unix(), 1)
+
+	sr.CreateExternalIncentive(
+		cross,
+		"gno.land/r/onbloc/bar:gno.land/r/onbloc/qux:100",
+		barPath, // reward in bar tokens (not GNS)
+		REWARD_AMOUNT,
+		startTime,
+		endTime,
+	)
+
+	// Skip to start time
+	nowTime := time.Now().Unix()
+	timeLeft := startTime - nowTime
+	blockLeft := timeLeft / 5
+	testing.SkipHeights(blockLeft)
+
+	ufmt.Printf("[INFO] created 90-day bar incentive (reward: %d, ~%d/sec)\n", REWARD_AMOUNT, REWARD_AMOUNT/INCENTIVE_DURATION)
+}
+
+func providerMintAndStake() {
+	testing.SetRealm(providerRealm)
+
+	bar.Approve(cross, poolAddr, maxInt64)
+	qux.Approve(cross, poolAddr, maxInt64)
+
+	testing.SkipHeights(1)
+	lpTokenId, liquidity, _, _ := pn.Mint(
+		cross,
+		barPath,
+		quxPath,
+		fee100,
+		int32(-100),
+		int32(100),
+		"500000",
+		"500000",
+		"1",
+		"1",
+		maxTimeout,
+		providerAddr,
+		providerAddr,
+		"",
+	)
+
+	gnft.Approve(cross, stakerAddr, positionIdFrom(int(lpTokenId)))
+	sr.StakeToken(cross, lpTokenId, "")
+
+	ufmt.Printf("[INFO] provider staked position %d (liquidity: %s)\n", lpTokenId, liquidity)
+}
+
+func userMintAndStake() {
+	testing.SetRealm(user1Realm)
+
+	bar.Approve(cross, poolAddr, maxInt64)
+	qux.Approve(cross, poolAddr, maxInt64)
+
+	testing.SkipHeights(1)
+	// Mint position with 1,000 bar + 1,000 qux → liquidity 200,510 (share ≈ 0.001996%)
+	lpTokenId, liquidity, _, _ := pn.Mint(
+		cross,
+		barPath,
+		quxPath,
+		fee100,
+		int32(-100),
+		int32(100),
+		"1000",
+		"1000",
+		"0",
+		"0",
+		maxTimeout,
+		user1Addr,
+		user1Addr,
+		"",
+	)
+
+	gnft.Approve(cross, stakerAddr, positionIdFrom(int(lpTokenId)))
+	sr.StakeToken(cross, lpTokenId, "")
+
+	ufmt.Printf("[INFO] user staked position %d (liquidity: %s, share ≈ 0.001996%%)\n", lpTokenId, liquidity)
+}
+
+func collectAfter5Sec(expectedReward int64) {
+	testing.SetRealm(user1Realm)
+
+	// Skip 1 block = 5 sec
+	// Each 5 sec: 128 bar/sec × 5 sec = 640 bar distributed to pool
+	// User raw per 5 sec: floor(640 × 200,510 / 100,455,718) ≈ 1
+	// Warmup 30%: floor(1 × 30 / 100) = 0 bar
+	//
+	// Because zero-reward skips do NOT advance lastCollectTime,
+	// rewards accumulate across skipped collections:
+	//   5 sec → raw 1, warmup 0 → skip (lastCollectTime unchanged)
+	//  10 sec → raw 2, warmup 0 → skip
+	//  15 sec → raw 3, warmup 0 → skip
+	//  20 sec → raw 5, warmup 1 → first non-zero reward
+	testing.SkipHeights(1)
+
+	barBefore := bar.BalanceOf(user1User)
+	sr.CollectReward(cross, 2)
+	barAfter := bar.BalanceOf(user1User)
+
+	reward := barAfter - barBefore
+	ufmt.Printf("[INFO] bar reward after 5 sec: %d (expected: %d)\n", reward, expectedReward)
+
+	if expectedReward >= 1 {
+		ufmt.Printf("[EXPECTED] first non-zero reward (%d bar) collected\n", reward)
+	} else {
+		println("[EXPECTED] zero reward, state not updated (lastCollectTime unchanged)")
+	}
+}
+
+func collectAfterOneDay() {
+	testing.SetRealm(user1Realm)
+
+	// Skip 17,280 blocks = 86,400 sec (1 day)
+	// lastCollectTime was set at 20 sec (step 9), so this covers 86,400 sec
+	// Cumulative since staking: 20 + 86,400 = 86,420 sec
+	// 128 bar/sec × 86,400 sec = 11,059,200 bar distributed
+	// User raw: floor(11,059,200 × 200,510 / 100,455,718) ≈ 22,072
+	// Warmup 30%: floor(22,072 × 30 / 100) = 6,622 bar
+	testing.SkipHeights(17280)
+
+	barBefore := bar.BalanceOf(user1User)
+	sr.CollectReward(cross, 2)
+	barAfter := bar.BalanceOf(user1User)
+
+	totalReward := barAfter - barBefore
+	ufmt.Printf("[INFO] bar reward after 1 day: %d\n", totalReward)
+
+	if totalReward > 0 {
+		println("[EXPECTED] accumulated reward collected successfully after 1 day")
+	} else {
+		println("[WARNING] no reward collected after 1 day")
+	}
+}
+
+func positionIdFrom(positionId int) grc721.TokenID {
+	return grc721.TokenID(strconv.Itoa(positionId))
+}
+
+// Output:
+// [SCENARIO] Testing zero-reward skip behavior on CollectReward
+//
+// [SCENARIO] 1. Initialize
+// [INFO] initialized accounts
+//
+// [SCENARIO] 2. Create pool (no internal tier, external-only)
+// [INFO] created pool (external-only, no internal tier)
+//
+// [SCENARIO] 3. Create and start 90-day external incentive (bar token)
+// [INFO] created 90-day bar incentive (reward: 1000000000, ~128/sec)
+//
+// [SCENARIO] 4. provider mints 100255208 liquidity position and stakes
+// [INFO] provider staked position 1 (liquidity: 100255208)
+//
+// [SCENARIO] 5. User mints 200510 liquidity position and stakes (0.001996% share)
+// [INFO] user staked position 2 (liquidity: 200510, share ≈ 0.001996%)
+//
+// [SCENARIO] 6. Collect at 5 sec (skip: 5 sec) → expect 0 bar (zero-reward skip)
+// [INFO] bar reward after 5 sec: 0 (expected: 0)
+// [EXPECTED] zero reward, state not updated (lastCollectTime unchanged)
+//
+// [SCENARIO] 7. Collect at 10 sec (skip: 5 sec) → expect 0 bar (zero-reward skip)
+// [INFO] bar reward after 5 sec: 0 (expected: 0)
+// [EXPECTED] zero reward, state not updated (lastCollectTime unchanged)
+//
+// [SCENARIO] 8. Collect at 15 sec (skip: 5 sec) → expect 0 bar (zero-reward skip)
+// [INFO] bar reward after 5 sec: 0 (expected: 0)
+// [EXPECTED] zero reward, state not updated (lastCollectTime unchanged)
+//
+// [SCENARIO] 9. Collect at 20 sec (skip: 5 sec) → expect 1 bar (first non-zero reward)
+// [INFO] bar reward after 5 sec: 1 (expected: 1)
+// [EXPECTED] first non-zero reward (1 bar) collected
+//
+// [SCENARIO] 10. Collect at 25 sec (skip: 5 sec) → expect 0 bar (cycle resets after collect)
+// [INFO] bar reward after 5 sec: 0 (expected: 0)
+// [EXPECTED] zero reward, state not updated (lastCollectTime unchanged)
+//
+// [SCENARIO] 11. Collect at 30 sec (skip: 5 sec) → expect 0 bar (still accumulating)
+// [INFO] bar reward after 5 sec: 0 (expected: 0)
+// [EXPECTED] zero reward, state not updated (lastCollectTime unchanged)
+//
+// [SCENARIO] 12. Collect at 35 sec (skip: 5 sec) → expect 0 bar (still accumulating)
+// [INFO] bar reward after 5 sec: 0 (expected: 0)
+// [EXPECTED] zero reward, state not updated (lastCollectTime unchanged)
+//
+// [SCENARIO] 13. Collect at 40 sec (skip: 5 sec) → expect 1 bar (second non-zero reward)
+// [INFO] bar reward after 5 sec: 1 (expected: 1)
+// [EXPECTED] first non-zero reward (1 bar) collected
+//
+// [SCENARIO] 14. Collect after 86,400 sec (1 day) → expect accumulated bar reward
+// [INFO] bar reward after 1 day: 6622
+// [EXPECTED] accumulated reward collected successfully after 1 day

--- a/contract/r/scenario/staker/collect_zero_reward_skip_external_multi_filetest.gno
+++ b/contract/r/scenario/staker/collect_zero_reward_skip_external_multi_filetest.gno
@@ -1,0 +1,380 @@
+// PKGPATH: gno.land/r/gnoswap/v1/main
+
+// POOLs:
+// 1. bar:qux:100 (no internal tier, two external incentives)
+
+// POSITIONs:
+// 1. provider: mints 500,000 bar + 500,000 qux → liquidity 100,255,208
+// 2. Target: mints 1,000 bar + 1,000 qux → liquidity 200,510 (share ≈ 0.001996%)
+
+// SCENARIO:
+// This test verifies that CollectReward handles multiple external incentives
+// independently. Two incentives with different reward rates are created:
+//
+// Incentive A (bar): 1,000,000,000 bar / 90 days → ~128 bar/sec (small)
+// Incentive B (qux): 10,000,000,000 qux / 90 days → ~1,286 qux/sec (large, 10x of A)
+//
+// At 5 sec with 0.001996% share:
+// - bar raw: floor(640 × 200,510 / 100,455,718) ≈ 1 → warmup 30%: 0 bar → SKIP
+// - qux raw: floor(6,430 × 200,510 / 100,455,718) ≈ 12 → warmup 30%: 3 qux → COLLECT
+//
+// Expected: qux is collected while bar is skipped (independent per incentive).
+// After sufficient time, bar also becomes non-zero and both are collected.
+
+package main
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"gno.land/p/demo/tokens/grc721"
+	testutils "gno.land/p/nt/testutils/v0"
+	ufmt "gno.land/p/nt/ufmt/v0"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/common"
+	"gno.land/r/gnoswap/gnft"
+	"gno.land/r/gnoswap/gns"
+
+	pl "gno.land/r/gnoswap/pool"
+	pn "gno.land/r/gnoswap/position"
+	sr "gno.land/r/gnoswap/staker"
+
+	prabc "gno.land/p/gnoswap/rbac"
+	_ "gno.land/r/gnoswap/rbac"
+
+	_ "gno.land/r/gnoswap/pool/v1"
+	_ "gno.land/r/gnoswap/position/v1"
+	_ "gno.land/r/gnoswap/staker/v1"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/qux"
+)
+
+var (
+	adminAddr, _ = access.GetAddress(prabc.ROLE_ADMIN.String())
+	adminUser    = adminAddr
+	adminRealm   = testing.NewUserRealm(adminAddr)
+
+	// provider: mints 500,000 bar + 500,000 qux → liquidity 100,255,208
+	providerAddr  = testutils.TestAddress("provider")
+	providerUser  = providerAddr
+	providerRealm = testing.NewUserRealm(providerAddr)
+
+	// Target: mints 1,000 bar + 1,000 qux → liquidity 200,510 (share ≈ 0.001996%)
+	user1Addr  = testutils.TestAddress("user1")
+	user1User  = user1Addr
+	user1Realm = testing.NewUserRealm(user1Addr)
+
+	externalCreatorAddr  = testutils.TestAddress("externalCreator")
+	externalCreatorUser  = externalCreatorAddr
+	externalCreatorRealm = testing.NewUserRealm(externalCreatorAddr)
+
+	stakerAddr, _ = access.GetAddress(prabc.ROLE_STAKER.String())
+	poolAddr, _   = access.GetAddress(prabc.ROLE_POOL.String())
+
+	barPath = "gno.land/r/onbloc/bar"
+	quxPath = "gno.land/r/onbloc/qux"
+
+	fee100 uint32 = 100
+
+	maxTimeout int64 = 9999999999
+	maxInt64   int64 = 9223372036854775807
+
+	depositGnsAmount int64 = 2_000_000_000
+
+	INCENTIVE_DURATION int64 = 90 * 24 * 60 * 60 // 90 days (7,776,000 sec)
+	BAR_REWARD_AMOUNT  int64 = 1_000_000_000     // ~128 bar/sec (small)
+	QUX_REWARD_AMOUNT  int64 = 10_000_000_000    // ~1,286 qux/sec (10x of bar)
+
+	poolPath = "gno.land/r/onbloc/bar:gno.land/r/onbloc/qux:100"
+)
+
+func main() {
+	println("[SCENARIO] Testing zero-reward skip with multiple external incentives (independent per incentive)")
+	println()
+
+	println("[SCENARIO] 1. Initialize")
+	initialize()
+	println()
+
+	println("[SCENARIO] 2. Create pool (no internal tier, external-only)")
+	createPool()
+	println()
+
+	println("[SCENARIO] 3. Create two external incentives: bar (~128/sec) and qux (~1,286/sec)")
+	createTwoExternalIncentives()
+	println()
+
+	println("[SCENARIO] 4. provider mints 100,255,208 liquidity position and stakes")
+	providerMintAndStake()
+	println()
+
+	println("[SCENARIO] 5. User mints 200,510 liquidity position and stakes (0.001996% share)")
+	userMintAndStake()
+	println()
+
+	println("[SCENARIO] 6. Collect at 5 sec → expect bar=0 (skip), qux>0 (collect)")
+	collectAt5Sec()
+	println()
+
+	println("[SCENARIO] 7. Collect at 25 sec → expect bar=1 and qux=15 (both collect)")
+	collectAt25Sec()
+	println()
+
+	println("[SCENARIO] 8. Collect after 86,400 sec (1 day) → expect bar=6,622, qux=66,532")
+	collectAfterOneDay()
+	println()
+}
+
+func initialize() {
+	testing.SetRealm(adminRealm)
+
+	sr.SetUnStakingFee(cross, 0)
+	pl.SetPoolCreationFee(cross, 0)
+	testing.SkipHeights(1)
+
+	bar.Transfer(cross, providerUser, 5000000)
+	qux.Transfer(cross, providerUser, 5000000)
+
+	bar.Transfer(cross, user1User, 5000000)
+	qux.Transfer(cross, user1User, 5000000)
+
+	// External creator gets tokens for both incentives + GNS deposit
+	bar.Transfer(cross, externalCreatorUser, BAR_REWARD_AMOUNT)
+	qux.Transfer(cross, externalCreatorUser, QUX_REWARD_AMOUNT)
+	gns.Transfer(cross, externalCreatorUser, depositGnsAmount)
+
+	println("[INFO] initialized accounts")
+}
+
+func createPool() {
+	testing.SetRealm(adminRealm)
+
+	testing.SkipHeights(1)
+	pl.CreatePool(
+		cross,
+		barPath,
+		quxPath,
+		fee100,
+		common.TickMathGetSqrtRatioAtTick(0).ToString(),
+	)
+
+	println("[INFO] created pool (external-only, no internal tier)")
+}
+
+func createTwoExternalIncentives() {
+	testing.SetRealm(externalCreatorRealm)
+
+	bar.Approve(cross, stakerAddr, maxInt64)
+	qux.Approve(cross, stakerAddr, maxInt64)
+	gns.Approve(cross, stakerAddr, maxInt64)
+
+	startTime := int64(1234569600) // +1 day midnight
+	endTime := startTime + INCENTIVE_DURATION
+
+	// Incentive A: bar token (~128 bar/sec) — small reward rate
+	sr.CreateExternalIncentive(
+		cross,
+		poolPath,
+		barPath,
+		BAR_REWARD_AMOUNT,
+		startTime,
+		endTime,
+	)
+
+	// Incentive B: qux token (~1,286 qux/sec) — 10x of bar
+	sr.CreateExternalIncentive(
+		cross,
+		poolPath,
+		quxPath,
+		QUX_REWARD_AMOUNT,
+		startTime,
+		endTime,
+	)
+
+	// Skip to start time
+	nowTime := time.Now().Unix()
+	timeLeft := startTime - nowTime
+	blockLeft := timeLeft / 5
+	testing.SkipHeights(blockLeft)
+
+	ufmt.Printf("[INFO] created bar incentive (~%d bar/sec) and qux incentive (~%d qux/sec)\n",
+		BAR_REWARD_AMOUNT/INCENTIVE_DURATION,
+		QUX_REWARD_AMOUNT/INCENTIVE_DURATION)
+}
+
+func providerMintAndStake() {
+	testing.SetRealm(providerRealm)
+
+	bar.Approve(cross, poolAddr, maxInt64)
+	qux.Approve(cross, poolAddr, maxInt64)
+
+	testing.SkipHeights(1)
+	lpTokenId, liquidity, _, _ := pn.Mint(
+		cross,
+		barPath,
+		quxPath,
+		fee100,
+		int32(-100),
+		int32(100),
+		"500000",
+		"500000",
+		"1",
+		"1",
+		maxTimeout,
+		providerAddr,
+		providerAddr,
+		"",
+	)
+
+	gnft.Approve(cross, stakerAddr, positionIdFrom(int(lpTokenId)))
+	sr.StakeToken(cross, lpTokenId, "")
+
+	ufmt.Printf("[INFO] provider staked position %d (liquidity: %s)\n", lpTokenId, liquidity)
+}
+
+func userMintAndStake() {
+	testing.SetRealm(user1Realm)
+
+	bar.Approve(cross, poolAddr, maxInt64)
+	qux.Approve(cross, poolAddr, maxInt64)
+
+	testing.SkipHeights(1)
+	// Mint position with 1,000 bar + 1,000 qux → liquidity 200,510 (share ≈ 0.001996%)
+	lpTokenId, liquidity, _, _ := pn.Mint(
+		cross,
+		barPath,
+		quxPath,
+		fee100,
+		int32(-100),
+		int32(100),
+		"1000",
+		"1000",
+		"0",
+		"0",
+		maxTimeout,
+		user1Addr,
+		user1Addr,
+		"",
+	)
+
+	gnft.Approve(cross, stakerAddr, positionIdFrom(int(lpTokenId)))
+	sr.StakeToken(cross, lpTokenId, "")
+
+	ufmt.Printf("[INFO] user staked position %d (liquidity: %s, share ≈ 0.001996%%)\n", lpTokenId, liquidity)
+}
+
+func collectAt5Sec() {
+	testing.SetRealm(user1Realm)
+
+	// Skip 1 block = 5 sec
+	// bar: 128/sec × 5 sec = 640, user raw ≈ 1, warmup 30% → 0 bar (SKIP)
+	// qux: 1,286/sec × 5 sec = 6,430, user raw ≈ 12, warmup 30% → 3 qux (COLLECT)
+	testing.SkipHeights(1)
+
+	barBefore := bar.BalanceOf(user1User)
+	quxBefore := qux.BalanceOf(user1User)
+	sr.CollectReward(cross, 2)
+	barAfter := bar.BalanceOf(user1User)
+	quxAfter := qux.BalanceOf(user1User)
+
+	barReward := barAfter - barBefore
+	quxReward := quxAfter - quxBefore
+	ufmt.Printf("[INFO] at 5 sec → bar: %d, qux: %d\n", barReward, quxReward)
+
+	if barReward == 0 && quxReward > 0 {
+		println("[EXPECTED] bar skipped (zero), qux collected (non-zero) → independent behavior")
+	} else if barReward == 0 && quxReward == 0 {
+		println("[INFO] both zero at 5 sec")
+	} else {
+		ufmt.Printf("[INFO] bar=%d, qux=%d\n", barReward, quxReward)
+	}
+}
+
+func collectAt25Sec() {
+	testing.SetRealm(user1Realm)
+
+	// Skip 4 more blocks = 20 sec → cumulative 25 sec
+	// bar: accumulated since staking (lastCollectTime not advanced due to skip)
+	//   128/sec × 25 sec = 3,200, user raw ≈ 6, warmup 30% → 1 bar
+	// qux: accumulated since last collect at 5 sec (lastCollectTime was advanced)
+	//   1,286/sec × 20 sec = 25,720, user raw ≈ 51, warmup 30% → 15 qux
+	testing.SkipHeights(4)
+
+	barBefore := bar.BalanceOf(user1User)
+	quxBefore := qux.BalanceOf(user1User)
+	sr.CollectReward(cross, 2)
+	barAfter := bar.BalanceOf(user1User)
+	quxAfter := qux.BalanceOf(user1User)
+
+	barReward := barAfter - barBefore
+	quxReward := quxAfter - quxBefore
+	ufmt.Printf("[INFO] at 25 sec → bar: %d, qux: %d\n", barReward, quxReward)
+
+	if barReward > 0 && quxReward > 0 {
+		println("[EXPECTED] both bar and qux collected (non-zero)")
+	} else {
+		ufmt.Printf("[INFO] bar=%d, qux=%d\n", barReward, quxReward)
+	}
+}
+
+func collectAfterOneDay() {
+	testing.SetRealm(user1Realm)
+
+	// Skip 17,280 blocks = 86,400 sec (1 day)
+	// bar: 128/sec × 86,400 sec × 0.001996% share → raw ≈ 22,072, warmup 30% → 6,622 bar
+	// qux: 1,286/sec × 86,400 sec × 0.001996% share → raw ≈ 221,776, warmup 30% → 66,532 qux
+	testing.SkipHeights(17280)
+
+	barBefore := bar.BalanceOf(user1User)
+	quxBefore := qux.BalanceOf(user1User)
+	sr.CollectReward(cross, 2)
+	barAfter := bar.BalanceOf(user1User)
+	quxAfter := qux.BalanceOf(user1User)
+
+	barReward := barAfter - barBefore
+	quxReward := quxAfter - quxBefore
+	ufmt.Printf("[INFO] after 1 day → bar: %d, qux: %d\n", barReward, quxReward)
+
+	if barReward > 0 && quxReward > 0 {
+		println("[EXPECTED] both external rewards accumulated after 1 day")
+	} else {
+		println("[WARNING] missing reward after 1 day")
+	}
+}
+
+func positionIdFrom(positionId int) grc721.TokenID {
+	return grc721.TokenID(strconv.Itoa(positionId))
+}
+
+// Output:
+// [SCENARIO] Testing zero-reward skip with multiple external incentives (independent per incentive)
+//
+// [SCENARIO] 1. Initialize
+// [INFO] initialized accounts
+//
+// [SCENARIO] 2. Create pool (no internal tier, external-only)
+// [INFO] created pool (external-only, no internal tier)
+//
+// [SCENARIO] 3. Create two external incentives: bar (~128/sec) and qux (~1,286/sec)
+// [INFO] created bar incentive (~128 bar/sec) and qux incentive (~1286 qux/sec)
+//
+// [SCENARIO] 4. provider mints 100,255,208 liquidity position and stakes
+// [INFO] provider staked position 1 (liquidity: 100255208)
+//
+// [SCENARIO] 5. User mints 200,510 liquidity position and stakes (0.001996% share)
+// [INFO] user staked position 2 (liquidity: 200510, share ≈ 0.001996%)
+//
+// [SCENARIO] 6. Collect at 5 sec → expect bar=0 (skip), qux>0 (collect)
+// [INFO] at 5 sec → bar: 0, qux: 3
+// [EXPECTED] bar skipped (zero), qux collected (non-zero) → independent behavior
+//
+// [SCENARIO] 7. Collect at 25 sec → expect bar=1 and qux=15 (both collect)
+// [INFO] at 25 sec → bar: 1, qux: 15
+// [EXPECTED] both bar and qux collected (non-zero)
+//
+// [SCENARIO] 8. Collect after 86,400 sec (1 day) → expect bar=6,622, qux=66,532
+// [INFO] after 1 day → bar: 6622, qux: 66532
+// [EXPECTED] both external rewards accumulated after 1 day

--- a/contract/r/scenario/staker/collect_zero_reward_skip_internal_filetest.gno
+++ b/contract/r/scenario/staker/collect_zero_reward_skip_internal_filetest.gno
@@ -1,0 +1,312 @@
+// PKGPATH: gno.land/r/gnoswap/v1/main
+
+// POOLs:
+// 1. bar:qux:100 (internal tier 1)
+//
+// POSITIONs:
+// 1. Provider: mints 5,000,000 bar + 5,000,000 qux → liquidity 1,002,552,082
+// 2. Target: mints 1 bar + 1 qux → liquidity 200 (share ≈ 0.00000002%)
+//
+// SCENARIO:
+// This test verifies that CollectReward skips state updates for internal (GNS)
+// rewards when warmup-applied reward is zero.
+//
+// GNS emission: ~8,026,540 GNS/block
+// User share: 200 / 1,002,552,282 ≈ 0.00000002%
+//   Per 5 sec (1 block): raw ≈ 1, warmup 30% → 0 GNS → SKIP
+//   Per 10 sec (2 blocks): raw ≈ 3, warmup 30% → 1 GNS → COLLECT
+//
+// Pattern: 0 → 1 → 0 → 1 → ... (alternating skip/collect every 5 sec)
+
+package main
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"gno.land/p/demo/tokens/grc721"
+	testutils "gno.land/p/nt/testutils/v0"
+	ufmt "gno.land/p/nt/ufmt/v0"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/common"
+	"gno.land/r/gnoswap/emission"
+	"gno.land/r/gnoswap/gnft"
+	"gno.land/r/gnoswap/gns"
+
+	pl "gno.land/r/gnoswap/pool"
+	pn "gno.land/r/gnoswap/position"
+	sr "gno.land/r/gnoswap/staker"
+
+	prabc "gno.land/p/gnoswap/rbac"
+	_ "gno.land/r/gnoswap/rbac"
+
+	_ "gno.land/r/gnoswap/pool/v1"
+	_ "gno.land/r/gnoswap/position/v1"
+	_ "gno.land/r/gnoswap/staker/v1"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/qux"
+)
+
+var (
+	adminAddr, _ = access.GetAddress(prabc.ROLE_ADMIN.String())
+	adminUser    = adminAddr
+	adminRealm   = testing.NewUserRealm(adminAddr)
+
+	providerAddr  = testutils.TestAddress("provider")
+	providerUser  = providerAddr
+	providerRealm = testing.NewUserRealm(providerAddr)
+
+	user1Addr  = testutils.TestAddress("user1")
+	user1User  = user1Addr
+	user1Realm = testing.NewUserRealm(user1Addr)
+
+	stakerAddr, _ = access.GetAddress(prabc.ROLE_STAKER.String())
+	poolAddr, _   = access.GetAddress(prabc.ROLE_POOL.String())
+
+	barPath = "gno.land/r/onbloc/bar"
+	quxPath = "gno.land/r/onbloc/qux"
+
+	fee100 uint32 = 100
+
+	maxTimeout int64 = 9999999999
+	maxInt64   int64 = 9223372036854775807
+)
+
+func main() {
+	println("[SCENARIO] Testing zero-reward skip behavior on CollectReward (internal GNS reward)")
+	println()
+
+	println("[SCENARIO] 1. Initialize")
+	initialize()
+	println()
+
+	println("[SCENARIO] 2. Create pool with internal tier 1")
+	createPool()
+	println()
+
+	println("[SCENARIO] 3. Provider mints position and stakes")
+	providerMintAndStake()
+	println()
+
+	println("[SCENARIO] 4. User mints tiny position (liquidity: 200) and stakes")
+	userMintAndStake()
+	println()
+
+	// 1st cycle: 5 sec → 0 (skip), 10 sec → 1 (collect)
+	println("[SCENARIO] 5. Collect at 5 sec → expect 0 GNS (zero-reward skip)")
+	collectGNSAfter5Sec(0)
+	println()
+
+	println("[SCENARIO] 6. Collect at 10 sec → expect 1 GNS (first non-zero reward)")
+	collectGNSAfter5Sec(1)
+	println()
+
+	// 2nd cycle: 15 sec → 0 (skip), 20 sec → 1 (collect)
+	println("[SCENARIO] 7. Collect at 15 sec → expect 0 GNS (cycle resets, skip again)")
+	collectGNSAfter5Sec(0)
+	println()
+
+	println("[SCENARIO] 8. Collect at 20 sec → expect 1 GNS (second non-zero reward)")
+	collectGNSAfter5Sec(1)
+	println()
+
+	// 3rd cycle: 25 sec → 0 (skip), 30 sec → 1 (collect)
+	println("[SCENARIO] 9. Collect at 25 sec → expect 0 GNS (skip)")
+	collectGNSAfter5Sec(0)
+	println()
+
+	println("[SCENARIO] 10. Collect at 30 sec → expect 1 GNS (third non-zero reward)")
+	collectGNSAfter5Sec(1)
+	println()
+
+	println("[SCENARIO] 11. Collect after 86,400 sec (1 day) → expect accumulated GNS")
+	collectGNSAfterOneDay()
+	println()
+}
+
+func initialize() {
+	testing.SetRealm(adminRealm)
+
+	// Enable GNS emission (required for internal rewards)
+	emission.SetDistributionStartTime(cross, time.Now().Unix()+1)
+	emission.MintAndDistributeGns(cross)
+	emission.MintAndDistributeGns(cross)
+
+	sr.SetUnStakingFee(cross, 0)
+	pl.SetPoolCreationFee(cross, 0)
+	testing.SkipHeights(1)
+
+	bar.Transfer(cross, providerUser, 5000000)
+	qux.Transfer(cross, providerUser, 5000000)
+
+	bar.Transfer(cross, user1User, 5000000)
+	qux.Transfer(cross, user1User, 5000000)
+
+	println("[INFO] initialized accounts with emission enabled")
+}
+
+func createPool() {
+	testing.SetRealm(adminRealm)
+
+	testing.SkipHeights(1)
+	pl.CreatePool(
+		cross,
+		barPath,
+		quxPath,
+		fee100,
+		common.TickMathGetSqrtRatioAtTick(0).ToString(),
+	)
+
+	// Set internal tier 1 → pool receives GNS emission
+	sr.SetPoolTier(cross, "gno.land/r/onbloc/bar:gno.land/r/onbloc/qux:100", 1)
+
+	println("[INFO] created pool with internal tier 1 (GNS emission enabled)")
+}
+
+func providerMintAndStake() {
+	testing.SetRealm(providerRealm)
+
+	bar.Approve(cross, poolAddr, maxInt64)
+	qux.Approve(cross, poolAddr, maxInt64)
+
+	testing.SkipHeights(1)
+	lpTokenId, liquidity, _, _ := pn.Mint(
+		cross,
+		barPath,
+		quxPath,
+		fee100,
+		int32(-100),
+		int32(100),
+		"5000000",
+		"5000000",
+		"1",
+		"1",
+		maxTimeout,
+		providerAddr,
+		providerAddr,
+		"",
+	)
+
+	gnft.Approve(cross, stakerAddr, positionIdFrom(int(lpTokenId)))
+	sr.StakeToken(cross, lpTokenId, "")
+
+	ufmt.Printf("[INFO] provider staked position %d (liquidity: %s)\n", lpTokenId, liquidity)
+}
+
+func userMintAndStake() {
+	testing.SetRealm(user1Realm)
+
+	bar.Approve(cross, poolAddr, maxInt64)
+	qux.Approve(cross, poolAddr, maxInt64)
+
+	testing.SkipHeights(1)
+	lpTokenId, liquidity, _, _ := pn.Mint(
+		cross,
+		barPath,
+		quxPath,
+		fee100,
+		int32(-100),
+		int32(100),
+		"1",
+		"1",
+		"0",
+		"0",
+		maxTimeout,
+		user1Addr,
+		user1Addr,
+		"",
+	)
+
+	gnft.Approve(cross, stakerAddr, positionIdFrom(int(lpTokenId)))
+	sr.StakeToken(cross, lpTokenId, "")
+
+	ufmt.Printf("[INFO] user staked position %d (liquidity: %s)\n", lpTokenId, liquidity)
+}
+
+func collectGNSAfter5Sec(expectedReward int64) {
+	testing.SetRealm(user1Realm)
+
+	testing.SkipHeights(1)
+
+	gnsBefore := gns.BalanceOf(user1User)
+	sr.CollectReward(cross, 2)
+	gnsAfter := gns.BalanceOf(user1User)
+
+	reward := gnsAfter - gnsBefore
+	ufmt.Printf("[INFO] GNS reward: %d (expected: %d)\n", reward, expectedReward)
+
+	if expectedReward >= 1 {
+		ufmt.Printf("[EXPECTED] non-zero GNS reward (%d) collected\n", reward)
+	} else {
+		println("[EXPECTED] zero GNS reward, state not updated (lastCollectTime unchanged)")
+	}
+}
+
+func collectGNSAfterOneDay() {
+	testing.SetRealm(user1Realm)
+
+	testing.SkipHeights(17280)
+
+	gnsBefore := gns.BalanceOf(user1User)
+	sr.CollectReward(cross, 2)
+	gnsAfter := gns.BalanceOf(user1User)
+
+	totalReward := gnsAfter - gnsBefore
+	ufmt.Printf("[INFO] GNS reward after 1 day: %d\n", totalReward)
+
+	if totalReward > 0 {
+		println("[EXPECTED] accumulated internal GNS reward collected after 1 day")
+	} else {
+		println("[WARNING] no internal GNS reward after 1 day")
+	}
+}
+
+func positionIdFrom(positionId int) grc721.TokenID {
+	return grc721.TokenID(strconv.Itoa(positionId))
+}
+
+// Output:
+// [SCENARIO] Testing zero-reward skip behavior on CollectReward (internal GNS reward)
+//
+// [SCENARIO] 1. Initialize
+// [INFO] initialized accounts with emission enabled
+//
+// [SCENARIO] 2. Create pool with internal tier 1
+// [INFO] created pool with internal tier 1 (GNS emission enabled)
+//
+// [SCENARIO] 3. Provider mints position and stakes
+// [INFO] provider staked position 1 (liquidity: 1002552082)
+//
+// [SCENARIO] 4. User mints tiny position (liquidity: 200) and stakes
+// [INFO] user staked position 2 (liquidity: 200)
+//
+// [SCENARIO] 5. Collect at 5 sec → expect 0 GNS (zero-reward skip)
+// [INFO] GNS reward: 0 (expected: 0)
+// [EXPECTED] zero GNS reward, state not updated (lastCollectTime unchanged)
+//
+// [SCENARIO] 6. Collect at 10 sec → expect 1 GNS (first non-zero reward)
+// [INFO] GNS reward: 1 (expected: 1)
+// [EXPECTED] non-zero GNS reward (1) collected
+//
+// [SCENARIO] 7. Collect at 15 sec → expect 0 GNS (cycle resets, skip again)
+// [INFO] GNS reward: 0 (expected: 0)
+// [EXPECTED] zero GNS reward, state not updated (lastCollectTime unchanged)
+//
+// [SCENARIO] 8. Collect at 20 sec → expect 1 GNS (second non-zero reward)
+// [INFO] GNS reward: 1 (expected: 1)
+// [EXPECTED] non-zero GNS reward (1) collected
+//
+// [SCENARIO] 9. Collect at 25 sec → expect 0 GNS (skip)
+// [INFO] GNS reward: 0 (expected: 0)
+// [EXPECTED] zero GNS reward, state not updated (lastCollectTime unchanged)
+//
+// [SCENARIO] 10. Collect at 30 sec → expect 1 GNS (third non-zero reward)
+// [INFO] GNS reward: 1 (expected: 1)
+// [EXPECTED] non-zero GNS reward (1) collected
+//
+// [SCENARIO] 11. Collect after 86,400 sec (1 day) → expect accumulated GNS
+// [INFO] GNS reward after 1 day: 13834
+// [EXPECTED] accumulated internal GNS reward collected after 1 day


### PR DESCRIPTION
## Summary

Fix `CollectReward` to skip state updates (including `lastCollectTime`) when the user's warmup-applied reward is zero. Previously, when a position's reward was zero but a penalty existed (due to warmup truncation), the state was still updated — advancing `lastCollectTime` and effectively discarding the accrued period. This caused tiny positions to permanently lose small rewards that should have accumulated over time.

### Changes

**`contract/r/gnoswap/staker/v1/staker.gno`**

- **External rewards**: Changed the skip condition from `rewardAmount == 0 && penalty == 0` to `rewardAmount == 0`. When user reward is zero, the entire external incentive update is skipped regardless of penalty, preserving `lastCollectTime` so rewards continue to accrue.
- **Internal rewards (GNS)**: Added `skipInternalUpdate` flag. When `reward.Internal == 0`, the fee handling, `lastCollectTime` update, penalty transfer, and emission tracking are all skipped. This prevents zero-reward collections from advancing the internal reward clock.

### Scenario Tests (3 new filetests)

| File | What it tests |
|------|---------------|
| `collect_zero_reward_skip_external_filetest.gno` | Single external incentive: collects every 5 sec, observes `0→0→0→1→0→0→0→1→...` pattern (20-sec cycle) |
| `collect_zero_reward_skip_internal_filetest.gno` | Internal GNS emission: same pattern with `0→1→0→1→...` (10-sec cycle due to higher emission rate) |
| `collect_zero_reward_skip_external_multi_filetest.gno` | Two external incentives (bar 128/sec, qux 1286/sec): verifies skip/collect is independent per incentive — bar=0 while qux>0 at 5 sec |

### Key Behavior

- Zero-reward skip does **not** advance `lastCollectTime`, so skipped periods are included in the next successful collection.
- Each external incentive is evaluated independently — one can skip while another collects.
- After sufficient accumulation, the full accrued amount is delivered (no reward loss).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * External incentive processing now continues correctly when a user's external reward is zero, preventing incorrect skips due to penalty checks or stale timestamps.

* **Refactor**
  * Reward collection avoids unnecessary internal payout steps, transfers, and protocol event emissions when there are no internal rewards, reducing redundant processing and noise in logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->