### PR TITLE
refactor(staker): unify reward `lastCollectTime` invariants

### DIFF
--- a/contract/r/gnoswap/staker/v1/getter.gno
+++ b/contract/r/gnoswap/staker/v1/getter.gno
@@ -284,9 +284,7 @@ func (s *stakerV1) GetDepositLiquidityAsString(lpTokenId uint64) string {
 
 // GetDepositInternalRewardLastCollectTimestamp returns the last collect timestamp of a deposit.
 func (s *stakerV1) GetDepositInternalRewardLastCollectTimestamp(lpTokenId uint64) int64 {
-	deposit := s.getDeposit(lpTokenId)
-
-	return deposit.InternalRewardLastCollectTime()
+	return s.getDepositResolver(lpTokenId).InternalRewardLastCollectTime()
 }
 
 // GetDepositCollectedInternalReward returns the collected internal reward amount.

--- a/contract/r/gnoswap/staker/v1/getter_test.gno
+++ b/contract/r/gnoswap/staker/v1/getter_test.gno
@@ -320,6 +320,14 @@ func TestGetterDepositBasicProperties(t *testing.T) {
 	}
 }
 
+func TestGetterDepositInternalLastCollectFallbackToStakeTime(t *testing.T) {
+	state := setupBasicTestState(t)
+	state.deposit.SetInternalRewardLastCollectTime(0)
+
+	lastCollectTime := state.instance.GetDepositInternalRewardLastCollectTimestamp(state.positionId)
+	uassert.Equal(t, state.fixedTimestamp, lastCollectTime)
+}
+
 func TestGetterDepositLiquidity(t *testing.T) {
 	state := setupBasicTestState(t)
 

--- a/contract/r/gnoswap/staker/v1/staker.gno
+++ b/contract/r/gnoswap/staker/v1/staker.gno
@@ -611,6 +611,7 @@ func (s *stakerV1) CollectReward(positionId uint64) (string, string, map[string]
 	internalRewardToUser := int64(0)
 	internalRewardToFee := int64(0)
 	internalRewardPenalty := int64(0)
+	totalEmissionSent := s.store.GetTotalEmissionSent()
 
 	// Skip internal reward state update when user reward is zero (only penalty).
 	// Do not update last collect time so the reward accrues until the next
@@ -640,61 +641,55 @@ func (s *stakerV1) CollectReward(positionId uint64) (string, string, map[string]
 			"currentTime", formatAnyInt(currentTime),
 			"currentHeight", formatAnyInt(blockHeight),
 		)
-	}
 
-	totalEmissionSent := s.store.GetTotalEmissionSent()
+		if internalRewardToUser > 0 {
+			// internal reward to user
+			totalEmissionSent = safeAddInt64(totalEmissionSent, internalRewardToUser)
+			depositResolver.addCollectedInternalReward(reward.Internal)
+		}
 
-	if internalRewardToUser > 0 {
-		// internal reward to user
-		totalEmissionSent = safeAddInt64(totalEmissionSent, internalRewardToUser)
-		depositResolver.addCollectedInternalReward(reward.Internal)
-	}
+		if internalRewardPenalty > 0 {
+			// internal penalty to community pool
+			totalEmissionSent = safeAddInt64(totalEmissionSent, internalRewardPenalty)
+			depositResolver.addCollectedInternalReward(internalRewardPenalty)
+		}
 
-	if internalRewardPenalty > 0 {
-		// internal penalty to community pool
-		totalEmissionSent = safeAddInt64(totalEmissionSent, internalRewardPenalty)
-		depositResolver.addCollectedInternalReward(internalRewardPenalty)
-	}
+		// Unclaimable must be processed after regular rewards so that accumulated
+		// unclaimable amounts are reset in the same collect window.
+		unClaimableInternal := s.processUnClaimableReward(depositResolver.TargetPoolPath(), currentTime)
+		if unClaimableInternal > 0 {
+			totalEmissionSent = safeAddInt64(totalEmissionSent, unClaimableInternal)
+		}
 
-	// Unclaimable must be processed after regular rewards so that accumulated
-	// unclaimable amounts are reset in the same collect window.
-	unClaimableInternal := s.processUnClaimableReward(depositResolver.TargetPoolPath(), currentTime)
-	if unClaimableInternal > 0 {
-		totalEmissionSent = safeAddInt64(totalEmissionSent, unClaimableInternal)
-	}
+		err = s.store.SetTotalEmissionSent(totalEmissionSent)
+		if err != nil {
+			panic(err)
+		}
 
-	err := s.store.SetTotalEmissionSent(totalEmissionSent)
-	if err != nil {
-		panic(err)
-	}
-
-	if !skipInternalUpdate {
 		// Update lastCollectTime for internal rewards (GNS emissions)
 		err = depositResolver.updateInternalRewardLastCollectTime(currentTime)
 		if err != nil {
 			panic(err)
 		}
-	}
 
-	deposits := s.getDeposits()
-	deposits.set(positionId, deposit)
+		deposits := s.getDeposits()
+		deposits.set(positionId, deposit)
 
-	if internalRewardToUser > 0 {
-		gns.Transfer(cross, deposit.Owner(), internalRewardToUser)
-	}
+		if internalRewardToUser > 0 {
+			gns.Transfer(cross, deposit.Owner(), internalRewardToUser)
+		}
 
-	if internalRewardPenalty > 0 {
-		gns.Transfer(cross, communityPoolAddr, internalRewardPenalty)
-	}
+		if internalRewardPenalty > 0 {
+			gns.Transfer(cross, communityPoolAddr, internalRewardPenalty)
+		}
 
-	if unClaimableInternal > 0 {
-		gns.Transfer(cross, communityPoolAddr, unClaimableInternal)
-	}
+		if unClaimableInternal > 0 {
+			gns.Transfer(cross, communityPoolAddr, unClaimableInternal)
+		}
 
-	rewardToUser := formatAnyInt(internalRewardToUser)
-	rewardPenalty := formatAnyInt(internalRewardPenalty)
+		rewardToUser := formatAnyInt(internalRewardToUser)
+		rewardPenalty := formatAnyInt(internalRewardPenalty)
 
-	if !skipInternalUpdate {
 		poolPath := depositResolver.TargetPoolPath()
 		pool, _ := s.getPools().Get(poolPath)
 		poolResolver := NewPoolResolver(pool)
@@ -727,9 +722,30 @@ func (s *stakerV1) CollectReward(positionId uint64) (string, string, map[string]
 			"lowerTickOutsideAccX128", lowerOutsideAccX128.ToString(),
 			"upperTickOutsideAccX128", upperOutsideAccX128.ToString(),
 		)
+
+		return rewardToUser, rewardPenalty, toUserExternalReward, toUserExternalPenalty
 	}
 
-	return rewardToUser, rewardPenalty, toUserExternalReward, toUserExternalPenalty
+	// Unclaimable must still be processed when regular internal rewards are
+	// skipped so accrued pool state is cleared for the collect window.
+	unClaimableInternal := s.processUnClaimableReward(depositResolver.TargetPoolPath(), currentTime)
+	if unClaimableInternal > 0 {
+		totalEmissionSent = safeAddInt64(totalEmissionSent, unClaimableInternal)
+	}
+
+	err := s.store.SetTotalEmissionSent(totalEmissionSent)
+	if err != nil {
+		panic(err)
+	}
+
+	deposits := s.getDeposits()
+	deposits.set(positionId, deposit)
+
+	if unClaimableInternal > 0 {
+		gns.Transfer(cross, communityPoolAddr, unClaimableInternal)
+	}
+
+	return formatAnyInt(internalRewardToUser), formatAnyInt(internalRewardPenalty), toUserExternalReward, toUserExternalPenalty
 }
 
 // UnStakeToken withdraws an LP token from staking, collecting all pending rewards

--- a/contract/r/gnoswap/staker/v1/staker.gno
+++ b/contract/r/gnoswap/staker/v1/staker.gno
@@ -607,28 +607,24 @@ func (s *stakerV1) CollectReward(positionId uint64) (string, string, map[string]
 		)
 	}
 
-	internalReward := int64(0)
-	internalRewardToUser := int64(0)
-	internalRewardToFee := int64(0)
-	internalRewardPenalty := int64(0)
 	totalEmissionSent := s.store.GetTotalEmissionSent()
 
 	// Skip internal reward state update when user reward is zero (only penalty).
 	// Do not update last collect time so the reward accrues until the next
 	// collection where a non-zero amount can be delivered.
-	skipInternalUpdate := reward.Internal == 0
+	hasInternalReward := reward.Internal > 0
 
 	// internal reward to user
-	if !skipInternalUpdate {
+	if hasInternalReward {
 		toUser, feeAmount, err := s.handleStakingRewardFee(GNS_PATH, reward.Internal, true)
 		if err != nil {
 			panic(err.Error())
 		}
 
-		internalReward = reward.Internal
-		internalRewardToUser = toUser
-		internalRewardToFee = feeAmount
-		internalRewardPenalty = reward.InternalPenalty
+		internalReward := reward.Internal
+		internalRewardToUser := toUser
+		internalRewardToFee := feeAmount
+		internalRewardPenalty := reward.InternalPenalty
 
 		chain.Emit(
 			"ProtocolFeeInternalReward",
@@ -745,7 +741,7 @@ func (s *stakerV1) CollectReward(positionId uint64) (string, string, map[string]
 		gns.Transfer(cross, communityPoolAddr, unClaimableInternal)
 	}
 
-	return formatAnyInt(internalRewardToUser), formatAnyInt(internalRewardPenalty), toUserExternalReward, toUserExternalPenalty
+	return "0", "0", toUserExternalReward, toUserExternalPenalty
 }
 
 // UnStakeToken withdraws an LP token from staking, collecting all pending rewards

--- a/contract/r/gnoswap/staker/v1/type.gno
+++ b/contract/r/gnoswap/staker/v1/type.gno
@@ -87,11 +87,24 @@ func (self *DepositResolver) addCollectedExternalReward(incentiveID string, rewa
 	self.SetCollectedExternalReward(incentiveID, collectedExternalReward)
 }
 
+// assertMonotonicCollectTime enforces that currentTime is not earlier than the
+// last observed collect time. label is used only to distinguish diagnostics.
+func (self *DepositResolver) assertMonotonicCollectTime(lastCollectTime, currentTime int64, label string) error {
+	if lastCollectTime > currentTime {
+		return makeErrorWithDetails(
+			errNotAvailableUpdateCollectTime,
+			"currentTime must be greater than "+label+" last collect time",
+		)
+	}
+
+	return nil
+}
+
 // updateInternalRewardLastCollectTime updates the last collect time for the internal reward.
 // It returns an error if the current time is less than the last collect time for the internal reward.
 func (self *DepositResolver) updateInternalRewardLastCollectTime(currentTime int64) error {
-	if self.InternalRewardLastCollectTime() > currentTime {
-		return makeErrorWithDetails(errNotAvailableUpdateCollectTime, "currentTime must be greater than internal reward last collect time")
+	if err := self.assertMonotonicCollectTime(self.InternalRewardLastCollectTime(), currentTime, "internal reward"); err != nil {
+		return err
 	}
 
 	self.SetInternalRewardLastCollectTime(currentTime)
@@ -102,13 +115,8 @@ func (self *DepositResolver) updateInternalRewardLastCollectTime(currentTime int
 // updateExternalRewardLastCollectTime lazily updates the last collect time for the external reward for the given incentive ID.
 // It returns an error if the current time is less than the last collect time for the external reward for the given incentive ID.
 func (self *DepositResolver) updateExternalRewardLastCollectTime(incentiveID string, currentTime int64) error {
-	if self.ExternalRewardLastCollectTimes() == nil {
-		self.SetExternalRewardLastCollectTimes(make(map[string]int64))
-	}
-
-	externalLastCollectTime, exists := self.Deposit.GetExternalRewardLastCollectTime(incentiveID)
-	if exists && externalLastCollectTime > currentTime {
-		return makeErrorWithDetails(errNotAvailableUpdateCollectTime, "currentTime must be greater than external reward last collect time")
+	if err := self.assertMonotonicCollectTime(self.ExternalRewardLastCollectTime(incentiveID), currentTime, "external reward"); err != nil {
+		return err
 	}
 
 	self.Deposit.SetExternalRewardLastCollectTime(incentiveID, currentTime)


### PR DESCRIPTION
## Description

This PR makes the staker reward cursor invariant explicit and symmetric across internal GNS rewards and external incentive rewards.

Both reward streams maintains a `lastCollectTime` cursor. That cursor is expected to move monotonically forward from the effective last collection time, where an unset to zero cursor falls back to the deposit's `StakeTime`. Before this change, the internal and external reward paths enforced that rule through different read paths, which made the invariant weaker for external rewards in defensive cases.

### Problem

`CollectReward` settles two independent reward streams:

- internal GNS emissions
- external incentive token rewards

Both streams update a `lastCollectTime` cursor to prevent collecting rewards over an invalid earlier interval. However the update paths were asymmetric:

- Internal reward updates used `DepositResolver.InternalRewardLastCollectTime()`, which falls back to `StakeTime()` when the stored cursor is zero.
- External reward updates read `Deposit.GetExternalRewardLastCollectTime(...)` directly, which bypassed the wrapped fallback behavior.

As a result, the external path did not enforce the same lower bound in two edge cases:

- when the external reward cursor did not exist yet
- when an external reward cursor entry existed but stored `0`

In those cases, the external path could skip or weaken the monotonic validation that the internal path already performed. The normal production flow is not expected to create those states intentionally, but the implementation still encoded two different strengths of the same invariant. That made the reward cursor logic harder to reason about and easier to regress later.

## Changes

- Add a shared monotonic collect-time assertion on `DepositResolver`.
- Route both internal and external reward cursor updates through the shared assertion.
- Validate external reward cursor updates through `ExternalRewardLastCollectTime(incentiveID)`, so missing or zero cursor state falls back to `StakeTime()` like the internal path.
- Remove the redundant external reward cursor map guard because `Deposit.SetExternalRewardLastCollectTime` already lazy-initializes the map.
- Align the public getter read path so the internal last collect timestamp uses the same wrapped resolver behavior as the external getter path.
- Consolidate the internal `CollectReward` update flow so reward accounting, cursor updates, transfers, and event emission live under one positive `hasInternalReward` branch.
- Narrow the scope of internal reward accounting variables and return explicit zero values from the no-internal-reward path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved internal reward collection handling with fallback timestamp logic when the last-collect timestamp is unavailable, now defaults to the deposit's stake time.

* **Tests**
  * Added test coverage for internal reward collection fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->