### PR TITLE
fix(gov/staker): make reward claims idempotent within the same timestamp

### DIFF
--- a/contract/r/gnoswap/gov/staker/v1/emission_reward_state.gno
+++ b/contract/r/gnoswap/gov/staker/v1/emission_reward_state.gno
@@ -1,8 +1,6 @@
 package v1
 
 import (
-	"errors"
-
 	u256 "gno.land/p/gnoswap/uint256"
 	"gno.land/r/gnoswap/gov/staker"
 )
@@ -129,11 +127,11 @@ func (self *EmissionRewardStateResolver) adjustStake(delta int64) {
 //   - currentTimestamp: current timestamp
 //
 // Returns:
-//   - int64: amount of rewards claimed
-//   - error: nil on success, error if claiming is not allowed
+//   - int64: amount of rewards claimed (0 if already claimed at this timestamp)
+//   - error: always nil in the current implementation
 func (self *EmissionRewardStateResolver) claimRewards(currentTimestamp int64) (int64, error) {
 	if !self.IsClaimable(currentTimestamp) {
-		return 0, errors.New("not claimable")
+		return 0, nil
 	}
 
 	accumulatedRewardAmount := self.GetAccumulatedRewardAmount()

--- a/contract/r/gnoswap/gov/staker/v1/emission_reward_state_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/emission_reward_state_test.gno
@@ -3,8 +3,8 @@ package v1
 import (
 	"testing"
 
-	uassert "gno.land/p/nt/uassert/v0"
 	u256 "gno.land/p/gnoswap/uint256"
+	uassert "gno.land/p/nt/uassert/v0"
 	"gno.land/r/gnoswap/gov/staker"
 )
 
@@ -334,37 +334,104 @@ func TestEmissionRewardState_removeStake(t *testing.T) {
 	}
 }
 
-// Test claimRewards
+// Test claimRewards including idempotent no-op cases.
 func TestEmissionRewardState_claimRewards(t *testing.T) {
 	tests := []struct {
-		name                     string
-		setupState               func(*EmissionRewardStateResolver)
-		currentHeight            int64
-		expectError              bool
-		expectedClaimedAmount    int64
-		expectedNewClaimedHeight int64
+		name                         string
+		setupState                   func(*EmissionRewardStateResolver)
+		currentHeight                int64
+		expectError                  bool
+		expectedClaimedAmount        int64
+		expectedNewClaimedHeight     int64
+		expectedClaimedRewardAmount  int64
+		expectedAccumulatedRewardAmt int64
 	}{
 		{
-			name: "Claim when not claimable",
-			setupState: func(s *EmissionRewardStateResolver) {
-				s.SetClaimedTimestamp(100)
-				s.SetAccumulatedRewardAmount(1000)
-				s.SetClaimedRewardAmount(500)
-			},
-			currentHeight: 100,
-			expectError:   true,
-		},
-		{
-			name: "Successful claim",
+			name: "Successful claim advances claimedRewardAmount and timestamp",
 			setupState: func(s *EmissionRewardStateResolver) {
 				s.SetClaimedTimestamp(50)
 				s.SetAccumulatedRewardAmount(1000)
 				s.SetClaimedRewardAmount(300)
 			},
-			currentHeight:            100,
-			expectError:              false,
-			expectedClaimedAmount:    700, // Previous claimed amount
-			expectedNewClaimedHeight: 100,
+			currentHeight:                100,
+			expectError:                  false,
+			expectedClaimedAmount:        700,
+			expectedNewClaimedHeight:     100,
+			expectedClaimedRewardAmount:  1000,
+			expectedAccumulatedRewardAmt: 1000,
+		},
+		{
+			name: "First-ever claim when never claimed before",
+			setupState: func(s *EmissionRewardStateResolver) {
+				s.SetClaimedTimestamp(0)
+				s.SetAccumulatedRewardAmount(500)
+				s.SetClaimedRewardAmount(0)
+			},
+			currentHeight:                100,
+			expectError:                  false,
+			expectedClaimedAmount:        500,
+			expectedNewClaimedHeight:     100,
+			expectedClaimedRewardAmount:  500,
+			expectedAccumulatedRewardAmt: 500,
+		},
+		{
+			name: "Claim with zero accumulated and zero claimed is a valid no-op claim",
+			setupState: func(s *EmissionRewardStateResolver) {
+				s.SetClaimedTimestamp(50)
+				s.SetAccumulatedRewardAmount(0)
+				s.SetClaimedRewardAmount(0)
+			},
+			currentHeight:                100,
+			expectError:                  false,
+			expectedClaimedAmount:        0,
+			expectedNewClaimedHeight:     100,
+			expectedClaimedRewardAmount:  0,
+			expectedAccumulatedRewardAmt: 0,
+		},
+		{
+			name: "Idempotent no-op when claimedTimestamp equals currentTimestamp (already fully claimed)",
+			setupState: func(s *EmissionRewardStateResolver) {
+				// Simulates state after a previous successful claim at the same timestamp.
+				s.SetClaimedTimestamp(100)
+				s.SetAccumulatedRewardAmount(1000)
+				s.SetClaimedRewardAmount(1000)
+			},
+			currentHeight:                100,
+			expectError:                  false,
+			expectedClaimedAmount:        0,
+			expectedNewClaimedHeight:     100,
+			expectedClaimedRewardAmount:  1000,
+			expectedAccumulatedRewardAmt: 1000,
+		},
+		{
+			name: "Idempotent no-op preserves unclaimed accumulated delta when called in the same second",
+			setupState: func(s *EmissionRewardStateResolver) {
+				// Pathological state where accumulated > claimed but claimedTimestamp is already
+				// at currentTimestamp. The idempotent skip must not silently advance claimed.
+				s.SetClaimedTimestamp(100)
+				s.SetAccumulatedRewardAmount(1000)
+				s.SetClaimedRewardAmount(400)
+			},
+			currentHeight:                100,
+			expectError:                  false,
+			expectedClaimedAmount:        0,
+			expectedNewClaimedHeight:     100,
+			expectedClaimedRewardAmount:  400, // must NOT advance
+			expectedAccumulatedRewardAmt: 1000,
+		},
+		{
+			name: "Idempotent no-op when claimedTimestamp is in the future",
+			setupState: func(s *EmissionRewardStateResolver) {
+				s.SetClaimedTimestamp(200)
+				s.SetAccumulatedRewardAmount(800)
+				s.SetClaimedRewardAmount(800)
+			},
+			currentHeight:                100,
+			expectError:                  false,
+			expectedClaimedAmount:        0,
+			expectedNewClaimedHeight:     200, // untouched
+			expectedClaimedRewardAmount:  800,
+			expectedAccumulatedRewardAmt: 800,
 		},
 	}
 
@@ -381,14 +448,56 @@ func TestEmissionRewardState_claimRewards(t *testing.T) {
 			// Then: Check result
 			if tt.expectError {
 				uassert.Error(t, err)
-			} else {
-				uassert.NoError(t, err)
-				uassert.Equal(t, claimedAmount, tt.expectedClaimedAmount)
-				uassert.Equal(t, resolver.GetClaimedTimestamp(), tt.expectedNewClaimedHeight)
-				uassert.Equal(t, resolver.GetClaimedRewardAmount(), resolver.GetAccumulatedRewardAmount())
+				return
 			}
+
+			uassert.NoError(t, err)
+			uassert.Equal(t, claimedAmount, tt.expectedClaimedAmount)
+			uassert.Equal(t, resolver.GetClaimedTimestamp(), tt.expectedNewClaimedHeight)
+			uassert.Equal(t, resolver.GetClaimedRewardAmount(), tt.expectedClaimedRewardAmount)
+			uassert.Equal(t, resolver.GetAccumulatedRewardAmount(), tt.expectedAccumulatedRewardAmt)
 		})
 	}
+}
+
+// Test that consecutive claimRewards calls within the same Unix second
+// are idempotent. The first call captures the full delta; subsequent
+// calls must return 0, leave state untouched, and never error.
+func TestEmissionRewardState_claimRewards_SameSecondIsIdempotent(t *testing.T) {
+	state := staker.NewEmissionRewardState(u256.NewUint(0))
+	resolver := NewEmissionRewardStateResolver(state)
+
+	resolver.SetClaimedTimestamp(50)
+	resolver.SetAccumulatedRewardAmount(1000)
+	resolver.SetClaimedRewardAmount(200)
+
+	// First claim at ts=100 captures the pending delta (800).
+	first, err := resolver.claimRewards(100)
+	uassert.NoError(t, err)
+	uassert.Equal(t, first, int64(800))
+	uassert.Equal(t, resolver.GetClaimedTimestamp(), int64(100))
+	uassert.Equal(t, resolver.GetClaimedRewardAmount(), int64(1000))
+
+	// Second and third calls at the same ts=100 must be no-ops.
+	second, err := resolver.claimRewards(100)
+	uassert.NoError(t, err)
+	uassert.Equal(t, second, int64(0))
+	uassert.Equal(t, resolver.GetClaimedTimestamp(), int64(100))
+	uassert.Equal(t, resolver.GetClaimedRewardAmount(), int64(1000))
+
+	third, err := resolver.claimRewards(100)
+	uassert.NoError(t, err)
+	uassert.Equal(t, third, int64(0))
+	uassert.Equal(t, resolver.GetClaimedTimestamp(), int64(100))
+	uassert.Equal(t, resolver.GetClaimedRewardAmount(), int64(1000))
+
+	// Advancing to ts=101 with newly accumulated rewards is claimable again.
+	resolver.SetAccumulatedRewardAmount(1500)
+	fourth, err := resolver.claimRewards(101)
+	uassert.NoError(t, err)
+	uassert.Equal(t, fourth, int64(500))
+	uassert.Equal(t, resolver.GetClaimedTimestamp(), int64(101))
+	uassert.Equal(t, resolver.GetClaimedRewardAmount(), int64(1500))
 }
 
 // Test updateRewardDebtX128
@@ -559,15 +668,18 @@ func TestEmissionRewardState_claimRewardsWithUpdateRewardDebtX128(t *testing.T) 
 			expectedClaimedAmount:         300, // Previous claimed amount
 		},
 		{
-			name: "Claim with update when not claimable",
+			name: "Claim with update when not claimable is an idempotent no-op",
 			setupState: func(s *EmissionRewardStateResolver) {
+				// Simulate state after a previous claim at the same timestamp.
 				s.SetClaimedTimestamp(100)
+				s.SetAccumulatedTimestamp(100)
 				s.SetAccumulatedRewardAmount(500)
-				s.SetClaimedRewardAmount(200)
+				s.SetClaimedRewardAmount(500)
 			},
 			accumulatedRewardX128PerStake: u256.NewUintFromInt64(1000),
 			currentHeight:                 100,
-			expectError:                   true,
+			expectError:                   false,
+			expectedClaimedAmount:         0,
 		},
 	}
 

--- a/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_state.gno
+++ b/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_state.gno
@@ -140,10 +140,10 @@ func (p *ProtocolFeeRewardStateResolver) removeStake(amount int64) {
 //
 // Returns:
 //   - map[string]int64: map of token path to claimed reward amount
-//   - error: nil on success, error if claiming is not allowed
+//   - error: nil on success, error if reward debt is stale
 func (p *ProtocolFeeRewardStateResolver) claimRewards(currentTimestamp int64) (map[string]int64, error) {
 	if !p.IsClaimable(currentTimestamp) {
-		return nil, errors.New("not claimable")
+		return make(map[string]int64), nil
 	}
 
 	if p.GetAccumulatedTimestamp() < currentTimestamp {

--- a/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_state_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_state_test.gno
@@ -309,40 +309,20 @@ func TestProtocolFeeRewardState_removeStake(t *testing.T) {
 	}
 }
 
-// Test claimRewards
+// Test claimRewards including idempotent no-op cases.
 func TestProtocolFeeRewardState_claimRewards(t *testing.T) {
 	tests := []struct {
-		name                  string
-		setupState            func(*ProtocolFeeRewardStateResolver)
-		currentTimestamp      int64
-		expectError           bool
-		expectedClaimedLength int
+		name                      string
+		setupState                func(*ProtocolFeeRewardStateResolver)
+		currentTimestamp          int64
+		expectError               bool
+		expectedClaimedLength     int
+		expectedClaimedPerToken   map[string]int64 // expected returned amounts; nil = skip check
+		expectedNewClaimedTs      int64
+		expectedClaimedStateAfter map[string]int64 // expected resolver.GetClaimedRewards after call; nil = skip check
 	}{
 		{
-			name: "Claim when not claimable",
-			setupState: func(s *ProtocolFeeRewardStateResolver) {
-				s.SetClaimedTimestamp(100)
-				s.SetAccumulatedRewards(map[string]int64{
-					"token1": 1000,
-				})
-			},
-			currentTimestamp: 100,
-			expectError:      true,
-		},
-		{
-			name: "Claim when accumulated height is less than current height",
-			setupState: func(s *ProtocolFeeRewardStateResolver) {
-				s.SetClaimedTimestamp(50)
-				s.SetAccumulatedTimestamp(50)
-				s.SetAccumulatedRewards(map[string]int64{
-					"token1": 1000,
-				})
-			},
-			currentTimestamp: 100,
-			expectError:      true, // Must update reward debt before claiming
-		},
-		{
-			name: "Successful claim",
+			name: "Successful claim advances claimed rewards and timestamp",
 			setupState: func(s *ProtocolFeeRewardStateResolver) {
 				s.SetClaimedTimestamp(50)
 				s.SetAccumulatedTimestamp(100)
@@ -358,6 +338,113 @@ func TestProtocolFeeRewardState_claimRewards(t *testing.T) {
 			currentTimestamp:      100,
 			expectError:           false,
 			expectedClaimedLength: 2,
+			expectedClaimedPerToken: map[string]int64{
+				"token1": 700,
+				"token2": 500,
+			},
+			expectedNewClaimedTs: 100,
+			expectedClaimedStateAfter: map[string]int64{
+				"token1": 1000,
+				"token2": 500,
+			},
+		},
+		{
+			name: "First-ever claim with no prior claimedRewards",
+			setupState: func(s *ProtocolFeeRewardStateResolver) {
+				s.SetClaimedTimestamp(0)
+				s.SetAccumulatedTimestamp(100)
+				s.SetAccumulatedRewards(map[string]int64{
+					"tokenA": 250,
+				})
+			},
+			currentTimestamp:      100,
+			expectError:           false,
+			expectedClaimedLength: 1,
+			expectedClaimedPerToken: map[string]int64{
+				"tokenA": 250,
+			},
+			expectedNewClaimedTs: 100,
+			expectedClaimedStateAfter: map[string]int64{
+				"tokenA": 250,
+			},
+		},
+		{
+			name: "Claim when accumulated timestamp is less than current (reward debt stale)",
+			setupState: func(s *ProtocolFeeRewardStateResolver) {
+				s.SetClaimedTimestamp(50)
+				s.SetAccumulatedTimestamp(50)
+				s.SetAccumulatedRewards(map[string]int64{
+					"token1": 1000,
+				})
+			},
+			currentTimestamp: 100,
+			expectError:      true, // Must update reward debt before claiming
+		},
+		{
+			name: "Idempotent no-op when claimedTimestamp equals currentTimestamp",
+			setupState: func(s *ProtocolFeeRewardStateResolver) {
+				// Simulates state after a previous successful claim at the same ts.
+				s.SetClaimedTimestamp(100)
+				s.SetAccumulatedTimestamp(100)
+				s.SetAccumulatedRewards(map[string]int64{
+					"token1": 1000,
+				})
+				s.SetClaimedRewards(map[string]int64{
+					"token1": 1000,
+				})
+			},
+			currentTimestamp:      100,
+			expectError:           false,
+			expectedClaimedLength: 0,
+			expectedNewClaimedTs:  100,
+			expectedClaimedStateAfter: map[string]int64{
+				"token1": 1000,
+			},
+		},
+		{
+			name: "Idempotent no-op preserves unclaimed delta when called in the same second",
+			setupState: func(s *ProtocolFeeRewardStateResolver) {
+				// Pathological state where accumulated > claimed but the claim already
+				// ran in this Unix second. The skip must NOT silently advance claimed.
+				s.SetClaimedTimestamp(100)
+				s.SetAccumulatedTimestamp(100)
+				s.SetAccumulatedRewards(map[string]int64{
+					"token1": 1000,
+					"token2": 500,
+				})
+				s.SetClaimedRewards(map[string]int64{
+					"token1": 400,
+					"token2": 0,
+				})
+			},
+			currentTimestamp:      100,
+			expectError:           false,
+			expectedClaimedLength: 0,
+			expectedNewClaimedTs:  100,
+			expectedClaimedStateAfter: map[string]int64{
+				"token1": 400,
+				"token2": 0,
+			},
+		},
+		{
+			name: "Idempotent no-op when claimedTimestamp is in the future",
+			setupState: func(s *ProtocolFeeRewardStateResolver) {
+				s.SetClaimedTimestamp(200)
+				s.SetAccumulatedTimestamp(200)
+				s.SetAccumulatedRewards(map[string]int64{
+					"token1": 800,
+				})
+				s.SetClaimedRewards(map[string]int64{
+					"token1": 800,
+				})
+			},
+			currentTimestamp:      100,
+			expectError:           false,
+			expectedClaimedLength: 0,
+			expectedNewClaimedTs:  200, // untouched
+			expectedClaimedStateAfter: map[string]int64{
+				"token1": 800,
+			},
 		},
 	}
 
@@ -375,14 +462,80 @@ func TestProtocolFeeRewardState_claimRewards(t *testing.T) {
 			if tt.expectError {
 				uassert.Error(t, err)
 				uassert.Equal(t, claimedRewards, nil)
-			} else {
-				uassert.NoError(t, err)
-				uassert.NotEqual(t, claimedRewards, nil)
-				uassert.Equal(t, len(claimedRewards), tt.expectedClaimedLength)
-				uassert.Equal(t, resolver.GetClaimedTimestamp(), tt.currentTimestamp)
+				return
+			}
+
+			uassert.NoError(t, err)
+			uassert.NotEqual(t, claimedRewards, nil)
+			uassert.Equal(t, len(claimedRewards), tt.expectedClaimedLength)
+			uassert.Equal(t, resolver.GetClaimedTimestamp(), tt.expectedNewClaimedTs)
+
+			if tt.expectedClaimedPerToken != nil {
+				for token, expected := range tt.expectedClaimedPerToken {
+					uassert.Equal(t, claimedRewards[token], expected)
+				}
+			}
+
+			if tt.expectedClaimedStateAfter != nil {
+				actualClaimed := resolver.GetClaimedRewards()
+				for token, expected := range tt.expectedClaimedStateAfter {
+					uassert.Equal(t, actualClaimed[token], expected)
+				}
 			}
 		})
 	}
+}
+
+// Test that consecutive claimRewards calls within the same Unix second
+func TestProtocolFeeRewardState_claimRewards_SameSecondIsIdempotent(t *testing.T) {
+	state := staker.NewProtocolFeeRewardState(make(map[string]*u256.Uint))
+	resolver := NewProtocolFeeRewardStateResolver(state)
+
+	resolver.SetClaimedTimestamp(50)
+	resolver.SetAccumulatedTimestamp(100)
+	resolver.SetAccumulatedRewards(map[string]int64{
+		"token1": 1000,
+		"token2": 300,
+	})
+	resolver.SetClaimedRewards(map[string]int64{
+		"token1": 200,
+		"token2": 0,
+	})
+
+	// First claim at ts=100 captures the pending delta.
+	first, err := resolver.claimRewards(100)
+	uassert.NoError(t, err)
+	uassert.Equal(t, first["token1"], int64(800))
+	uassert.Equal(t, first["token2"], int64(300))
+	uassert.Equal(t, resolver.GetClaimedTimestamp(), int64(100))
+
+	// Second and third calls at the same ts=100 must be no-ops.
+	second, err := resolver.claimRewards(100)
+	uassert.NoError(t, err)
+	uassert.Equal(t, len(second), 0)
+	uassert.Equal(t, resolver.GetClaimedTimestamp(), int64(100))
+
+	third, err := resolver.claimRewards(100)
+	uassert.NoError(t, err)
+	uassert.Equal(t, len(third), 0)
+	uassert.Equal(t, resolver.GetClaimedTimestamp(), int64(100))
+
+	// State must remain exactly as the first claim left it.
+	claimedAfter := resolver.GetClaimedRewards()
+	uassert.Equal(t, claimedAfter["token1"], int64(1000))
+	uassert.Equal(t, claimedAfter["token2"], int64(300))
+
+	// Advancing to ts=101 with newly accumulated rewards is claimable again.
+	resolver.SetAccumulatedTimestamp(101)
+	resolver.SetAccumulatedRewards(map[string]int64{
+		"token1": 1500,
+		"token2": 300,
+	})
+	fourth, err := resolver.claimRewards(101)
+	uassert.NoError(t, err)
+	uassert.Equal(t, fourth["token1"], int64(500))
+	uassert.Equal(t, fourth["token2"], int64(0))
+	uassert.Equal(t, resolver.GetClaimedTimestamp(), int64(101))
 }
 
 // Test updateRewardDebtX128
@@ -544,7 +697,7 @@ func TestProtocolFeeRewardState_EdgeCases(t *testing.T) {
 			description: "Should handle nil reward debt for new tokens",
 		},
 		{
-			name: "Multiple claim attempts",
+			name: "Multiple claim attempts in the same second are idempotent",
 			setupTest: func(s *ProtocolFeeRewardStateResolver) {
 				s.SetClaimedTimestamp(50)
 				s.SetAccumulatedTimestamp(100)
@@ -555,18 +708,22 @@ func TestProtocolFeeRewardState_EdgeCases(t *testing.T) {
 					"token1": 0,
 				})
 
-				// First claim
+				// First claim returns the full accumulated reward
 				rewards1, err1 := s.claimRewards(100)
 				uassert.NoError(t, err1)
 				if rewards1["token1"] != 1000 {
 					t.Errorf("Expected 1000, got %d", rewards1["token1"])
 				}
 
-				// Second claim should fail (same height)
-				_, err2 := s.claimRewards(100)
-				uassert.Error(t, err2)
+				// Second claim at the same timestamp is an idempotent no-op:
+				// it must not error, and must return no additional rewards.
+				rewards2, err2 := s.claimRewards(100)
+				uassert.NoError(t, err2)
+				if rewards2["token1"] != 0 {
+					t.Errorf("Expected 0 on second claim, got %d", rewards2["token1"])
+				}
 			},
-			description: "Should handle multiple claim attempts correctly",
+			description: "Second claim in the same Unix second must be a no-op, not an error",
 		},
 		{
 			name: "Zero staked amount calculation",

--- a/contract/r/scenario/gov/staker/collect_reward_pool_creation_fee_same_block_filetest.gno
+++ b/contract/r/scenario/gov/staker/collect_reward_pool_creation_fee_same_block_filetest.gno
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	testutils "gno.land/p/nt/testutils/v0"
-	uassert "gno.land/p/nt/uassert/v0"
 	ufmt "gno.land/p/nt/ufmt/v0"
 
 	prbac "gno.land/p/gnoswap/rbac"
@@ -27,8 +26,6 @@ import (
 )
 
 var (
-	t *testing.T
-
 	adminAddr  = access.MustGetAddress(prbac.ROLE_ADMIN.String())
 	adminRealm = testing.NewUserRealm(adminAddr)
 
@@ -61,12 +58,12 @@ func main() {
 	})
 	println()
 
-	println("[SCENARIO] 4. Not available to claim protocol fee reward in same block")
+	println("[SCENARIO] 4. Second claim in the same block is an idempotent no-op")
 	createPoolByAdmin(barPath, quxPath, 100)
-	uassert.AbortsContains(t, "not claimable", func() {
+	checkBalanceFn(gnsPath, aliceAddr, func() {
 		collectProtocolFee(aliceAddr)
 	})
-	println("[EXPECTED] not claimable protocol fee reward twice in same block")
+	println("[EXPECTED] second claim in the same block returns zero additional reward")
 }
 
 func delegateWithMint(from, to address, amount int64) {
@@ -122,6 +119,8 @@ func checkBalanceFn(tokenPath string, addr address, fn func()) {
 // [INFO] collected protocol fee reward for  g1v9kxjcm9ta047h6lta047h6lta047h6lzd40gh
 // [EXPECTED] g1v9kxjcm9ta047h6lta047h6lta047h6lzd40gh's balance of gno.land/r/gnoswap/gns: 200000000
 //
-// [SCENARIO] 4. Not available to claim protocol fee reward in same block
+// [SCENARIO] 4. Second claim in the same block is an idempotent no-op
 // [INFO] created gno.land/r/onbloc/bar:gno.land/r/onbloc/qux:100 pool (poolCreationFee: 100000000)
-// [EXPECTED] not claimable protocol fee reward twice in same block
+// [INFO] collected protocol fee reward for  g1v9kxjcm9ta047h6lta047h6lta047h6lzd40gh
+// [EXPECTED] g1v9kxjcm9ta047h6lta047h6lta047h6lzd40gh's balance of gno.land/r/gnoswap/gns: 0
+// [EXPECTED] second claim in the same block returns zero additional reward


### PR DESCRIPTION
## Descriptions

Reward collection could invoke `claimRewards` more than once in the same Unix second (e.g. same block). When `IsClaimable` was false, the v1 resolvers returned a **hard error** (`"not claimable"`), which surfaced as **aborts/panics** in higher-level flows even though no additional rewards should be paid.

This change treats that path as a **safe, idempotent no-op**: return **zero claimed value** with **`nil` error**, without mutating claimed timestamps or claimed reward snapshots.

## Changes

- **`EmissionRewardStateResolver.claimRewards`**: if not claimable, return `(0, nil)` instead of an error; document that `0` means “already handled at this timestamp.”
- **`ProtocolFeeRewardStateResolver.claimRewards`**: if not claimable, return an **empty map** and **`nil`** instead of an error. **Stale reward debt** (`accumulatedTimestamp < currentTimestamp`) still returns an error as before.
- **Tests**: expanded `claimRewards` table tests for first claim, zero-reward no-op, same-second idempotency, “pathological” accumulated-vs-claimed edge cases, and future `claimedTimestamp`; added dedicated **same-second idempotency** tests for both resolvers; aligned combined `claimRewardsWithUpdateRewardDebtX128` expectations.
- **Scenario**: `collect_reward_pool_creation_fee_same_block_filetest` now expects the **second collect in the same block** to be a **no-op** (no abort on `"not claimable"`), with expectations updated accordingly.

## Motivation

Prevents **double-collect in the same timestamp** from failing the transaction when the correct behavior is **no additional payout** and **unchanged accounting** beyond the first successful claim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reward claim idempotency: consecutive attempts to claim rewards at the same timestamp now complete gracefully without errors, preventing unnecessary rejections.
  * Refined error handling in reward operations to more accurately reflect validation constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->