### PR TITLE
refactor(gov/staker): remove unused emission reward balance

### DIFF
--- a/contract/r/gnoswap/gov/staker/_mock_test.gno
+++ b/contract/r/gnoswap/gov/staker/_mock_test.gno
@@ -95,14 +95,6 @@ func (m *MockGovStaker) GetUnDelegationLockupPeriod() int64 {
 	return res[0].(int64)
 }
 
-func (m *MockGovStaker) GetEmissionRewardBalance() int64 {
-	res, ok := m.Response.Get("GetEmissionRewardBalance")
-	if !ok {
-		return 0
-	}
-	return res[0].(int64)
-}
-
 func (m *MockGovStaker) GetTotalxGnsSupply() int64 {
 	res, ok := m.Response.Get("GetTotalxGnsSupply")
 	if !ok {

--- a/contract/r/gnoswap/gov/staker/getters.gno
+++ b/contract/r/gnoswap/gov/staker/getters.gno
@@ -24,11 +24,6 @@ func GetUnDelegationLockupPeriod() int64 {
 	return getImplementation().GetUnDelegationLockupPeriod()
 }
 
-// GetEmissionRewardBalance returns the current emission reward balance.
-func GetEmissionRewardBalance() int64 {
-	return getImplementation().GetEmissionRewardBalance()
-}
-
 // GetDelegationCount returns the total number of delegations.
 func GetDelegationCount() int {
 	return getImplementation().GetDelegationCount()

--- a/contract/r/gnoswap/gov/staker/store.gno
+++ b/contract/r/gnoswap/gov/staker/store.gno
@@ -12,7 +12,6 @@ import (
 const (
 	// Basic configuration
 	StoreKeyUnDelegationLockupPeriod = "unDelegationLockupPeriod"
-	StoreKeyEmissionRewardBalance    = "emissionRewardBalance"
 	StoreKeyTotalDelegatedAmount     = "totalDelegatedAmount"
 	StoreKeyTotalLockedAmount        = "totalLockedAmount"
 
@@ -66,28 +65,6 @@ func (s *govStakerStore) GetUnDelegationLockupPeriod() int64 {
 
 func (s *govStakerStore) SetUnDelegationLockupPeriod(period int64) error {
 	return s.kvStore.Set(StoreKeyUnDelegationLockupPeriod, period)
-}
-
-func (s *govStakerStore) HasEmissionRewardBalanceStoreKey() bool {
-	return s.kvStore.Has(StoreKeyEmissionRewardBalance)
-}
-
-func (s *govStakerStore) GetEmissionRewardBalance() int64 {
-	result, err := s.kvStore.Get(StoreKeyEmissionRewardBalance)
-	if err != nil {
-		panic(err)
-	}
-
-	balance, ok := result.(int64)
-	if !ok {
-		panic(ufmt.Sprintf("failed to cast result to int64: %T", result))
-	}
-
-	return balance
-}
-
-func (s *govStakerStore) SetEmissionRewardBalance(balance int64) error {
-	return s.kvStore.Set(StoreKeyEmissionRewardBalance, balance)
 }
 
 func (s *govStakerStore) HasTotalDelegatedAmountStoreKey() bool {

--- a/contract/r/gnoswap/gov/staker/store_test.gno
+++ b/contract/r/gnoswap/gov/staker/store_test.gno
@@ -213,62 +213,6 @@ func TestStoreSetAndGetUnDelegationLockupPeriod(t *testing.T) {
 	}
 }
 
-func TestStoreSetAndGetEmissionRewardBalance(t *testing.T) {
-	tests := []struct {
-		name         string
-		setupFn      func(IGovStakerStore)
-		testFn       func(*testing.T, IGovStakerStore)
-		shouldPanic  bool
-		panicMessage string
-	}{
-		{
-			name: "set and get emission reward balance successfully",
-			setupFn: func(gs IGovStakerStore) {
-				gs.SetEmissionRewardBalance(1000000)
-			},
-			testFn: func(t *testing.T, gs IGovStakerStore) {
-				uassert.True(t, gs.HasEmissionRewardBalanceStoreKey(), "should have emission reward balance after setting")
-				retrieved := gs.GetEmissionRewardBalance()
-				uassert.Equal(t, int64(1000000), retrieved)
-			},
-		},
-		{
-			name: "should not have emission reward balance initially",
-			testFn: func(t *testing.T, gs IGovStakerStore) {
-				uassert.False(t, gs.HasEmissionRewardBalanceStoreKey(), "should not have emission reward balance initially")
-			},
-		},
-		{
-			name: "panic when getting uninitialized emission reward balance",
-			testFn: func(t *testing.T, gs IGovStakerStore) {
-				gs.GetEmissionRewardBalance()
-			},
-			shouldPanic:  true,
-			panicMessage: "should panic when getting uninitialized emission reward balance",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			resetTestState(t)
-			gs := NewGovStakerStore(kvStore)
-
-			if tt.setupFn != nil {
-				tt.setupFn(gs)
-			}
-
-			if tt.shouldPanic {
-				defer func() {
-					r := recover()
-					uassert.NotEqual(t, nil, r, tt.panicMessage)
-				}()
-			}
-
-			tt.testFn(t, gs)
-		})
-	}
-}
-
 func TestStoreSetAndGetTotalDelegatedAmount(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -912,7 +856,6 @@ func TestStoreMultipleSetAndGet(t *testing.T) {
 			name: "set and get all store values",
 			setupFn: func(gs IGovStakerStore) {
 				gs.SetUnDelegationLockupPeriod(86400)
-				gs.SetEmissionRewardBalance(1000000)
 				gs.SetTotalDelegatedAmount(500000)
 				gs.SetTotalLockedAmount(250000)
 
@@ -933,7 +876,6 @@ func TestStoreMultipleSetAndGet(t *testing.T) {
 			},
 			verifyFn: func(t *testing.T, gs IGovStakerStore) {
 				uassert.True(t, gs.HasUnDelegationLockupPeriodStoreKey())
-				uassert.True(t, gs.HasEmissionRewardBalanceStoreKey())
 				uassert.True(t, gs.HasTotalDelegatedAmountStoreKey())
 				uassert.True(t, gs.HasTotalLockedAmountStoreKey())
 				uassert.True(t, gs.HasDelegationsStoreKey())
@@ -942,7 +884,6 @@ func TestStoreMultipleSetAndGet(t *testing.T) {
 				uassert.True(t, gs.HasUserDelegationHistoryStoreKey())
 
 				uassert.Equal(t, int64(86400), gs.GetUnDelegationLockupPeriod())
-				uassert.Equal(t, int64(1000000), gs.GetEmissionRewardBalance())
 				uassert.Equal(t, int64(500000), gs.GetTotalDelegatedAmount())
 				uassert.Equal(t, int64(250000), gs.GetTotalLockedAmount())
 				uassert.Equal(t, int64(5), gs.GetDelegationCounter().Get())

--- a/contract/r/gnoswap/gov/staker/types.gno
+++ b/contract/r/gnoswap/gov/staker/types.gno
@@ -34,7 +34,6 @@ type IGovStakerReward interface {
 type IGovStakerGetter interface {
 	// Store data getters
 	GetUnDelegationLockupPeriod() int64
-	GetEmissionRewardBalance() int64
 
 	// Delegation getters
 	GetTotalxGnsSupply() int64
@@ -87,10 +86,6 @@ type IGovStakerStore interface {
 	HasUnDelegationLockupPeriodStoreKey() bool
 	GetUnDelegationLockupPeriod() int64
 	SetUnDelegationLockupPeriod(period int64) error
-
-	HasEmissionRewardBalanceStoreKey() bool
-	GetEmissionRewardBalance() int64
-	SetEmissionRewardBalance(balance int64) error
 
 	HasTotalDelegatedAmountStoreKey() bool
 	GetTotalDelegatedAmount() int64

--- a/contract/r/gnoswap/gov/staker/v1/_mock_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/_mock_test.gno
@@ -14,7 +14,6 @@ type mockGovStakerStore struct {
 	// Basic configuration
 	unDelegationLockupPeriod       int64
 	hasUnDelegationLockupPeriodKey bool
-	emissionRewardBalance          int64
 	totalDelegatedAmount           int64
 	totalLockedAmount              int64
 
@@ -63,19 +62,6 @@ func (m *mockGovStakerStore) GetUnDelegationLockupPeriod() int64 {
 func (m *mockGovStakerStore) SetUnDelegationLockupPeriod(period int64) error {
 	m.unDelegationLockupPeriod = period
 	m.hasUnDelegationLockupPeriodKey = true
-	return nil
-}
-
-func (m *mockGovStakerStore) HasEmissionRewardBalanceStoreKey() bool {
-	return true // Always available in mock
-}
-
-func (m *mockGovStakerStore) GetEmissionRewardBalance() int64 {
-	return m.emissionRewardBalance
-}
-
-func (m *mockGovStakerStore) SetEmissionRewardBalance(balance int64) error {
-	m.emissionRewardBalance = balance
 	return nil
 }
 

--- a/contract/r/gnoswap/gov/staker/v1/getter.gno
+++ b/contract/r/gnoswap/gov/staker/v1/getter.gno
@@ -33,11 +33,6 @@ func (gs *govStakerV1) GetUnDelegationLockupPeriod() int64 {
 	return gs.store.GetUnDelegationLockupPeriod()
 }
 
-// GetEmissionRewardBalance returns the current emission reward balance.
-func (gs *govStakerV1) GetEmissionRewardBalance() int64 {
-	return gs.store.GetEmissionRewardBalance()
-}
-
 // GetDelegationCount returns the total number of delegations.
 func (gs *govStakerV1) GetDelegationCount() int {
 	delegations := gs.store.GetAllDelegations()

--- a/contract/r/gnoswap/gov/staker/v1/getter_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/getter_test.gno
@@ -133,47 +133,6 @@ func TestGetter_GetUnDelegationLockupPeriod(t *testing.T) {
 	}
 }
 
-// TestGetter_GetEmissionRewardBalance tests GetEmissionRewardBalance
-func TestGetter_GetEmissionRewardBalance(t *testing.T) {
-	tests := []struct {
-		name     string
-		balance  int64
-		expected int64
-	}{
-		{
-			name:     "Zero balance",
-			balance:  0,
-			expected: 0,
-		},
-		{
-			name:     "Positive balance",
-			balance:  50000,
-			expected: 50000,
-		},
-		{
-			name:     "Large balance",
-			balance:  999_999_999_999,
-			expected: 999_999_999_999,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Given: Setup store with emission balance
-			store := newMockGovStakerStore().(*mockGovStakerStore)
-			store.SetEmissionRewardBalance(tt.balance)
-
-			gs := &govStakerV1{store: store}
-
-			// When: Get emission reward balance
-			result := gs.GetEmissionRewardBalance()
-
-			// Then: Should return correct balance
-			uassert.Equal(t, result, tt.expected)
-		})
-	}
-}
-
 // TestGetter_GetDelegationCount tests GetDelegationCount
 func TestGetter_GetDelegationCount(t *testing.T) {
 	tests := []struct {

--- a/contract/r/gnoswap/gov/staker/v1/init.gno
+++ b/contract/r/gnoswap/gov/staker/v1/init.gno
@@ -29,13 +29,6 @@ func initStoreData(store staker.IGovStakerStore) error {
 		}
 	}
 
-	if !store.HasEmissionRewardBalanceStoreKey() {
-		err := store.SetEmissionRewardBalance(int64(0))
-		if err != nil {
-			return err
-		}
-	}
-
 	if !store.HasTotalDelegatedAmountStoreKey() {
 		err := store.SetTotalDelegatedAmount(int64(0))
 		if err != nil {

--- a/contract/r/gnoswap/gov/staker/v1/init_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/init_test.gno
@@ -20,7 +20,6 @@ func TestInit_initStoreData(t *testing.T) {
 
 		// verify all keys are set
 		hasUnDelegationLockup := store.HasUnDelegationLockupPeriodStoreKey()
-		hasEmissionRewardBalance := store.HasEmissionRewardBalanceStoreKey()
 		hasTotalDelegated := store.HasTotalDelegatedAmountStoreKey()
 		hasTotalLocked := store.HasTotalLockedAmountStoreKey()
 		hasDelegationCounter := store.HasDelegationCounterStoreKey()
@@ -33,7 +32,6 @@ func TestInit_initStoreData(t *testing.T) {
 		hasDelegationManager := store.HasDelegationManagerStoreKey()
 
 		uassert.True(t, hasUnDelegationLockup)
-		uassert.True(t, hasEmissionRewardBalance)
 		uassert.True(t, hasTotalDelegated)
 		uassert.True(t, hasTotalLocked)
 		uassert.True(t, hasDelegationCounter)

--- a/contract/r/scenario/getter/gov_staker_getter_filetest.gno
+++ b/contract/r/scenario/getter/gov_staker_getter_filetest.gno
@@ -99,10 +99,6 @@ func testGovStakerGetters(delegationId1 int64) {
 	lockupPeriod := staker.GetUnDelegationLockupPeriod()
 	println("[EXPECTED] Undelegation Lockup Period:", lockupPeriod)
 
-	// GetEmissionRewardBalance
-	emissionRewardBalance := staker.GetEmissionRewardBalance()
-	println("[EXPECTED] Emission Reward Balance:", emissionRewardBalance)
-
 	println()
 
 	// GetDelegationCount
@@ -275,7 +271,6 @@ func testGovStakerGetters(delegationId1 int64) {
 // [EXPECTED] Total Delegated: 500000000
 // [EXPECTED] Total Locked Amount: 500000000
 // [EXPECTED] Undelegation Lockup Period: 604800
-// [EXPECTED] Emission Reward Balance: 0
 //
 // [EXPECTED] Delegation Count: 1
 // [EXPECTED] Delegation IDs (offset=0, limit=10): 1 delegations

--- a/contract/r/scenario/upgrade/implements/v2_invalid/gov/staker/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v2_invalid/gov/staker/test_impl.gno
@@ -96,13 +96,6 @@ func (t *TestGovStaker) GetUnDelegationLockupPeriod() int64 {
 	return t.instance.GetUnDelegationLockupPeriod()
 }
 
-func (t *TestGovStaker) GetEmissionRewardBalance() int64 {
-	if !t.isActive("GetEmissionRewardBalance") {
-		panic("test implementation: GetEmissionRewardBalance not supported")
-	}
-	return t.instance.GetEmissionRewardBalance()
-}
-
 func (t *TestGovStaker) GetTotalxGnsSupply() int64 {
 	if !t.isActive("GetTotalxGnsSupply") {
 		panic("test implementation: GetTotalxGnsSupply not supported")

--- a/contract/r/scenario/upgrade/implements/v3_valid/gov/staker/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/gov/staker/test_impl.gno
@@ -100,10 +100,6 @@ func (t *TestGovStaker) GetUnDelegationLockupPeriod() int64 {
 	return t.instance.GetUnDelegationLockupPeriod()
 }
 
-func (t *TestGovStaker) GetEmissionRewardBalance() int64 {
-	return t.instance.GetEmissionRewardBalance()
-}
-
 func (t *TestGovStaker) GetDelegationCount() int {
 	return t.instance.GetDelegationCount()
 }


### PR DESCRIPTION
## Descriptions

This change removes dead code around **emission reward balance** from the gov staker module. The value was persisted under a dedicated store key and exposed via getters, but it was **not used** by the rest of the staker logic, so the storage surface, interfaces, and call sites are dropped to reduce maintenance and avoid implying a feature that does not exist in behavior.

## What changed

- **Store**: Removed `StoreKeyEmissionRewardBalance` and `Has/Get/SetEmissionRewardBalance` helpers from `store.gno`.
- **Types**: Removed emission reward balance methods from `IGovStakerGetter` and `IGovStakerStore` in `types.gno`.
- **Public API**: Removed `GetEmissionRewardBalance` from the staker facade (`getters.gno`) and v1 implementation (`v1/getter.gno`).
- **Initialization**: Stopped seeding a zero emission reward balance in `v1/init.gno` (`initStoreData`).
- **Tests & mocks**: Updated unit tests, v1 mocks, scenario filetests, and upgrade test implementations to match the slimmer interface.

## Notes for reviewers

- Callers that previously relied on `GetEmissionRewardBalance` or the store key must be updated; this branch already adjusts in-repo tests and scenario helpers accordingly.
- No replacement storage was added; this is intentional cleanup of unused state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed test coverage for emission reward balance operations, including unit tests for initialization verification, getter functionality, and storage mechanism validation across multiple files

* **Chores**
  * Removed emission reward balance query capability from the governance staking module, including public getter methods, underlying storage implementations, initialization logic, and related interface definitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->