### PR TITLE
fix(referral): rate limit cancellation

### DIFF
--- a/contract/r/gnoswap/referral/README.md
+++ b/contract/r/gnoswap/referral/README.md
@@ -8,9 +8,9 @@ Manages referral relationships between users with cooldown periods to prevent ga
 
 ## Global Functions
 
-### `TryRegister(cur realm, addr address, referral string) bool`
-Attempts to register a referral relationship. Returns true on success, false on failure.
-Emits `ReferralRegistrationFailed` event on error.
+### `TryRegister(cur realm, addr address, referral string) string`
+Attempts to register or remove a referral relationship. Returns the effective referrer string.
+Emits `ReferralRegistrationFailed` on non-empty registration failure.
 
 ### `GetReferral(addr string) string`
 Returns the referral address for the given address. Returns empty string if not found.
@@ -20,6 +20,9 @@ Returns true if the given address has a referral.
 
 ### `IsEmpty() bool`
 Returns true if no referrals exist in the system.
+
+### `GetLastOpTimestamp(addr string) (int64, error)`
+Returns the timestamp of the last successful referral registration, update, or removal.
 
 ### `ContractAddress() string`
 Returns the address of the referral contract. Use this address as the referral parameter in `TryRegister` to remove an existing referral.
@@ -82,7 +85,7 @@ func CheckUserHasReferral(userAddr string) bool {
 ## Security
 
 - One referral per address
-- 24-hour change cooldown
+- 24-hour cooldown for registration, update, and cancellation
 - No self-referrals
-- Immutable during cooldown
+- Successful cancellation refreshes the cooldown timestamp
 - Only authorized callers can modify referrals

--- a/contract/r/gnoswap/referral/doc.gno
+++ b/contract/r/gnoswap/referral/doc.gno
@@ -31,7 +31,8 @@
 //     registered referrer.
 //   - IsEmpty() bool: Returns true if no referral relationships exist.
 //   - GetLastOpTimestamp(addr string) (int64, error): Returns the last
-//     referral operation timestamp for the given user address.
+//     successful referral registration, update, or removal timestamp for
+//     the given user address.
 //   - TryRegister(cur realm, addr address, referral string) string:
 //     Attempts to register a new referral and returns the effective referrer.
 //     Empty input returns the user's stored referral without attempting registration.
@@ -45,8 +46,10 @@
 //  2. The keeper validates the caller's permissions via isValidCaller.
 //  3. Address validation ensures both addresses are valid and not
 //     self-referencing.
-//  4. Rate limiting checks prevent operations more than once per 24 hours.
-//  5. The referral is stored in the AVL tree and an event is emitted when registration occurs.
+//  4. Registration, update, and removal attempts are rate-limited to prevent
+//     rapid referral churn.
+//  5. A successful removal updates the last-operation timestamp.
+//  6. The referral is stored in the AVL tree and an event is emitted when registration occurs.
 //
 // ## Authorized Callers
 //
@@ -65,8 +68,11 @@
 // operations for each address. This means:
 //
 //   - A new referral can only be registered once per 24 hours per address
-//   - Updates and removals are also subject to the same rate limit
-//   - Attempting operations within the cooldown period returns ErrTooManyRequests
+//   - Updates and removals are subject to the same rate limit
+//   - Successful removal updates the last-operation timestamp, so immediate
+//     re-registration is still blocked
+//   - Attempting a referral operation within the cooldown period returns
+//     ErrTooManyRequests
 //
 // ## Events
 //
@@ -136,11 +142,13 @@
 //   - Self-referral is not allowed
 //   - Operations are rate-limited to once per 24 hours per address
 //   - Only authorized contracts can register/update/remove referrals
-//   - Zero address as referrer triggers removal of the referral
+//   - Passing the referral contract address as the referrer triggers
+//     removal of the referral
 //
 // ## Notes
 //
 //   - The contract uses RBAC (Role-Based Access Control) for authorization
-//   - Rate limiting state persists across transactions
+//   - Rate limiting state persists across transactions, including after a
+//     successful removal
 //   - Events are emitted for all state changes for off-chain tracking
 package referral

--- a/contract/r/gnoswap/referral/global_keeper_test.gno
+++ b/contract/r/gnoswap/referral/global_keeper_test.gno
@@ -350,6 +350,33 @@ func TestGlobalKeeper_GetLastOpTimestamp(t *testing.T) {
 	}
 }
 
+func TestGlobalKeeper_GetLastOpTimestampAfterRemoval(t *testing.T) {
+	cleanup(t)
+	testing.SetRealm(routerRealm)
+
+	userAddr := testutils.TestAddress("user-removal")
+	refAddr := testutils.TestAddress("referrer-removal")
+
+	uassert.Equal(t, refAddr.String(), TryRegister(cross, userAddr, refAddr.String()))
+	uassert.True(t, HasReferral(userAddr.String()))
+
+	uassert.Equal(t, refAddr.String(), TryRegister(cross, userAddr, contractAddress().String()))
+	uassert.True(t, HasReferral(userAddr.String()))
+
+	k := gReferralKeeper.(*keeper)
+	k.lastOps.Set(userAddr.String(), int64(0))
+	beforeRemoval := time.Now().Unix()
+	uassert.Equal(t, "", TryRegister(cross, userAddr, contractAddress().String()))
+
+	got, err := GetLastOpTimestamp(userAddr.String())
+	uassert.NoError(t, err)
+	uassert.True(t, got >= beforeRemoval)
+	uassert.False(t, HasReferral(userAddr.String()))
+
+	result := TryRegister(cross, userAddr, testutils.TestAddress("ref-next").String())
+	uassert.Equal(t, "", result)
+}
+
 func TestGlobalKeeper_TryRegisterFallbacks(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/contract/r/gnoswap/referral/keeper.gno
+++ b/contract/r/gnoswap/referral/keeper.gno
@@ -38,19 +38,21 @@ func (k *keeper) register(addr, refAddr address) (address, error) {
 	addrStr := addr.String()
 	refAddrStr := refAddr.String()
 
+	if err := k.checkRateLimit(addrStr); err != nil {
+		return zeroAddress, err
+	}
+
 	if isRemovalRequest(refAddr) {
 		if k.has(addr) {
 			_, ok := k.store.Remove(addrStr)
 			if !ok {
 				return zeroAddress, ErrNotFound
 			}
+
+			k.lastOps.Set(addrStr, time.Now().Unix())
 		}
 
 		return zeroAddress, nil
-	}
-
-	if err := k.checkRateLimit(addrStr); err != nil {
-		return zeroAddress, err
 	}
 
 	k.store.Set(addrStr, refAddrStr)

--- a/contract/r/gnoswap/referral/keeper_test.gno
+++ b/contract/r/gnoswap/referral/keeper_test.gno
@@ -3,6 +3,7 @@ package referral
 import (
 	"chain/runtime"
 	"testing"
+	"time"
 
 	testutils "gno.land/p/nt/testutils/v0"
 	uassert "gno.land/p/nt/uassert/v0"
@@ -273,7 +274,7 @@ func TestKeeper_ContractAddressRemoval(t *testing.T) {
 		uassert.False(t, HasReferral(user.String()), "Referral should not exist after removal")
 	})
 
-	t.Run("Contract address removal is not rate limited", func(t *testing.T) {
+	t.Run("Contract address removal is rate limited", func(t *testing.T) {
 		cleanup(t)
 		testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/router"))
 
@@ -286,10 +287,11 @@ func TestKeeper_ContractAddressRemoval(t *testing.T) {
 		uassert.True(t, HasReferral(user.String()))
 
 		// Immediately try to remove with contract address (no time passage)
-		// This should succeed because contract address removal bypasses rate limit
+		// This should fail because contract address removal now respects the cooldown
 		result = TryRegister(cross, user, contractAddress().String())
-		uassert.Equal(t, "", result, "Contract address removal should bypass rate limit")
-		uassert.False(t, HasReferral(user.String()))
+		uassert.Equal(t, referrer.String(), result, "Blocked removal should fall back to the stored referral")
+		uassert.True(t, HasReferral(user.String()))
+		uassert.Equal(t, referrer.String(), GetReferral(user.String()))
 	})
 
 	t.Run("Re-register after contract address removal", func(t *testing.T) {
@@ -305,13 +307,22 @@ func TestKeeper_ContractAddressRemoval(t *testing.T) {
 		uassert.Equal(t, referrer1.String(), result)
 		uassert.Equal(t, referrer1.String(), GetReferral(user.String()))
 
-		// Remove with contract address (bypasses rate limit)
+		k := gReferralKeeper.(*keeper)
+		k.lastOps.Set(user.String(), int64(0))
+
+		beforeRemoval := time.Now().Unix()
+
+		// Remove with contract address after cooldown has elapsed
 		result = TryRegister(cross, user, contractAddress().String())
 		uassert.Equal(t, "", result)
 		uassert.False(t, HasReferral(user.String()))
 
-		// Re-register with new referrer should be rate limited
-		// because lastOps was set during first registration
+		lastOp, err := GetLastOpTimestamp(user.String())
+		uassert.NoError(t, err)
+		uassert.True(t, lastOp >= beforeRemoval)
+
+		// Re-register with new referrer should still be rate limited,
+		// but now relative to the removal timestamp.
 		result = TryRegister(cross, user, referrer2.String())
 		uassert.Equal(t, "", result, "Re-registration should be rate limited")
 	})
@@ -328,7 +339,7 @@ func TestKeeper_ContractAddressRemoval(t *testing.T) {
 		uassert.False(t, HasReferral(user.String()))
 	})
 
-	t.Run("Multiple contract address removals are allowed", func(t *testing.T) {
+	t.Run("Second contract address removal is blocked during cooldown", func(t *testing.T) {
 		cleanup(t)
 		testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/router"))
 
@@ -337,11 +348,14 @@ func TestKeeper_ContractAddressRemoval(t *testing.T) {
 
 		// Register
 		TryRegister(cross, user, referrer.String())
+		k := gReferralKeeper.(*keeper)
+		k.lastOps.Set(user.String(), int64(0))
 
-		// Multiple contract address calls should all succeed
-		for i := 0; i < 3; i++ {
-			result := TryRegister(cross, user, contractAddress().String())
-			uassert.Equal(t, "", result, "Multiple contract address calls should succeed")
-		}
+		result := TryRegister(cross, user, contractAddress().String())
+		uassert.Equal(t, "", result)
+		uassert.False(t, HasReferral(user.String()))
+
+		result = TryRegister(cross, user, contractAddress().String())
+		uassert.Equal(t, "", result, "Immediate second removal should be blocked during cooldown")
 	})
 }

--- a/contract/r/gnoswap/referral/rate_limit_test.gno
+++ b/contract/r/gnoswap/referral/rate_limit_test.gno
@@ -69,20 +69,41 @@ func TestRateLimit_IsAddressSpecific(t *testing.T) {
 	uassert.True(t, k.has(user2))
 }
 
-func TestRateLimit_ContractAddressNotRateLimited(t *testing.T) {
+func TestRateLimit_ContractAddressRateLimited(t *testing.T) {
 	cleanup := setupValidCaller(t)
 	defer cleanup()
 	k := setupRateLimitKeeper(t)
 
 	userAddr := testutils.TestAddress("user1")
+	referrerAddr := testutils.TestAddress("referrer1")
 
-	// contract address registration (removal) is not rate limited
-	for i := 0; i < 3; i++ {
-		_, err := k.register(userAddr, contractAddress())
-		uassert.NoError(t, err)
-	}
+	_, err := k.register(userAddr, referrerAddr)
+	uassert.NoError(t, err)
 
+	_, err = k.register(userAddr, contractAddress())
+	uassert.ErrorIs(t, err, ErrTooManyRequests)
+	uassert.True(t, k.has(userAddr))
+}
+
+func TestRateLimit_ContractAddressAllowedAfterCooldown(t *testing.T) {
+	cleanup := setupValidCaller(t)
+	defer cleanup()
+	k := setupRateLimitKeeper(t)
+
+	userAddr := testutils.TestAddress("user2")
+	referrerAddr := testutils.TestAddress("referrer2")
+
+	_, err := k.register(userAddr, referrerAddr)
+	uassert.NoError(t, err)
+
+	k.lastOps.Set(userAddr.String(), time.Now().Unix()-MinTimeBetweenUpdates)
+
+	_, err = k.register(userAddr, contractAddress())
+	uassert.NoError(t, err)
 	uassert.False(t, k.has(userAddr))
+	lastOp, err := k.getLastOpTimestamp(userAddr)
+	uassert.NoError(t, err)
+	uassert.True(t, lastOp > 0)
 }
 
 func TestRateLimit_TimeBoundaries(t *testing.T) {

--- a/contract/r/scenario/router/swap_with_referral_system_filetest.gno
+++ b/contract/r/scenario/router/swap_with_referral_system_filetest.gno
@@ -87,7 +87,7 @@ func main() {
 	ufmt.Printf("[EXPECTED] User1 referral after first swap: '%s'\n", afterReferral)
 	println()
 
-	println("[SCENARIO] 4. Same User Swap with referral contract address (should delete existing referrer)")
+	println("[SCENARIO] 4. Same User Swap with referral contract address (should keep existing referrer during cooldown)")
 	swapWithReferrer(user1Addr, referral.ContractAddress())
 
 	testing.SetRealm(testing.NewUserRealm(user1Addr))
@@ -280,13 +280,13 @@ func swapWithReferrer(userAddr address, referrer string) {
 // [EXPECTED] GNS balance changed: 995078
 // [EXPECTED] User1 referral after first swap: 'g1wfjkvetjwfjhyv2lta047h6lta047h6lf0xcls'
 //
-// [SCENARIO] 4. Same User Swap with referral contract address (should delete existing referrer)
+// [SCENARIO] 4. Same User Swap with referral contract address (should keep existing referrer during cooldown)
 // [INFO] Swapping with referrer: 'g1u0p5ld4aq6sk5l26ys27wk8nftj080l3era4wn'
 // [EXPECTED] inputAmount: 1000000
 // [EXPECTED] outputAmount: -989266
 // [EXPECTED] WUGNOT balance changed: -1000000
 // [EXPECTED] GNS balance changed: 989266
-// [EXPECTED] User1 referral after swap with empty referrer: ''
+// [EXPECTED] User1 referral after swap with empty referrer: 'g1wfjkvetjwfjhyv2lta047h6lta047h6lf0xcls'
 //
 // [SCENARIO] 5. Register Referrer Again and Swap with Different Referrer
 // [INFO] Swapping with referrer: 'g1wfjkvetjwfjhyv2lta047h6lta047h6lf0xcls'
@@ -294,13 +294,13 @@ func swapWithReferrer(userAddr address, referrer string) {
 // [EXPECTED] outputAmount: -983505
 // [EXPECTED] WUGNOT balance changed: -1000000
 // [EXPECTED] GNS balance changed: 983505
-// [INFO] User1 referral after re-registration: ''
+// [INFO] User1 referral after re-registration: 'g1wfjkvetjwfjhyv2lta047h6lta047h6lf0xcls'
 // [INFO] Swapping with referrer: 'g1wfjkvetjwfjhyvjlta047h6lta047h6l2tdl74'
 // [EXPECTED] inputAmount: 1000000
 // [EXPECTED] outputAmount: -977795
 // [EXPECTED] WUGNOT balance changed: -1000000
 // [EXPECTED] GNS balance changed: 977795
-// [EXPECTED] User1 referral after swap with different referrer: ''
+// [EXPECTED] User1 referral after swap with different referrer: 'g1wfjkvetjwfjhyv2lta047h6lta047h6lf0xcls'
 //
 // [SCENARIO] 6. New User Swap with Referrer (should register new referrer)
 // [INFO] User g1w4ek2u3jta047h6lta047h6lta047h6l9huexc setup complete - WUGNOT: 100000000
@@ -314,7 +314,7 @@ func swapWithReferrer(userAddr address, referrer string) {
 //
 // [SCENARIO] 7. Rate Limit Expiration - Re-registration After 24 Hours
 // [INFO] Skipped 17280 blocks (24 hours)
-// [INFO] User1 referral before re-registration: ''
+// [INFO] User1 referral before re-registration: 'g1wfjkvetjwfjhyv2lta047h6lta047h6lf0xcls'
 // [INFO] Swapping with referrer: 'g1wfjkvetjwfjhydzlta047h6lta047h6lk48j6m'
 // [EXPECTED] inputAmount: 1000000
 // [EXPECTED] outputAmount: -966521


### PR DESCRIPTION
## Summary
- apply the referral cooldown check to cancellation requests as well, and keep updating `lastOps` on successful removal
- add regression coverage for blocked immediate cancellation, allowed cancellation after cooldown, and blocked re-registration after removal
- update referral docs to describe the current cooldown and fallback semantics

## Verification
- make test PKG=gno.land/r/gnoswap/referral

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `GetLastOpTimestamp` to retrieve the timestamp of the last successful referral operation

* **API Changes**
  * `TryRegister` now returns the effective referrer address (string) instead of a boolean success flag

* **Improvements**
  * Rate limiting now covers registration, updates, and removal operations
  * Successful removal operations now refresh the cooldown timestamp, preventing immediate re-registration
  * Removal mechanism now triggered via contract address instead of zero address

* **Documentation**
  * Updated referral contract documentation to reflect new API and rate-limiting behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->