### PR TITLE
fix(staker): emit incentive shortfall events

### DIFF
--- a/contract/r/gnoswap/staker/v1/external_incentive.gno
+++ b/contract/r/gnoswap/staker/v1/external_incentive.gno
@@ -184,6 +184,19 @@ func (s *stakerV1) EndExternalIncentive(targetPoolPath, incentiveId string, refu
 	stakerAddr := access.MustGetAddress(prbac.ROLE_STAKER.String())
 	poolLeftExternalRewardAmount := common.BalanceOf(incentiveResolver.RewardToken(), stakerAddr)
 	if poolLeftExternalRewardAmount < refund {
+		previousRealm := runtime.PreviousRealm()
+		chain.Emit(
+			"EndExternalIncentiveShortfall",
+			"prevAddr", previousRealm.Address().String(),
+			"prevRealm", previousRealm.PkgPath(),
+			"incentiveId", incentiveId,
+			"targetPoolPath", targetPoolPath,
+			"refundee", refundAddress.String(),
+			"refundToken", incentiveResolver.RewardToken(),
+			"expectedRefundAmount", formatAnyInt(refund),
+			"actualRefundAmount", formatAnyInt(poolLeftExternalRewardAmount),
+			"creator", incentiveResolver.Creator().String(),
+		)
 		refund = poolLeftExternalRewardAmount
 	}
 
@@ -324,6 +337,19 @@ func (s *stakerV1) CollectExternalIncentivePenalty(
 	stakerAddr := access.MustGetAddress(prbac.ROLE_STAKER.String())
 	balance := common.BalanceOf(incentiveResolver.RewardToken(), stakerAddr)
 	if balance < penaltyAmount {
+		previousRealm := runtime.PreviousRealm()
+		chain.Emit(
+			"CollectExternalIncentivePenaltyShortfall",
+			"prevAddr", previousRealm.Address().String(),
+			"prevRealm", previousRealm.PkgPath(),
+			"targetPoolPath", targetPoolPath,
+			"incentiveId", incentiveId,
+			"refundAddress", refundAddress.String(),
+			"refundToken", incentiveResolver.RewardToken(),
+			"expectedPenaltyAmount", formatAnyInt(penaltyAmount),
+			"actualPenaltyAmount", formatAnyInt(balance),
+			"creator", incentiveResolver.Creator().String(),
+		)
 		penaltyAmount = balance
 	}
 


### PR DESCRIPTION
## Summary
- emit `EndExternalIncentiveShortfall` when the final refund is capped by the staker's live reward-token balance
- emit `CollectExternalIncentivePenaltyShortfall` when penalty collection is capped by the same balance shortfall
- keep the existing refund and penalty cap behavior unchanged while making the exceptional path traceable on-chain

## Testing
- make clean && make test PKG=gno.land/r/gnoswap/staker/v1 RUN=TestEndExternalIncentive
- make clean && make test PKG=gno.land/r/gnoswap/staker/v1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of insufficient token balance scenarios in external incentive operations with enhanced event logging to record shortfalls and track expected versus actual amounts for better system transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->