### PR TITLE
refactor(gov/governance): enhance invalid parameter proposals

### DIFF
--- a/contract/r/gnoswap/gov/governance/v1/governance_propose_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_propose_test.gno
@@ -1164,7 +1164,7 @@ func TestGovernancePropose_ParameterChangeValidation(t *testing.T) {
 				"gno.land/r/gnoswap/staker*EXE*SetUnStakingFee*EXE*700*GOV*" +
 				"gno.land/r/gnoswap/emission*EXE*SetDistributionStartTime*EXE*800*GOV*" +
 				"gno.land/r/gnoswap/halt*EXE*SetHaltLevel*EXE*900*GOV*" +
-				"gno.land/r/gnoswap/rbac*EXE*RemoveRole*EXE*admin",
+				"gno.land/r/gnoswap/rbac*EXE*RegisterRole*EXE*new_role," + testutils.TestAddress("role").String(),
 			shouldFail: false,
 		},
 		{
@@ -1252,6 +1252,20 @@ func TestGovernancePropose_ParameterChangeValidation(t *testing.T) {
 			shouldFail:    true,
 		},
 		{
+			name:          "fail - pool CollectProtocol invalid amount0Requested",
+			numToExecute:  1,
+			executions:    "gno.land/r/gnoswap/pool*EXE*CollectProtocol*EXE*gno.land/r/gnoswap/gns,gno.land/r/gnoswap/test_token/foo,500," + testutils.TestAddress("recipient").String() + ",invalid,100",
+			expectedError: "invalid int64 value: invalid",
+			shouldFail:    true,
+		},
+		{
+			name:          "fail - pool CollectProtocol negative amount1Requested",
+			numToExecute:  1,
+			executions:    "gno.land/r/gnoswap/pool*EXE*CollectProtocol*EXE*gno.land/r/gnoswap/gns,gno.land/r/gnoswap/test_token/foo,500," + testutils.TestAddress("recipient").String() + ",100,-1",
+			expectedError: "amount1Requested must be non-negative",
+			shouldFail:    true,
+		},
+		{
 			name:          "fail - rbac RegisterRole empty role address",
 			numToExecute:  1,
 			executions:    "gno.land/r/gnoswap/rbac*EXE*RegisterRole*EXE*new_role,",
@@ -1259,10 +1273,31 @@ func TestGovernancePropose_ParameterChangeValidation(t *testing.T) {
 			shouldFail:    true,
 		},
 		{
+			name:          "fail - rbac RegisterRole empty role name",
+			numToExecute:  1,
+			executions:    "gno.land/r/gnoswap/rbac*EXE*RegisterRole*EXE*   ," + testutils.TestAddress("role").String(),
+			expectedError: "role name is empty",
+			shouldFail:    true,
+		},
+		{
 			name:          "fail - rbac UpdateRoleAddress empty role address",
 			numToExecute:  1,
 			executions:    "gno.land/r/gnoswap/rbac*EXE*UpdateRoleAddress*EXE*router,",
 			expectedError: "invalid address",
+			shouldFail:    true,
+		},
+		{
+			name:          "fail - rbac UpdateRoleAddress admin role",
+			numToExecute:  1,
+			executions:    "gno.land/r/gnoswap/rbac*EXE*UpdateRoleAddress*EXE*admin," + testutils.TestAddress("role").String(),
+			expectedError: "admin role cannot be updated",
+			shouldFail:    true,
+		},
+		{
+			name:          "fail - rbac RemoveRole system role",
+			numToExecute:  1,
+			executions:    "gno.land/r/gnoswap/rbac*EXE*RemoveRole*EXE*admin",
+			expectedError: "system role cannot be removed",
 			shouldFail:    true,
 		},
 		{

--- a/contract/r/gnoswap/gov/governance/v1/parameter_registry.gno
+++ b/contract/r/gnoswap/gov/governance/v1/parameter_registry.gno
@@ -3,6 +3,7 @@ package v1
 import (
 	"strings"
 
+	prbac "gno.land/p/gnoswap/rbac"
 	avl "gno.land/p/nt/avl/v0"
 	ufmt "gno.land/p/nt/ufmt/v0"
 
@@ -346,8 +347,8 @@ func CreateParameterHandlers() *ParameterRegistry {
 				stringValidator,  // token1Path
 				uint64Validator,  // fee
 				addressValidator, // recipient
-				nil,              // amount0Requested (validated in pool logic)
-				nil,              // amount1Requested (validated in pool logic)
+				nonNegativeInt64Validator("amount0Requested"),
+				nonNegativeInt64Validator("amount1Requested"),
 			},
 			handlerFunc: func(params []string) error {
 				pl.CollectProtocol(
@@ -616,7 +617,7 @@ func CreateParameterHandlers() *ParameterRegistry {
 			function:   "RegisterRole",
 			paramCount: 2,
 			paramValidators: []paramValidator{
-				stringValidator,  // roleName
+				roleNameValidator,
 				addressValidator, // roleAddress
 			},
 			handlerFunc: func(params []string) error {
@@ -634,7 +635,7 @@ func CreateParameterHandlers() *ParameterRegistry {
 			function:   "UpdateRoleAddress",
 			paramCount: 2,
 			paramValidators: []paramValidator{
-				stringValidator,  // roleName
+				updatableRoleNameValidator,
 				addressValidator, // roleAddress
 			},
 			handlerFunc: func(params []string) error {
@@ -652,7 +653,7 @@ func CreateParameterHandlers() *ParameterRegistry {
 			function:   "RemoveRole",
 			paramCount: 1,
 			paramValidators: []paramValidator{
-				stringValidator, // roleName
+				removableRoleNameValidator,
 			},
 			handlerFunc: func(params []string) error {
 				roleName := params[0]
@@ -922,6 +923,52 @@ func uint8RangeValidator(name string) paramValidator {
 			value := parseInt64(s)
 			if value < 0 || value > 255 {
 				panic(ufmt.Sprintf("%s out of range: %d", name, value))
+			}
+		})
+	}
+}
+
+func roleNameValidator(s string) error {
+	return runValidator(func() {
+		roleName := strings.TrimSpace(s)
+		if roleName == "" {
+			panic(ufmt.Sprintf("role name is empty: %q", s))
+		}
+	})
+}
+
+func updatableRoleNameValidator(s string) error {
+	return runValidator(func() {
+		roleName := strings.TrimSpace(s)
+		if err := roleNameValidator(s); err != nil {
+			panic(err)
+		}
+
+		if roleName == prbac.ROLE_ADMIN.String() {
+			panic(ufmt.Sprintf("admin role cannot be updated: %s", roleName))
+		}
+	})
+}
+
+func removableRoleNameValidator(s string) error {
+	return runValidator(func() {
+		roleName := strings.TrimSpace(s)
+		if err := roleNameValidator(s); err != nil {
+			panic(err)
+		}
+
+		if prbac.IsSystemRole(roleName) {
+			panic(ufmt.Sprintf("system role cannot be removed: %s", roleName))
+		}
+	})
+}
+
+func nonNegativeInt64Validator(name string) paramValidator {
+	return func(s string) error {
+		return runValidator(func() {
+			value := parseInt64(s)
+			if value < 0 {
+				panic(ufmt.Sprintf("%s must be non-negative: %d", name, value))
 			}
 		})
 	}

--- a/contract/r/gnoswap/gov/governance/v1/parameter_registry.gno
+++ b/contract/r/gnoswap/gov/governance/v1/parameter_registry.gno
@@ -940,7 +940,7 @@ func roleNameValidator(s string) error {
 func updatableRoleNameValidator(s string) error {
 	return runValidator(func() {
 		roleName := strings.TrimSpace(s)
-		if err := roleNameValidator(s); err != nil {
+		if err := roleNameValidator(roleName); err != nil {
 			panic(err)
 		}
 
@@ -953,7 +953,7 @@ func updatableRoleNameValidator(s string) error {
 func removableRoleNameValidator(s string) error {
 	return runValidator(func() {
 		roleName := strings.TrimSpace(s)
-		if err := roleNameValidator(s); err != nil {
+		if err := roleNameValidator(roleName); err != nil {
 			panic(err)
 		}
 

--- a/contract/r/gnoswap/gov/governance/v1/parameter_registry_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/parameter_registry_test.gno
@@ -320,6 +320,12 @@ func TestValidateExecutions(t *testing.T) {
 			expectedError: false,
 		},
 		{
+			name:          "Success - pool CollectProtocol one-sided zero request",
+			numToExecute:  1,
+			executions:    "gno.land/r/gnoswap/pool*EXE*CollectProtocol*EXE*gno.land/r/gnoswap/gns,gno.land/r/gnoland/wugnot,3000," + testutils.TestAddress("recipient").String() + ",0,1000000",
+			expectedError: false,
+		},
+		{
 			name:          "Success - pool SetFeeProtocol",
 			numToExecute:  1,
 			executions:    "gno.land/r/gnoswap/pool*EXE*SetFeeProtocol*EXE*1,2",

--- a/contract/r/gnoswap/gov/governance/v1/parameter_registry_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/parameter_registry_test.gno
@@ -585,6 +585,20 @@ func TestValidateExecutions(t *testing.T) {
 			expectedErrorContains: "invalid address",
 		},
 		{
+			name:                  "Failure - pool CollectProtocol invalid amount0Requested",
+			numToExecute:          1,
+			executions:            "gno.land/r/gnoswap/pool*EXE*CollectProtocol*EXE*gno.land/r/gnoswap/gns,gno.land/r/gnoswap/test_token/foo,500," + testutils.TestAddress("recipient").String() + ",invalid,100",
+			expectedError:         true,
+			expectedErrorContains: "invalid int64 value: invalid",
+		},
+		{
+			name:                  "Failure - pool CollectProtocol negative amount1Requested",
+			numToExecute:          1,
+			executions:            "gno.land/r/gnoswap/pool*EXE*CollectProtocol*EXE*gno.land/r/gnoswap/gns,gno.land/r/gnoswap/test_token/foo,500," + testutils.TestAddress("recipient").String() + ",100,-1",
+			expectedError:         true,
+			expectedErrorContains: "amount1Requested must be non-negative",
+		},
+		{
 			name:                  "Failure - rbac RegisterRole empty role address",
 			numToExecute:          1,
 			executions:            "gno.land/r/gnoswap/rbac*EXE*RegisterRole*EXE*new_role,",
@@ -592,11 +606,32 @@ func TestValidateExecutions(t *testing.T) {
 			expectedErrorContains: "invalid address",
 		},
 		{
+			name:                  "Failure - rbac RegisterRole empty role name",
+			numToExecute:          1,
+			executions:            "gno.land/r/gnoswap/rbac*EXE*RegisterRole*EXE*   ," + testutils.TestAddress("role").String(),
+			expectedError:         true,
+			expectedErrorContains: "role name is empty",
+		},
+		{
 			name:                  "Failure - rbac UpdateRoleAddress empty role address",
 			numToExecute:          1,
 			executions:            "gno.land/r/gnoswap/rbac*EXE*UpdateRoleAddress*EXE*router,",
 			expectedError:         true,
 			expectedErrorContains: "invalid address",
+		},
+		{
+			name:                  "Failure - rbac UpdateRoleAddress admin role",
+			numToExecute:          1,
+			executions:            "gno.land/r/gnoswap/rbac*EXE*UpdateRoleAddress*EXE*admin," + testutils.TestAddress("role").String(),
+			expectedError:         true,
+			expectedErrorContains: "admin role cannot be updated",
+		},
+		{
+			name:                  "Failure - rbac RemoveRole system role",
+			numToExecute:          1,
+			executions:            "gno.land/r/gnoswap/rbac*EXE*RemoveRole*EXE*admin",
+			expectedError:         true,
+			expectedErrorContains: "system role cannot be removed",
 		},
 		{
 			name:                  "Failure - launchpad CreateProject empty recipient",

--- a/contract/r/gnoswap/gov/governance/v1/proposal_data_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal_data_test.gno
@@ -125,6 +125,20 @@ func TestProposalData_Validation(t *testing.T) {
 			expectedErrorMessage: "[GNOSWAP-GOVERNANCE-001] invalid input || numToExecute is less than or equal to 0",
 		},
 		{
+			name:                 "Failure - ParameterChange invalid CollectProtocol amount",
+			proposalType:         governance.ParameterChange,
+			execution:            governance.NewExecutionInfo(1, []string{"gno.land/r/gnoswap/pool*EXE*CollectProtocol*EXE*gno.land/r/gnoswap/gns,gno.land/r/gnoswap/test_token/foo,500," + testutils.TestAddress("recipient").String() + ",invalid,100"}),
+			expectedError:        true,
+			expectedErrorMessage: "[GNOSWAP-GOVERNANCE-001] invalid input || execution[0]: param[4]: invalid int64 value: invalid",
+		},
+		{
+			name:                 "Failure - ParameterChange invalid RBAC admin update",
+			proposalType:         governance.ParameterChange,
+			execution:            governance.NewExecutionInfo(1, []string{"gno.land/r/gnoswap/rbac*EXE*UpdateRoleAddress*EXE*admin," + testutils.TestAddress("role").String()}),
+			expectedError:        true,
+			expectedErrorMessage: "[GNOSWAP-GOVERNANCE-001] invalid input || execution[0]: param[0]: admin role cannot be updated: admin",
+		},
+		{
 			name:                 "Failure - ParameterChange max execution count takes precedence over mismatch",
 			proposalType:         governance.ParameterChange,
 			execution:            governance.NewExecutionInfo(11, []string{"pkg1*EXE*func1*EXE*param1"}),

--- a/contract/r/gnoswap/gov/governance/v1/proposal_data_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal_data_test.gno
@@ -97,6 +97,12 @@ func TestProposalData_Validation(t *testing.T) {
 			expectedError: false,
 		},
 		{
+			name:          "Success - Valid ParameterChange proposal with one-sided CollectProtocol",
+			proposalType:  governance.ParameterChange,
+			execution:     governance.NewExecutionInfo(1, []string{"gno.land/r/gnoswap/pool*EXE*CollectProtocol*EXE*gno.land/r/gnoswap/gns,gno.land/r/gnoswap/test_token/foo,500," + testutils.TestAddress("recipient").String() + ",0,100"}),
+			expectedError: false,
+		},
+		{
 			name:                 "Failure - CommunityPoolSpend with invalid address",
 			proposalType:         governance.CommunityPoolSpend,
 			spendInfo:            governance.NewCommunityPoolSpendInfo(address(""), validTokenPath, 1000),


### PR DESCRIPTION
## Summary
- reject malformed `CollectProtocol` proposal params at proposal creation time instead of failing during execution
- reject semantically invalid RBAC proposal actions such as updating the admin role or removing system roles
- add governance proposal and parameter registry coverage for the new early-validation paths

## Testing
- make test PKG=gno.land/r/gnoswap/gov/governance/v1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened proposal validation: enforce non-negative numeric values for protocol-collection parameters and allow one-sided zero requests.
  * Enhanced RBAC constraints to reject empty role names and to block updating or removing protected admin/system roles.

* **Tests**
  * Expanded test coverage for parameter parsing, one-sided requests, and RBAC edge cases (invalid amounts, empty names, admin immutability).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->