### PR TITLE
fix(position): use MulDiv for unclaimed fee

### DIFF
--- a/contract/r/gnoswap/position/v1/getter.gno
+++ b/contract/r/gnoswap/position/v1/getter.gno
@@ -175,18 +175,9 @@ func (p *positionV1) GetUnclaimedFee(positionId uint64) (*u256.Uint, *u256.Uint)
 	feeGrowthInside1X128 = u256.Zero().Sub(feeGrowthInside1X128, tickUpperFeeGrowthAbove1)
 
 	diffGrowthInside0X128 := u256.Zero().Sub(feeGrowthInside0X128, feeGrowthInside0LastX128)
-	unclaimedFee0X128, overflow := u256.Zero().MulOverflow(liquidity, diffGrowthInside0X128)
-	if overflow {
-		panic(errOverflow)
-	}
-	unclaimedFee0 := u256.Zero().Div(unclaimedFee0X128, q128)
+	unclaimedFee0 := u256.MulDiv(diffGrowthInside0X128, liquidity, q128)
 
 	diffGrowthInside1X128 := u256.Zero().Sub(feeGrowthInside1X128, feeGrowthInside1LastX128)
-	unclaimedFee1X128, overflow := u256.Zero().MulOverflow(liquidity, diffGrowthInside1X128)
-	if overflow {
-		panic(errOverflow)
-	}
-
-	unclaimedFee1 := u256.Zero().Div(unclaimedFee1X128, q128)
+	unclaimedFee1 := u256.MulDiv(diffGrowthInside1X128, liquidity, q128)
 	return unclaimedFee0, unclaimedFee1
 }

--- a/contract/r/gnoswap/position/v1/getter_test.gno
+++ b/contract/r/gnoswap/position/v1/getter_test.gno
@@ -3,6 +3,7 @@ package v1
 import (
 	"testing"
 
+	u256 "gno.land/p/gnoswap/uint256"
 	uassert "gno.land/p/nt/uassert/v0"
 )
 
@@ -557,6 +558,43 @@ func TestGetUnclaimedFee(t *testing.T) {
 			uassert.Equal(t, tc.expectedFee1, fee1.ToString())
 		})
 	}
+}
+
+func TestGetUnclaimedFeeUsesMulDivForLargeIntermediateProduct(t *testing.T) {
+	setupPositionGetter(t)
+
+	position := mockInstance.mustGetPosition(1)
+	position.SetLiquidity(MAX_UINT256)
+	position.SetFeeGrowthInside0LastX128("0")
+	position.SetFeeGrowthInside1LastX128("0")
+	mockInstance.mustUpdatePosition(1, *position)
+
+	storedPool := mustGetStoredTestPool(position.PoolKey())
+	storedPool.SetFeeGrowthGlobal0X128(u256.NewUint(2))
+	storedPool.SetFeeGrowthGlobal1X128(u256.Zero())
+
+	lowerTick, err := storedPool.GetTick(position.TickLower())
+	if err != nil {
+		t.Fatalf("failed to get lower tick: %v", err)
+	}
+	lowerTick.SetFeeGrowthOutside0X128("0")
+	lowerTick.SetFeeGrowthOutside1X128("0")
+	storedPool.SetTick(position.TickLower(), lowerTick)
+
+	upperTick, err := storedPool.GetTick(position.TickUpper())
+	if err != nil {
+		t.Fatalf("failed to get upper tick: %v", err)
+	}
+	upperTick.SetFeeGrowthOutside0X128("0")
+	upperTick.SetFeeGrowthOutside1X128("0")
+	storedPool.SetTick(position.TickUpper(), upperTick)
+
+	expectedFee0 := u256.MulDiv(u256.NewUint(2), u256.MustFromDecimal(MAX_UINT256), q128)
+
+	fee0, fee1 := mockInstance.GetUnclaimedFee(1)
+
+	uassert.Equal(t, expectedFee0.ToString(), fee0.ToString())
+	uassert.Equal(t, "0", fee1.ToString())
 }
 
 func TestMustGetPositionPanic(t *testing.T) {


### PR DESCRIPTION
## Summary
- replace `GetUnclaimedFee` intermediate `MulOverflow` + `Div` with `u256.MulDiv` so the getter matches the protocol's full-precision fee calculation path
- add a regression test covering the large-intermediate-product case where the final quotient is valid but the old getter path would panic

## Verification
- make test PKG=gno.land/r/gnoswap/position/v1
- make test PKG=gno.land/r/gnoswap/scenario/position

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized fee calculation logic to handle large liquidity values more reliably.

* **Tests**
  * Added test coverage for fee calculations with maximum liquidity values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->