### PR TITLE
feat(gnft): allow position ownership transfers

### DIFF
--- a/contract/r/gnoswap/gnft/gnft.gno
+++ b/contract/r/gnoswap/gnft/gnft.gno
@@ -94,12 +94,8 @@ func SetTokenURI(cur realm, tid grc721.TokenID, tURI grc721.TokenURI) (bool, err
 //   - tid: token ID to transfer
 //
 // Returns error if transfer fails.
-// Only callable by staker contract.
 func SafeTransferFrom(cur realm, from, to address, tid grc721.TokenID) error {
 	halt.AssertIsNotHaltedPosition()
-
-	caller := runtime.PreviousRealm().Address()
-	access.AssertIsStaker(caller)
 
 	assertFromIsValidAddress(from)
 	assertToIsValidAddress(to)
@@ -117,12 +113,8 @@ func SafeTransferFrom(cur realm, from, to address, tid grc721.TokenID) error {
 //   - tid: token ID
 //
 // Returns error if transfer fails.
-// Only callable by staker contract.
 func TransferFrom(cur realm, from, to address, tid grc721.TokenID) error {
 	halt.AssertIsNotHaltedPosition()
-
-	caller := runtime.PreviousRealm().Address()
-	access.AssertIsStaker(caller)
 
 	assertFromIsValidAddress(from)
 	assertToIsValidAddress(to)

--- a/contract/r/gnoswap/gnft/gnft_test.gno
+++ b/contract/r/gnoswap/gnft/gnft_test.gno
@@ -531,10 +531,6 @@ func TestGetApproved(t *testing.T) {
 }
 
 func TestTransferFrom(t *testing.T) {
-	resetObject(t)
-	testing.SetRealm(positionRealm)
-	Mint(cross, addr01, tid(1))
-
 	tests := []struct {
 		name              string
 		setup             func(cur realm)
@@ -557,15 +553,33 @@ func TestTransferFrom(t *testing.T) {
 		},
 		{
 			name:              "transfer token owned by other user without approval",
-			callerRealm:       stakerRealm,
+			callerRealm:       addr02Realm,
 			fromAddr:          addr01,
 			toAddr:            addr02,
 			tokenIdToTransfer: 1,
 			shouldPanic:       true,
-			panicMsg:          "caller is not token owner or approved || caller g1q6d4ns7zkr492rgl0pcgf5ajaf2dlz0nnptky3 is not owner g1v9jxgu3sx9047h6lta047h6lta047h6l0js7st or approved for token 1",
+			panicMsg:          "caller is not token owner or approved || caller g1v9jxgu3sxf047h6lta047h6lta047h6l8tv5at is not owner g1v9jxgu3sx9047h6lta047h6lta047h6l0js7st or approved for token 1",
 		},
 		{
-			name: "transfer token owned by other user with approval",
+			name: "approved user transfers token",
+			setup: func(cur realm) {
+				testing.SetRealm(addr01Realm)
+				Approve(cross, addr02, tid(1))
+			},
+			callerRealm:       addr02Realm,
+			fromAddr:          addr01,
+			toAddr:            addr02,
+			tokenIdToTransfer: 1,
+		},
+		{
+			name:        "owner transfers own token",
+			callerRealm: addr01Realm,
+			fromAddr:    addr01,
+			toAddr:      addr02,
+			tokenIdToTransfer: 1,
+		},
+		{
+			name: "approved staker transfer still works",
 			setup: func(cur realm) {
 				testing.SetRealm(addr01Realm)
 				Approve(cross, stakerRealm.Address(), tid(1))
@@ -573,17 +587,6 @@ func TestTransferFrom(t *testing.T) {
 			callerRealm:       stakerRealm,
 			fromAddr:          addr01,
 			toAddr:            addr02,
-			tokenIdToTransfer: 1,
-		},
-		{
-			name: "transfer token owned by caller",
-			setup: func(cur realm) {
-				testing.SetRealm(addr02Realm)
-				Approve(cross, stakerRealm.Address(), tid(1))
-			},
-			callerRealm:       stakerRealm,
-			fromAddr:          addr02,
-			toAddr:            addr01,
 			tokenIdToTransfer: 1,
 		},
 		{
@@ -605,15 +608,6 @@ func TestTransferFrom(t *testing.T) {
 			panicMsg:          "[GNOSWAP-GNFT-002] invalid address || to address (this_is_invalid_address)",
 		},
 		{
-			name:              "not-staker contract transfer",
-			callerRealm:       addr01Realm,
-			fromAddr:          addr01,
-			toAddr:            addr02,
-			tokenIdToTransfer: 1,
-			shouldPanic:       true,
-			panicMsg:          "unauthorized: caller g1v9jxgu3sx9047h6lta047h6lta047h6l0js7st is not staker",
-		},
-		{
 			name: "transfer to self",
 			setup: func(cur realm) {
 				testing.SetRealm(positionRealm)
@@ -632,6 +626,10 @@ func TestTransferFrom(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			resetObject(t)
+			testing.SetRealm(positionRealm)
+			Mint(cross, addr01, tid(1))
+
 			if tt.setup != nil {
 				tt.setup(cross)
 			}
@@ -903,10 +901,6 @@ func TestMustOwnerOf(t *testing.T) {
 }
 
 func TestSafeTransferFrom(t *testing.T) {
-	resetObject(t)
-	testing.SetRealm(positionRealm)
-	Mint(cross, addr01, tid(1))
-
 	tests := []struct {
 		name        string
 		setup       func(cur realm)
@@ -918,7 +912,15 @@ func TestSafeTransferFrom(t *testing.T) {
 		panicMsg    string
 	}{
 		{
-			name: "owner transfers own token",
+			name:        "owner safe-transfers own token",
+			callerRealm: addr01Realm,
+			from:        addr01,
+			to:          addr02,
+			tokenId:     1,
+			shouldPanic: false,
+		},
+		{
+			name: "approved staker safe-transfers token",
 			setup: func(cur realm) {
 				testing.SetRealm(addr01Realm)
 				Approve(cross, stakerRealm.Address(), tid(1))
@@ -932,15 +934,15 @@ func TestSafeTransferFrom(t *testing.T) {
 		{
 			name: "non-owner transfers without approval",
 			setup: func(cur realm) {
-				testing.SetRealm(addr02Realm)
-				Approve(cross, stakerRealm.Address(), tid(1))
+				testing.SetRealm(positionRealm)
+				Mint(cross, addr01, tid(2))
 			},
-			callerRealm: stakerRealm,
+			callerRealm: addr02Realm,
 			from:        addr01,
 			to:          addr02,
-			tokenId:     1,
+			tokenId:     2,
 			shouldPanic: true,
-			panicMsg:    "transfer from incorrect owner || from g1v9jxgu3sx9047h6lta047h6lta047h6l0js7st is not the owner g1v9jxgu3sxf047h6lta047h6lta047h6l8tv5at of token 1",
+			panicMsg:    "caller is not token owner or approved || caller g1v9jxgu3sxf047h6lta047h6lta047h6l8tv5at is not owner g1v9jxgu3sx9047h6lta047h6lta047h6l0js7st or approved for token 2",
 		},
 		{
 			name:        "transfer non-existent token",
@@ -961,15 +963,6 @@ func TestSafeTransferFrom(t *testing.T) {
 			panicMsg:    "[GNOSWAP-GNFT-002] invalid address || to address ()",
 		},
 		{
-			name:        "not-staker contract transfer",
-			callerRealm: addr01Realm,
-			from:        addr01,
-			to:          addr02,
-			tokenId:     1,
-			shouldPanic: true,
-			panicMsg:    "unauthorized: caller g1v9jxgu3sx9047h6lta047h6lta047h6l0js7st is not staker",
-		},
-		{
 			name: "safe transfer to self",
 			setup: func(cur realm) {
 				testing.SetRealm(positionRealm)
@@ -988,6 +981,10 @@ func TestSafeTransferFrom(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			resetObject(t)
+			testing.SetRealm(positionRealm)
+			Mint(cross, addr01, tid(1))
+
 			if tt.setup != nil {
 				tt.setup(cross)
 			}

--- a/contract/r/scenario/position/position_transfer_approval_for_all_scope_filetest.gno
+++ b/contract/r/scenario/position/position_transfer_approval_for_all_scope_filetest.gno
@@ -1,0 +1,137 @@
+// position transfer approval-for-all scope
+// Verify operator-for-all approval remains scoped to the original owner only.
+
+// PKGPATH: gno.land/r/gnoswap/v1/main
+
+package main
+
+import (
+	"strconv"
+	"testing"
+
+	"gno.land/p/demo/tokens/grc721"
+	testutils "gno.land/p/nt/testutils/v0"
+	uassert "gno.land/p/nt/uassert/v0"
+
+	prbac "gno.land/p/gnoswap/rbac"
+	_ "gno.land/r/gnoswap/rbac"
+
+	_ "gno.land/r/gnoswap/pool/v1"
+	_ "gno.land/r/gnoswap/position/v1"
+	_ "gno.land/r/gnoswap/staker/v1"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/common"
+	"gno.land/r/gnoswap/gnft"
+	pl "gno.land/r/gnoswap/pool"
+	pn "gno.land/r/gnoswap/position"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/foo"
+)
+
+var (
+	adminAddr, _ = access.GetAddress(prbac.ROLE_ADMIN.String())
+	adminRealm   = testing.NewUserRealm(adminAddr)
+	poolAddr, _  = access.GetAddress(prbac.ROLE_POOL.String())
+
+	aliceAddr   = testutils.TestAddress("alice")
+	aliceRealm  = testing.NewUserRealm(aliceAddr)
+	bobAddr     = testutils.TestAddress("bob")
+	bobRealm    = testing.NewUserRealm(bobAddr)
+	charlieAddr = testutils.TestAddress("charlie")
+	charlieRealm = testing.NewUserRealm(charlieAddr)
+
+	barPath = "gno.land/r/onbloc/bar"
+	fooPath = "gno.land/r/onbloc/foo"
+
+	fee500     uint32 = 500
+	maxTimeout int64  = 9999999999
+	maxInt64   int64  = 9223372036854775807
+
+	t *testing.T
+	position1 uint64
+	position2 uint64
+)
+
+func main() {
+	println("[SCENARIO] 1. Create pool and mint two positions for alice")
+	setupAndMintTwoPositions()
+	println()
+
+	println("[SCENARIO] 2. Alice approves charlie for all NFTs")
+	approveOperatorForAll()
+	println()
+
+	println("[SCENARIO] 3. Alice transfers one position to bob")
+	transferOnePositionToBob()
+	println()
+
+	println("[SCENARIO] 4. Charlie can still manage alice-owned position only")
+	verifyOperatorScope()
+	println()
+}
+
+func setupAndMintTwoPositions() {
+	testing.SetRealm(adminRealm)
+	pl.SetPoolCreationFee(cross, 0)
+	pl.CreatePool(cross, barPath, fooPath, fee500, common.TickMathGetSqrtRatioAtTick(0).ToString())
+	bar.Transfer(cross, aliceAddr, 2_000_000)
+	foo.Transfer(cross, aliceAddr, 2_000_000)
+
+	testing.SetRealm(aliceRealm)
+	bar.Approve(cross, poolAddr, maxInt64)
+	foo.Approve(cross, poolAddr, maxInt64)
+	position1, _, _, _ = pn.Mint(cross, barPath, fooPath, fee500, -5000, 5000, "100000", "100000", "1", "1", maxTimeout, aliceAddr, aliceAddr, "")
+	position2, _, _, _ = pn.Mint(cross, barPath, fooPath, fee500, -3000, 3000, "100000", "100000", "1", "1", maxTimeout, aliceAddr, aliceAddr, "")
+	println("[EXPECTED] positions minted for alice:", position1, position2)
+}
+
+func approveOperatorForAll() {
+	testing.SetRealm(aliceRealm)
+	gnft.SetApprovalForAll(cross, charlieAddr, true)
+	println("[EXPECTED] approval-for-all set for charlie:", gnft.IsApprovedForAll(aliceAddr, charlieAddr))
+}
+
+func transferOnePositionToBob() {
+	testing.SetRealm(aliceRealm)
+	gnft.TransferFrom(cross, aliceAddr, bobAddr, positionIdToTokenId(position1))
+	println("[EXPECTED] owner of transferred position:", pn.GetPositionOwner(position1).String())
+	println("[EXPECTED] owner of remaining alice position:", pn.GetPositionOwner(position2).String())
+}
+
+func verifyOperatorScope() {
+	testing.SetRealm(charlieRealm)
+	uassert.AbortsContains(t, "caller is not token owner or approved", func() {
+		gnft.TransferFrom(cross, bobAddr, charlieAddr, positionIdToTokenId(position1))
+	})
+	println("[EXPECTED] charlie cannot transfer bob-owned position")
+
+	gnft.TransferFrom(cross, aliceAddr, charlieAddr, positionIdToTokenId(position2))
+	println("[EXPECTED] charlie can still transfer alice-owned position")
+	println("[EXPECTED] new owner of alice-owned position:", pn.GetPositionOwner(position2).String())
+
+	_ = bobRealm
+	_ = charlieRealm
+	_ = bobAddr
+}
+
+func positionIdToTokenId(id uint64) grc721.TokenID {
+	return grc721.TokenID(strconv.Itoa(int(id)))
+}
+
+// Output:
+// [SCENARIO] 1. Create pool and mint two positions for alice
+// [EXPECTED] positions minted for alice: 1 2
+//
+// [SCENARIO] 2. Alice approves charlie for all NFTs
+// [EXPECTED] approval-for-all set for charlie: true
+//
+// [SCENARIO] 3. Alice transfers one position to bob
+// [EXPECTED] owner of transferred position: g1vfhkyh6lta047h6lta047h6lta047h6l03vdhu
+// [EXPECTED] owner of remaining alice position: g1v9kxjcm9ta047h6lta047h6lta047h6lzd40gh
+//
+// [SCENARIO] 4. Charlie can still manage alice-owned position only
+// [EXPECTED] charlie cannot transfer bob-owned position
+// [EXPECTED] charlie can still transfer alice-owned position
+// [EXPECTED] new owner of alice-owned position: g1vd5xzunvd9j47h6lta047h6lta047h6l6a3cm8

--- a/contract/r/scenario/position/position_transfer_clears_approval_filetest.gno
+++ b/contract/r/scenario/position/position_transfer_clears_approval_filetest.gno
@@ -1,0 +1,147 @@
+// position transfer clears token approval
+// Verify token-level approval is cleared when ownership moves.
+
+// PKGPATH: gno.land/r/gnoswap/v1/main
+
+package main
+
+import (
+	"strconv"
+	"testing"
+
+	"gno.land/p/demo/tokens/grc721"
+	testutils "gno.land/p/nt/testutils/v0"
+	uassert "gno.land/p/nt/uassert/v0"
+
+	prbac "gno.land/p/gnoswap/rbac"
+	_ "gno.land/r/gnoswap/rbac"
+
+	_ "gno.land/r/gnoswap/pool/v1"
+	_ "gno.land/r/gnoswap/position/v1"
+	_ "gno.land/r/gnoswap/staker/v1"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/common"
+	"gno.land/r/gnoswap/gnft"
+	pl "gno.land/r/gnoswap/pool"
+	pn "gno.land/r/gnoswap/position"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/foo"
+)
+
+var (
+	adminAddr, _ = access.GetAddress(prbac.ROLE_ADMIN.String())
+	adminRealm   = testing.NewUserRealm(adminAddr)
+	poolAddr, _  = access.GetAddress(prbac.ROLE_POOL.String())
+
+	aliceAddr   = testutils.TestAddress("alice")
+	aliceRealm  = testing.NewUserRealm(aliceAddr)
+	bobAddr     = testutils.TestAddress("bob")
+	bobRealm    = testing.NewUserRealm(bobAddr)
+	charlieAddr = testutils.TestAddress("charlie")
+	charlieRealm = testing.NewUserRealm(charlieAddr)
+
+	barPath = "gno.land/r/onbloc/bar"
+	fooPath = "gno.land/r/onbloc/foo"
+
+	fee500     uint32 = 500
+	maxTimeout int64  = 9999999999
+	maxInt64   int64  = 9223372036854775807
+
+	t *testing.T
+	positionId uint64
+)
+
+func main() {
+	println("[SCENARIO] 1. Create pool and mint position for alice")
+	setupAndMint()
+	println()
+
+	println("[SCENARIO] 2. Alice approves charlie for the token")
+	approveCharlie()
+	println()
+
+	println("[SCENARIO] 3. Alice transfers the position to bob")
+	transferToBob()
+	println()
+
+	println("[SCENARIO] 4. Old token approval is cleared")
+	verifyApprovalCleared()
+	println()
+
+	println("[SCENARIO] 5. Bob can still transfer as the new owner")
+	verifyBobCanTransfer()
+	println()
+}
+
+func setupAndMint() {
+	testing.SetRealm(adminRealm)
+	pl.SetPoolCreationFee(cross, 0)
+	pl.CreatePool(cross, barPath, fooPath, fee500, common.TickMathGetSqrtRatioAtTick(0).ToString())
+	bar.Transfer(cross, aliceAddr, 1_000_000)
+	foo.Transfer(cross, aliceAddr, 1_000_000)
+
+	testing.SetRealm(aliceRealm)
+	bar.Approve(cross, poolAddr, maxInt64)
+	foo.Approve(cross, poolAddr, maxInt64)
+	positionId, _, _, _ = pn.Mint(cross, barPath, fooPath, fee500, -5000, 5000, "100000", "100000", "1", "1", maxTimeout, aliceAddr, aliceAddr, "")
+
+	println("[EXPECTED] position minted for alice:", positionId)
+	println("[EXPECTED] initial owner:", pn.GetPositionOwner(positionId).String())
+}
+
+func approveCharlie() {
+	testing.SetRealm(aliceRealm)
+	gnft.Approve(cross, charlieAddr, positionIdToTokenId(positionId))
+	approved, _ := gnft.GetApproved(positionIdToTokenId(positionId))
+	println("[EXPECTED] approved address before transfer:", approved.String())
+}
+
+func transferToBob() {
+	testing.SetRealm(aliceRealm)
+	gnft.TransferFrom(cross, aliceAddr, bobAddr, positionIdToTokenId(positionId))
+	println("[EXPECTED] new owner after transfer:", pn.GetPositionOwner(positionId).String())
+}
+
+func verifyApprovalCleared() {
+	approved, _ := gnft.GetApproved(positionIdToTokenId(positionId))
+	println("[EXPECTED] approved address after transfer:", approved.String())
+	if approved != address("") {
+		panic("token approval should be cleared after transfer")
+	}
+
+	testing.SetRealm(charlieRealm)
+	uassert.AbortsContains(t, "caller is not token owner or approved", func() {
+		gnft.TransferFrom(cross, bobAddr, charlieAddr, positionIdToTokenId(positionId))
+	})
+	println("[EXPECTED] old approved account can no longer transfer")
+}
+
+func verifyBobCanTransfer() {
+	testing.SetRealm(bobRealm)
+	gnft.TransferFrom(cross, bobAddr, charlieAddr, positionIdToTokenId(positionId))
+	println("[EXPECTED] final owner after bob transfer:", pn.GetPositionOwner(positionId).String())
+}
+
+func positionIdToTokenId(id uint64) grc721.TokenID {
+	return grc721.TokenID(strconv.Itoa(int(id)))
+}
+
+// Output:
+// [SCENARIO] 1. Create pool and mint position for alice
+// [EXPECTED] position minted for alice: 1
+// [EXPECTED] initial owner: g1v9kxjcm9ta047h6lta047h6lta047h6lzd40gh
+//
+// [SCENARIO] 2. Alice approves charlie for the token
+// [EXPECTED] approved address before transfer: g1vd5xzunvd9j47h6lta047h6lta047h6l6a3cm8
+//
+// [SCENARIO] 3. Alice transfers the position to bob
+// [EXPECTED] new owner after transfer: g1vfhkyh6lta047h6lta047h6lta047h6l03vdhu
+//
+// [SCENARIO] 4. Old token approval is cleared
+// [EXPECTED] approved address after transfer:
+// [EXPECTED] old approved account can no longer transfer
+//
+// [SCENARIO] 5. Bob can still transfer as the new owner
+// [EXPECTED] final owner after bob transfer: g1vd5xzunvd9j47h6lta047h6lta047h6l6a3cm8

--- a/contract/r/scenario/position/position_transfer_fee_rights_filetest.gno
+++ b/contract/r/scenario/position/position_transfer_fee_rights_filetest.gno
@@ -1,0 +1,175 @@
+// position transfer fee rights
+// Verify uncollected fees follow the transferred owner.
+
+// PKGPATH: gno.land/r/gnoswap/v1/main
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	testutils "gno.land/p/nt/testutils/v0"
+	uassert "gno.land/p/nt/uassert/v0"
+	ufmt "gno.land/p/nt/ufmt/v0"
+
+	prbac "gno.land/p/gnoswap/rbac"
+	_ "gno.land/r/gnoswap/rbac"
+
+	_ "gno.land/r/gnoswap/pool/v1"
+	_ "gno.land/r/gnoswap/position/v1"
+	_ "gno.land/r/gnoswap/staker/v1"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/common"
+	"gno.land/r/gnoswap/gnft"
+	"gno.land/r/gnoswap/pool"
+	"gno.land/r/gnoswap/position"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/foo"
+)
+
+const (
+	int64Max int64 = 9223372036854775807
+	minPrice string = "4295128740"
+	maxPrice string = "1461446703485210103287273052203988822378723970341"
+)
+
+var (
+	adminAddr, _  = access.GetAddress(prbac.ROLE_ADMIN.String())
+	adminRealm    = testing.NewUserRealm(adminAddr)
+	poolAddr, _   = access.GetAddress(prbac.ROLE_POOL.String())
+	aliceAddr     = testutils.TestAddress("alice")
+	aliceRealm    = testing.NewUserRealm(aliceAddr)
+	bobAddr       = testutils.TestAddress("bob")
+	bobRealm      = testing.NewUserRealm(bobAddr)
+	barPath       = "gno.land/r/onbloc/bar"
+	fooPath       = "gno.land/r/onbloc/foo"
+	fee           = uint32(3000)
+	t             *testing.T
+)
+
+func main() {
+	println("[SCENARIO] 1. Create pool and mint fee-earning position")
+	setupAndMint()
+	println()
+
+	println("[SCENARIO] 2. Execute swaps to accrue fees")
+	executeSwaps()
+	println()
+
+	println("[SCENARIO] 3. Transfer fee-bearing position to bob")
+	transferToBob()
+	println()
+
+	println("[SCENARIO] 4. Old owner cannot collect transferred fees")
+	verifyAliceCannotCollect()
+	println()
+
+	println("[SCENARIO] 5. New owner collects the accrued fees")
+	verifyBobCollects()
+	println()
+}
+
+func setupAndMint() {
+	testing.SetRealm(adminRealm)
+	pool.SetPoolCreationFee(cross, 0)
+	bar.Transfer(cross, aliceAddr, 10_000_000_000)
+	foo.Transfer(cross, aliceAddr, 10_000_000_000)
+	pool.CreatePool(cross, barPath, fooPath, fee, common.TickMathGetSqrtRatioAtTick(0).ToString())
+
+	testing.SetRealm(aliceRealm)
+	bar.Approve(cross, poolAddr, int64Max)
+	foo.Approve(cross, poolAddr, int64Max)
+	position.Mint(cross, barPath, fooPath, fee, -960, 960, "50000000", "50000000", "0", "0", time.Now().Unix()+3600, aliceAddr, aliceAddr, "")
+	println("[EXPECTED] position minted for alice")
+}
+
+func executeSwaps() {
+	testing.SetRealm(adminRealm)
+	bar.Approve(cross, poolAddr, int64Max)
+	foo.Approve(cross, poolAddr, int64Max)
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/router"))
+	pool.Swap(cross, barPath, fooPath, fee, adminAddr, true, "10000000", minPrice, adminAddr, func(cur realm, amount0Delta, amount1Delta int64, _ *pool.CallbackMarker) error {
+		return mockSwapCallback(amount0Delta, amount1Delta, true)
+	})
+	pool.Swap(cross, barPath, fooPath, fee, adminAddr, false, "10000000", maxPrice, adminAddr, func(cur realm, amount0Delta, amount1Delta int64, _ *pool.CallbackMarker) error {
+		return mockSwapCallback(amount0Delta, amount1Delta, false)
+	})
+	println("[EXPECTED] swaps executed and fees accrued")
+}
+
+func transferToBob() {
+	testing.SetRealm(aliceRealm)
+	gnft.TransferFrom(cross, aliceAddr, bobAddr, "1")
+	println("[EXPECTED] owner after transfer:", position.GetPositionOwner(1).String())
+}
+
+func verifyAliceCannotCollect() {
+	testing.SetRealm(aliceRealm)
+	uassert.AbortsContains(t, "caller has no permission", func() {
+		position.CollectFee(cross, 1)
+	})
+	println("[EXPECTED] alice cannot collect after transfer")
+}
+
+func verifyBobCollects() {
+	testing.SetRealm(bobRealm)
+	beforeBar := bar.BalanceOf(bobAddr)
+	beforeFoo := foo.BalanceOf(bobAddr)
+	_, fee0, fee1, _, _, _ := position.CollectFee(cross, 1)
+	afterBar := bar.BalanceOf(bobAddr)
+	afterFoo := foo.BalanceOf(bobAddr)
+
+	ufmt.Printf("[EXPECTED] bob collected fee0: %s\n", fee0)
+	ufmt.Printf("[EXPECTED] bob collected fee1: %s\n", fee1)
+	println("[EXPECTED] bob balance increased on at least one token:", afterBar > beforeBar || afterFoo > beforeFoo)
+	if afterBar <= beforeBar && afterFoo <= beforeFoo {
+		panic("bob should receive accrued fees after transfer")
+	}
+	if fee0 == "0" && fee1 == "0" {
+		panic("transferred position should have non-zero collectable fees")
+	}
+	println("[EXPECTED] new owner successfully collected transferred fees")
+}
+
+func mockSwapCallback(amount0Delta, amount1Delta int64, zeroForOne bool) error {
+	testing.SetRealm(adminRealm)
+
+	if zeroForOne {
+		if amount0Delta > 0 {
+			bar.Transfer(cross, poolAddr, amount0Delta)
+		}
+		if amount1Delta > 0 {
+			foo.Transfer(cross, poolAddr, amount1Delta)
+		}
+		return nil
+	}
+	if amount0Delta > 0 {
+		bar.Transfer(cross, poolAddr, amount0Delta)
+	}
+	if amount1Delta > 0 {
+		foo.Transfer(cross, poolAddr, amount1Delta)
+	}
+	return nil
+}
+
+// Output:
+// [SCENARIO] 1. Create pool and mint fee-earning position
+// [EXPECTED] position minted for alice
+//
+// [SCENARIO] 2. Execute swaps to accrue fees
+// [EXPECTED] swaps executed and fees accrued
+//
+// [SCENARIO] 3. Transfer fee-bearing position to bob
+// [EXPECTED] owner after transfer: g1vfhkyh6lta047h6lta047h6lta047h6l03vdhu
+//
+// [SCENARIO] 4. Old owner cannot collect transferred fees
+// [EXPECTED] alice cannot collect after transfer
+//
+// [SCENARIO] 5. New owner collects the accrued fees
+// [EXPECTED] bob collected fee0: 29700
+// [EXPECTED] bob collected fee1: 29700
+// [EXPECTED] bob balance increased on at least one token: true
+// [EXPECTED] new owner successfully collected transferred fees

--- a/contract/r/scenario/position/position_transfer_ownership_filetest.gno
+++ b/contract/r/scenario/position/position_transfer_ownership_filetest.gno
@@ -1,0 +1,293 @@
+// position ownership transfer scenario
+// Transfer an unstaked GNFT-backed position and verify permissions follow the new owner.
+
+// PKGPATH: gno.land/r/gnoswap/v1/main
+
+package main
+
+import (
+	"strconv"
+	"testing"
+
+	"gno.land/p/demo/tokens/grc721"
+	testutils "gno.land/p/nt/testutils/v0"
+	uassert "gno.land/p/nt/uassert/v0"
+
+	prbac "gno.land/p/gnoswap/rbac"
+	_ "gno.land/r/gnoswap/rbac"
+
+	_ "gno.land/r/gnoswap/pool/v1"
+	_ "gno.land/r/gnoswap/position/v1"
+	_ "gno.land/r/gnoswap/staker/v1"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/common"
+	"gno.land/r/gnoswap/gnft"
+	pl "gno.land/r/gnoswap/pool"
+	pn "gno.land/r/gnoswap/position"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/foo"
+)
+
+var (
+	adminAddr, _ = access.GetAddress(prbac.ROLE_ADMIN.String())
+	adminRealm   = testing.NewUserRealm(adminAddr)
+	poolAddr, _  = access.GetAddress(prbac.ROLE_POOL.String())
+
+	aliceAddr  = testutils.TestAddress("alice")
+	aliceRealm = testing.NewUserRealm(aliceAddr)
+	bobAddr    = testutils.TestAddress("bob")
+	bobRealm   = testing.NewUserRealm(bobAddr)
+
+	barPath = "gno.land/r/onbloc/bar"
+	fooPath = "gno.land/r/onbloc/foo"
+
+	fee500     uint32 = 500
+	maxTimeout int64  = 9999999999
+	maxInt64   int64  = 9223372036854775807
+
+	t *testing.T
+
+	positionId uint64
+)
+
+func main() {
+	println("[SCENARIO] 1. Create pool and mint position for alice")
+	createPoolAndMintPosition()
+	println()
+
+	println("[SCENARIO] 2. Transfer position ownership to bob")
+	transferOwnershipToBob()
+	println()
+
+	println("[SCENARIO] 3. Verify old owner permissions are revoked")
+	verifyAliceCannotManageTransferredPosition()
+	println()
+
+	println("[SCENARIO] 4. Verify new owner can manage transferred position")
+	verifyBobCanIncreaseLiquidity()
+	println()
+
+	println("[SCENARIO] 5. Verify new owner can decrease liquidity")
+	verifyBobCanDecreaseLiquidity()
+	println()
+
+	println("[SCENARIO] 6. Verify new owner can reposition the transferred position")
+	verifyBobCanReposition()
+	println()
+}
+
+func createPoolAndMintPosition() {
+	testing.SetRealm(adminRealm)
+	pl.SetPoolCreationFee(cross, 0)
+	pl.CreatePool(cross, barPath, fooPath, fee500, common.TickMathGetSqrtRatioAtTick(0).ToString())
+
+	bar.Transfer(cross, aliceAddr, 1_000_000)
+	foo.Transfer(cross, aliceAddr, 1_000_000)
+	bar.Transfer(cross, bobAddr, 1_000_000)
+	foo.Transfer(cross, bobAddr, 1_000_000)
+
+	testing.SetRealm(aliceRealm)
+	bar.Approve(cross, poolAddr, maxInt64)
+	foo.Approve(cross, poolAddr, maxInt64)
+
+	var liquidity, amount0, amount1 string
+	positionId, liquidity, amount0, amount1 = pn.Mint(
+		cross,
+		barPath,
+		fooPath,
+		fee500,
+		-5000,
+		5000,
+		"100000",
+		"100000",
+		"1",
+		"1",
+		maxTimeout,
+		aliceAddr,
+		aliceAddr,
+		"",
+	)
+
+	println("[EXPECTED] Position created for alice with ID:", positionId)
+	println("[EXPECTED] Initial liquidity:", liquidity)
+	println("[EXPECTED] Mint amount0:", amount0)
+	println("[EXPECTED] Mint amount1:", amount1)
+	println("[EXPECTED] Initial owner:", pn.GetPositionOwner(positionId).String())
+	println("[EXPECTED] Initial position operator:", pn.GetPositionOperator(positionId).String())
+}
+
+func transferOwnershipToBob() {
+	testing.SetRealm(aliceRealm)
+	gnft.TransferFrom(cross, aliceAddr, bobAddr, positionIdToTokenId(positionId))
+
+	owner := pn.GetPositionOwner(positionId)
+	println("[EXPECTED] Owner after transfer:", owner.String())
+	println("[EXPECTED] GNFT owner after transfer:", gnft.MustOwnerOf(positionIdToTokenId(positionId)).String())
+
+	if owner != bobAddr {
+		panic("position ownership should move to bob after GNFT transfer")
+	}
+	if pn.GetPositionOperator(positionId) != address("") {
+		panic("unstaked transferred position should keep zero operator")
+	}
+
+	testing.SetRealm(bobRealm)
+	bar.Approve(cross, poolAddr, maxInt64)
+	foo.Approve(cross, poolAddr, maxInt64)
+	println("[EXPECTED] Bob approved pool tokens for follow-up management")
+}
+
+func verifyAliceCannotManageTransferredPosition() {
+	testing.SetRealm(aliceRealm)
+
+	uassert.AbortsContains(t, "caller has no permission", func() {
+		pn.IncreaseLiquidity(cross, positionId, "1000", "1000", "1", "1", maxTimeout)
+	})
+	println("[EXPECTED] Alice can no longer increase liquidity")
+
+	uassert.AbortsContains(t, "caller has no permission", func() {
+		pn.DecreaseLiquidity(cross, positionId, "1", "0", "0", maxTimeout)
+	})
+	println("[EXPECTED] Alice can no longer decrease liquidity")
+
+	uassert.AbortsContains(t, "caller has no permission", func() {
+		pn.CollectFee(cross, positionId)
+	})
+	println("[EXPECTED] Alice can no longer collect fees")
+}
+
+func verifyBobCanIncreaseLiquidity() {
+	testing.SetRealm(bobRealm)
+
+	_, addedLiquidity, amount0, amount1, poolPath := pn.IncreaseLiquidity(
+		cross,
+		positionId,
+		"1000",
+		"1000",
+		"1",
+		"1",
+		maxTimeout,
+	)
+
+	println("[EXPECTED] Bob increased liquidity on transferred position")
+	println("[EXPECTED] Added liquidity:", addedLiquidity)
+	println("[EXPECTED] Added amount0:", amount0)
+	println("[EXPECTED] Added amount1:", amount1)
+	println("[EXPECTED] Pool path:", poolPath)
+	println("[EXPECTED] Owner after increase remains bob:", pn.GetPositionOwner(positionId).String())
+
+	if pn.GetPositionOwner(positionId) != bobAddr {
+		panic("bob should remain the owner after managing transferred position")
+	}
+}
+
+func verifyBobCanDecreaseLiquidity() {
+	testing.SetRealm(bobRealm)
+
+	_, liquidityRemoved, fee0, fee1, amount0, amount1, poolPath := pn.DecreaseLiquidity(
+		cross,
+		positionId,
+		"1000",
+		"0",
+		"0",
+		maxTimeout,
+	)
+
+	println("[EXPECTED] Bob decreased liquidity on transferred position")
+	println("[EXPECTED] Liquidity removed:", liquidityRemoved)
+	println("[EXPECTED] Fee0 collected during decrease:", fee0)
+	println("[EXPECTED] Fee1 collected during decrease:", fee1)
+	println("[EXPECTED] Amount0 returned:", amount0)
+	println("[EXPECTED] Amount1 returned:", amount1)
+	println("[EXPECTED] Pool path after decrease:", poolPath)
+	println("[EXPECTED] Owner after decrease remains bob:", pn.GetPositionOwner(positionId).String())
+}
+
+func verifyBobCanReposition() {
+	testing.SetRealm(bobRealm)
+	remainingLiquidity := pn.GetPositionLiquidity(positionId)
+	pn.DecreaseLiquidity(
+		cross,
+		positionId,
+		remainingLiquidity,
+		"0",
+		"0",
+		maxTimeout,
+	)
+
+	_, liquidity, tickLower, tickUpper, amount0, amount1 := pn.Reposition(
+		cross,
+		positionId,
+		-3000,
+		3000,
+		"1000",
+		"1000",
+		"1",
+		"1",
+		maxTimeout,
+	)
+
+	println("[EXPECTED] Bob repositioned the transferred position")
+	println("[EXPECTED] Reposition liquidity:", liquidity)
+	println("[EXPECTED] New tick lower:", tickLower)
+	println("[EXPECTED] New tick upper:", tickUpper)
+	println("[EXPECTED] Reposition amount0 used:", amount0)
+	println("[EXPECTED] Reposition amount1 used:", amount1)
+	println("[EXPECTED] Getter tick lower:", pn.GetPositionTickLower(positionId))
+	println("[EXPECTED] Getter tick upper:", pn.GetPositionTickUpper(positionId))
+	println("[EXPECTED] Owner after reposition remains bob:", pn.GetPositionOwner(positionId).String())
+}
+
+func positionIdToTokenId(id uint64) grc721.TokenID {
+	return grc721.TokenID(strconv.Itoa(int(id)))
+}
+
+// Output:
+// [SCENARIO] 1. Create pool and mint position for alice
+// [EXPECTED] Position created for alice with ID: 1
+// [EXPECTED] Initial liquidity: 452101
+// [EXPECTED] Mint amount0: 100000
+// [EXPECTED] Mint amount1: 100000
+// [EXPECTED] Initial owner: g1v9kxjcm9ta047h6lta047h6lta047h6lzd40gh
+// [EXPECTED] Initial position operator:
+//
+// [SCENARIO] 2. Transfer position ownership to bob
+// [EXPECTED] Owner after transfer: g1vfhkyh6lta047h6lta047h6lta047h6l03vdhu
+// [EXPECTED] GNFT owner after transfer: g1vfhkyh6lta047h6lta047h6lta047h6l03vdhu
+// [EXPECTED] Bob approved pool tokens for follow-up management
+//
+// [SCENARIO] 3. Verify old owner permissions are revoked
+// [EXPECTED] Alice can no longer increase liquidity
+// [EXPECTED] Alice can no longer decrease liquidity
+// [EXPECTED] Alice can no longer collect fees
+//
+// [SCENARIO] 4. Verify new owner can manage transferred position
+// [EXPECTED] Bob increased liquidity on transferred position
+// [EXPECTED] Added liquidity: 4521
+// [EXPECTED] Added amount0: 1000
+// [EXPECTED] Added amount1: 1000
+// [EXPECTED] Pool path: gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500
+// [EXPECTED] Owner after increase remains bob: g1vfhkyh6lta047h6lta047h6lta047h6l03vdhu
+//
+// [SCENARIO] 5. Verify new owner can decrease liquidity
+// [EXPECTED] Bob decreased liquidity on transferred position
+// [EXPECTED] Liquidity removed: 1000
+// [EXPECTED] Fee0 collected during decrease: 0
+// [EXPECTED] Fee1 collected during decrease: 0
+// [EXPECTED] Amount0 returned: 221
+// [EXPECTED] Amount1 returned: 221
+// [EXPECTED] Pool path after decrease: gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500
+// [EXPECTED] Owner after decrease remains bob: g1vfhkyh6lta047h6lta047h6lta047h6l03vdhu
+//
+// [SCENARIO] 6. Verify new owner can reposition the transferred position
+// [EXPECTED] Bob repositioned the transferred position
+// [EXPECTED] Reposition liquidity: 7179
+// [EXPECTED] New tick lower: -3000
+// [EXPECTED] New tick upper: 3000
+// [EXPECTED] Reposition amount0 used: 1000
+// [EXPECTED] Reposition amount1 used: 1000
+// [EXPECTED] Getter tick lower: -3000
+// [EXPECTED] Getter tick upper: 3000
+// [EXPECTED] Owner after reposition remains bob: g1vfhkyh6lta047h6lta047h6lta047h6l03vdhu

--- a/contract/r/scenario/staker/staked_position_transfer_blocked_filetest.gno
+++ b/contract/r/scenario/staker/staked_position_transfer_blocked_filetest.gno
@@ -1,0 +1,102 @@
+// staked position transfer blocked
+// Verify a staked position cannot be transferred by the previous owner.
+
+// PKGPATH: gno.land/r/gnoswap/v1/main
+
+package main
+
+import (
+	"testing"
+
+	testutils "gno.land/p/nt/testutils/v0"
+	uassert "gno.land/p/nt/uassert/v0"
+
+	prbac "gno.land/p/gnoswap/rbac"
+	_ "gno.land/r/gnoswap/rbac"
+
+	_ "gno.land/r/gnoswap/pool/v1"
+	_ "gno.land/r/gnoswap/position/v1"
+	_ "gno.land/r/gnoswap/staker/v1"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/common"
+	"gno.land/r/gnoswap/gnft"
+	pl "gno.land/r/gnoswap/pool"
+	pn "gno.land/r/gnoswap/position"
+	sr "gno.land/r/gnoswap/staker"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/foo"
+)
+
+var (
+	adminAddr, _  = access.GetAddress(prbac.ROLE_ADMIN.String())
+	adminRealm    = testing.NewUserRealm(adminAddr)
+	poolAddr, _   = access.GetAddress(prbac.ROLE_POOL.String())
+	stakerAddr, _ = access.GetAddress(prbac.ROLE_STAKER.String())
+	aliceAddr     = testutils.TestAddress("alice")
+	aliceRealm    = testing.NewUserRealm(aliceAddr)
+	bobAddr       = testutils.TestAddress("bob")
+	barPath       = "gno.land/r/onbloc/bar"
+	fooPath       = "gno.land/r/onbloc/foo"
+	fee500        = uint32(500)
+	maxTimeout int64 = 9999999999
+	maxInt64 int64 = 9223372036854775807
+	t *testing.T
+)
+
+func main() {
+	println("[SCENARIO] 1. Create pool and mint position")
+	setupAndMint()
+	println()
+
+	println("[SCENARIO] 2. Stake the position")
+	stakePosition()
+	println()
+
+	println("[SCENARIO] 3. Previous owner cannot transfer while staked")
+	verifyTransferBlocked()
+	println()
+}
+
+func setupAndMint() {
+	testing.SetRealm(adminRealm)
+	pl.SetPoolCreationFee(cross, 0)
+	sr.SetUnStakingFee(cross, 0)
+	pl.CreatePool(cross, barPath, fooPath, fee500, common.TickMathGetSqrtRatioAtTick(0).ToString())
+	sr.SetPoolTier(cross, pl.GetPoolPath(barPath, fooPath, fee500), 1)
+	bar.Transfer(cross, aliceAddr, 1_000_000)
+	foo.Transfer(cross, aliceAddr, 1_000_000)
+	testing.SetRealm(aliceRealm)
+	bar.Approve(cross, poolAddr, maxInt64)
+	foo.Approve(cross, poolAddr, maxInt64)
+	pn.Mint(cross, barPath, fooPath, fee500, -5000, 5000, "100000", "100000", "1", "1", maxTimeout, aliceAddr, aliceAddr, "")
+	println("[EXPECTED] owner before staking:", pn.GetPositionOwner(1).String())
+}
+
+func stakePosition() {
+	testing.SetRealm(aliceRealm)
+	gnft.Approve(cross, stakerAddr, "1")
+	sr.StakeToken(cross, 1, "")
+	println("[EXPECTED] owner while staked:", pn.GetPositionOwner(1).String())
+}
+
+func verifyTransferBlocked() {
+	testing.SetRealm(aliceRealm)
+	uassert.AbortsContains(t, "caller is not token owner or approved", func() {
+		gnft.TransferFrom(cross, aliceAddr, bobAddr, "1")
+	})
+	println("[EXPECTED] staked position cannot be transferred by previous owner")
+	println("[EXPECTED] owner remains staker:", pn.GetPositionOwner(1).String())
+}
+
+// Output:
+// [SCENARIO] 1. Create pool and mint position
+// [EXPECTED] owner before staking: g1v9kxjcm9ta047h6lta047h6lta047h6lzd40gh
+//
+// [SCENARIO] 2. Stake the position
+// [EXPECTED] owner while staked: g1q6d4ns7zkr492rgl0pcgf5ajaf2dlz0nnptky3
+//
+// [SCENARIO] 3. Previous owner cannot transfer while staked
+// [EXPECTED] staked position cannot be transferred by previous owner
+// [EXPECTED] owner remains staker: g1q6d4ns7zkr492rgl0pcgf5ajaf2dlz0nnptky3

--- a/contract/r/scenario/staker/transferred_position_stake_flow_filetest.gno
+++ b/contract/r/scenario/staker/transferred_position_stake_flow_filetest.gno
@@ -1,0 +1,207 @@
+// transferred position stake flow
+// Transfer a position before staking, then verify the new owner can stake, collect, and unstake it.
+
+// PKGPATH: gno.land/r/gnoswap/v1/main
+
+package main
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"gno.land/p/demo/tokens/grc721"
+	testutils "gno.land/p/nt/testutils/v0"
+	ufmt "gno.land/p/nt/ufmt/v0"
+
+	prbac "gno.land/p/gnoswap/rbac"
+	_ "gno.land/r/gnoswap/rbac"
+
+	_ "gno.land/r/gnoswap/pool/v1"
+	_ "gno.land/r/gnoswap/position/v1"
+	_ "gno.land/r/gnoswap/staker/v1"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/common"
+	"gno.land/r/gnoswap/emission"
+	"gno.land/r/gnoswap/gnft"
+	"gno.land/r/gnoswap/gns"
+	pl "gno.land/r/gnoswap/pool"
+	pn "gno.land/r/gnoswap/position"
+	sr "gno.land/r/gnoswap/staker"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/foo"
+)
+
+var (
+	adminAddr, _  = access.GetAddress(prbac.ROLE_ADMIN.String())
+	adminRealm    = testing.NewUserRealm(adminAddr)
+	poolAddr, _   = access.GetAddress(prbac.ROLE_POOL.String())
+	stakerAddr, _ = access.GetAddress(prbac.ROLE_STAKER.String())
+
+	aliceAddr  = testutils.TestAddress("alice")
+	aliceRealm = testing.NewUserRealm(aliceAddr)
+	bobAddr    = testutils.TestAddress("bob")
+	bobRealm   = testing.NewUserRealm(bobAddr)
+
+	barPath = "gno.land/r/onbloc/bar"
+	fooPath = "gno.land/r/onbloc/foo"
+
+	fee500     uint32 = 500
+	maxTimeout int64  = 9999999999
+	maxInt64   int64  = 9223372036854775807
+
+	positionId uint64
+)
+
+func main() {
+	println("[SCENARIO] 1. Initialize emission and mint position for alice")
+	initializeAndMint()
+	println()
+
+	println("[SCENARIO] 2. Transfer position from alice to bob")
+	transferToBob()
+	println()
+
+	println("[SCENARIO] 3. Bob prepares transferred position for staking")
+	prepareBobStaking()
+	println()
+
+	println("[SCENARIO] 4. Bob stakes transferred position")
+	stakeAsBob()
+	println()
+
+	println("[SCENARIO] 5. Bob collects reward and unstakes transferred position")
+	collectAndUnstakeAsBob()
+	println()
+}
+
+func initializeAndMint() {
+	testing.SetRealm(adminRealm)
+	emission.SetDistributionStartTime(cross, time.Now().Unix()+1)
+	pl.SetPoolCreationFee(cross, 0)
+	sr.SetUnStakingFee(cross, 0)
+	pl.CreatePool(cross, barPath, fooPath, fee500, common.TickMathGetSqrtRatioAtTick(0).ToString())
+	sr.SetPoolTier(cross, pl.GetPoolPath(barPath, fooPath, fee500), 1)
+
+	bar.Transfer(cross, aliceAddr, 1_000_000)
+	foo.Transfer(cross, aliceAddr, 1_000_000)
+
+	testing.SetRealm(aliceRealm)
+	bar.Approve(cross, poolAddr, maxInt64)
+	foo.Approve(cross, poolAddr, maxInt64)
+
+	var liquidity, amount0, amount1 string
+	positionId, liquidity, amount0, amount1 = pn.Mint(
+		cross,
+		barPath,
+		fooPath,
+		fee500,
+		-5000,
+		5000,
+		"100000",
+		"100000",
+		"1",
+		"1",
+		maxTimeout,
+		aliceAddr,
+		aliceAddr,
+		"",
+	)
+
+	println("[EXPECTED] Minted transferable position ID:", positionId)
+	println("[EXPECTED] Liquidity:", liquidity)
+	println("[EXPECTED] Amount0:", amount0)
+	println("[EXPECTED] Amount1:", amount1)
+}
+
+func transferToBob() {
+	testing.SetRealm(aliceRealm)
+	gnft.TransferFrom(cross, aliceAddr, bobAddr, positionIdToTokenId(positionId))
+
+	println("[EXPECTED] New position owner:", pn.GetPositionOwner(positionId).String())
+	println("[EXPECTED] GNFT owner:", gnft.MustOwnerOf(positionIdToTokenId(positionId)).String())
+}
+
+func prepareBobStaking() {
+	testing.SetRealm(bobRealm)
+	gnft.Approve(cross, stakerAddr, positionIdToTokenId(positionId))
+	println("[EXPECTED] Bob approved staker for transferred position")
+
+	if pn.GetPositionOwner(positionId) != bobAddr {
+		panic("bob should still own the transferred position before staking")
+	}
+
+	println("[EXPECTED] Bob remains the owner before staking: ", pn.GetPositionOwner(positionId).String())
+}
+
+func stakeAsBob() {
+	testing.SetRealm(bobRealm)
+	poolPath := sr.StakeToken(cross, positionId, "")
+
+	println("[EXPECTED] Bob staked transferred position in pool:", poolPath)
+	println("[EXPECTED] GNFT owner while staked:", gnft.MustOwnerOf(positionIdToTokenId(positionId)).String())
+	println("[EXPECTED] Position operator while staked:", pn.GetPositionOperator(positionId).String())
+
+	if pn.GetPositionOperator(positionId) != bobAddr {
+		panic("bob should become the position operator while the transferred NFT is staked")
+	}
+}
+
+func collectAndUnstakeAsBob() {
+	testing.SetRealm(bobRealm)
+	testing.SkipHeights(10)
+
+	before := gns.BalanceOf(bobAddr)
+	sr.CollectReward(cross, positionId)
+	after := gns.BalanceOf(bobAddr)
+	reward := after - before
+	ufmt.Printf("[EXPECTED] Bob collected reward: %d\n", reward)
+
+	if reward <= 0 {
+		panic("bob should receive reward from transferred staked position")
+	}
+
+	poolPath := sr.UnStakeToken(cross, positionId)
+	println("[EXPECTED] Bob unstaked transferred position from pool:", poolPath)
+	println("[EXPECTED] Final GNFT owner:", gnft.MustOwnerOf(positionIdToTokenId(positionId)).String())
+	println("[EXPECTED] Final position operator:", pn.GetPositionOperator(positionId).String())
+
+	if gnft.MustOwnerOf(positionIdToTokenId(positionId)) != bobAddr {
+		panic("transferred position should return to bob after unstaking")
+	}
+	if pn.GetPositionOperator(positionId) != address("") {
+		panic("unstaked transferred position should clear operator")
+	}
+}
+
+func positionIdToTokenId(id uint64) grc721.TokenID {
+	return grc721.TokenID(strconv.Itoa(int(id)))
+}
+
+// Output:
+// [SCENARIO] 1. Initialize emission and mint position for alice
+// [EXPECTED] Minted transferable position ID: 1
+// [EXPECTED] Liquidity: 452101
+// [EXPECTED] Amount0: 100000
+// [EXPECTED] Amount1: 100000
+//
+// [SCENARIO] 2. Transfer position from alice to bob
+// [EXPECTED] New position owner: g1vfhkyh6lta047h6lta047h6lta047h6l03vdhu
+// [EXPECTED] GNFT owner: g1vfhkyh6lta047h6lta047h6lta047h6l03vdhu
+//
+// [SCENARIO] 3. Bob prepares transferred position for staking
+// [EXPECTED] Bob approved staker for transferred position
+// [EXPECTED] Bob remains the owner before staking:  g1vfhkyh6lta047h6lta047h6lta047h6l03vdhu
+//
+// [SCENARIO] 4. Bob stakes transferred position
+// [EXPECTED] Bob staked transferred position in pool: gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500
+// [EXPECTED] GNFT owner while staked: g1q6d4ns7zkr492rgl0pcgf5ajaf2dlz0nnptky3
+// [EXPECTED] Position operator while staked: g1vfhkyh6lta047h6lta047h6lta047h6l03vdhu
+//
+// [SCENARIO] 5. Bob collects reward and unstakes transferred position
+// [EXPECTED] Bob collected reward: 39330040
+// [EXPECTED] Bob unstaked transferred position from pool: gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:500
+// [EXPECTED] Final GNFT owner: g1vfhkyh6lta047h6lta047h6lta047h6l03vdhu
+// [EXPECTED] Final position operator:

--- a/contract/r/scenario/staker/transferred_position_unstake_retransfer_filetest.gno
+++ b/contract/r/scenario/staker/transferred_position_unstake_retransfer_filetest.gno
@@ -1,0 +1,133 @@
+// transferred position unstake and retransfer
+// Verify a transferred position can be staked, unstaked, then transferred again to a third owner.
+
+// PKGPATH: gno.land/r/gnoswap/v1/main
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	testutils "gno.land/p/nt/testutils/v0"
+
+	prbac "gno.land/p/gnoswap/rbac"
+	_ "gno.land/r/gnoswap/rbac"
+
+	_ "gno.land/r/gnoswap/pool/v1"
+	_ "gno.land/r/gnoswap/position/v1"
+	_ "gno.land/r/gnoswap/staker/v1"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/common"
+	"gno.land/r/gnoswap/gnft"
+	pl "gno.land/r/gnoswap/pool"
+	pn "gno.land/r/gnoswap/position"
+	sr "gno.land/r/gnoswap/staker"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/foo"
+)
+
+var (
+	adminAddr, _  = access.GetAddress(prbac.ROLE_ADMIN.String())
+	adminRealm    = testing.NewUserRealm(adminAddr)
+	poolAddr, _   = access.GetAddress(prbac.ROLE_POOL.String())
+	stakerAddr, _ = access.GetAddress(prbac.ROLE_STAKER.String())
+	aliceAddr     = testutils.TestAddress("alice")
+	aliceRealm    = testing.NewUserRealm(aliceAddr)
+	bobAddr       = testutils.TestAddress("bob")
+	bobRealm      = testing.NewUserRealm(bobAddr)
+	charlieAddr   = testutils.TestAddress("charlie")
+	charlieRealm  = testing.NewUserRealm(charlieAddr)
+	barPath       = "gno.land/r/onbloc/bar"
+	fooPath       = "gno.land/r/onbloc/foo"
+	fee500        = uint32(500)
+	maxTimeout int64 = 9999999999
+	maxInt64 int64 = 9223372036854775807
+)
+
+func main() {
+	println("[SCENARIO] 1. Mint position for alice and transfer to bob")
+	setupTransferToBob()
+	println()
+
+	println("[SCENARIO] 2. Bob stakes and unstakes the transferred position")
+	stakeAndUnstakeAsBob()
+	println()
+
+	println("[SCENARIO] 3. Bob transfers the recovered position to charlie")
+	retransferToCharlie()
+	println()
+
+	println("[SCENARIO] 4. Charlie can operate the re-transferred position")
+	verifyCharlieCanOperate()
+	println()
+}
+
+func setupTransferToBob() {
+	testing.SetRealm(adminRealm)
+	pl.SetPoolCreationFee(cross, 0)
+	sr.SetUnStakingFee(cross, 0)
+	pl.CreatePool(cross, barPath, fooPath, fee500, common.TickMathGetSqrtRatioAtTick(0).ToString())
+	sr.SetPoolTier(cross, pl.GetPoolPath(barPath, fooPath, fee500), 1)
+	bar.Transfer(cross, aliceAddr, 1_000_000)
+	foo.Transfer(cross, aliceAddr, 1_000_000)
+	bar.Transfer(cross, bobAddr, 1_000_000)
+	foo.Transfer(cross, bobAddr, 1_000_000)
+	bar.Transfer(cross, charlieAddr, 1_000_000)
+	foo.Transfer(cross, charlieAddr, 1_000_000)
+
+	testing.SetRealm(aliceRealm)
+	bar.Approve(cross, poolAddr, maxInt64)
+	foo.Approve(cross, poolAddr, maxInt64)
+	pn.Mint(cross, barPath, fooPath, fee500, -5000, 5000, "100000", "100000", "1", "1", maxTimeout, aliceAddr, aliceAddr, "")
+	gnft.TransferFrom(cross, aliceAddr, bobAddr, "1")
+	println("[EXPECTED] owner after alice -> bob transfer:", pn.GetPositionOwner(1).String())
+}
+
+func stakeAndUnstakeAsBob() {
+	testing.SetRealm(bobRealm)
+	gnft.Approve(cross, stakerAddr, "1")
+	sr.StakeToken(cross, 1, "")
+	println("[EXPECTED] owner while bob stake is active:", pn.GetPositionOwner(1).String())
+	testing.SkipHeights(5)
+	sr.UnStakeToken(cross, 1)
+	println("[EXPECTED] owner after bob unstake:", pn.GetPositionOwner(1).String())
+	println("[EXPECTED] operator after bob unstake:", pn.GetPositionOperator(1).String())
+}
+
+func retransferToCharlie() {
+	testing.SetRealm(bobRealm)
+	gnft.TransferFrom(cross, bobAddr, charlieAddr, "1")
+	println("[EXPECTED] owner after bob -> charlie transfer:", pn.GetPositionOwner(1).String())
+}
+
+func verifyCharlieCanOperate() {
+	testing.SetRealm(charlieRealm)
+	bar.Approve(cross, poolAddr, maxInt64)
+	foo.Approve(cross, poolAddr, maxInt64)
+	_, liquidity, amount0, amount1, _ := pn.IncreaseLiquidity(cross, 1, "1000", "1000", "1", "1", time.Now().Unix()+3600)
+	println("[EXPECTED] charlie owner after increase:", pn.GetPositionOwner(1).String())
+	println("[EXPECTED] charlie added liquidity:", liquidity)
+	println("[EXPECTED] charlie amount0 used:", amount0)
+	println("[EXPECTED] charlie amount1 used:", amount1)
+}
+
+// Output:
+// [SCENARIO] 1. Mint position for alice and transfer to bob
+// [EXPECTED] owner after alice -> bob transfer: g1vfhkyh6lta047h6lta047h6lta047h6l03vdhu
+//
+// [SCENARIO] 2. Bob stakes and unstakes the transferred position
+// [EXPECTED] owner while bob stake is active: g1q6d4ns7zkr492rgl0pcgf5ajaf2dlz0nnptky3
+// [EXPECTED] owner after bob unstake: g1vfhkyh6lta047h6lta047h6lta047h6l03vdhu
+// [EXPECTED] operator after bob unstake:
+//
+// [SCENARIO] 3. Bob transfers the recovered position to charlie
+// [EXPECTED] owner after bob -> charlie transfer: g1vd5xzunvd9j47h6lta047h6lta047h6l6a3cm8
+//
+// [SCENARIO] 4. Charlie can operate the re-transferred position
+// [EXPECTED] charlie owner after increase: g1vd5xzunvd9j47h6lta047h6lta047h6l6a3cm8
+// [EXPECTED] charlie added liquidity: 4521
+// [EXPECTED] charlie amount0 used: 1000
+// [EXPECTED] charlie amount1 used: 1000


### PR DESCRIPTION
## Summary
- enable GNFT transfer-based position ownership transfers by removing the added transfer capability comment-only noise from the first commit while preserving the code change
- verify direct owner actions after transfer, including increase, decrease, and reposition flows
- add lifecycle scenarios for approval reset, approval-for-all scope, fee rights, staked custody blocking, and unstake/retransfer behavior

## Testing
- make test PKG=gno.land/r/gnoswap/scenario/position
- make test PKG=gno.land/r/gnoswap/scenario/staker