### PR TITLE
refactor(router):string optimization

### DIFF
--- a/contract/r/gnoswap/router/v1/base.gno
+++ b/contract/r/gnoswap/router/v1/base.gno
@@ -177,13 +177,10 @@ func (p *SwapRouteParams) ExpectedExactAmountByFee(feeBps uint64) int64 {
 }
 
 func (p *SwapRouteParams) SwapCount() int64 {
-	swapCount := int64(0)
-
-	for _, route := range strings.Split(p.routeArr, ",") {
-		swapCount += int64(strings.Count(route, POOL_SEPARATOR) + 1)
-	}
-
-	return swapCount
+	// Total swaps = number_of_routes + total_pool_separators
+	// = (commas + 1) + POOL_SEPARATOR count
+	// Equivalent to the loop: for each route, count = POOL_SEPs_in_route + 1.
+	return int64(strings.Count(p.routeArr, ",")+1) + int64(strings.Count(p.routeArr, POOL_SEPARATOR))
 }
 
 func (p *SwapRouteParams) IsSetSqrtPriceLimitX96() bool {

--- a/contract/r/gnoswap/router/v1/utils.gno
+++ b/contract/r/gnoswap/router/v1/utils.gno
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	"bytes"
 	"math"
 	"strconv"
 	"strings"
@@ -169,13 +168,11 @@ func validateRoutePath(routePath, inputToken, outputToken string) error {
 		err                   error
 	)
 
-	// multi-hop routePath
-	if strings.Contains(routePath, POOL_SEPARATOR) {
-		pools := strings.Split(routePath, POOL_SEPARATOR)
-
-		// Get first token from first pool
-		firstPool := pools[0]
-		firstToken, _, _, err = getDataForSinglePathWithError(firstPool)
+	// Split once: len>1 means multi-hop, avoiding a redundant strings.Contains scan.
+	pools := strings.Split(routePath, POOL_SEPARATOR)
+	if len(pools) > 1 {
+		// multi-hop routePath
+		firstToken, _, _, err = getDataForSinglePathWithError(pools[0])
 		if err != nil {
 			return err
 		}
@@ -186,9 +183,7 @@ func validateRoutePath(routePath, inputToken, outputToken string) error {
 			return err
 		}
 
-		// Get last token from last pool
-		lastPool := pools[len(pools)-1]
-		_, lastToken, _, err = getDataForSinglePathWithError(lastPool)
+		_, lastToken, _, err = getDataForSinglePathWithError(pools[len(pools)-1])
 		if err != nil {
 			return err
 		}
@@ -253,7 +248,16 @@ func splitSingleChar(s string, sep byte) []string {
 		return []string{""}
 	}
 
-	result := make([]string, 0, bytes.Count([]byte(s), []byte{sep})+1)
+	// count := bytes.Count([]byte(s), []byte{sep})
+	// Avoid allocating []byte(s) just for counting — scan string bytes directly.
+	count := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == sep {
+			count++
+		}
+	}
+
+	result := make([]string, 0, count+1)
 	start := 0
 	for i := range s {
 		if s[i] == sep {


### PR DESCRIPTION
  ## Summary                                                                                                                                                                           
- Optimize `SwapCount()` to use a single-expression formula instead of a loop
- Avoid unnecessary `[]byte` allocation in `splitSingleChar` by scanning string bytes directly
                                                                                                   
## Note
                                                                                                                                                                   
Gas savings from this change are marginal (< 1%). This is closer to a code readability and structural refactor than a meaningful gas optimization.

## Test Plan

No new tests required. Existing tests cover all changes:

**eliminate redundant string scans**
- `TestSwapRouteParams_SwapCount` — validates SwapCount() logic change (single / multi route)
- `TestSwapRouteParams_SwapCount_Complex` — covers SwapCount() accuracy across complex route combinations
- `TestSwapCountCalculation` — validates swap count calculation per route
- `validateRoutePath` (strings.Contains → single strings.Split call): `TestValidateRoutePath` in utils_test.gno:336 — covers multi-hop / single-hop path validation
- `splitSingleChar` (bytes.Count → direct byte scan): utils_test.gno:198 — covers split result correctness