### PR TITLE
fix(gov/staker): update undelegate halt condition to check withdrawal

### DIFF
--- a/contract/r/gnoswap/gov/staker/v1/staker_delegate.gno
+++ b/contract/r/gnoswap/gov/staker/v1/staker_delegate.gno
@@ -122,7 +122,7 @@ func (gs *govStakerV1) Undelegate(
 	from address,
 	amount int64,
 ) int64 {
-	halt.AssertIsNotHaltedGovStaker()
+	halt.AssertIsNotHaltedWithdraw()
 
 	prevRealm := runtime.PreviousRealm()
 	caller := prevRealm.Address()

--- a/contract/r/scenario/halt/emergency_mode_collect_paths_allowed_filetest.gno
+++ b/contract/r/scenario/halt/emergency_mode_collect_paths_allowed_filetest.gno
@@ -129,91 +129,95 @@ func main() {
 	testProtocolFeeDistributeAllowed()
 	println()
 
-	println("[SCENARIO] 8. gov_staker.CollectReward remains allowed")
+	println("[SCENARIO] 8. gov_staker.Undelegate remains allowed")
+	testGovStakerUndDelegateAllowed()
+	println()
+
+	println("[SCENARIO] 9. gov_staker.CollectReward remains allowed")
 	testGovStakerCollectAllowed()
 	println()
 
-	println("[SCENARIO] 9. gov_staker.CollectUndelegatedGns remains allowed")
+	println("[SCENARIO] 10. gov_staker.CollectUndelegatedGns remains allowed")
 	testGovStakerCollectUndelegatedAllowed()
 	println()
 
-	println("[SCENARIO] 10. launchpad.CollectRewardByDepositId remains allowed")
+	println("[SCENARIO] 11. launchpad.CollectRewardByDepositId remains allowed")
 	testLaunchpadCollectRewardAllowed()
 	println()
 
-	println("[SCENARIO] 11. launchpad.CollectDepositGns remains allowed")
+	println("[SCENARIO] 12. launchpad.CollectDepositGns remains allowed")
 	testLaunchpadCollectDepositAllowed()
 	println()
 
-	println("[SCENARIO] 12. launchpad.CollectProtocolFee remains allowed")
+	println("[SCENARIO] 13. launchpad.CollectProtocolFee remains allowed")
 	testLaunchpadCollectProtocolFeeAllowed()
 	println()
 
-	println("[SCENARIO] 13. community_pool.TransferToken remains allowed")
+	println("[SCENARIO] 14. community_pool.TransferToken remains allowed")
 	testCommunityPoolTransferAllowed()
 	println()
 
-	println("[SCENARIO] 14. pool.Burn remains allowed")
+	println("[SCENARIO] 15. pool.Burn remains allowed")
 	testPoolBurnAllowed()
 	println()
 
-	println("[SCENARIO] 15. pool.Collect remains allowed")
+	println("[SCENARIO] 16. pool.Collect remains allowed")
 	testPoolCollectAllowed()
 	println()
 
-	println("[SCENARIO] 16. pool.HandleWithdrawalFee remains allowed")
+	println("[SCENARIO] 17. pool.HandleWithdrawalFee remains allowed")
 	testPoolHandleWithdrawalFeeAllowed()
 	println()
 
-	println("[SCENARIO] 17. pool.CollectProtocol remains allowed")
+	println("[SCENARIO] 18. pool.CollectProtocol remains allowed")
 	testPoolCollectProtocolAllowed()
 	println()
 
-	println("[SCENARIO] 18. staker.EndExternalIncentive remains allowed")
+	println("[SCENARIO] 19. staker.EndExternalIncentive remains allowed")
 	testStakerEndExternalIncentiveAllowed()
 	println()
 
-	println("[SCENARIO] 19. staker.CollectExternalIncentivePenalty remains allowed")
+	println("[SCENARIO] 20. staker.CollectExternalIncentivePenalty remains allowed")
 	testStakerCollectExternalIncentivePenaltyAllowed()
 	println()
 
-	println("[SCENARIO] 20. gov_staker.CollectRewardFromLaunchPad remains allowed")
+	println("[SCENARIO] 21. gov_staker.CollectRewardFromLaunchPad remains allowed")
 	testGovStakerCollectRewardFromLaunchPadAllowed()
 	println()
 
-	println("[SCENARIO] 21. gov_staker.SetAmountByProjectWallet(add=false) remains allowed")
+	println("[SCENARIO] 22. gov_staker.SetAmountByProjectWallet(add=false) remains allowed")
 	testGovStakerSetAmountByProjectWalletRemoveAllowed()
 	println()
 
-	println("[SCENARIO] 22. xgns.Burn remains allowed")
+	println("[SCENARIO] 23. xgns.Burn remains allowed")
 	testXGnsBurnAllowed()
 	println()
 
-	println("[SCENARIO] 23. governance.ProposeText remains allowed")
+	println("[SCENARIO] 24. governance.ProposeText remains allowed")
 	testGovernanceProposeTextAllowed()
 	println()
 
-	println("[SCENARIO] 24. governance.Cancel remains allowed")
+	println("[SCENARIO] 25. governance.Cancel remains allowed")
 	testGovernanceCancelAllowed()
 	println()
 
-	println("[SCENARIO] 25. governance.ProposeCommunityPoolSpend remains allowed")
+	println("[SCENARIO] 26. governance.ProposeCommunityPoolSpend remains allowed")
 	testGovernanceProposeCommunityPoolSpendAllowed()
 	println()
 
-	println("[SCENARIO] 26. governance.ProposeParameterChange remains allowed")
+	println("[SCENARIO] 27. governance.ProposeParameterChange remains allowed")
 	testGovernanceProposeParameterChangeAllowed()
 	println()
 
-	println("[SCENARIO] 27. governance.Vote remains allowed")
+	println("[SCENARIO] 28. governance.Vote remains allowed")
 	testGovernanceVoteAllowed()
 	println()
 
-	println("[SCENARIO] 28. governance.Execute remains allowed")
+	println("[SCENARIO] 29. governance.Execute remains allowed")
 	testGovernanceExecuteAllowed()
 	println()
 
-	println("[SCENARIO] 29. governance.Reconfigure remains allowed")
+	println("[SCENARIO] 30. governance.Reconfigure remains allowed")
 	testGovernanceReconfigureAllowed()
 	println()
 }
@@ -376,6 +380,12 @@ func testStakerUnstakeAllowed() {
 	ufmt.Println("[EXPECTED] staker.UnStakeToken succeeded in emergency mode")
 }
 
+func testGovStakerUndDelegateAllowed() {
+	testing.SetRealm(bobRealm2)
+	govstaker.Undelegate(cross, bobAddr2, undelegatedAmount)
+	ufmt.Println("[EXPECTED] gov_staker.Undelegate succeeded in emergency mode")
+}
+
 func testGovStakerCollectAllowed() {
 	testing.SetRealm(bobRealm2)
 	beforeGnsBalance := gns.BalanceOf(bobAddr2)
@@ -391,8 +401,8 @@ func testGovStakerCollectUndelegatedAllowed() {
 	testing.SetRealm(bobRealm2)
 	beforeGnsBalance := gns.BalanceOf(bobAddr2)
 	collectedAmount := govstaker.CollectUndelegatedGns(cross)
-	uassert.Equal(t, undelegatedAmount, collectedAmount)
-	uassert.Equal(t, beforeGnsBalance+undelegatedAmount, gns.BalanceOf(bobAddr2))
+	afterGnsBalance := gns.BalanceOf(bobAddr2)
+	uassert.Equal(t, afterGnsBalance-beforeGnsBalance, collectedAmount)
 	ufmt.Printf("[EXPECTED] gov_staker.CollectUndelegatedGns amount: %d\n", collectedAmount)
 	ufmt.Println("[EXPECTED] gov_staker.CollectUndelegatedGns succeeded in emergency mode")
 }
@@ -649,90 +659,93 @@ func assertPositiveString(value string, label string) {
 // [EXPECTED] protocol_fee.DistributeProtocolFee BAR amount: 1000000
 // [EXPECTED] protocol_fee.DistributeProtocolFee succeeded in emergency mode
 //
-// [SCENARIO] 8. gov_staker.CollectReward remains allowed
+// [SCENARIO] 8. gov_staker.Undelegate remains allowed
+// [EXPECTED] gov_staker.Undelegate succeeded in emergency mode
+//
+// [SCENARIO] 9. gov_staker.CollectReward remains allowed
 // [EXPECTED] gov_staker.CollectReward GNS delta: 0, BAR delta: 500
 // [EXPECTED] gov_staker.CollectReward succeeded in emergency mode
 //
-// [SCENARIO] 9. gov_staker.CollectUndelegatedGns remains allowed
-// [EXPECTED] gov_staker.CollectUndelegatedGns amount: 1000000
+// [SCENARIO] 10. gov_staker.CollectUndelegatedGns remains allowed
+// [EXPECTED] gov_staker.CollectUndelegatedGns amount: 2000000
 // [EXPECTED] gov_staker.CollectUndelegatedGns succeeded in emergency mode
 //
-// [SCENARIO] 10. launchpad.CollectRewardByDepositId remains allowed
+// [SCENARIO] 11. launchpad.CollectRewardByDepositId remains allowed
 // [EXPECTED] launchpad.CollectRewardByDepositId OBL amount: 99999999
 // [EXPECTED] launchpad.CollectRewardByDepositId succeeded in emergency mode
 //
-// [SCENARIO] 11. launchpad.CollectDepositGns remains allowed
+// [SCENARIO] 12. launchpad.CollectDepositGns remains allowed
 // [EXPECTED] launchpad.CollectDepositGns amount: 1000000000
 // [EXPECTED] launchpad.CollectDepositGns succeeded in emergency mode
 //
-// [SCENARIO] 12. launchpad.CollectProtocolFee remains allowed
+// [SCENARIO] 13. launchpad.CollectProtocolFee remains allowed
 // [EXPECTED] launchpad.CollectProtocolFee BAR delta: 125062
 // [EXPECTED] launchpad.CollectProtocolFee succeeded in emergency mode
 //
-// [SCENARIO] 13. community_pool.TransferToken remains allowed
+// [SCENARIO] 14. community_pool.TransferToken remains allowed
 // [EXPECTED] community_pool.TransferToken amount: 1
 // [EXPECTED] community_pool.TransferToken succeeded in emergency mode
 //
-// [SCENARIO] 14. pool.Burn remains allowed
+// [SCENARIO] 15. pool.Burn remains allowed
 // [EXPECTED] pool.Burn amount0: 5, amount1: 5
 // [EXPECTED] pool.Burn succeeded in emergency mode
 //
-// [SCENARIO] 15. pool.Collect remains allowed
+// [SCENARIO] 16. pool.Collect remains allowed
 // [EXPECTED] pool.Collect amount0: 17, amount1: 17
 // [EXPECTED] pool.Collect succeeded in emergency mode
 //
-// [SCENARIO] 16. pool.HandleWithdrawalFee remains allowed
+// [SCENARIO] 17. pool.HandleWithdrawalFee remains allowed
 // [EXPECTED] pool.HandleWithdrawalFee fee0: 10, fee1: 10, net0: 990, net1: 990
 // [EXPECTED] pool.HandleWithdrawalFee succeeded in emergency mode
 //
-// [SCENARIO] 17. pool.CollectProtocol remains allowed
+// [SCENARIO] 18. pool.CollectProtocol remains allowed
 // [EXPECTED] pool.CollectProtocol amount0: 1000, amount1: 1000
 // [EXPECTED] pool.CollectProtocol succeeded in emergency mode
 //
-// [SCENARIO] 18. staker.EndExternalIncentive remains allowed
+// [SCENARIO] 19. staker.EndExternalIncentive remains allowed
 // [EXPECTED] staker.EndExternalIncentive BAR delta: 1000000000, GNS delta: 1000000000
 // [EXPECTED] staker.EndExternalIncentive succeeded in emergency mode
 //
-// [SCENARIO] 19. staker.CollectExternalIncentivePenalty remains allowed
+// [SCENARIO] 20. staker.CollectExternalIncentivePenalty remains allowed
 // [EXPECTED] staker.CollectExternalIncentivePenalty amount: 0
 // [EXPECTED] staker.CollectExternalIncentivePenalty succeeded in emergency mode
 //
-// [SCENARIO] 20. gov_staker.CollectRewardFromLaunchPad remains allowed
+// [SCENARIO] 21. gov_staker.CollectRewardFromLaunchPad remains allowed
 // [EXPECTED] gov_staker.CollectRewardFromLaunchPad BAR delta: 125062, GNS delta: 0
 // [EXPECTED] gov_staker.CollectRewardFromLaunchPad succeeded in emergency mode
 //
-// [SCENARIO] 21. gov_staker.SetAmountByProjectWallet(add=false) remains allowed
+// [SCENARIO] 22. gov_staker.SetAmountByProjectWallet(add=false) remains allowed
 // [EXPECTED] gov_staker.SetAmountByProjectWallet(add=false) amount: 1
 // [EXPECTED] gov_staker.SetAmountByProjectWallet(add=false) succeeded in emergency mode
 //
-// [SCENARIO] 22. xgns.Burn remains allowed
+// [SCENARIO] 23. xgns.Burn remains allowed
 // [EXPECTED] xgns.Burn amount: 1
 // [EXPECTED] xgns.Burn succeeded in emergency mode
 //
-// [SCENARIO] 23. governance.ProposeText remains allowed
+// [SCENARIO] 24. governance.ProposeText remains allowed
 // [EXPECTED] governance.ProposeText proposalId: 1
 // [EXPECTED] governance.ProposeText succeeded in emergency mode
 //
-// [SCENARIO] 24. governance.Cancel remains allowed
+// [SCENARIO] 25. governance.Cancel remains allowed
 // [EXPECTED] governance.Cancel proposalId: 1
 // [EXPECTED] governance.Cancel succeeded in emergency mode
 //
-// [SCENARIO] 25. governance.ProposeCommunityPoolSpend remains allowed
+// [SCENARIO] 26. governance.ProposeCommunityPoolSpend remains allowed
 // [EXPECTED] governance.ProposeCommunityPoolSpend proposalId: 2
 // [EXPECTED] governance.ProposeCommunityPoolSpend succeeded in emergency mode
 //
-// [SCENARIO] 26. governance.ProposeParameterChange remains allowed
+// [SCENARIO] 27. governance.ProposeParameterChange remains allowed
 // [EXPECTED] governance.ProposeParameterChange proposalId: 3
 // [EXPECTED] governance.ProposeParameterChange succeeded in emergency mode
 //
-// [SCENARIO] 27. governance.Vote remains allowed
+// [SCENARIO] 28. governance.Vote remains allowed
 // [EXPECTED] governance.Vote alice: 1000000000, carol: 1000000000
 // [EXPECTED] governance.Vote succeeded in emergency mode
 //
-// [SCENARIO] 28. governance.Execute remains allowed
+// [SCENARIO] 29. governance.Execute remains allowed
 // [EXPECTED] governance.Execute proposalId: 3
 // [EXPECTED] governance.Execute succeeded in emergency mode
 //
-// [SCENARIO] 29. governance.Reconfigure remains allowed
+// [SCENARIO] 30. governance.Reconfigure remains allowed
 // [EXPECTED] governance.Reconfigure version: 3
 // [EXPECTED] governance.Reconfigure succeeded in emergency mode

--- a/contract/r/scenario/halt/emergency_mode_core_functions_blocked_filetest.gno
+++ b/contract/r/scenario/halt/emergency_mode_core_functions_blocked_filetest.gno
@@ -233,12 +233,6 @@ func testBlockedEntriesOneByOne() {
 	})
 	printBlockedExpected("gov_staker", "Delegate", "gov_staker")
 
-	printBlockedScenario("gov_staker", "Undelegate")
-	uassert.AbortsContains(t, "halted: gov_staker", func() {
-		govstaker.Undelegate(cross, bobAddr, 1000000)
-	})
-	printBlockedExpected("gov_staker", "Undelegate", "gov_staker")
-
 	printBlockedScenario("gov_staker", "Redelegate")
 	uassert.AbortsContains(t, "halted: gov_staker", func() {
 		govstaker.Redelegate(cross, bobAddr, aliceAddr, 1000000)
@@ -500,95 +494,92 @@ func positionIdFrom(positionId any) grc721.TokenID {
 // [SCENARIO] 18. gov_staker.Delegate is blocked
 // [EXPECTED] gov_staker.Delegate blocked by gov_staker halt
 //
-// [SCENARIO] 19. gov_staker.Undelegate is blocked
-// [EXPECTED] gov_staker.Undelegate blocked by gov_staker halt
-//
-// [SCENARIO] 20. gov_staker.Redelegate is blocked
+// [SCENARIO] 19. gov_staker.Redelegate is blocked
 // [EXPECTED] gov_staker.Redelegate blocked by gov_staker halt
 //
-// [SCENARIO] 21. launchpad.CreateProject is blocked
+// [SCENARIO] 20. launchpad.CreateProject is blocked
 // [EXPECTED] launchpad.CreateProject blocked by launchpad halt
 //
-// [SCENARIO] 22. launchpad.DepositGns is blocked
+// [SCENARIO] 21. launchpad.DepositGns is blocked
 // [EXPECTED] launchpad.DepositGns blocked by launchpad halt
 //
-// [SCENARIO] 23. launchpad.TransferLeftFromProjectByAdmin is blocked
+// [SCENARIO] 22. launchpad.TransferLeftFromProjectByAdmin is blocked
 // [EXPECTED] launchpad.TransferLeftFromProjectByAdmin blocked by launchpad halt
 //
-// [SCENARIO] 24. pool.SetPoolCreationFee is blocked
+// [SCENARIO] 23. pool.SetPoolCreationFee is blocked
 // [EXPECTED] pool.SetPoolCreationFee blocked by pool halt
 //
-// [SCENARIO] 25. pool.SetWithdrawalFee is blocked
+// [SCENARIO] 24. pool.SetWithdrawalFee is blocked
 // [EXPECTED] pool.SetWithdrawalFee blocked by pool halt
 //
-// [SCENARIO] 26. pool.SetFeeProtocol is blocked
+// [SCENARIO] 25. pool.SetFeeProtocol is blocked
 // [EXPECTED] pool.SetFeeProtocol blocked by pool halt
 //
-// [SCENARIO] 27. router.SetSwapFee is blocked
+// [SCENARIO] 26. router.SetSwapFee is blocked
 // [EXPECTED] router.SetSwapFee blocked by router halt
 //
-// [SCENARIO] 28. staker.SetPoolTier is blocked
+// [SCENARIO] 27. staker.SetPoolTier is blocked
 // [EXPECTED] staker.SetPoolTier blocked by staker halt
 //
-// [SCENARIO] 29. staker.ChangePoolTier is blocked
+// [SCENARIO] 28. staker.ChangePoolTier is blocked
 // [EXPECTED] staker.ChangePoolTier blocked by staker halt
 //
-// [SCENARIO] 30. staker.RemovePoolTier is blocked
+// [SCENARIO] 29. staker.RemovePoolTier is blocked
 // [EXPECTED] staker.RemovePoolTier blocked by staker halt
 //
-// [SCENARIO] 31. staker.SetWarmUp is blocked
+// [SCENARIO] 30. staker.SetWarmUp is blocked
 // [EXPECTED] staker.SetWarmUp blocked by staker halt
 //
-// [SCENARIO] 32. staker.SetDepositGnsAmount is blocked
+// [SCENARIO] 31. staker.SetDepositGnsAmount is blocked
 // [EXPECTED] staker.SetDepositGnsAmount blocked by staker halt
 //
-// [SCENARIO] 33. staker.SetMinimumRewardAmount is blocked
+// [SCENARIO] 32. staker.SetMinimumRewardAmount is blocked
 // [EXPECTED] staker.SetMinimumRewardAmount blocked by staker halt
 //
-// [SCENARIO] 34. staker.SetTokenMinimumRewardAmount is blocked
+// [SCENARIO] 33. staker.SetTokenMinimumRewardAmount is blocked
 // [EXPECTED] staker.SetTokenMinimumRewardAmount blocked by staker halt
 //
-// [SCENARIO] 35. staker.SetUnStakingFee is blocked
+// [SCENARIO] 34. staker.SetUnStakingFee is blocked
 // [EXPECTED] staker.SetUnStakingFee blocked by staker halt
 //
-// [SCENARIO] 36. protocol_fee.SetDevOpsPct is blocked
+// [SCENARIO] 35. protocol_fee.SetDevOpsPct is blocked
 // [EXPECTED] protocol_fee.SetDevOpsPct blocked by protocol_fee halt
 //
-// [SCENARIO] 37. protocol_fee.SetGovStakerPct is blocked
+// [SCENARIO] 36. protocol_fee.SetGovStakerPct is blocked
 // [EXPECTED] protocol_fee.SetGovStakerPct blocked by protocol_fee halt
 //
-// [SCENARIO] 38. protocol_fee.AddToProtocolFee is blocked
+// [SCENARIO] 37. protocol_fee.AddToProtocolFee is blocked
 // [EXPECTED] protocol_fee.AddToProtocolFee blocked by protocol_fee halt
 //
-// [SCENARIO] 39. gov_staker.SetAmountByProjectWallet is blocked
+// [SCENARIO] 38. gov_staker.SetAmountByProjectWallet is blocked
 // [EXPECTED] gov_staker.SetAmountByProjectWallet blocked by gov_staker halt
 //
-// [SCENARIO] 40. gov_staker.CleanStakerDelegationSnapshotByAdmin is blocked
+// [SCENARIO] 39. gov_staker.CleanStakerDelegationSnapshotByAdmin is blocked
 // [EXPECTED] gov_staker.CleanStakerDelegationSnapshotByAdmin blocked by gov_staker halt
 //
-// [SCENARIO] 41. gov_staker.SetUnDelegationLockupPeriodByAdmin is blocked
+// [SCENARIO] 40. gov_staker.SetUnDelegationLockupPeriodByAdmin is blocked
 // [EXPECTED] gov_staker.SetUnDelegationLockupPeriodByAdmin blocked by gov_staker halt
 //
-// [SCENARIO] 42. emission.SetDistributionStartTime is blocked
+// [SCENARIO] 41. emission.SetDistributionStartTime is blocked
 // [EXPECTED] emission.SetDistributionStartTime blocked by emission halt
 //
-// [SCENARIO] 43. emission.ChangeDistributionPct is blocked
+// [SCENARIO] 42. emission.ChangeDistributionPct is blocked
 // [EXPECTED] emission.ChangeDistributionPct blocked by emission halt
 //
-// [SCENARIO] 44. position.IncreaseLiquidity is blocked
+// [SCENARIO] 43. position.IncreaseLiquidity is blocked
 // [EXPECTED] position.IncreaseLiquidity blocked by position halt
 //
-// [SCENARIO] 45. position.Reposition is blocked
+// [SCENARIO] 44. position.Reposition is blocked
 // [EXPECTED] position.Reposition blocked by position halt
 //
-// [SCENARIO] 46. staker.CreateExternalIncentive is blocked
+// [SCENARIO] 45. staker.CreateExternalIncentive is blocked
 // [EXPECTED] staker.CreateExternalIncentive blocked by staker halt
 //
-// [SCENARIO] 47. staker.AddToken is blocked
+// [SCENARIO] 46. staker.AddToken is blocked
 // [EXPECTED] staker.AddToken blocked by staker halt
 //
-// [SCENARIO] 48. staker.RemoveToken is blocked
+// [SCENARIO] 47. staker.RemoveToken is blocked
 // [EXPECTED] staker.RemoveToken blocked by staker halt
 //
-// [SCENARIO] 49. xgns.Mint is blocked
+// [SCENARIO] 48. xgns.Mint is blocked
 // [EXPECTED] xgns.Mint blocked by xgns halt


### PR DESCRIPTION
## Summary

Switch the halt guard on `gov_staker.Undelegate` from `AssertIsNotHaltedGovStaker` to `AssertIsNotHaltedWithdraw` so that undelegation — which is part of the user withdrawal path — is gated by the withdraw operation halt instead of the broader gov-staker halt. This aligns `Undelegate` with the existing convention used elsewhere in the module: increase operations are guarded by `GovStaker`, decrease/withdrawal operations are guarded by `Withdraw`.

Closes GSW-2682.

## Motivation

`Undelegate` removes voting power and starts the GNS lockup that ends with `CollectUndelegatedGns`. It is the entry point of the user withdrawal flow, not a delegation/increase operation. The previous guard had two undesirable consequences:

- **Emergency mode** (`OpTypeGovStaker = true`, `OpTypeWithdraw = false`) blocked users from initiating undelegation, breaking the documented intent of emergency mode: *"only governance and withdraw operations remain enabled for emergency recovery"* (`halt/config.gno`). With the previous guard, users could not start the withdrawal flow even though `CollectUndelegatedGns` was permitted.
- It was inconsistent with the rest of `gov/staker/v1`. `CollectUndelegatedGns` already uses `AssertIsNotHaltedWithdraw`, and `SetAmountByProjectWallet` explicitly branches between `GovStaker` (add) and `Withdraw` (remove). `Undelegate` was the only decrease-side function still guarded by `GovStaker`.

## Behavior Change by Halt Mode

| Halt mode | `Undelegate` (before) | `Undelegate` (after) |
|-----------|:---------------------:|:--------------------:|
| None | allowed | allowed |
| SafeMode | allowed | **blocked** |
| Emergency | **blocked** | allowed |
| Complete | blocked | blocked |

- **SafeMode**: `Undelegate` is now blocked together with `CollectUndelegatedGns`, treating the entire withdrawal pipeline uniformly when withdrawals are paused.
- **Emergency**: `Undelegate` is now allowed, restoring the intended emergency-recovery path so users can begin the lockup and later collect via `CollectUndelegatedGns`.

`Redelegate` is intentionally left on `AssertIsNotHaltedGovStaker`: it uses `unDelegateWithoutLockup` and reassigns voting power immediately, which is semantically an active governance operation rather than a withdrawal.

## Internal Call Safety

`Undelegate` calls `emission.MintAndDistributeGns(cross)` before processing the unstake. In emergency mode `OpTypeEmission` is halted, but `MintAndDistributeGns` checks `halt.IsHaltedEmission()` and silently returns `(0, false)` instead of panicking, so the new guard does not introduce a hidden failure path.

## Changes

- `contract/r/gnoswap/gov/staker/v1/staker_delegate.gno`: replace `halt.AssertIsNotHaltedGovStaker()` with `halt.AssertIsNotHaltedWithdraw()` in `Undelegate`.
- `contract/r/scenario/halt/emergency_mode_collect_paths_allowed_filetest.gno`: add `testGovStakerUndDelegateAllowed` and assert that `Undelegate` succeeds in emergency mode; renumber subsequent scenarios; relax the `CollectUndelegatedGns` assertion to compare the actual GNS balance delta (covers the additional amount now collectible after the new undelegate in this scenario).
- `contract/r/scenario/halt/emergency_mode_core_functions_blocked_filetest.gno`: remove the `gov_staker.Undelegate is blocked` case (no longer applicable) and renumber subsequent scenarios.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the halt condition that blocks undelegation operations to use the correct withdrawal-specific condition instead of the previous condition.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoswap-labs/gnoswap/pull/1288)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->