### PR TITLE
refactor(gov/governance): remove unused param in hasActiveProposal

### DIFF
--- a/contract/r/gnoswap/gov/governance/v1/governance_propose.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_propose.gno
@@ -58,7 +58,7 @@ func (gv *governanceV1) ProposeText(
 	}
 
 	// Check if caller already has an active proposal (one proposal per address)
-	if gv.hasActiveProposal(callerAddress, createdAt) {
+	if gv.hasActiveProposal(callerAddress) {
 		panic(errAlreadyActiveProposal)
 	}
 
@@ -167,7 +167,7 @@ func (gv *governanceV1) ProposeCommunityPoolSpend(
 	}
 
 	// Check if caller already has an active proposal (one proposal per address)
-	if gv.hasActiveProposal(callerAddress, createdAt) {
+	if gv.hasActiveProposal(callerAddress) {
 		panic(errAlreadyActiveProposal)
 	}
 
@@ -274,7 +274,7 @@ func (gv *governanceV1) ProposeParameterChange(
 	}
 
 	// Check if caller already has an active proposal (one proposal per address)
-	if gv.hasActiveProposal(callerAddress, createdAt) {
+	if gv.hasActiveProposal(callerAddress) {
 		panic(errAlreadyActiveProposal)
 	}
 

--- a/contract/r/gnoswap/gov/governance/v1/instance.gno
+++ b/contract/r/gnoswap/gov/governance/v1/instance.gno
@@ -99,7 +99,7 @@ func (g *governanceV1) getUserProposals(user string) []*governance.Proposal {
 	return proposals
 }
 
-func (g *governanceV1) hasActiveProposal(proposerAddress address, current int64) bool {
+func (g *governanceV1) hasActiveProposal(proposerAddress address) bool {
 	proposals := g.getUserProposals(proposerAddress.String())
 
 	return len(proposals) > 0

--- a/contract/r/gnoswap/gov/governance/v1/instance.gno
+++ b/contract/r/gnoswap/gov/governance/v1/instance.gno
@@ -99,6 +99,7 @@ func (g *governanceV1) getUserProposals(user string) []*governance.Proposal {
 	return proposals
 }
 
+// hasActiveProposal assumes removeInactiveUserProposals has already pruned stale proposals.
 func (g *governanceV1) hasActiveProposal(proposerAddress address) bool {
 	proposals := g.getUserProposals(proposerAddress.String())
 

--- a/contract/r/gnoswap/gov/governance/v1/instance_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/instance_test.gno
@@ -53,6 +53,7 @@ func TestInstance_RemoveInactiveUserProposals(t *testing.T) {
 		currentTime            int64
 		expectedRemainingCount int
 		expectedRemainingIDs   []int64
+		expectedHasActive      bool
 	}{
 		{
 			name:                   "No proposals for user",
@@ -60,6 +61,7 @@ func TestInstance_RemoveInactiveUserProposals(t *testing.T) {
 			currentTime:            baseCreatedAt,
 			expectedRemainingCount: 0,
 			expectedRemainingIDs:   nil,
+			expectedHasActive:      false,
 		},
 		{
 			name: "All proposals are active - none should be removed",
@@ -77,6 +79,7 @@ func TestInstance_RemoveInactiveUserProposals(t *testing.T) {
 			currentTime:            baseCreatedAt + config.VotingStartDelay + 50, // during voting period
 			expectedRemainingCount: 1,
 			expectedRemainingIDs:   []int64{1},
+			expectedHasActive:      true,
 		},
 		{
 			name: "All proposals are expired - all should be removed",
@@ -94,6 +97,7 @@ func TestInstance_RemoveInactiveUserProposals(t *testing.T) {
 			currentTime:            expiredTime + 100, // after expired
 			expectedRemainingCount: 0,
 			expectedRemainingIDs:   nil,
+			expectedHasActive:      false,
 		},
 		{
 			name: "Mixed active and inactive proposals - only inactive should be removed",
@@ -124,6 +128,7 @@ func TestInstance_RemoveInactiveUserProposals(t *testing.T) {
 			currentTime:            expiredTime + 50 + config.VotingStartDelay + 50, // during new proposal's voting period
 			expectedRemainingCount: 1,
 			expectedRemainingIDs:   []int64{2},
+			expectedHasActive:      true,
 		},
 		{
 			name: "Canceled proposal should be removed",
@@ -145,6 +150,7 @@ func TestInstance_RemoveInactiveUserProposals(t *testing.T) {
 			currentTime:            baseCreatedAt + 50,
 			expectedRemainingCount: 0,
 			expectedRemainingIDs:   nil,
+			expectedHasActive:      false,
 		},
 		{
 			name: "Multiple expired proposals - all should be removed",
@@ -164,6 +170,7 @@ func TestInstance_RemoveInactiveUserProposals(t *testing.T) {
 			currentTime:            expiredTime + 100,
 			expectedRemainingCount: 0,
 			expectedRemainingIDs:   nil,
+			expectedHasActive:      false,
 		},
 		{
 			name: "Multiple active proposals - none should be removed",
@@ -183,6 +190,7 @@ func TestInstance_RemoveInactiveUserProposals(t *testing.T) {
 			currentTime:            baseCreatedAt + config.VotingStartDelay + 50, // during voting period
 			expectedRemainingCount: 3,
 			expectedRemainingIDs:   []int64{1, 2, 3},
+			expectedHasActive:      true,
 		},
 	}
 
@@ -200,6 +208,7 @@ func TestInstance_RemoveInactiveUserProposals(t *testing.T) {
 
 			proposals := gv.getUserProposals(proposerAddr.String())
 			uassert.Equal(t, len(proposals), tc.expectedRemainingCount)
+			uassert.Equal(t, gv.hasActiveProposal(proposerAddr), tc.expectedHasActive)
 
 			// Verify remaining proposal IDs
 			if tc.expectedRemainingIDs != nil {

--- a/contract/r/gnoswap/gov/governance/v1/instance_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/instance_test.gno
@@ -64,6 +64,24 @@ func TestInstance_RemoveInactiveUserProposals(t *testing.T) {
 			expectedHasActive:      false,
 		},
 		{
+			name: "Upcoming proposal should remain active",
+			setup: func(gv *governanceV1) {
+				proposal := governance.NewProposal(
+					1,
+					NewProposalStatus(config, 1000, false, baseCreatedAt),
+					governance.NewProposalMetadata("Test Title", "Test Description"),
+					NewProposalTextData(),
+					proposerAddr, 1, baseCreatedAt,
+					100,
+				)
+				gv.addProposal(proposal)
+			},
+			currentTime:            baseCreatedAt + config.VotingStartDelay - 10,
+			expectedRemainingCount: 1,
+			expectedRemainingIDs:   []int64{1},
+			expectedHasActive:      true,
+		},
+		{
 			name: "All proposals are active - none should be removed",
 			setup: func(gv *governanceV1) {
 				proposal := governance.NewProposal(
@@ -151,6 +169,33 @@ func TestInstance_RemoveInactiveUserProposals(t *testing.T) {
 			expectedRemainingCount: 0,
 			expectedRemainingIDs:   nil,
 			expectedHasActive:      false,
+		},
+		{
+			name: "Executable proposal should remain active",
+			setup: func(gv *governanceV1) {
+				proposal := governance.NewProposal(
+					1,
+					NewProposalStatus(config, 1000, true, baseCreatedAt),
+					governance.NewProposalMetadata("Test Title", "Test Description"),
+					NewProposalCommunityPoolSpendData(
+						"gno.land/r/gnoswap/gns",
+						testutils.TestAddress("recipient"),
+						100,
+						"gno.land/r/gnoswap/community_pool",
+					),
+					proposerAddr, 1, baseCreatedAt,
+					100,
+				)
+
+				proposalResolver := NewProposalResolver(proposal)
+				_ = proposalResolver.Vote(true, 600)
+
+				gv.addProposal(proposal)
+			},
+			currentTime:            baseCreatedAt + config.VotingStartDelay + config.VotingPeriod + config.ExecutionDelay + 50,
+			expectedRemainingCount: 1,
+			expectedRemainingIDs:   []int64{1},
+			expectedHasActive:      true,
 		},
 		{
 			name: "Multiple expired proposals - all should be removed",


### PR DESCRIPTION
## Summary
- remove the unused `current` parameter from `hasActiveProposal` now that proposal activity is already determined during stale-proposal cleanup
- update all governance proposal entrypoints to keep the existing prune-then-check flow while calling the helper with its actual dependency surface
- extend the instance cleanup test to assert `hasActiveProposal` matches the remaining proposal set after inactive proposals are removed

## Testing
- make test PKG=gno.land/r/gnoswap/gov/governance/v1 RUN=TestInstance_RemoveInactiveUserProposals
- make test PKG=gno.land/r/gnoswap/gov/governance/v1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined proposal eligibility checks: activity is now determined by the presence of existing proposals, reducing false negatives and preventing conflicting submissions.
* **Tests**
  * Updated governance tests to cover pre-voting and executable proposal scenarios and to verify the revised active-proposal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->