### PR TITLE
chore(protocol_fee): emit event on adding to protocol fee

### DIFF
--- a/contract/r/gnoswap/protocol_fee/v1/protocol_fee.gno
+++ b/contract/r/gnoswap/protocol_fee/v1/protocol_fee.gno
@@ -184,6 +184,14 @@ func (pf *protocolFeeV1) AddToProtocolFee(tokenPath string, amount int64) error 
 	protocolFeeAddr := access.MustGetAddress(prabc.ROLE_PROTOCOL_FEE.String())
 	common.SafeGRC20TransferFrom(cross, tokenPath, caller, protocolFeeAddr, amount)
 
+	chain.Emit(
+		"AddToProtocolFee",
+		"prevAddr", caller.String(),
+		"prevRealm", runtime.PreviousRealm().PkgPath(),
+		"tokenPath", tokenPath,
+		"amount", strconv.FormatInt(amount, 10),
+	)
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Emit an `AddToProtocolFee` event whenever protocol fees are pulled into the protocol-fee realm. This makes fee accumulation observable from off-chain indexers and dashboards, matching the event-emission convention already followed by other state-changing methods in this realm (`TransferProtocolFee`, `SetDevOpsPct`, `SetGovStakerPct`).

## Motivation

`AddToProtocolFee` is the single funnel through which pool swap fees, router router-fees, and staker unstaking fees flow into the protocol-fee realm:

- `pool/v1/protocol_fee.gno`
- `router/v1/protocol_fee_swap.gno`
- `staker/v1/protocol_fee_unstaking.gno`

Until now the function executed `SafeGRC20TransferFrom` silently and returned. Off-chain consumers had no direct event to subscribe to in order to track per-token protocol-fee inflow — they had to derive it indirectly from each upstream caller's events, which is fragile and module-specific. Emitting at the sink gives indexers a single, canonical signal for protocol-fee accumulation per token.

This also aligns with the audit-noted invariant *"every fee transfer must call `AddToProtocolFee`"*: pairing that invariant with an event makes accounting verifiable from logs.

## Changes

- `contract/r/gnoswap/protocol_fee/v1/protocol_fee.gno`: emit `AddToProtocolFee` after the GRC-20 transfer succeeds, carrying `prevAddr`, `prevRealm`, `tokenPath`, and `amount`.

Emission is placed after `SafeGRC20TransferFrom` so the event only fires for transfers that actually settled; the early returns for `amount == 0` and the halt / negative-amount paths intentionally do not emit. The field shape matches the existing emit calls in the same file (`prevAddr`, `prevRealm`, then the operation-specific payload), so downstream consumers can use the same parsing pattern.

## Behavior

- No state or control-flow change: the event is purely additive.
- Gas: one additional `chain.Emit` per non-zero `AddToProtocolFee` call.
- No breaking changes for callers; existing callers (`pool`, `router`, `staker`) need no updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Protocol fee collection operations now emit tracking events, providing enhanced visibility into fee amounts and collection sources across the protocol.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoswap-labs/gnoswap/pull/1289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->