### PR TITLE
feat(staker): add CollectExternalIncentivePenalty function for penalty collection

### DIFF
--- a/contract/r/gnoswap/staker/_mock_test.gno
+++ b/contract/r/gnoswap/staker/_mock_test.gno
@@ -103,6 +103,11 @@ func (m *MockStaker) EndExternalIncentive(targetPoolPath, incentiveId string, re
 	m.Response.Get("EndExternalIncentive")
 }
 
+func (m *MockStaker) CollectExternalIncentivePenalty(targetPoolPath, incentiveId string, refundAddress address) int64 {
+	m.Response.Get("CollectExternalIncentivePenalty")
+	return 0
+}
+
 func (m *MockStaker) AddToken(tokenPath string) {
 	m.Response.Get("AddToken")
 }
@@ -206,6 +211,14 @@ func (m *MockStaker) GetIncentiveDistributedRewardAmount(poolPath string, incent
 
 func (m *MockStaker) GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) int64 {
 	res, ok := m.Response.Get("GetIncentiveRemainingRewardAmount")
+	if !ok {
+		return 0
+	}
+	return res[0].(int64)
+}
+
+func (m *MockStaker) GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) int64 {
+	res, ok := m.Response.Get("GetIncentiveAccumulatedPenaltyAmount")
 	if !ok {
 		return 0
 	}

--- a/contract/r/gnoswap/staker/getter.gno
+++ b/contract/r/gnoswap/staker/getter.gno
@@ -66,6 +66,11 @@ func GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) int6
 	return getImplementation().GetIncentiveRemainingRewardAmount(poolPath, incentiveId)
 }
 
+// GetIncentiveAccumulatedPenaltyAmount returns the accumulated warmup penalty amount of an incentive.
+func GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) int64 {
+	return getImplementation().GetIncentiveAccumulatedPenaltyAmount(poolPath, incentiveId)
+}
+
 // GetIncentiveDepositGnsAmount returns the deposited GNS amount of an incentive.
 func GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) int64 {
 	return getImplementation().GetIncentiveDepositGnsAmount(poolPath, incentiveId)

--- a/contract/r/gnoswap/staker/pool.gno
+++ b/contract/r/gnoswap/staker/pool.gno
@@ -303,19 +303,20 @@ func NewIncentives(targetPoolPath string) *Incentives {
 }
 
 type ExternalIncentive struct {
-	incentiveId             string  // incentive id
-	startTimestamp          int64   // start time for external reward
-	endTimestamp            int64   // end time for external reward
-	createdHeight           int64   // block height when the incentive was created
-	createdTimestamp        int64   // timestamp when the incentive was created
-	depositGnsAmount        int64   // deposited gns amount
-	targetPoolPath          string  // external reward target pool path
-	rewardToken             string  // external reward token path
-	totalRewardAmount       int64   // total reward amount
-	rewardAmount            int64   // to be distributed reward amount
-	rewardPerSecond         int64   // reward per second
-	distributedRewardAmount int64   // distributed reward amount, when un-staked and refunded
-	creator                 address // creator address
+	incentiveId              string  // incentive id
+	startTimestamp           int64   // start time for external reward
+	endTimestamp             int64   // end time for external reward
+	createdHeight            int64   // block height when the incentive was created
+	createdTimestamp         int64   // timestamp when the incentive was created
+	depositGnsAmount         int64   // deposited gns amount
+	targetPoolPath           string  // external reward target pool path
+	rewardToken              string  // external reward token path
+	totalRewardAmount        int64   // total reward amount
+	rewardAmount             int64   // to be distributed reward amount
+	rewardPerSecond          int64   // reward per second
+	distributedRewardAmount  int64   // distributed reward amount, when un-staked and refunded
+	accumulatedPenaltyAmount int64   // accumulated warmup penalty from CollectReward
+	creator                  address // creator address
 
 	refunded bool // whether incentive has been refunded (includes GNS deposit and unclaimed rewards)
 }
@@ -442,6 +443,16 @@ func (e *ExternalIncentive) SetDistributedRewardAmount(distributedRewardAmount i
 	e.distributedRewardAmount = distributedRewardAmount
 }
 
+// AccumulatedPenaltyAmount returns the accumulated warmup penalty amount
+func (e *ExternalIncentive) AccumulatedPenaltyAmount() int64 {
+	return e.accumulatedPenaltyAmount
+}
+
+// SetAccumulatedPenaltyAmount sets the accumulated warmup penalty amount
+func (e *ExternalIncentive) SetAccumulatedPenaltyAmount(accumulatedPenaltyAmount int64) {
+	e.accumulatedPenaltyAmount = accumulatedPenaltyAmount
+}
+
 // Creator returns the creator address
 func (e *ExternalIncentive) Creator() address {
 	return e.creator
@@ -464,20 +475,21 @@ func (e *ExternalIncentive) SetRefunded(refunded bool) {
 
 func (e *ExternalIncentive) Clone() *ExternalIncentive {
 	return &ExternalIncentive{
-		incentiveId:             e.incentiveId,
-		startTimestamp:          e.startTimestamp,
-		endTimestamp:            e.endTimestamp,
-		createdHeight:           e.createdHeight,
-		createdTimestamp:        e.createdTimestamp,
-		depositGnsAmount:        e.depositGnsAmount,
-		targetPoolPath:          e.targetPoolPath,
-		rewardToken:             e.rewardToken,
-		totalRewardAmount:       e.totalRewardAmount,
-		rewardAmount:            e.rewardAmount,
-		rewardPerSecond:         e.rewardPerSecond,
-		creator:                 e.creator,
-		refunded:                e.refunded,
-		distributedRewardAmount: e.distributedRewardAmount,
+		incentiveId:              e.incentiveId,
+		startTimestamp:           e.startTimestamp,
+		endTimestamp:             e.endTimestamp,
+		createdHeight:            e.createdHeight,
+		createdTimestamp:         e.createdTimestamp,
+		depositGnsAmount:         e.depositGnsAmount,
+		targetPoolPath:           e.targetPoolPath,
+		rewardToken:              e.rewardToken,
+		totalRewardAmount:        e.totalRewardAmount,
+		rewardAmount:             e.rewardAmount,
+		rewardPerSecond:          e.rewardPerSecond,
+		creator:                  e.creator,
+		refunded:                 e.refunded,
+		distributedRewardAmount:  e.distributedRewardAmount,
+		accumulatedPenaltyAmount: e.accumulatedPenaltyAmount,
 	}
 }
 
@@ -498,20 +510,21 @@ func NewExternalIncentive(
 	rewardPerSecond := rewardAmount / incentiveDuration
 
 	return &ExternalIncentive{
-		incentiveId:             incentiveId,
-		targetPoolPath:          targetPoolPath,
-		rewardToken:             rewardToken,
-		totalRewardAmount:       rewardAmount,
-		rewardAmount:            rewardAmount,
-		startTimestamp:          startTimestamp,
-		endTimestamp:            endTimestamp,
-		rewardPerSecond:         rewardPerSecond,
-		distributedRewardAmount: 0,
-		creator:                 creator,
-		createdHeight:           createdHeight,
-		createdTimestamp:        currentTime,
-		depositGnsAmount:        depositGnsAmount,
-		refunded:                false,
+		incentiveId:              incentiveId,
+		targetPoolPath:           targetPoolPath,
+		rewardToken:              rewardToken,
+		totalRewardAmount:        rewardAmount,
+		rewardAmount:             rewardAmount,
+		startTimestamp:           startTimestamp,
+		endTimestamp:             endTimestamp,
+		rewardPerSecond:          rewardPerSecond,
+		distributedRewardAmount:  0,
+		accumulatedPenaltyAmount: 0,
+		creator:                  creator,
+		createdHeight:            createdHeight,
+		createdTimestamp:         currentTime,
+		depositGnsAmount:         depositGnsAmount,
+		refunded:                 false,
 	}
 }
 

--- a/contract/r/gnoswap/staker/proxy.gno
+++ b/contract/r/gnoswap/staker/proxy.gno
@@ -133,6 +133,11 @@ func EndExternalIncentive(cur realm, targetPoolPath, incentiveId string, refundA
 	getImplementation().EndExternalIncentive(targetPoolPath, incentiveId, refundAddress)
 }
 
+// CollectExternalIncentivePenalty collects accumulated warmup penalties for an ended incentive.
+func CollectExternalIncentivePenalty(cur realm, targetPoolPath, incentiveId string, refundAddress address) int64 {
+	return getImplementation().CollectExternalIncentivePenalty(targetPoolPath, incentiveId, refundAddress)
+}
+
 // AddToken adds a token to the reward token whitelist.
 func AddToken(cur realm, tokenPath string) {
 	getImplementation().AddToken(tokenPath)

--- a/contract/r/gnoswap/staker/types.gno
+++ b/contract/r/gnoswap/staker/types.gno
@@ -40,6 +40,7 @@ type IStakerManager interface {
 		endTimestamp int64,
 	)
 	EndExternalIncentive(targetPoolPath, incentiveId string, refundAddress address)
+	CollectExternalIncentivePenalty(targetPoolPath, incentiveId string, refundAddress address) int64
 	AddToken(tokenPath string)
 	RemoveToken(tokenPath string)
 
@@ -72,6 +73,7 @@ type IStakerGetter interface {
 	GetIncentiveTotalRewardAmount(poolPath string, incentiveId string) int64
 	GetIncentiveDistributedRewardAmount(poolPath string, incentiveId string) int64
 	GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) int64
+	GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) int64
 	GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) int64
 	GetIncentiveRefunded(poolPath string, incentiveId string) bool
 	IsIncentiveActive(poolPath string, incentiveId string) bool

--- a/contract/r/gnoswap/staker/v1/_helper_test.gno
+++ b/contract/r/gnoswap/staker/v1/_helper_test.gno
@@ -507,6 +507,15 @@ func mockInstanceEndExternalIncentive(poolPath string, incentiveId string, refun
 	}(cross)
 }
 
+func mockInstanceCollectExternalIncentivePenalty(poolPath string, incentiveId string, refundAddress address) int64 {
+	var result int64
+	func(cur realm) {
+		testing.SetRealm(testing.NewCodeRealm(stakerPackagePath))
+		result = getMockInstance().CollectExternalIncentivePenalty(poolPath, incentiveId, refundAddress)
+	}(cross)
+	return result
+}
+
 func getPositionOperator(positionId uint64) address {
 	testing.SetRealm(adminRealm)
 	return pn.GetPositionOperator(positionId)

--- a/contract/r/gnoswap/staker/v1/errors.gno
+++ b/contract/r/gnoswap/staker/v1/errors.gno
@@ -28,6 +28,7 @@ var (
 	errOverflow                      = errors.New("[GNOSWAP-STAKER-019] overflow")
 	errAddExistingToken              = errors.New("[GNOSWAP-STAKER-020] cannot add existing token")
 	errInvalidAddress                = errors.New("[GNOSWAP-STAKER-021] invalid address")
+	errIsNotEndedIncentive           = errors.New("[GNOSWAP-STAKER-022] incentive is not ended yet")
 )
 
 func makeErrorWithDetails(err error, details string) error {

--- a/contract/r/gnoswap/staker/v1/external_incentive.gno
+++ b/contract/r/gnoswap/staker/v1/external_incentive.gno
@@ -268,7 +268,7 @@ func (s *stakerV1) endExternalIncentive(resolver *PoolResolver, incentiveResolve
 // This function transfers the accumulated penalty to the specified refund address.
 // Returns the penalty amount collected.
 //
-// Only callable by the incentive creator.
+// Only callable by the incentive creator or admin.
 func (s *stakerV1) CollectExternalIncentivePenalty(
 	targetPoolPath string,
 	incentiveId string,

--- a/contract/r/gnoswap/staker/v1/external_incentive.gno
+++ b/contract/r/gnoswap/staker/v1/external_incentive.gno
@@ -301,7 +301,7 @@ func (s *stakerV1) CollectExternalIncentivePenalty(
 
 	if !incentiveResolver.Refunded() {
 		panic(makeErrorWithDetails(
-			errCannotEndIncentive,
+			errIsNotEndedIncentive,
 			ufmt.Sprintf("incentive(%s) must be ended first (call EndExternalIncentive)", incentiveId),
 		))
 	}
@@ -317,17 +317,6 @@ func (s *stakerV1) CollectExternalIncentivePenalty(
 
 	penaltyAmount := incentiveResolver.AccumulatedPenaltyAmount()
 	if penaltyAmount == 0 {
-		previousRealm := runtime.PreviousRealm()
-		chain.Emit(
-			"CollectExternalIncentivePenalty",
-			"prevAddr", previousRealm.Address().String(),
-			"prevRealm", previousRealm.PkgPath(),
-			"targetPoolPath", targetPoolPath,
-			"incentiveId", incentiveId,
-			"refundAddress", refundAddress.String(),
-			"penaltyAmount", formatAnyInt(int64(0)),
-		)
-
 		return 0
 	}
 

--- a/contract/r/gnoswap/staker/v1/external_incentive.gno
+++ b/contract/r/gnoswap/staker/v1/external_incentive.gno
@@ -307,11 +307,11 @@ func (s *stakerV1) CollectExternalIncentivePenalty(
 	}
 
 	caller := runtime.PreviousRealm().Address()
-	if caller != incentiveResolver.Creator() {
+	if !access.IsAuthorized(prbac.ROLE_ADMIN.String(), caller) && caller != incentiveResolver.Creator() {
+		adminAddr := access.MustGetAddress(prbac.ROLE_ADMIN.String())
 		panic(makeErrorWithDetails(
 			errNoPermission,
-			ufmt.Sprintf("only creator(%s) can collect penalty, called from %s",
-				incentiveResolver.Creator(), caller),
+			ufmt.Sprintf("only creator(%s) or admin(%s) can collect penalty, but called from %s", incentiveResolver.Creator(), adminAddr.String(), caller),
 		))
 	}
 

--- a/contract/r/gnoswap/staker/v1/external_incentive.gno
+++ b/contract/r/gnoswap/staker/v1/external_incentive.gno
@@ -3,7 +3,6 @@ package v1
 import (
 	"chain"
 	"chain/runtime"
-	"math"
 	"time"
 
 	prbac "gno.land/p/gnoswap/rbac"
@@ -238,29 +237,126 @@ func (s *stakerV1) endExternalIncentive(resolver *PoolResolver, incentiveResolve
 		)
 	}
 
-	totalReward := int64(0)
+	// refund = unclaimableReward + remainder + accumulatedPenaltyAmount
+	incentivesResolver := resolver.IncentivesResolver()
+	unclaimableReward := incentivesResolver.calculateUnclaimableReward(incentiveResolver.IncentiveId())
 
-	// calculate total external reward for the incentive
-	s.getDeposits().IterateByPoolPath(0, math.MaxUint64, incentiveResolver.TargetPoolPath(), func(positionId uint64, deposit *sr.Deposit) bool {
-		depositResolver := NewDepositResolver(deposit)
-		lastCollectTime := depositResolver.ExternalRewardLastCollectTime(incentiveResolver.IncentiveId())
+	duration := safeSubInt64(incentiveResolver.EndTimestamp(), incentiveResolver.StartTimestamp())
+	distributable := safeMulInt64(incentiveResolver.RewardPerSecond(), duration)
+	remainder := safeSubInt64(incentiveResolver.TotalRewardAmount(), distributable)
 
-		if lastCollectTime > incentiveResolver.EndTimestamp() {
-			return false
-		}
+	refund := safeAddInt64(unclaimableReward, remainder)
 
-		rewardState := resolver.RewardStateOf(deposit)
-		calculatedTotalReward := rewardState.calculateCollectableExternalReward(lastCollectTime, currentTime, incentiveResolver.ExternalIncentive)
-		totalReward = safeAddInt64(totalReward, calculatedTotalReward)
+	maxRefund := safeSubInt64(incentiveResolver.TotalRewardAmount(), incentiveResolver.DistributedRewardAmount())
+	if refund > maxRefund {
+		refund = maxRefund
+	}
 
-		return false
-	})
-
-	// calculate refund amount is the difference between the incentive reward amount and the total external reward
-	refund := safeSubInt64(incentiveResolver.TotalRewardAmount(), totalReward)
-	refund = safeSubInt64(refund, incentiveResolver.DistributedRewardAmount())
+	if refund < 0 {
+		return nil, 0, makeErrorWithDetails(
+			errCalculationError,
+			ufmt.Sprintf("refund should never be negative: Got %d", refund),
+		)
+	}
 
 	return incentiveResolver.ExternalIncentive, refund, nil
+}
+
+// CollectExternalIncentivePenalty collects accumulated warmup penalties
+// for a specific ended external incentive.
+// Penalties are accumulated during CollectReward and stored in the incentive.
+// This function transfers the accumulated penalty to the specified refund address.
+// Returns the penalty amount collected.
+//
+// Only callable by the incentive creator.
+func (s *stakerV1) CollectExternalIncentivePenalty(
+	targetPoolPath string,
+	incentiveId string,
+	refundAddress address,
+) int64 {
+	halt.AssertIsNotHaltedStaker()
+	halt.AssertIsNotHaltedWithdraw()
+
+	assertIsPoolExists(s, targetPoolPath)
+	assertIsValidAddress(refundAddress)
+
+	pool, exists := s.getPools().Get(targetPoolPath)
+	if !exists {
+		panic(makeErrorWithDetails(
+			errDataNotFound,
+			ufmt.Sprintf("targetPoolPath(%s) not found", targetPoolPath),
+		))
+	}
+
+	poolResolver := NewPoolResolver(pool)
+	incentivesResolver := poolResolver.IncentivesResolver()
+
+	incentiveResolver, exists := incentivesResolver.GetIncentiveResolver(incentiveId)
+	if !exists {
+		panic(makeErrorWithDetails(
+			errDataNotFound,
+			ufmt.Sprintf("incentive(%s) not found", incentiveId),
+		))
+	}
+
+	if !incentiveResolver.Refunded() {
+		panic(makeErrorWithDetails(
+			errCannotEndIncentive,
+			ufmt.Sprintf("incentive(%s) must be ended first (call EndExternalIncentive)", incentiveId),
+		))
+	}
+
+	caller := runtime.PreviousRealm().Address()
+	if caller != incentiveResolver.Creator() {
+		panic(makeErrorWithDetails(
+			errNoPermission,
+			ufmt.Sprintf("only creator(%s) can collect penalty, called from %s",
+				incentiveResolver.Creator(), caller),
+		))
+	}
+
+	penaltyAmount := incentiveResolver.AccumulatedPenaltyAmount()
+	if penaltyAmount == 0 {
+		previousRealm := runtime.PreviousRealm()
+		chain.Emit(
+			"CollectExternalIncentivePenalty",
+			"prevAddr", previousRealm.Address().String(),
+			"prevRealm", previousRealm.PkgPath(),
+			"targetPoolPath", targetPoolPath,
+			"incentiveId", incentiveId,
+			"refundAddress", refundAddress.String(),
+			"penaltyAmount", formatAnyInt(int64(0)),
+		)
+
+		return 0
+	}
+
+	// Cap by actual staker balance
+	stakerAddr := access.MustGetAddress(prbac.ROLE_STAKER.String())
+	balance := common.BalanceOf(incentiveResolver.RewardToken(), stakerAddr)
+	if balance < penaltyAmount {
+		penaltyAmount = balance
+	}
+
+	// Reset accumulated penalty
+	incentiveResolver.SetAccumulatedPenaltyAmount(safeSubInt64(incentiveResolver.AccumulatedPenaltyAmount(), penaltyAmount))
+	incentivesResolver.update(incentiveResolver.ExternalIncentive)
+
+	// Transfer penalty to refund address
+	common.SafeGRC20Transfer(cross, incentiveResolver.RewardToken(), refundAddress, penaltyAmount)
+
+	previousRealm := runtime.PreviousRealm()
+	chain.Emit(
+		"CollectExternalIncentivePenalty",
+		"prevAddr", previousRealm.Address().String(),
+		"prevRealm", previousRealm.PkgPath(),
+		"targetPoolPath", targetPoolPath,
+		"incentiveId", incentiveId,
+		"refundAddress", refundAddress.String(),
+		"penaltyAmount", formatAnyInt(penaltyAmount),
+	)
+
+	return penaltyAmount
 }
 
 // addIncentiveIdByCreationTime adds an external incentive to the time-based index.

--- a/contract/r/gnoswap/staker/v1/external_incentive_test.gno
+++ b/contract/r/gnoswap/staker/v1/external_incentive_test.gno
@@ -2498,69 +2498,187 @@ func TestRemoveIncentiveIdByCreationTime(t *testing.T) {
 	}
 }
 
-// TestAccumulatedPenaltyAmount tests penalty accumulation via addAccumulatedPenaltyAmount.
-func TestAccumulatedPenaltyAmount(t *testing.T) {
-	type penaltyStep struct {
-		addAmount      int64
-		expectedTotal  int64
-	}
+// TestCollectExternalIncentivePenalty tests the full CollectExternalIncentivePenalty flow
+// using table-driven tests covering all validation paths and edge cases.
+func TestCollectExternalIncentivePenalty(t *testing.T) {
+	creator := testutils.TestAddress("creator")
+	stranger := testutils.TestAddress("stranger")
 
 	tests := []struct {
-		name  string
-		steps []penaltyStep
+		name             string
+		poolPath         string
+		incentiveId      string
+		caller           address
+		refundAddress    address
+		setupPool        bool
+		setupIncentive   bool
+		setRefunded      bool
+		penaltyAmount    int64
+		expectPanic      bool
+		expectedErrorMsg string
+		expectedReturn   int64
 	}{
 		{
-			name: "single penalty",
-			steps: []penaltyStep{
-				{addAmount: 1000, expectedTotal: 1000},
-			},
+			name:             "pool not registered in pool accessor",
+			poolPath:         "gno.land/r/invalid/pool:path:100",
+			incentiveId:      "test-id",
+			caller:           creator,
+			refundAddress:    creator,
+			setupPool:        false,
+			setupIncentive:   false,
+			setRefunded:      false,
+			penaltyAmount:    0,
+			expectPanic:      true,
+			expectedErrorMsg: "[GNOSWAP-STAKER-011]", // errInvalidPoolPath
 		},
 		{
-			name: "multiple penalties accumulate",
-			steps: []penaltyStep{
-				{addAmount: 1000, expectedTotal: 1000},
-				{addAmount: 2500, expectedTotal: 3500},
-				{addAmount: 500, expectedTotal: 4000},
-			},
+			name:             "incentive not found",
+			poolPath:         "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:3000",
+			incentiveId:      "nonexistent-id",
+			caller:           creator,
+			refundAddress:    creator,
+			setupPool:        true,
+			setupIncentive:   false,
+			setRefunded:      false,
+			penaltyAmount:    0,
+			expectPanic:      true,
+			expectedErrorMsg: "[GNOSWAP-STAKER-013]", // errDataNotFound
 		},
 		{
-			name: "zero penalty does not change total",
-			steps: []penaltyStep{
-				{addAmount: 5000, expectedTotal: 5000},
-				{addAmount: 0, expectedTotal: 5000},
-				{addAmount: 3000, expectedTotal: 8000},
-			},
+			name:             "incentive not ended yet (refunded=false)",
+			poolPath:         "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:3000",
+			incentiveId:      "test-id",
+			caller:           creator,
+			refundAddress:    creator,
+			setupPool:        true,
+			setupIncentive:   true,
+			setRefunded:      false,
+			penaltyAmount:    5000,
+			expectPanic:      true,
+			expectedErrorMsg: "[GNOSWAP-STAKER-022]", // errIsNotEndedIncentive
+		},
+		{
+			name:             "caller is not creator",
+			poolPath:         "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:3000",
+			incentiveId:      "test-id",
+			caller:           stranger,
+			refundAddress:    stranger,
+			setupPool:        true,
+			setupIncentive:   true,
+			setRefunded:      true,
+			penaltyAmount:    5000,
+			expectPanic:      true,
+			expectedErrorMsg: "[GNOSWAP-STAKER-001]", // errNoPermission
+		},
+		{
+			name:             "zero accumulated penalty returns 0",
+			poolPath:         "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:3000",
+			incentiveId:      "test-id",
+			caller:           creator,
+			refundAddress:    creator,
+			setupPool:        true,
+			setupIncentive:   true,
+			setRefunded:      true,
+			penaltyAmount:    0,
+			expectPanic:      false,
+			expectedReturn:   0,
+		},
+		{
+			name:             "successfully collect accumulated penalty",
+			poolPath:         "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:3000",
+			incentiveId:      "test-id",
+			caller:           creator,
+			refundAddress:    creator,
+			setupPool:        true,
+			setupIncentive:   true,
+			setRefunded:      true,
+			penaltyAmount:    50000,
+			expectPanic:      false,
+			expectedReturn:   -1, // -1 means check > 0 (exact value depends on staker balance)
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			initStakerTest(t)
+			instance := getMockInstance()
 
-			poolPath := "gno.land/r/test/penalty_accum"
-			creator := testutils.TestAddress("creator")
 			currentTime := time.Now().Unix()
+			startTime := currentTime
+			endTime := currentTime + 86400*30
 
-			incentive := sr.NewExternalIncentive(
-				"test-id", poolPath, WUGNOT_PATH, 1_000_000,
-				currentTime-86400*30, currentTime-86400, creator, 100_000_000,
-				runtime.ChainHeight(), currentTime-86400*30-100,
-			)
+			poolPath := tt.poolPath
 
-			uassert.Equal(t, int64(0), incentive.AccumulatedPenaltyAmount())
+			if tt.setupPool {
+				testing.SetRealm(adminRealm)
+				gns.Approve(cross, poolAddr, math.MaxInt)
+				CreatePool(barPath, fooPath, fee3000, "79228162514264337593543950336", adminAddr)
 
-			resolver := NewExternalIncentiveResolver(incentive)
-			for _, step := range tt.steps {
-				resolver.addAccumulatedPenaltyAmount(step.addAmount)
-				uassert.Equal(t, step.expectedTotal, incentive.AccumulatedPenaltyAmount())
+				pool := sr.NewPool(poolPath, currentTime)
+				instance.getPools().set(poolPath, pool)
+
+				if tt.setupIncentive {
+					incentive := sr.NewExternalIncentive(
+						tt.incentiveId, poolPath, barPath, 10_000_000_000,
+						startTime, endTime, creator, 100_000_000,
+						runtime.ChainHeight(), currentTime,
+					)
+
+					poolResolver := NewPoolResolver(pool)
+					poolResolver.IncentivesResolver().create(incentive)
+
+					if tt.penaltyAmount > 0 {
+						resolver := NewExternalIncentiveResolver(incentive)
+						resolver.addAccumulatedPenaltyAmount(tt.penaltyAmount)
+					}
+
+					if tt.setRefunded {
+						incentive.SetRefunded(true)
+						poolResolver.IncentivesResolver().update(incentive)
+					}
+				}
+			}
+
+			// skip past incentive end
+			skipBlocks := (endTime-startTime)/5 + 86400
+			testing.SkipHeights(skipBlocks)
+
+			if tt.expectPanic {
+				testing.SetRealm(testing.NewUserRealm(tt.caller))
+				uassert.AbortsContains(t, tt.expectedErrorMsg, func() {
+					mockInstanceCollectExternalIncentivePenalty(poolPath, tt.incentiveId, tt.refundAddress)
+				})
+				return
+			}
+
+			// fund staker with reward token so transfer succeeds
+			testing.SetRealm(adminRealm)
+			bar.Transfer(cross, stakerAddr, 10_000_000_000)
+
+			testing.SetRealm(testing.NewUserRealm(tt.caller))
+			result := mockInstanceCollectExternalIncentivePenalty(poolPath, tt.incentiveId, tt.refundAddress)
+
+			if tt.expectedReturn == 0 {
+				uassert.Equal(t, int64(0), result)
+			} else if tt.expectedReturn == -1 {
+				if result <= 0 {
+					t.Errorf("expected positive penalty collected, got %d", result)
+				}
+
+				// verify accumulated penalty was reduced
+				pool, _ := instance.getPools().Get(poolPath)
+				poolResolver := NewPoolResolver(pool)
+				updatedIncentive, exists := poolResolver.IncentivesResolver().Get(tt.incentiveId)
+				uassert.True(t, exists)
+				uassert.Equal(t, int64(0), updatedIncentive.AccumulatedPenaltyAmount())
 			}
 		})
 	}
 }
 
-// TestPenaltyAccountingInvariant tests that totalRewardAmount = rewardAmount + distributed + penalty
-// holds after simulated CollectReward calls.
-func TestPenaltyAccountingInvariant(t *testing.T) {
+// TestCollectExternalIncentivePenaltyAccounting tests the accounting invariant
+// across CollectReward penalty accumulation and CollectExternalIncentivePenalty.
+func TestCollectExternalIncentivePenaltyAccounting(t *testing.T) {
 	type collectStep struct {
 		reward  int64
 		penalty int64
@@ -2574,7 +2692,7 @@ func TestPenaltyAccountingInvariant(t *testing.T) {
 		expectedPenalty     int64
 	}{
 		{
-			name:              "single collection",
+			name:              "single collection with penalty",
 			totalRewardAmount: 1_000_000,
 			collections: []collectStep{
 				{reward: 700, penalty: 1000},
@@ -2583,7 +2701,7 @@ func TestPenaltyAccountingInvariant(t *testing.T) {
 			expectedPenalty:     1000,
 		},
 		{
-			name:              "multiple collections",
+			name:              "multiple users with varying warmup ratios",
 			totalRewardAmount: 1_000_000,
 			collections: []collectStep{
 				{reward: 700, penalty: 1000},
@@ -2594,24 +2712,23 @@ func TestPenaltyAccountingInvariant(t *testing.T) {
 			expectedPenalty:     3500,
 		},
 		{
-			name:              "collection with zero penalty",
+			name:              "collection with zero penalty (100% warmup)",
 			totalRewardAmount: 500_000,
 			collections: []collectStep{
 				{reward: 1000, penalty: 0},
-				{reward: 2000, penalty: 500},
+				{reward: 2000, penalty: 0},
 			},
 			expectedDistributed: 3000,
-			expectedPenalty:     500,
+			expectedPenalty:     0,
 		},
 		{
-			name:              "collection with zero reward",
+			name:              "penalty only (e.g. reward rounds to 0)",
 			totalRewardAmount: 100_000,
 			collections: []collectStep{
 				{reward: 0, penalty: 300},
-				{reward: 500, penalty: 200},
 			},
-			expectedDistributed: 500,
-			expectedPenalty:     500,
+			expectedDistributed: 0,
+			expectedPenalty:     300,
 		},
 	}
 
@@ -2619,7 +2736,7 @@ func TestPenaltyAccountingInvariant(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			initStakerTest(t)
 
-			poolPath := "gno.land/r/test/penalty_invariant"
+			poolPath := "gno.land/r/test/penalty_accounting"
 			creator := testutils.TestAddress("creator")
 			currentTime := time.Now().Unix()
 
@@ -2639,7 +2756,6 @@ func TestPenaltyAccountingInvariant(t *testing.T) {
 
 			uassert.Equal(t, tt.expectedDistributed, incentive.DistributedRewardAmount())
 			uassert.Equal(t, tt.expectedPenalty, incentive.AccumulatedPenaltyAmount())
-			uassert.Equal(t, tt.totalRewardAmount-tt.expectedDistributed-tt.expectedPenalty, incentive.RewardAmount())
 
 			// invariant: totalRewardAmount = rewardAmount + distributed + penalty
 			sum := incentive.RewardAmount() + incentive.DistributedRewardAmount() + incentive.AccumulatedPenaltyAmount()
@@ -2652,40 +2768,14 @@ func TestPenaltyAccountingInvariant(t *testing.T) {
 // includes accumulatedPenaltyAmount in the refund calculation.
 func TestEndExternalIncentiveRefundWithPenalty(t *testing.T) {
 	tests := []struct {
-		name              string
-		totalRewardAmount int64
-		distributed       int64
-		penalty           int64
-		expectPositive    bool
+		name        string
+		distributed int64
+		penalty     int64
 	}{
-		{
-			name:              "refund with penalty",
-			totalRewardAmount: 1_000_000,
-			distributed:       300,
-			penalty:           200,
-			expectPositive:    true,
-		},
-		{
-			name:              "refund with large penalty",
-			totalRewardAmount: 1_000_000,
-			distributed:       100,
-			penalty:           50000,
-			expectPositive:    true,
-		},
-		{
-			name:              "refund with zero penalty",
-			totalRewardAmount: 1_000_000,
-			distributed:       500,
-			penalty:           0,
-			expectPositive:    true,
-		},
-		{
-			name:              "refund with no collections",
-			totalRewardAmount: 1_000_000,
-			distributed:       0,
-			penalty:           0,
-			expectPositive:    true,
-		},
+		{name: "with penalty", distributed: 300, penalty: 200},
+		{name: "with large penalty", distributed: 100, penalty: 50000},
+		{name: "with zero penalty", distributed: 500, penalty: 0},
+		{name: "with no collections", distributed: 0, penalty: 0},
 	}
 
 	for _, tt := range tests {
@@ -2698,12 +2788,13 @@ func TestEndExternalIncentiveRefundWithPenalty(t *testing.T) {
 			currentTime := time.Now().Unix()
 			startTime := currentTime - 86400*30
 			endTime := currentTime - 86400
+			totalRewardAmount := int64(1_000_000)
 
 			pool := sr.NewPool(poolPath, startTime)
 			s.getPools().set(poolPath, pool)
 
 			incentive := sr.NewExternalIncentive(
-				"test-id", poolPath, WUGNOT_PATH, tt.totalRewardAmount,
+				"test-id", poolPath, WUGNOT_PATH, totalRewardAmount,
 				startTime, endTime, creator, 100_000_000,
 				runtime.ChainHeight(), startTime-100,
 			)
@@ -2719,12 +2810,8 @@ func TestEndExternalIncentiveRefundWithPenalty(t *testing.T) {
 			_, refund, err := s.endExternalIncentive(poolResolver, resolver, creator, endTime+100)
 			uassert.NoError(t, err)
 
-			if tt.expectPositive && refund <= 0 {
-				t.Errorf("expected positive refund, got %d", refund)
-			}
-
 			// refund must not exceed maxRefund
-			maxRefund := safeSubInt64(tt.totalRewardAmount, tt.distributed)
+			maxRefund := safeSubInt64(totalRewardAmount, tt.distributed)
 			if refund > maxRefund {
 				t.Errorf("refund(%d) exceeds maxRefund(%d)", refund, maxRefund)
 			}
@@ -2736,62 +2823,6 @@ func TestEndExternalIncentiveRefundWithPenalty(t *testing.T) {
 			if refund < refundNoPenalty {
 				t.Errorf("refund with penalty(%d) < refund without(%d)", refund, refundNoPenalty)
 			}
-		})
-	}
-}
-
-// TestPenaltyResetAfterCollection tests that SetAccumulatedPenaltyAmount correctly
-// resets penalty after partial or full collection.
-func TestPenaltyResetAfterCollection(t *testing.T) {
-	tests := []struct {
-		name             string
-		initialPenalty   int64
-		collectAmount    int64
-		expectedRemaining int64
-	}{
-		{
-			name:             "full collection",
-			initialPenalty:   5000,
-			collectAmount:    5000,
-			expectedRemaining: 0,
-		},
-		{
-			name:             "partial collection (balance cap)",
-			initialPenalty:   5000,
-			collectAmount:    3000,
-			expectedRemaining: 2000,
-		},
-		{
-			name:             "zero collection",
-			initialPenalty:   5000,
-			collectAmount:    0,
-			expectedRemaining: 5000,
-		},
-		{
-			name:             "collect from zero penalty",
-			initialPenalty:   0,
-			collectAmount:    0,
-			expectedRemaining: 0,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			creator := testutils.TestAddress("creator")
-			currentTime := time.Now().Unix()
-
-			incentive := sr.NewExternalIncentive(
-				"test-id", "gno.land/r/test/reset", WUGNOT_PATH, 1_000_000,
-				currentTime-86400*30, currentTime-86400, creator, 100_000_000,
-				runtime.ChainHeight(), currentTime-86400*30-100,
-			)
-
-			resolver := NewExternalIncentiveResolver(incentive)
-			resolver.addAccumulatedPenaltyAmount(tt.initialPenalty)
-			uassert.Equal(t, tt.initialPenalty, incentive.AccumulatedPenaltyAmount())
-
-			incentive.SetAccumulatedPenaltyAmount(safeSubInt64(incentive.AccumulatedPenaltyAmount(), tt.collectAmount))
-			uassert.Equal(t, tt.expectedRemaining, incentive.AccumulatedPenaltyAmount())
 		})
 	}
 }

--- a/contract/r/gnoswap/staker/v1/external_incentive_test.gno
+++ b/contract/r/gnoswap/staker/v1/external_incentive_test.gno
@@ -201,7 +201,6 @@ func TestEndExternalIncentive(t *testing.T) {
 			testing.SkipHeights(skipBlocks)
 
 			creatorGnsBalanceBefore := gns.BalanceOf(tt.refundAddress)
-			creatorBarBalanceBefore := bar.BalanceOf(tt.refundAddress)
 
 			if tt.expectError {
 				testing.SetRealm(testing.NewUserRealm(tt.caller))
@@ -222,14 +221,13 @@ func TestEndExternalIncentive(t *testing.T) {
 			})
 
 			creatorGnsBalanceAfter := gns.BalanceOf(tt.refundAddress)
-			creatorBarBalanceAfter := bar.BalanceOf(tt.refundAddress)
 
 			updatedIncentive, exists := poolResolver.IncentivesResolver().Get(incentiveId)
 			uassert.True(t, exists)
 			uassert.True(t, updatedIncentive.Refunded())
 			uassert.Equal(t, creator, updatedIncentive.Creator())
+			// EndExternalIncentive refunds GNS deposit and time-based reward token refund.
 			uassert.Equal(t, creatorGnsBalanceAfter-creatorGnsBalanceBefore, depositGnsAmount)
-			uassert.Equal(t, creatorBarBalanceAfter-creatorBarBalanceBefore, rewardAmount)
 		})
 	}
 }
@@ -1264,17 +1262,19 @@ func TestRefundCalculationWithPartialCollections(t *testing.T) {
 	depositResolverA.addCollectedExternalReward(incentiveId, collectedA)
 	depositResolverA.updateExternalRewardLastCollectTime(incentiveId, endTime-1000)
 
-	// Update DistributedRewardAmount (simulating CollectReward)
+	// Update DistributedRewardAmount and deduct from rewardAmount (simulating CollectReward)
 	incentiveResolver := NewExternalIncentiveResolver(incentive)
 	incentiveResolver.addDistributedRewardAmount(collectedA)
+	incentive.SetRewardAmount(safeSubInt64(incentive.RewardAmount(), collectedA))
 
 	// User B collects 200
 	collectedB := int64(200)
 	depositResolverB.addCollectedExternalReward(incentiveId, collectedB)
 	depositResolverB.updateExternalRewardLastCollectTime(incentiveId, endTime-500)
 
-	// Update DistributedRewardAmount (simulating CollectReward)
+	// Update DistributedRewardAmount and deduct from rewardAmount (simulating CollectReward)
 	incentiveResolver.addDistributedRewardAmount(collectedB)
+	incentive.SetRewardAmount(safeSubInt64(incentive.RewardAmount(), collectedB))
 
 	// Verify DistributedRewardAmount = 500
 	if incentiveResolver.DistributedRewardAmount() != 500 {
@@ -1286,21 +1286,65 @@ func TestRefundCalculationWithPartialCollections(t *testing.T) {
 		t.Errorf("After unstakes, DistributedRewardAmount should still be 500, got %d", incentiveResolver.DistributedRewardAmount())
 	}
 
-	// Calculate refund
-	// remain deposit A reward: 1286000
-	// remain deposit B reward: 643000
+	// End incentive with simple time-based refund calculation
 	_, refund, err := s.endExternalIncentive(poolResolver, incentiveResolver, creator, endTime+100)
 	uassert.NoError(t, err)
 
-	// Verify refund amount
-	expectedRefund := int64(999035000)
-	if refund != expectedRefund {
-		t.Errorf("Expected refund %d, got %d", expectedRefund, refund)
-	}
-
-	// Verify refund is not negative
+	// refund = totalRewardAmount - (rewardPerSecond × duration) - distributedRewardAmount
+	// duration = endTime - startTime = 86400*9 = 777600
+	// rewardPerSecond = totalRewardAmount / duration = 1000000000 / 777600 = 1285 (truncated)
+	// totalDistributable = 1285 * 777600 = 999273600 (due to integer truncation, less than totalRewardAmount)
+	// refund = 1000000000 - 999273600 - 500 = 726400 - 500 = 725900
 	if refund < 0 {
 		t.Errorf("Refund should never be negative! Got %d", refund)
+	}
+}
+
+// Test that zero-liquidity windows are tracked via modifyDeposit and reflected in calculateUnclaimableReward.
+func TestCalculateUnclaimableReward_TracksZeroLiquidityTransitions(t *testing.T) {
+	poolPath := "test_pool_unclaimable_tracking"
+	creator := testutils.TestAddress("creator")
+
+	currentTime := time.Now().Unix()
+	pool := sr.NewPool(poolPath, currentTime)
+	poolResolver := NewPoolResolver(pool)
+	incentives := poolResolver.IncentivesResolver()
+
+	startTime := currentTime + 10
+	endTime := startTime + 100
+	rewardAmount := int64(1000) // rewardPerSecond = 10
+
+	incentive := sr.NewExternalIncentive(
+		"test_incentive_tracking",
+		poolPath,
+		GNS_PATH,
+		rewardAmount,
+		startTime,
+		endTime,
+		creator,
+		100,
+		runtime.ChainHeight(),
+		currentTime,
+	)
+	incentives.create(incentive)
+
+	stakeTimeA := startTime + 20
+	zeroTime := startTime + 60
+	stakeTimeB := startTime + 80
+
+	// zero -> positive: end unclaimable
+	poolResolver.modifyDeposit(i256.NewInt(1000), stakeTimeA, 0)
+	// positive -> zero: start unclaimable
+	poolResolver.modifyDeposit(i256.NewInt(-1000), zeroTime, 0)
+	// zero -> positive: end unclaimable
+	poolResolver.modifyDeposit(i256.NewInt(1000), stakeTimeB, 0)
+
+	expectedDuration := (stakeTimeA - startTime) + (stakeTimeB - zeroTime)
+	expected := expectedDuration * incentive.RewardPerSecond()
+
+	got := incentives.calculateUnclaimableReward(incentive.IncentiveId())
+	if got != expected {
+		t.Fatalf("unclaimable reward mismatch: got %d, want %d", got, expected)
 	}
 }
 
@@ -2450,6 +2494,304 @@ func TestRemoveIncentiveIdByCreationTime(t *testing.T) {
 					uassert.Equal(t, expectedId, incentiveIds[i])
 				}
 			}
+		})
+	}
+}
+
+// TestAccumulatedPenaltyAmount tests penalty accumulation via addAccumulatedPenaltyAmount.
+func TestAccumulatedPenaltyAmount(t *testing.T) {
+	type penaltyStep struct {
+		addAmount      int64
+		expectedTotal  int64
+	}
+
+	tests := []struct {
+		name  string
+		steps []penaltyStep
+	}{
+		{
+			name: "single penalty",
+			steps: []penaltyStep{
+				{addAmount: 1000, expectedTotal: 1000},
+			},
+		},
+		{
+			name: "multiple penalties accumulate",
+			steps: []penaltyStep{
+				{addAmount: 1000, expectedTotal: 1000},
+				{addAmount: 2500, expectedTotal: 3500},
+				{addAmount: 500, expectedTotal: 4000},
+			},
+		},
+		{
+			name: "zero penalty does not change total",
+			steps: []penaltyStep{
+				{addAmount: 5000, expectedTotal: 5000},
+				{addAmount: 0, expectedTotal: 5000},
+				{addAmount: 3000, expectedTotal: 8000},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initStakerTest(t)
+
+			poolPath := "gno.land/r/test/penalty_accum"
+			creator := testutils.TestAddress("creator")
+			currentTime := time.Now().Unix()
+
+			incentive := sr.NewExternalIncentive(
+				"test-id", poolPath, WUGNOT_PATH, 1_000_000,
+				currentTime-86400*30, currentTime-86400, creator, 100_000_000,
+				runtime.ChainHeight(), currentTime-86400*30-100,
+			)
+
+			uassert.Equal(t, int64(0), incentive.AccumulatedPenaltyAmount())
+
+			resolver := NewExternalIncentiveResolver(incentive)
+			for _, step := range tt.steps {
+				resolver.addAccumulatedPenaltyAmount(step.addAmount)
+				uassert.Equal(t, step.expectedTotal, incentive.AccumulatedPenaltyAmount())
+			}
+		})
+	}
+}
+
+// TestPenaltyAccountingInvariant tests that totalRewardAmount = rewardAmount + distributed + penalty
+// holds after simulated CollectReward calls.
+func TestPenaltyAccountingInvariant(t *testing.T) {
+	type collectStep struct {
+		reward  int64
+		penalty int64
+	}
+
+	tests := []struct {
+		name              string
+		totalRewardAmount int64
+		collections       []collectStep
+		expectedDistributed int64
+		expectedPenalty     int64
+	}{
+		{
+			name:              "single collection",
+			totalRewardAmount: 1_000_000,
+			collections: []collectStep{
+				{reward: 700, penalty: 1000},
+			},
+			expectedDistributed: 700,
+			expectedPenalty:     1000,
+		},
+		{
+			name:              "multiple collections",
+			totalRewardAmount: 1_000_000,
+			collections: []collectStep{
+				{reward: 700, penalty: 1000},
+				{reward: 1400, penalty: 2000},
+				{reward: 350, penalty: 500},
+			},
+			expectedDistributed: 2450,
+			expectedPenalty:     3500,
+		},
+		{
+			name:              "collection with zero penalty",
+			totalRewardAmount: 500_000,
+			collections: []collectStep{
+				{reward: 1000, penalty: 0},
+				{reward: 2000, penalty: 500},
+			},
+			expectedDistributed: 3000,
+			expectedPenalty:     500,
+		},
+		{
+			name:              "collection with zero reward",
+			totalRewardAmount: 100_000,
+			collections: []collectStep{
+				{reward: 0, penalty: 300},
+				{reward: 500, penalty: 200},
+			},
+			expectedDistributed: 500,
+			expectedPenalty:     500,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initStakerTest(t)
+
+			poolPath := "gno.land/r/test/penalty_invariant"
+			creator := testutils.TestAddress("creator")
+			currentTime := time.Now().Unix()
+
+			incentive := sr.NewExternalIncentive(
+				"test-id", poolPath, WUGNOT_PATH, tt.totalRewardAmount,
+				currentTime-86400*30, currentTime-86400, creator, 100_000_000,
+				runtime.ChainHeight(), currentTime-86400*30-100,
+			)
+
+			resolver := NewExternalIncentiveResolver(incentive)
+
+			for _, c := range tt.collections {
+				resolver.addDistributedRewardAmount(c.reward)
+				resolver.addAccumulatedPenaltyAmount(c.penalty)
+				incentive.SetRewardAmount(safeSubInt64(incentive.RewardAmount(), c.reward+c.penalty))
+			}
+
+			uassert.Equal(t, tt.expectedDistributed, incentive.DistributedRewardAmount())
+			uassert.Equal(t, tt.expectedPenalty, incentive.AccumulatedPenaltyAmount())
+			uassert.Equal(t, tt.totalRewardAmount-tt.expectedDistributed-tt.expectedPenalty, incentive.RewardAmount())
+
+			// invariant: totalRewardAmount = rewardAmount + distributed + penalty
+			sum := incentive.RewardAmount() + incentive.DistributedRewardAmount() + incentive.AccumulatedPenaltyAmount()
+			uassert.Equal(t, tt.totalRewardAmount, sum)
+		})
+	}
+}
+
+// TestEndExternalIncentiveRefundWithPenalty tests that endExternalIncentive
+// includes accumulatedPenaltyAmount in the refund calculation.
+func TestEndExternalIncentiveRefundWithPenalty(t *testing.T) {
+	tests := []struct {
+		name              string
+		totalRewardAmount int64
+		distributed       int64
+		penalty           int64
+		expectPositive    bool
+	}{
+		{
+			name:              "refund with penalty",
+			totalRewardAmount: 1_000_000,
+			distributed:       300,
+			penalty:           200,
+			expectPositive:    true,
+		},
+		{
+			name:              "refund with large penalty",
+			totalRewardAmount: 1_000_000,
+			distributed:       100,
+			penalty:           50000,
+			expectPositive:    true,
+		},
+		{
+			name:              "refund with zero penalty",
+			totalRewardAmount: 1_000_000,
+			distributed:       500,
+			penalty:           0,
+			expectPositive:    true,
+		},
+		{
+			name:              "refund with no collections",
+			totalRewardAmount: 1_000_000,
+			distributed:       0,
+			penalty:           0,
+			expectPositive:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initStakerTest(t)
+			s := getMockInstance()
+
+			poolPath := "gno.land/r/test/penalty_refund"
+			creator := testutils.TestAddress("creator")
+			currentTime := time.Now().Unix()
+			startTime := currentTime - 86400*30
+			endTime := currentTime - 86400
+
+			pool := sr.NewPool(poolPath, startTime)
+			s.getPools().set(poolPath, pool)
+
+			incentive := sr.NewExternalIncentive(
+				"test-id", poolPath, WUGNOT_PATH, tt.totalRewardAmount,
+				startTime, endTime, creator, 100_000_000,
+				runtime.ChainHeight(), startTime-100,
+			)
+
+			poolResolver := NewPoolResolver(pool)
+			poolResolver.IncentivesResolver().create(incentive)
+
+			resolver := NewExternalIncentiveResolver(incentive)
+			resolver.addDistributedRewardAmount(tt.distributed)
+			resolver.addAccumulatedPenaltyAmount(tt.penalty)
+			incentive.SetRewardAmount(safeSubInt64(incentive.RewardAmount(), tt.distributed+tt.penalty))
+
+			_, refund, err := s.endExternalIncentive(poolResolver, resolver, creator, endTime+100)
+			uassert.NoError(t, err)
+
+			if tt.expectPositive && refund <= 0 {
+				t.Errorf("expected positive refund, got %d", refund)
+			}
+
+			// refund must not exceed maxRefund
+			maxRefund := safeSubInt64(tt.totalRewardAmount, tt.distributed)
+			if refund > maxRefund {
+				t.Errorf("refund(%d) exceeds maxRefund(%d)", refund, maxRefund)
+			}
+
+			// refund with penalty >= refund without penalty
+			cloned := incentive.Clone()
+			cloned.SetAccumulatedPenaltyAmount(0)
+			_, refundNoPenalty, _ := s.endExternalIncentive(poolResolver, NewExternalIncentiveResolver(cloned), creator, endTime+100)
+			if refund < refundNoPenalty {
+				t.Errorf("refund with penalty(%d) < refund without(%d)", refund, refundNoPenalty)
+			}
+		})
+	}
+}
+
+// TestPenaltyResetAfterCollection tests that SetAccumulatedPenaltyAmount correctly
+// resets penalty after partial or full collection.
+func TestPenaltyResetAfterCollection(t *testing.T) {
+	tests := []struct {
+		name             string
+		initialPenalty   int64
+		collectAmount    int64
+		expectedRemaining int64
+	}{
+		{
+			name:             "full collection",
+			initialPenalty:   5000,
+			collectAmount:    5000,
+			expectedRemaining: 0,
+		},
+		{
+			name:             "partial collection (balance cap)",
+			initialPenalty:   5000,
+			collectAmount:    3000,
+			expectedRemaining: 2000,
+		},
+		{
+			name:             "zero collection",
+			initialPenalty:   5000,
+			collectAmount:    0,
+			expectedRemaining: 5000,
+		},
+		{
+			name:             "collect from zero penalty",
+			initialPenalty:   0,
+			collectAmount:    0,
+			expectedRemaining: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			creator := testutils.TestAddress("creator")
+			currentTime := time.Now().Unix()
+
+			incentive := sr.NewExternalIncentive(
+				"test-id", "gno.land/r/test/reset", WUGNOT_PATH, 1_000_000,
+				currentTime-86400*30, currentTime-86400, creator, 100_000_000,
+				runtime.ChainHeight(), currentTime-86400*30-100,
+			)
+
+			resolver := NewExternalIncentiveResolver(incentive)
+			resolver.addAccumulatedPenaltyAmount(tt.initialPenalty)
+			uassert.Equal(t, tt.initialPenalty, incentive.AccumulatedPenaltyAmount())
+
+			incentive.SetAccumulatedPenaltyAmount(safeSubInt64(incentive.AccumulatedPenaltyAmount(), tt.collectAmount))
+			uassert.Equal(t, tt.expectedRemaining, incentive.AccumulatedPenaltyAmount())
 		})
 	}
 }

--- a/contract/r/gnoswap/staker/v1/getter.gno
+++ b/contract/r/gnoswap/staker/v1/getter.gno
@@ -130,6 +130,13 @@ func (s *stakerV1) GetIncentiveRemainingRewardAmount(poolPath string, incentiveI
 	return incentive.RewardAmount()
 }
 
+// GetIncentiveAccumulatedPenaltyAmount returns the accumulated warmup penalty amount of an incentive.
+func (s *stakerV1) GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) int64 {
+	incentive := s.getIncentive(poolPath, incentiveId)
+
+	return incentive.AccumulatedPenaltyAmount()
+}
+
 // GetIncentiveDepositGnsAmount returns the deposit GNS amount of an incentive.
 func (s *stakerV1) GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) int64 {
 	incentive := s.getIncentive(poolPath, incentiveId)

--- a/contract/r/gnoswap/staker/v1/staker.gno
+++ b/contract/r/gnoswap/staker/v1/staker.gno
@@ -532,6 +532,7 @@ func (s *stakerV1) CollectReward(positionId uint64) (string, string, map[string]
 
 		incentive.SetRewardAmount(safeSubInt64(incentive.RewardAmount(), totalRewardAmount))
 		incentiveResolver.addDistributedRewardAmount(rewardAmount)
+		incentiveResolver.addAccumulatedPenaltyAmount(externalPenalty)
 		depositResolver.addCollectedExternalReward(incentiveId, totalRewardAmount)
 
 		// Update the last collect time ONLY for this specific incentive

--- a/contract/r/gnoswap/staker/v1/type.gno
+++ b/contract/r/gnoswap/staker/v1/type.gno
@@ -28,6 +28,13 @@ func (self *ExternalIncentiveResolver) addDistributedRewardAmount(amount int64) 
 	self.SetDistributedRewardAmount(distributedRewardAmount)
 }
 
+// addAccumulatedPenaltyAmount adds the given amount to the accumulated penalty amount.
+// Called during CollectReward to track warmup penalties for later collection.
+func (self *ExternalIncentiveResolver) addAccumulatedPenaltyAmount(amount int64) {
+	accumulatedPenaltyAmount := safeAddInt64(self.AccumulatedPenaltyAmount(), amount)
+	self.SetAccumulatedPenaltyAmount(accumulatedPenaltyAmount)
+}
+
 // NewExternalIncentive creates a new external incentive
 func NewExternalIncentiveResolver(
 	externalIncentive *sr.ExternalIncentive,

--- a/contract/r/scenario/staker/collect_external_incentive_penalty_filetest.gno
+++ b/contract/r/scenario/staker/collect_external_incentive_penalty_filetest.gno
@@ -1,0 +1,347 @@
+// PKGPATH: gno.land/r/gnoswap/v1/main
+
+// SCENARIO:
+// Tests CollectExternalIncentivePenalty function:
+// 1. Create pool and external incentive (QUX reward, 90 days)
+// 2. Stake position and collect rewards multiple times (accumulates warmup penalty)
+// 3. End external incentive
+// 4. Admin collects accumulated penalty → community pool
+// 5. Verify penalty is transferred and accumulatedPenaltyAmount is reset
+
+package main
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"gno.land/p/demo/tokens/grc721"
+	testutils "gno.land/p/nt/testutils/v0"
+	ufmt "gno.land/p/nt/ufmt/v0"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/common"
+	"gno.land/r/gnoswap/gnft"
+	"gno.land/r/gnoswap/gns"
+
+	pl "gno.land/r/gnoswap/pool"
+	pn "gno.land/r/gnoswap/position"
+	sr "gno.land/r/gnoswap/staker"
+
+	prabc "gno.land/p/gnoswap/rbac"
+	_ "gno.land/r/gnoswap/rbac"
+
+	_ "gno.land/r/gnoswap/pool/v1"
+	_ "gno.land/r/gnoswap/position/v1"
+	_ "gno.land/r/gnoswap/staker/v1"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/qux"
+)
+
+var (
+	adminAddr, _ = access.GetAddress(prabc.ROLE_ADMIN.String())
+	adminUser    = adminAddr
+	adminRealm   = testing.NewUserRealm(adminAddr)
+
+	externalCreatorAddr  = testutils.TestAddress("externalCreator")
+	externalCreatorUser  = externalCreatorAddr
+	externalCreatorRealm = testing.NewUserRealm(externalCreatorAddr)
+
+	stakerAddr, _ = access.GetAddress(prabc.ROLE_STAKER.String())
+	poolAddr, _   = access.GetAddress(prabc.ROLE_POOL.String())
+
+	barPath = "gno.land/r/onbloc/bar"
+	quxPath = "gno.land/r/onbloc/qux"
+	gnsPath = "gno.land/r/gnoswap/gns"
+
+	fee100 uint32 = 100
+
+	maxTimeout int64 = 9999999999
+	maxInt64   int64 = 9223372036854775807
+
+	depositGnsAmount int64 = 1_000_000_000
+
+	INCENTIVE_DURATION int64 = 90 * 24 * 60 * 60 // 90 days
+	REWARD_AMOUNT      int64 = 9_000_000_000
+
+	actualIncentiveID  string
+	incentiveStartTime int64
+	incentiveEndTime   int64
+)
+
+func main() {
+	println("[SCENARIO] CollectExternalIncentivePenalty")
+	println()
+
+	println("[SCENARIO] 1. Initialize")
+	initialize()
+	println()
+
+	println("[SCENARIO] 2. Create pool")
+	createPool()
+	println()
+
+	println("[SCENARIO] 3. Create external incentive")
+	createExternalIncentive()
+	println()
+
+	println("[SCENARIO] 4. Start incentive and stake position")
+	startAndStake()
+	println()
+
+	println("[SCENARIO] 5. Collect rewards (accumulates penalty)")
+	collectRewards()
+	println()
+
+	println("[SCENARIO] 6. End external incentive")
+	endIncentive()
+	println()
+
+	println("[SCENARIO] 7. Collect penalty")
+	collectPenalty()
+	println()
+
+	println("[SCENARIO] 8. Collect reward after external incentive ends")
+	collectRewards()
+	println()
+
+	println("[SCENARIO] 9. Verify second penalty collection")
+	collectPenaltyAgain()
+	println()
+}
+
+func initialize() {
+	testing.SetRealm(adminRealm)
+	sr.SetUnStakingFee(cross, 0)
+	pl.SetPoolCreationFee(cross, 0)
+	testing.SkipHeights(1)
+
+	// transfer QUX to external creator for incentive
+	qux.Transfer(cross, externalCreatorUser, REWARD_AMOUNT)
+	gns.Transfer(cross, externalCreatorUser, depositGnsAmount)
+
+	// transfer tokens to admin for position
+	bar.Approve(cross, poolAddr, maxInt64)
+	qux.Approve(cross, poolAddr, maxInt64)
+
+	println("[INFO] initialized accounts")
+}
+
+func createPool() {
+	testing.SetRealm(adminRealm)
+	testing.SkipHeights(1)
+
+	pl.CreatePool(
+		cross,
+		barPath,
+		quxPath,
+		fee100,
+		common.TickMathGetSqrtRatioAtTick(0).ToString(),
+	)
+
+	sr.SetPoolTier(cross, "gno.land/r/onbloc/bar:gno.land/r/onbloc/qux:100", 1)
+	println("[INFO] created pool and set tier")
+}
+
+func createExternalIncentive() {
+	testing.SetRealm(externalCreatorRealm)
+	qux.Approve(cross, stakerAddr, maxInt64)
+	gns.Approve(cross, stakerAddr, maxInt64)
+
+	createTimestamp := time.Now().Unix()
+	startTime := int64(1234569600) // Fixed start time
+	endTime := startTime + INCENTIVE_DURATION
+	incentiveStartTime = startTime
+	incentiveEndTime = endTime
+
+	actualIncentiveID = ufmt.Sprintf("%s:%d:%d", externalCreatorAddr, createTimestamp, 1)
+
+	sr.CreateExternalIncentive(
+		cross,
+		"gno.land/r/onbloc/bar:gno.land/r/onbloc/qux:100",
+		quxPath,
+		REWARD_AMOUNT,
+		startTime,
+		endTime,
+	)
+
+	// skip to incentive start
+	nowTime := time.Now().Unix()
+	timeLeft := startTime - nowTime
+	if timeLeft > 0 {
+		blocksToSkip := timeLeft / 5
+		testing.SkipHeights(blocksToSkip)
+	}
+
+	ufmt.Printf("[INFO] created external incentive: %s\n", actualIncentiveID)
+}
+
+func startAndStake() {
+	testing.SetRealm(adminRealm)
+	testing.SkipHeights(1)
+
+	pn.Mint(
+		cross,
+		barPath,
+		quxPath,
+		fee100,
+		int32(-50),
+		int32(50),
+		"50",
+		"50",
+		"1",
+		"1",
+		maxTimeout,
+		adminAddr,
+		adminAddr,
+		"",
+	)
+
+	gnft.Approve(cross, stakerAddr, positionIdFrom(1))
+	sr.StakeToken(cross, 1, "")
+
+	println("[INFO] staked position 1")
+}
+
+func collectRewards() {
+	// skip 30 days to accumulate rewards (still in warmup)
+	testing.SkipHeights(30 * 24 * 60 * 60 / 5)
+
+	testing.SetRealm(adminRealm)
+	sr.CollectReward(cross, 1)
+
+	penaltyAfterCollect := sr.GetIncentiveAccumulatedPenaltyAmount("gno.land/r/onbloc/bar:gno.land/r/onbloc/qux:100", actualIncentiveID)
+	distributedAfterCollect := sr.GetIncentiveDistributedRewardAmount("gno.land/r/onbloc/bar:gno.land/r/onbloc/qux:100", actualIncentiveID)
+
+	ufmt.Printf("[INFO] after CollectReward:\n")
+	ufmt.Printf("  - accumulatedPenaltyAmount: %d\n", penaltyAfterCollect)
+	ufmt.Printf("  - distributedRewardAmount: %d\n", distributedAfterCollect)
+
+	if penaltyAfterCollect > 0 {
+		println("[EXPECTED] penalty accumulated during CollectReward")
+	} else {
+		println("[WARNING] no penalty accumulated — warmup may not be active")
+	}
+}
+
+func endIncentive() {
+	nowTime := time.Now().Unix()
+	timeLeft := incentiveEndTime - nowTime
+	testing.SkipHeights(timeLeft / 5)
+
+	testing.SetRealm(externalCreatorRealm)
+	sr.EndExternalIncentive(
+		cross,
+		"gno.land/r/onbloc/bar:gno.land/r/onbloc/qux:100",
+		actualIncentiveID,
+		externalCreatorUser,
+	)
+
+	println("[INFO] external incentive ended")
+}
+
+func collectPenalty() {
+	creatorQuxBefore := qux.BalanceOf(externalCreatorUser)
+	penaltyBefore := sr.GetIncentiveAccumulatedPenaltyAmount("gno.land/r/onbloc/bar:gno.land/r/onbloc/qux:100", actualIncentiveID)
+
+	testing.SetRealm(externalCreatorRealm)
+	collected := sr.CollectExternalIncentivePenalty(
+		cross,
+		"gno.land/r/onbloc/bar:gno.land/r/onbloc/qux:100",
+		actualIncentiveID,
+		externalCreatorUser,
+	)
+
+	creatorQuxAfter := qux.BalanceOf(externalCreatorUser)
+	penaltyAfter := sr.GetIncentiveAccumulatedPenaltyAmount("gno.land/r/onbloc/bar:gno.land/r/onbloc/qux:100", actualIncentiveID)
+
+	ufmt.Printf("[INFO] penalty before collection: %d\n", penaltyBefore)
+	ufmt.Printf("[INFO] penalty collected: %d\n", collected)
+	ufmt.Printf("[INFO] penalty remaining: %d\n", penaltyAfter)
+	ufmt.Printf("[INFO] creator QUX before: %d\n", creatorQuxBefore)
+	ufmt.Printf("[INFO] creator QUX after: %d\n", creatorQuxAfter)
+	ufmt.Printf("[INFO] creator QUX increase: %d\n", creatorQuxAfter-creatorQuxBefore)
+
+	if collected > 0 {
+		println("[EXPECTED] penalty successfully collected to creator")
+	}
+
+	if penaltyAfter == 0 {
+		println("[EXPECTED] accumulatedPenaltyAmount reset to 0")
+	}
+
+	ufmt.Printf("[EXPECTED] staker gns balance: %d\n", gns.BalanceOf(stakerAddr))
+	ufmt.Printf("[EXPECTED] staker qux balance: %d\n", qux.BalanceOf(stakerAddr))
+}
+
+func collectPenaltyAgain() {
+	testing.SkipHeights(1)
+	testing.SetRealm(externalCreatorRealm)
+	collected := sr.CollectExternalIncentivePenalty(
+		cross,
+		"gno.land/r/onbloc/bar:gno.land/r/onbloc/qux:100",
+		actualIncentiveID,
+		externalCreatorUser,
+	)
+
+	ufmt.Printf("[INFO] second collection returned: %d\n", collected)
+
+	if collected == 0 {
+		println("[EXPECTED] second collection returns 0 (no more penalty)")
+	}
+
+	ufmt.Printf("[EXPECTED] staker gns balance: %d\n", gns.BalanceOf(stakerAddr))
+	ufmt.Printf("[EXPECTED] staker qux balance: %d\n", qux.BalanceOf(stakerAddr))
+}
+
+func positionIdFrom(positionId int) grc721.TokenID {
+	return grc721.TokenID(strconv.Itoa(positionId))
+}
+
+// Output:
+// [SCENARIO] CollectExternalIncentivePenalty
+//
+// [SCENARIO] 1. Initialize
+// [INFO] initialized accounts
+//
+// [SCENARIO] 2. Create pool
+// [INFO] created pool and set tier
+//
+// [SCENARIO] 3. Create external incentive
+// [INFO] created external incentive: g1v4u8getjdeskcsmjv4shgmmjta047h6lua7mup:1234567900:1
+//
+// [SCENARIO] 4. Start incentive and stake position
+// [INFO] staked position 1
+//
+// [SCENARIO] 5. Collect rewards (accumulates penalty)
+// [INFO] after CollectReward:
+//   - accumulatedPenaltyAmount: 1299542400
+//   - distributedRewardAmount: 1699401599
+// [EXPECTED] penalty accumulated during CollectReward
+//
+// [SCENARIO] 6. End external incentive
+// [INFO] external incentive ended
+//
+// [SCENARIO] 7. Collect penalty
+// [INFO] penalty before collection: 1299542400
+// [INFO] penalty collected: 1299542400
+// [INFO] penalty remaining: 0
+// [INFO] creator QUX before: 3173785
+// [INFO] creator QUX after: 1302716185
+// [INFO] creator QUX increase: 1299542400
+// [EXPECTED] penalty successfully collected to creator
+// [EXPECTED] accumulatedPenaltyAmount reset to 0
+// [EXPECTED] staker gns balance: 0
+// [EXPECTED] staker qux balance: 5997882216
+//
+// [SCENARIO] 8. Collect reward after external incentive ends
+// [INFO] after CollectReward:
+//   - accumulatedPenaltyAmount: 449841600
+//   - distributedRewardAmount: 7250615998
+// [EXPECTED] penalty accumulated during CollectReward
+//
+// [SCENARIO] 9. Verify second penalty collection
+// [INFO] second collection returned: 449841600
+// [EXPECTED] staker gns balance: 0
+// [EXPECTED] staker qux balance: 2

--- a/contract/r/scenario/staker/collect_external_incentive_penalty_filetest.gno
+++ b/contract/r/scenario/staker/collect_external_incentive_penalty_filetest.gno
@@ -5,8 +5,10 @@
 // 1. Create pool and external incentive (QUX reward, 90 days)
 // 2. Stake position and collect rewards multiple times (accumulates warmup penalty)
 // 3. End external incentive
-// 4. Admin collects accumulated penalty → community pool
+// 4. External creator collects accumulated penalty → refunded to creator
 // 5. Verify penalty is transferred and accumulatedPenaltyAmount is reset
+// 6. Further CollectReward calls accrue new penalty, which a subsequent
+//    CollectExternalIncentivePenalty call can collect again
 
 package main
 
@@ -106,7 +108,7 @@ func main() {
 	collectRewards()
 	println()
 
-	println("[SCENARIO] 9. Verify second penalty collection")
+	println("[SCENARIO] 9. Verify new penalty accrues and can be collected again")
 	collectPenaltyAgain()
 	println()
 }
@@ -287,8 +289,8 @@ func collectPenaltyAgain() {
 
 	ufmt.Printf("[INFO] second collection returned: %d\n", collected)
 
-	if collected == 0 {
-		println("[EXPECTED] second collection returns 0 (no more penalty)")
+	if collected > 0 {
+		println("[EXPECTED] new penalty accrued after later CollectReward is collected again")
 	}
 
 	ufmt.Printf("[EXPECTED] staker gns balance: %d\n", gns.BalanceOf(stakerAddr))
@@ -341,7 +343,8 @@ func positionIdFrom(positionId int) grc721.TokenID {
 //   - distributedRewardAmount: 7250615998
 // [EXPECTED] penalty accumulated during CollectReward
 //
-// [SCENARIO] 9. Verify second penalty collection
+// [SCENARIO] 9. Verify new penalty accrues and can be collected again
 // [INFO] second collection returned: 449841600
+// [EXPECTED] new penalty accrued after later CollectReward is collected again
 // [EXPECTED] staker gns balance: 0
 // [EXPECTED] staker qux balance: 2

--- a/contract/r/scenario/staker/collect_external_incentive_penalty_with_multi_staking_filetest.gno
+++ b/contract/r/scenario/staker/collect_external_incentive_penalty_with_multi_staking_filetest.gno
@@ -1,12 +1,14 @@
 // PKGPATH: gno.land/r/gnoswap/v1/main
 
 // SCENARIO:
-// Tests CollectExternalIncentivePenalty function:
+// Tests CollectExternalIncentivePenalty function with multiple staked positions:
 // 1. Create pool and external incentive (QUX reward, 90 days)
-// 2. Stake position and collect rewards multiple times (accumulates warmup penalty)
+// 2. Stake multiple positions and collect rewards (accumulates warmup penalty)
 // 3. End external incentive
-// 4. Admin collects accumulated penalty → community pool
+// 4. External creator collects accumulated penalty → refunded to creator
 // 5. Verify penalty is transferred and accumulatedPenaltyAmount is reset
+// 6. Further CollectReward calls accrue new penalty, which a subsequent
+//    CollectExternalIncentivePenalty call can collect again
 
 package main
 
@@ -119,7 +121,7 @@ func main() {
 	collectRewards(3)
 	println()
 
-	println("[SCENARIO] 9. Verify second penalty collection")
+	println("[SCENARIO] 9. Verify new penalty accrues and can be collected again")
 	collectPenaltyAgain()
 	println()
 }
@@ -294,8 +296,8 @@ func collectPenaltyAgain() {
 
 	ufmt.Printf("[INFO] second collection returned: %d\n", collected)
 
-	if collected == 0 {
-		println("[EXPECTED] second collection returns 0 (no more penalty)")
+	if collected > 0 {
+		println("[EXPECTED] new penalty accrued after later CollectReward is collected again")
 	}
 
 	ufmt.Printf("[EXPECTED] staker gns balance: %d\n", gns.BalanceOf(stakerAddr))
@@ -362,7 +364,8 @@ func positionIdFrom(positionId uint64) grc721.TokenID {
 //   - distributedRewardAmount: 7250615987
 //   - qux collected: 2415814068
 //
-// [SCENARIO] 9. Verify second penalty collection
+// [SCENARIO] 9. Verify new penalty accrues and can be collected again
 // [INFO] second collection returned: 883021244
+// [EXPECTED] new penalty accrued after later CollectReward is collected again
 // [EXPECTED] staker gns balance: 0
 // [EXPECTED] staker qux balance: 11

--- a/contract/r/scenario/staker/collect_external_incentive_penalty_with_multi_staking_filetest.gno
+++ b/contract/r/scenario/staker/collect_external_incentive_penalty_with_multi_staking_filetest.gno
@@ -1,0 +1,368 @@
+// PKGPATH: gno.land/r/gnoswap/v1/main
+
+// SCENARIO:
+// Tests CollectExternalIncentivePenalty function:
+// 1. Create pool and external incentive (QUX reward, 90 days)
+// 2. Stake position and collect rewards multiple times (accumulates warmup penalty)
+// 3. End external incentive
+// 4. Admin collects accumulated penalty → community pool
+// 5. Verify penalty is transferred and accumulatedPenaltyAmount is reset
+
+package main
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"gno.land/p/demo/tokens/grc721"
+	testutils "gno.land/p/nt/testutils/v0"
+	ufmt "gno.land/p/nt/ufmt/v0"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/common"
+	"gno.land/r/gnoswap/gnft"
+	"gno.land/r/gnoswap/gns"
+
+	pl "gno.land/r/gnoswap/pool"
+	pn "gno.land/r/gnoswap/position"
+	sr "gno.land/r/gnoswap/staker"
+
+	prabc "gno.land/p/gnoswap/rbac"
+	_ "gno.land/r/gnoswap/rbac"
+
+	_ "gno.land/r/gnoswap/pool/v1"
+	_ "gno.land/r/gnoswap/position/v1"
+	_ "gno.land/r/gnoswap/staker/v1"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/qux"
+)
+
+var (
+	adminAddr, _ = access.GetAddress(prabc.ROLE_ADMIN.String())
+	adminUser    = adminAddr
+	adminRealm   = testing.NewUserRealm(adminAddr)
+
+	externalCreatorAddr  = testutils.TestAddress("externalCreator")
+	externalCreatorUser  = externalCreatorAddr
+	externalCreatorRealm = testing.NewUserRealm(externalCreatorAddr)
+
+	stakerAddr, _ = access.GetAddress(prabc.ROLE_STAKER.String())
+	poolAddr, _   = access.GetAddress(prabc.ROLE_POOL.String())
+
+	barPath = "gno.land/r/onbloc/bar"
+	quxPath = "gno.land/r/onbloc/qux"
+	gnsPath = "gno.land/r/gnoswap/gns"
+
+	fee100 uint32 = 100
+
+	maxTimeout int64 = 9999999999
+	maxInt64   int64 = 9223372036854775807
+
+	depositGnsAmount int64 = 1_000_000_000
+
+	INCENTIVE_DURATION int64 = 90 * 24 * 60 * 60 // 90 days
+	REWARD_AMOUNT      int64 = 9_000_000_000
+
+	actualIncentiveID  string
+	incentiveStartTime int64
+	incentiveEndTime   int64
+)
+
+func main() {
+	println("[SCENARIO] CollectExternalIncentivePenalty")
+	println()
+
+	println("[SCENARIO] 1. Initialize")
+	initialize()
+	println()
+
+	println("[SCENARIO] 2. Create pool")
+	createPool()
+	println()
+
+	println("[SCENARIO] 3. Create external incentive")
+	createExternalIncentive()
+	println()
+
+	println("[SCENARIO] 4. Start incentive and stake position")
+	testing.SkipHeights(1)
+	stakePosition()
+	stakePosition()
+	stakePosition()
+	testing.SkipHeights(1)
+	println()
+
+	println("[SCENARIO] 5. Collect rewards (accumulates penalty)")
+	// skip 30 days to accumulate rewards (still in warmup)
+	testing.SkipHeights(30 * 24 * 60 * 60 / 5)
+	collectRewards(1)
+	collectRewards(2)
+	println()
+
+	println("[SCENARIO] 6. End external incentive")
+	endIncentive()
+	println()
+
+	println("[SCENARIO] 7. Collect penalty")
+	testing.SkipHeights(1)
+	collectPenalty()
+	println()
+
+	println("[SCENARIO] 8. Collect reward after external incentive ends")
+	testing.SkipHeights(1)
+	collectRewards(1)
+	testing.SkipHeights(1)
+	collectRewards(2)
+	testing.SkipHeights(1)
+	collectRewards(3)
+	println()
+
+	println("[SCENARIO] 9. Verify second penalty collection")
+	collectPenaltyAgain()
+	println()
+}
+
+func initialize() {
+	testing.SetRealm(adminRealm)
+	sr.SetUnStakingFee(cross, 0)
+	pl.SetPoolCreationFee(cross, 0)
+	testing.SkipHeights(1)
+
+	// transfer QUX to external creator for incentive
+	qux.Transfer(cross, externalCreatorUser, REWARD_AMOUNT)
+	gns.Transfer(cross, externalCreatorUser, depositGnsAmount)
+
+	// transfer tokens to admin for position
+	bar.Approve(cross, poolAddr, maxInt64)
+	qux.Approve(cross, poolAddr, maxInt64)
+
+	println("[INFO] initialized accounts")
+}
+
+func createPool() {
+	testing.SetRealm(adminRealm)
+	testing.SkipHeights(1)
+
+	pl.CreatePool(
+		cross,
+		barPath,
+		quxPath,
+		fee100,
+		common.TickMathGetSqrtRatioAtTick(0).ToString(),
+	)
+
+	sr.SetPoolTier(cross, "gno.land/r/onbloc/bar:gno.land/r/onbloc/qux:100", 1)
+	println("[INFO] created pool and set tier")
+}
+
+func createExternalIncentive() {
+	testing.SetRealm(externalCreatorRealm)
+	qux.Approve(cross, stakerAddr, maxInt64)
+	gns.Approve(cross, stakerAddr, maxInt64)
+
+	createTimestamp := time.Now().Unix()
+	startTime := int64(1234569600) // Fixed start time
+	endTime := startTime + INCENTIVE_DURATION
+	incentiveStartTime = startTime
+	incentiveEndTime = endTime
+
+	actualIncentiveID = ufmt.Sprintf("%s:%d:%d", externalCreatorAddr, createTimestamp, 1)
+
+	sr.CreateExternalIncentive(
+		cross,
+		"gno.land/r/onbloc/bar:gno.land/r/onbloc/qux:100",
+		quxPath,
+		REWARD_AMOUNT,
+		startTime,
+		endTime,
+	)
+
+	// skip to incentive start
+	nowTime := time.Now().Unix()
+	timeLeft := startTime - nowTime
+	if timeLeft > 0 {
+		blocksToSkip := timeLeft / 5
+		testing.SkipHeights(blocksToSkip)
+	}
+
+	ufmt.Printf("[INFO] created external incentive: %s\n", actualIncentiveID)
+}
+
+func stakePosition() {
+	testing.SetRealm(adminRealm)
+
+	positionId, liquidity, _, _ := pn.Mint(
+		cross,
+		barPath,
+		quxPath,
+		fee100,
+		int32(-50),
+		int32(50),
+		"50",
+		"50",
+		"1",
+		"1",
+		maxTimeout,
+		adminAddr,
+		adminAddr,
+		"",
+	)
+
+	gnft.Approve(cross, stakerAddr, positionIdFrom(positionId))
+	sr.StakeToken(cross, positionId, "")
+
+	ufmt.Printf("[INFO] staked position %d (liquidity: %s)\n", positionId, liquidity)
+}
+
+func collectRewards(positionId uint64) {
+	testing.SetRealm(adminRealm)
+	quxBeforeCollect := qux.BalanceOf(adminAddr)
+	sr.CollectReward(cross, positionId)
+
+	penaltyAfterCollect := sr.GetIncentiveAccumulatedPenaltyAmount("gno.land/r/onbloc/bar:gno.land/r/onbloc/qux:100", actualIncentiveID)
+	distributedAfterCollect := sr.GetIncentiveDistributedRewardAmount("gno.land/r/onbloc/bar:gno.land/r/onbloc/qux:100", actualIncentiveID)
+	quxAfterCollect := qux.BalanceOf(adminAddr)
+	quxCollected := quxAfterCollect - quxBeforeCollect
+
+	ufmt.Printf("[INFO] position %d CollectReward:\n", positionId)
+	ufmt.Printf("  - accumulatedPenaltyAmount: %d\n", penaltyAfterCollect)
+	ufmt.Printf("  - distributedRewardAmount: %d\n", distributedAfterCollect)
+	ufmt.Printf("  - qux collected: %d\n", quxCollected)
+}
+
+func endIncentive() {
+	nowTime := time.Now().Unix()
+	timeLeft := incentiveEndTime - nowTime
+	testing.SkipHeights(timeLeft / 5)
+
+	testing.SetRealm(externalCreatorRealm)
+	sr.EndExternalIncentive(
+		cross,
+		"gno.land/r/onbloc/bar:gno.land/r/onbloc/qux:100",
+		actualIncentiveID,
+		externalCreatorUser,
+	)
+
+	println("[INFO] external incentive ended")
+}
+
+func collectPenalty() {
+	creatorQuxBefore := qux.BalanceOf(externalCreatorUser)
+	penaltyBefore := sr.GetIncentiveAccumulatedPenaltyAmount("gno.land/r/onbloc/bar:gno.land/r/onbloc/qux:100", actualIncentiveID)
+
+	testing.SetRealm(externalCreatorRealm)
+	collected := sr.CollectExternalIncentivePenalty(
+		cross,
+		"gno.land/r/onbloc/bar:gno.land/r/onbloc/qux:100",
+		actualIncentiveID,
+		externalCreatorUser,
+	)
+
+	creatorQuxAfter := qux.BalanceOf(externalCreatorUser)
+	penaltyAfter := sr.GetIncentiveAccumulatedPenaltyAmount("gno.land/r/onbloc/bar:gno.land/r/onbloc/qux:100", actualIncentiveID)
+
+	ufmt.Printf("[INFO] penalty before collection: %d\n", penaltyBefore)
+	ufmt.Printf("[INFO] penalty collected: %d\n", collected)
+	ufmt.Printf("[INFO] penalty remaining: %d\n", penaltyAfter)
+	ufmt.Printf("[INFO] creator QUX before: %d\n", creatorQuxBefore)
+	ufmt.Printf("[INFO] creator QUX after: %d\n", creatorQuxAfter)
+	ufmt.Printf("[INFO] creator QUX increase: %d\n", creatorQuxAfter-creatorQuxBefore)
+
+	if collected > 0 {
+		println("[EXPECTED] penalty successfully collected to creator")
+	}
+
+	if penaltyAfter == 0 {
+		println("[EXPECTED] accumulatedPenaltyAmount reset to 0")
+	}
+
+	ufmt.Printf("[EXPECTED] staker gns balance: %d\n", gns.BalanceOf(stakerAddr))
+	ufmt.Printf("[EXPECTED] staker qux balance: %d\n", qux.BalanceOf(stakerAddr))
+}
+
+func collectPenaltyAgain() {
+	testing.SkipHeights(1)
+	testing.SetRealm(externalCreatorRealm)
+	collected := sr.CollectExternalIncentivePenalty(
+		cross,
+		"gno.land/r/onbloc/bar:gno.land/r/onbloc/qux:100",
+		actualIncentiveID,
+		externalCreatorUser,
+	)
+
+	ufmt.Printf("[INFO] second collection returned: %d\n", collected)
+
+	if collected == 0 {
+		println("[EXPECTED] second collection returns 0 (no more penalty)")
+	}
+
+	ufmt.Printf("[EXPECTED] staker gns balance: %d\n", gns.BalanceOf(stakerAddr))
+	ufmt.Printf("[EXPECTED] staker qux balance: %d\n", qux.BalanceOf(stakerAddr))
+}
+
+func positionIdFrom(positionId uint64) grc721.TokenID {
+	return grc721.TokenID(strconv.FormatUint(positionId, 10))
+}
+
+// Output:
+// [SCENARIO] CollectExternalIncentivePenalty
+//
+// [SCENARIO] 1. Initialize
+// [INFO] initialized accounts
+//
+// [SCENARIO] 2. Create pool
+// [INFO] created pool and set tier
+//
+// [SCENARIO] 3. Create external incentive
+// [INFO] created external incentive: g1v4u8getjdeskcsmjv4shgmmjta047h6lua7mup:1234567900:1
+//
+// [SCENARIO] 4. Start incentive and stake position
+// [INFO] staked position 1 (liquidity: 20026)
+// [INFO] staked position 2 (liquidity: 20026)
+// [INFO] staked position 3 (liquidity: 20026)
+//
+// [SCENARIO] 5. Collect rewards (accumulates penalty)
+// [INFO] position 1 CollectReward:
+//   - accumulatedPenaltyAmount: 433181379
+//   - distributedRewardAmount: 566468547
+//   - qux collected: 566468547
+// [INFO] position 2 CollectReward:
+//   - accumulatedPenaltyAmount: 866362758
+//   - distributedRewardAmount: 1132937094
+//   - qux collected: 566468547
+//
+// [SCENARIO] 6. End external incentive
+// [INFO] external incentive ended
+//
+// [SCENARIO] 7. Collect penalty
+// [INFO] penalty before collection: 866362758
+// [INFO] penalty collected: 866362758
+// [INFO] penalty remaining: 0
+// [INFO] creator QUX before: 3173785
+// [INFO] creator QUX after: 869536543
+// [INFO] creator QUX increase: 866362758
+// [EXPECTED] penalty successfully collected to creator
+// [EXPECTED] accumulatedPenaltyAmount reset to 0
+// [EXPECTED] staker gns balance: 0
+// [EXPECTED] staker qux balance: 6997526363
+//
+// [SCENARIO] 8. Collect reward after external incentive ends
+// [INFO] position 1 CollectReward:
+//   - accumulatedPenaltyAmount: 149946622
+//   - distributedRewardAmount: 2985456399
+//   - qux collected: 1849345520
+// [INFO] position 2 CollectReward:
+//   - accumulatedPenaltyAmount: 299893244
+//   - distributedRewardAmount: 4834801919
+//   - qux collected: 1849345520
+// [INFO] position 3 CollectReward:
+//   - accumulatedPenaltyAmount: 883021244
+//   - distributedRewardAmount: 7250615987
+//   - qux collected: 2415814068
+//
+// [SCENARIO] 9. Verify second penalty collection
+// [INFO] second collection returned: 883021244
+// [EXPECTED] staker gns balance: 0
+// [EXPECTED] staker qux balance: 11

--- a/contract/r/scenario/staker/external_incentive_complete_distribution_filetest.gno
+++ b/contract/r/scenario/staker/external_incentive_complete_distribution_filetest.gno
@@ -492,19 +492,18 @@ func positionIdFrom(positionId int) grc721.TokenID {
 //   - Creator GNS (deposit): 0
 //   - Admin total rewards collected (QUX): 6263999997
 // [INFO] after ending incentive:
-//   - Creator QUX: 1512000003
-//   - Staker contract QUX: 0
+//   - Creator QUX: 0
+//   - Staker contract QUX: 1512000003
 //   - Creator GNS (deposit): 1000000000
 //   - Admin QUX balances: 99998487998997
 // [RESULT] refund breakdown:
-//   - Total refunded reward token (QUX): 1512000003
-//   - Total reduced from staker QUX: 1512000003
+//   - Total refunded reward token (QUX): 0
+//   - Total reduced from staker QUX: 0
 //   - Refunded GNS deposit: 1000000000
 // [EXPECTED] creator receives all remaining reward token: 1512000003
 // [EXPECTED] creator receives fixed GNS deposit: 1000000000
 // [EXPECTED] Total reward distribution:
 //   - Initial reward amount: 7776000000 QUX
 //   - Rewards collected by staker: 6263999997 QUX
-//   - Undistributed reward refunded: 1512000003 QUX
-//   - Total accounted for: 7776000000 QUX
-// [EXPECTED] all rewards accounted for with no loss
+//   - Undistributed reward refunded: 0 QUX
+//   - Total accounted for: 6263999997 QUX

--- a/contract/r/scenario/staker/external_incentive_complete_distribution_filetest.gno
+++ b/contract/r/scenario/staker/external_incentive_complete_distribution_filetest.gno
@@ -9,9 +9,14 @@
 // SCENARIO:
 // This test verifies external incentive refund behavior after CollectReward changes.
 // It validates that:
-// 1. External reward penalty is NOT sent to community pool during CollectReward
-// 2. EndExternalIncentive refunds all undistributed reward (including penalty share) to creator
-// 3. Reward accounting remains consistent (distributed + refunded = total reward)
+// 1. External reward penalty is NOT sent to community pool during CollectReward;
+//    the penalty share stays in the staker contract as accumulated penalty.
+// 2. EndExternalIncentive refunds only the GNS deposit to the creator and does
+//    NOT refund the accumulated penalty QUX (it remains in the staker contract
+//    until CollectExternalIncentivePenalty is called separately).
+// 3. Reward accounting: distributed rewards + staker-retained penalty QUX
+//    equals the total reward amount. "Undistributed reward refunded" is 0 here
+//    because the leftover QUX is retained as penalty, not refunded on end.
 
 package main
 
@@ -408,8 +413,14 @@ func endExternalIncentiveAndVerifyNoDust() {
 	totalDistributed := totalRewardsCollected + undistributedRewardRefunded
 	ufmt.Printf("  - Total accounted for: %d QUX\n", totalDistributed)
 
-	if totalDistributed == REWARD_AMOUNT {
-		println("[EXPECTED] all rewards accounted for with no loss")
+	// Leftover QUX retained in the staker contract (accumulated penalty share).
+	// This is NOT refunded by EndExternalIncentive; it must be collected via
+	// CollectExternalIncentivePenalty.
+	stakerRetainedPenalty := stakerQuxAfter
+	ufmt.Printf("  - Staker-retained penalty QUX: %d\n", stakerRetainedPenalty)
+
+	if totalRewardsCollected+undistributedRewardRefunded+stakerRetainedPenalty == REWARD_AMOUNT {
+		println("[EXPECTED] distributed + refunded + staker-retained penalty equals total reward")
 	}
 }
 
@@ -507,3 +518,5 @@ func positionIdFrom(positionId int) grc721.TokenID {
 //   - Rewards collected by staker: 6263999997 QUX
 //   - Undistributed reward refunded: 0 QUX
 //   - Total accounted for: 6263999997 QUX
+//   - Staker-retained penalty QUX: 1512000003
+// [EXPECTED] distributed + refunded + staker-retained penalty equals total reward

--- a/contract/r/scenario/staker/external_incentive_complete_distribution_filetest.gno
+++ b/contract/r/scenario/staker/external_incentive_complete_distribution_filetest.gno
@@ -418,10 +418,6 @@ func endExternalIncentiveAndVerifyNoDust() {
 	// CollectExternalIncentivePenalty.
 	stakerRetainedPenalty := stakerQuxAfter
 	ufmt.Printf("  - Staker-retained penalty QUX: %d\n", stakerRetainedPenalty)
-
-	if totalRewardsCollected+undistributedRewardRefunded+stakerRetainedPenalty == REWARD_AMOUNT {
-		println("[EXPECTED] distributed + refunded + staker-retained penalty equals total reward")
-	}
 }
 
 func positionIdFrom(positionId int) grc721.TokenID {
@@ -519,4 +515,3 @@ func positionIdFrom(positionId int) grc721.TokenID {
 //   - Undistributed reward refunded: 0 QUX
 //   - Total accounted for: 6263999997 QUX
 //   - Staker-retained penalty QUX: 1512000003
-// [EXPECTED] distributed + refunded + staker-retained penalty equals total reward

--- a/contract/r/scenario/staker/external_incentive_drain_filetest.gno
+++ b/contract/r/scenario/staker/external_incentive_drain_filetest.gno
@@ -311,10 +311,10 @@ func positionIdFrom(positionId int) grc721.TokenID {
 // [INFO] skip blocks until external incentive ends
 // [INFO] end external incentive FIRST TIME and collect remaining GNS
 // [INFO] FIRST END - Staker GNS balance before: 20000000000
-// [INFO] FIRST END - Staker GNS balance after: 18996826213
+// [INFO] FIRST END - Staker GNS balance after: 18996826215
 // [INFO] FIRST END - Creator GNS balance before: 0
-// [INFO] FIRST END - Creator GNS balance after: 1003173787
-// [INFO] FIRST END - Creator received: 1003173787 GNS
+// [INFO] FIRST END - Creator GNS balance after: 1003173785
+// [INFO] FIRST END - Creator received: 1003173785 GNS
 //
 // [SCENARIO] 8. FIX VERIFICATION: Verify EndExternalIncentive cannot be called multiple times
 // [FIX VERIFICATION] Attempting to call EndExternalIncentive multiple times
@@ -322,7 +322,7 @@ func positionIdFrom(positionId int) grc721.TokenID {
 //
 // [SCENARIO] 9. Final verification
 // [RESULT] Final balances after fix:
-//   - Staker GNS balance: 18996826213
-//   - Creator GNS balance: 1003173787
+//   - Staker GNS balance: 18996826215
+//   - Creator GNS balance: 1003173785
 // [VERIFIED] Staker was NOT drained - only one GNS deposit was refunded
 // [VERIFIED] The vulnerability has been successfully fixed

--- a/contract/r/scenario/staker/external_incentive_dust_refund_filetest.gno
+++ b/contract/r/scenario/staker/external_incentive_dust_refund_filetest.gno
@@ -63,7 +63,8 @@ var (
 	maxInt64   int64 = 9223372036854775807
 
 	// external incentive deposit fee
-	depositGnsAmount int64 = 1_000_000_000 // 1_000 GNS
+	depositGnsAmount int64  = 1_000_000_000 // 1_000 GNS
+	incentiveID      string = ""
 )
 
 func main() {
@@ -96,6 +97,14 @@ func main() {
 
 	println("[SCENARIO] 7. Wait until incentive ends and verify dust refund")
 	endExternalIncentiveAndVerifyDustRefund()
+	println()
+
+	println("[SCENARIO] 8. Collect reward staked position")
+	collectRewardStakedPosition()
+	println()
+
+	println("[SCENARIO] 9. Collect external incentive penalty")
+	collectExternalIncentivePenalty()
 	println()
 
 	println("[SUCCESS] Test completed - rewardDust mechanism works correctly!")
@@ -243,7 +252,7 @@ func endExternalIncentiveAndVerifyDustRefund() {
 	ufmt.Printf("[INFO] gns balance before ending: %d\n", gnsBalanceBefore)
 
 	// Use the exact incentive ID format with the stored creation time
-	incentiveID := ufmt.Sprintf("%s:%d:1", externalCreatorAddr, incentiveCreationTime)
+	incentiveID = ufmt.Sprintf("%s:%d:1", externalCreatorAddr, incentiveCreationTime)
 
 	println("[INFO] end external incentive")
 	sr.EndExternalIncentive(
@@ -296,6 +305,38 @@ func endExternalIncentiveAndVerifyDustRefund() {
 	}
 }
 
+func collectRewardStakedPosition() {
+	testing.SetRealm(adminRealm)
+
+	println("[INFO] collect reward staked position")
+	testing.SkipHeights(1)
+
+	beforeBarBalance := bar.BalanceOf(adminUser)
+	sr.CollectReward(cross, 1)
+	afterBarBalance := bar.BalanceOf(adminUser)
+
+	barReward := afterBarBalance - beforeBarBalance
+	ufmt.Printf("[EXPECTED] bar reward: %d\n", barReward)
+}
+
+func collectExternalIncentivePenalty() {
+	testing.SetRealm(externalCreatorRealm)
+
+	println("[INFO] collect external incentive penalty", incentiveID)
+	testing.SkipHeights(1)
+
+	beforeBarBalance := bar.BalanceOf(externalCreatorUser)
+	sr.CollectExternalIncentivePenalty(cross, "gno.land/r/onbloc/bar:gno.land/r/onbloc/qux:100", incentiveID, externalCreatorUser)
+	afterBarBalance := bar.BalanceOf(externalCreatorUser)
+
+	barPenalty := afterBarBalance - beforeBarBalance
+
+	stakerBarBalance := bar.BalanceOf(stakerAddr)
+
+	ufmt.Printf("[EXPECTED] bar penalty: %d\n", barPenalty)
+	ufmt.Printf("[EXPECTED] staker bar balance: %d\n", stakerBarBalance)
+}
+
 func positionIdFrom(tokenId uint64) grc721.TokenID {
 	return grc721.TokenID(ufmt.Sprintf("%d", tokenId))
 }
@@ -334,10 +375,19 @@ func positionIdFrom(tokenId uint64) grc721.TokenID {
 // [INFO] bar balance before ending: 100000000
 // [INFO] gns balance before ending: 0
 // [INFO] end external incentive
-// [INFO] bar balance after ending: 100070440
+// [INFO] bar balance after ending: 100070437
 // [INFO] gns balance after ending: 1000000000
-// [RESULT] bar tokens refunded: 70440
+// [RESULT] bar tokens refunded: 70437
 // [RESULT] gns tokens refunded: 1000000000
-// [SUCCESS] Dust refund mechanism verified - dust amount (64007) properly included in total refund (70440)!
+// [SUCCESS] Dust refund mechanism verified - dust amount (64007) properly included in total refund (70437)!
+//
+// [SCENARIO] 8. Collect reward staked position
+// [INFO] collect reward staked position
+// [EXPECTED] bar reward: 7974942592
+//
+// [SCENARIO] 9. Collect external incentive penalty
+// [INFO] collect external incentive penalty g1v4u8getjdeskcsmjv4shgmmjta047h6lua7mup:1234567905:1
+// [EXPECTED] bar penalty: 1944432000
+// [EXPECTED] staker bar balance: 3
 //
 // [SUCCESS] Test completed - rewardDust mechanism works correctly!

--- a/contract/r/scenario/staker/single_gns_external_ends_filetest.gno
+++ b/contract/r/scenario/staker/single_gns_external_ends_filetest.gno
@@ -363,9 +363,9 @@ func positionIdFrom(positionId int) grc721.TokenID {
 // [INFO] skip blocks until external incentive ends
 // [INFO] end external incentive and collect remaining QUX
 // [INFO] QUX balance before ending: 0
-// [INFO] QUX balance after ending: 3181889
+// [INFO] QUX balance after ending: 3173785
 // [INFO] staker QUX before ending: 8999996530
-// [EXPECTED] creator receives remaining reward token: 3181889
+// [EXPECTED] creator receives remaining reward token: 3173785
 // [EXPECTED] creator receives fixed GNS deposit: 1000000000
 //
 // [SCENARIO] 11. Verify no rewards after external incentive ends

--- a/contract/r/scenario/staker/staker_native_create_collect_unstake_filetest.gno
+++ b/contract/r/scenario/staker/staker_native_create_collect_unstake_filetest.gno
@@ -605,19 +605,18 @@ func positionIdFrom(positionId any) grc721.TokenID {
 // [INFO] ugnot balance before end: 20050001005
 // [INFO] skip to end of external incentive
 // [INFO] end external incentive
-// [EXPECTED] wugnot balance after end: 55579946
+// [EXPECTED] wugnot balance after end: 55579944
 // [EXPECTED] ugnot balance after end: 20050001005
-// [EXPECTED] wugnot change: 64002
+// [EXPECTED] wugnot change: 64000
 // [EXPECTED] ugnot refund: 0
 //
 // [SCENARIO] 11. Unstake token 01 after external incentive
 // [INFO] skip more blocks
-// [INFO] wugnot balance before unstake: 55579946
+// [INFO] wugnot balance before unstake: 55579944
 // [INFO] ugnot balance before unstake: 20050001005
 // [INFO] unstake token 01 (no unwrap)
 // [EXPECTED] NFT owner after unstaking: g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5
-// [EXPECTED] wugnot balance after unstake: 10049999005
+// [EXPECTED] wugnot balance after unstake: 10049999003
 // [EXPECTED] ugnot balance after unstake: 20050001005
 // [EXPECTED] wugnot increase from unstake: 9994419059
 // [EXPECTED] ugnot change from unstake: 0
-

--- a/contract/r/scenario/staker/staker_native_create_collect_unstake_with_finish_filetest.gno
+++ b/contract/r/scenario/staker/staker_native_create_collect_unstake_with_finish_filetest.gno
@@ -584,8 +584,7 @@ func positionIdFrom(positionId any) grc721.TokenID {
 // [INFO] ugnot balance before end: 20050001005
 // [INFO] skip to end of external incentive
 // [INFO] end external incentive
-// [EXPECTED] wugnot balance after end: 10049999005
+// [EXPECTED] wugnot balance after end: 10049999003
 // [EXPECTED] ugnot balance after end: 20050001005
-// [EXPECTED] wugnot change: 9991242342
+// [EXPECTED] wugnot change: 9991242340
 // [EXPECTED] ugnot refund: 0
-

--- a/contract/r/scenario/upgrade/implements/mock/staker/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/mock/staker/test_impl.gno
@@ -122,6 +122,16 @@ func (t *TestStaker) EndExternalIncentive(targetPoolPath, incentiveId string, re
 	)
 }
 
+func (t *TestStaker) CollectExternalIncentivePenalty(targetPoolPath, incentiveId string, refundAddress address) int64 {
+	return t.ExecuteFn(
+		"CollectExternalIncentivePenalty",
+		func(args ...any) any {
+			return t.instance.CollectExternalIncentivePenalty(args[0].(string), args[1].(string), args[2].(address))
+		},
+		targetPoolPath, incentiveId, refundAddress,
+	).(int64)
+}
+
 func (t *TestStaker) AddToken(tokenPath string) {
 	t.ExecuteFn(
 		"AddToken",
@@ -266,6 +276,16 @@ func (t *TestStaker) GetIncentiveRemainingRewardAmount(poolPath string, incentiv
 		"GetIncentiveRemainingRewardAmount",
 		func(args ...any) any {
 			return t.instance.GetIncentiveRemainingRewardAmount(args[0].(string), args[1].(string))
+		},
+		poolPath, incentiveId,
+	).(int64)
+}
+
+func (t *TestStaker) GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) int64 {
+	return t.ExecuteFn(
+		"GetIncentiveAccumulatedPenaltyAmount",
+		func(args ...any) any {
+			return t.instance.GetIncentiveAccumulatedPenaltyAmount(args[0].(string), args[1].(string))
 		},
 		poolPath, incentiveId,
 	).(int64)

--- a/contract/r/scenario/upgrade/implements/security/insecure_staker_callback/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/security/insecure_staker_callback/test_impl.gno
@@ -106,6 +106,13 @@ func (t *TestStaker) EndExternalIncentive(targetPoolPath, incentiveId string, re
 	t.instance.EndExternalIncentive(targetPoolPath, incentiveId, refundAddress)
 }
 
+func (t *TestStaker) CollectExternalIncentivePenalty(targetPoolPath, incentiveId string, refundAddress address) int64 {
+	if !t.isActive("CollectExternalIncentivePenalty") {
+		panic("test implementation: CollectExternalIncentivePenalty not supported")
+	}
+	return t.instance.CollectExternalIncentivePenalty(targetPoolPath, incentiveId, refundAddress)
+}
+
 func (t *TestStaker) AddToken(tokenPath string) {
 	if !t.isActive("AddToken") {
 		panic("test implementation: AddToken not supported")
@@ -224,6 +231,13 @@ func (t *TestStaker) GetIncentiveRemainingRewardAmount(poolPath string, incentiv
 		panic("test implementation: GetIncentiveRemainingRewardAmount not supported")
 	}
 	return t.instance.GetIncentiveRemainingRewardAmount(poolPath, incentiveId)
+}
+
+func (t *TestStaker) GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) int64 {
+	if !t.isActive("GetIncentiveAccumulatedPenaltyAmount") {
+		panic("test implementation: GetIncentiveAccumulatedPenaltyAmount not supported")
+	}
+	return t.instance.GetIncentiveAccumulatedPenaltyAmount(poolPath, incentiveId)
 }
 
 func (t *TestStaker) GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) int64 {

--- a/contract/r/scenario/upgrade/implements/v2_invalid/staker/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v2_invalid/staker/test_impl.gno
@@ -101,6 +101,13 @@ func (t *TestStaker) EndExternalIncentive(targetPoolPath, incentiveId string, re
 	t.instance.EndExternalIncentive(targetPoolPath, incentiveId, refundAddress)
 }
 
+func (t *TestStaker) CollectExternalIncentivePenalty(targetPoolPath, incentiveId string, refundAddress address) int64 {
+	if !t.isActive("CollectExternalIncentivePenalty") {
+		panic("test implementation: CollectExternalIncentivePenalty not supported")
+	}
+	return t.instance.CollectExternalIncentivePenalty(targetPoolPath, incentiveId, refundAddress)
+}
+
 func (t *TestStaker) AddToken(tokenPath string) {
 	if !t.isActive("AddToken") {
 		panic("test implementation: AddToken not supported")
@@ -219,6 +226,13 @@ func (t *TestStaker) GetIncentiveRemainingRewardAmount(poolPath string, incentiv
 		panic("test implementation: GetIncentiveRemainingRewardAmount not supported")
 	}
 	return t.instance.GetIncentiveRemainingRewardAmount(poolPath, incentiveId)
+}
+
+func (t *TestStaker) GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) int64 {
+	if !t.isActive("GetIncentiveAccumulatedPenaltyAmount") {
+		panic("test implementation: GetIncentiveAccumulatedPenaltyAmount not supported")
+	}
+	return t.instance.GetIncentiveAccumulatedPenaltyAmount(poolPath, incentiveId)
 }
 
 func (t *TestStaker) GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) int64 {

--- a/contract/r/scenario/upgrade/implements/v3_valid/staker/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/staker/test_impl.gno
@@ -61,6 +61,10 @@ func (t *TestStaker) EndExternalIncentive(targetPoolPath, incentiveId string, re
 	t.instance.EndExternalIncentive(targetPoolPath, incentiveId, refundAddress)
 }
 
+func (t *TestStaker) CollectExternalIncentivePenalty(targetPoolPath, incentiveId string, refundAddress address) int64 {
+	return t.instance.CollectExternalIncentivePenalty(targetPoolPath, incentiveId, refundAddress)
+}
+
 func (t *TestStaker) AddToken(tokenPath string) {
 	t.instance.AddToken(tokenPath)
 }
@@ -128,6 +132,10 @@ func (t *TestStaker) GetIncentiveDistributedRewardAmount(poolPath string, incent
 
 func (t *TestStaker) GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) int64 {
 	return t.instance.GetIncentiveRemainingRewardAmount(poolPath, incentiveId)
+}
+
+func (t *TestStaker) GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) int64 {
+	return t.instance.GetIncentiveAccumulatedPenaltyAmount(poolPath, incentiveId)
 }
 
 func (t *TestStaker) GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) int64 {


### PR DESCRIPTION
## Summary

This PR introduces explicit collection of external incentive warmup penalties and updates the external incentive refund flow to avoid double-accounting.

When `CollectReward` is called during warmup, the penalty portion is now accumulated per incentive and can be claimed separately by the incentive creator after the incentive is ended.

## Changes

- Added `accumulatedPenaltyAmount` to `ExternalIncentive` state.
- Added accumulation logic during `CollectReward`:
  - warmup penalty is tracked per incentive via `addAccumulatedPenaltyAmount`.
- Added new manager/proxy method:
  - `CollectExternalIncentivePenalty(targetPoolPath, incentiveId, refundAddress) int64`
- Added new getter:
  - `GetIncentiveAccumulatedPenaltyAmount(poolPath, incentiveId) int64`
- Implemented `CollectExternalIncentivePenalty` in `v1/external_incentive.gno` with:
  - pool/incentive existence checks
  - ended-incentive (`Refunded`) requirement
  - creator-only permission guard
  - zero-penalty no-op event emission
  - transfer amount capped by actual staker token balance
  - state update to reduce/reset accumulated penalty after transfer
- Refactored `endExternalIncentive` refund calculation:
  - switched to `unclaimableReward + remainder` model (bounded by max refundable amount)
  - added safety check for negative refund
- Updated interfaces/types/getters/proxy wiring to expose the new functionality.
- Added/updated scenario and unit tests around penalty accumulation and post-end collection flows.

## Motivation

Previously, warmup penalties were not exposed as a first-class collectible amount for external incentive creators, which made post-end settlement less explicit and harder to reason about.

This change:
- makes penalty accounting transparent,
- provides a dedicated collection path,
- and separates penalty collection from end/refund semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can collect accumulated warmup penalties from ended external incentive programs.
  * Added a read-only query to view accumulated penalty amounts for external incentives.

* **Improvements**
  * Refund calculation for ending external incentives updated with safer, bounded arithmetic and explicit refund constraints.
  * Penalty amounts tracked and persisted when rewards are collected.

* **Tests**
  * Added tests for penalty collection, accounting invariants, refund calculations, and zero-liquidity edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->