### PR TITLE
refactor(staker): optimize reward calculation in warmup loop

### DIFF
--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
@@ -401,9 +401,8 @@ func (self *RewardState) rewardPerWarmup(startTime, endTime int64, rewardPerSeco
 		return nil
 	}
 
-	// Cache startTime's tick — updated at end of each iteration to avoid re-querying
-	// the same time value that was already resolved as the previous iteration's endTick.
 	startTick := self.pool.CurrentTick(startTime)
+	startRaw := self.pool.CalculateRawRewardForPosition(startTime, startTick, self.deposit.Deposit)
 
 	for i, warmup := range self.deposit.Warmups() {
 		if startTime >= warmup.NextWarmupTime {
@@ -412,13 +411,9 @@ func (self *RewardState) rewardPerWarmup(startTime, endTime int64, rewardPerSeco
 		}
 
 		if endTime < warmup.NextWarmupTime {
-			rewardAcc := self.pool.CalculateRewardForPosition(
-				startTime,
-				startTick,
-				endTime,
-				self.pool.CurrentTick(endTime),
-				self.deposit.Deposit,
-			)
+			endTick := self.pool.CurrentTick(endTime)
+			endRaw := self.pool.CalculateRawRewardForPosition(endTime, endTick, self.deposit.Deposit)
+			rewardAcc := u256.Zero().Sub(endRaw, startRaw)
 
 			rewardAcc = u256.Zero().Mul(rewardAcc, self.deposit.Liquidity())
 			rewardAcc = u256.MulDiv(rewardAcc, u256.NewUintFromInt64(rewardPerSecond), q128)
@@ -428,13 +423,8 @@ func (self *RewardState) rewardPerWarmup(startTime, endTime int64, rewardPerSeco
 		}
 
 		endTick := self.pool.CurrentTick(warmup.NextWarmupTime)
-		rewardAcc := self.pool.CalculateRewardForPosition(
-			startTime,
-			startTick,
-			warmup.NextWarmupTime,
-			endTick,
-			self.deposit.Deposit,
-		)
+		endRaw := self.pool.CalculateRawRewardForPosition(warmup.NextWarmupTime, endTick, self.deposit.Deposit)
+		rewardAcc := u256.Zero().Sub(endRaw, startRaw)
 
 		rewardAcc = u256.Zero().Mul(rewardAcc, self.deposit.Liquidity())
 		rewardAcc = u256.MulDiv(rewardAcc, u256.NewUintFromInt64(rewardPerSecond), q128)
@@ -442,6 +432,7 @@ func (self *RewardState) rewardPerWarmup(startTime, endTime int64, rewardPerSeco
 
 		startTime = warmup.NextWarmupTime
 		startTick = endTick
+		startRaw = endRaw
 	}
 
 	return nil

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
@@ -254,11 +254,6 @@ func (self *PoolResolver) RewardStateOf(deposit *sr.Deposit) *RewardState {
 		penalties: make([]int64, warmups),
 	}
 
-	for i := range result.rewards {
-		result.rewards[i] = 0
-		result.penalties[i] = 0
-	}
-
 	return result
 }
 

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
@@ -561,18 +561,3 @@ func (self *PoolResolver) CalculateRawRewardForPosition(currentTime int64, curre
 
 	return rewardAcc
 }
-
-// Calculate actual reward in [startTime, endTime) for a position by
-// subtracting the startTime's raw reward from the endTime's raw reward
-func (self *PoolResolver) CalculateRewardForPosition(
-	startTime int64,
-	startTick int32,
-	endTime int64,
-	endTick int32,
-	deposit *sr.Deposit,
-) *u256.Uint {
-	rewardAcc := self.CalculateRawRewardForPosition(endTime, endTick, deposit)
-	debtAcc := self.CalculateRawRewardForPosition(startTime, startTick, deposit)
-
-	return u256.Zero().Sub(rewardAcc, debtAcc)
-}

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
@@ -401,6 +401,10 @@ func (self *RewardState) rewardPerWarmup(startTime, endTime int64, rewardPerSeco
 		return nil
 	}
 
+	// Cache startTime's tick — updated at end of each iteration to avoid re-querying
+	// the same time value that was already resolved as the previous iteration's endTick.
+	startTick := self.pool.CurrentTick(startTime)
+
 	for i, warmup := range self.deposit.Warmups() {
 		if startTime >= warmup.NextWarmupTime {
 			// passed the warmup
@@ -410,7 +414,7 @@ func (self *RewardState) rewardPerWarmup(startTime, endTime int64, rewardPerSeco
 		if endTime < warmup.NextWarmupTime {
 			rewardAcc := self.pool.CalculateRewardForPosition(
 				startTime,
-				self.pool.CurrentTick(startTime),
+				startTick,
 				endTime,
 				self.pool.CurrentTick(endTime),
 				self.deposit.Deposit,
@@ -423,11 +427,12 @@ func (self *RewardState) rewardPerWarmup(startTime, endTime int64, rewardPerSeco
 			break
 		}
 
+		endTick := self.pool.CurrentTick(warmup.NextWarmupTime)
 		rewardAcc := self.pool.CalculateRewardForPosition(
 			startTime,
-			self.pool.CurrentTick(startTime),
+			startTick,
 			warmup.NextWarmupTime,
-			self.pool.CurrentTick(warmup.NextWarmupTime),
+			endTick,
 			self.deposit.Deposit,
 		)
 
@@ -436,6 +441,7 @@ func (self *RewardState) rewardPerWarmup(startTime, endTime int64, rewardPerSeco
 		self.rewards[i] = safeAddInt64(self.rewards[i], safeConvertToInt64(rewardAcc))
 
 		startTime = warmup.NextWarmupTime
+		startTick = endTick
 	}
 
 	return nil


### PR DESCRIPTION
  ## Summary
- Remove redundant zero initialization in `RewardState` — `make([]int64, n)` already zero-initializes
- Cache `CurrentTick` result per warmup iteration instead of querying the same value twice
- Cache raw reward at each warmup boundary and reuse as the next iteration's start basis, reducing `CalculateRawRewardForPosition` calls per warmup

## Test Plan

No new tests required. Existing tests cover all changes:

**remove redundant zero initialization in RewardState**
`TestRewardStateOf` — confirms slice length is correct after construction

**cache CurrentTick per warmup iteration**
`TestCanonicalWarmup_1` — verifies per-tier reward accuracy one block at a time

**cache raw reward at warmup boundary to reduce ReverseIterate calls**
`TestCanonicalWarmup_2` — AssertEmulatedRewardOf called once after 40 blocks, exercises startRaw carry-forward across all 4 warmup boundaries in a single rewardPerWarmup call

`TestHistoricalTickDensity_DoesNotChangeRewardCalculation` — covers tick crossing combined with warmup accumulator
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved staking reward calculations and warmup handling to make reward accumulation more efficient and consistent across segments, reducing redundant computations and improving correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->