### PR TITLE
fix(staker): scale external incentive rewardPerSecond by 2^128 to reduce dust loss

### DIFF
--- a/contract/r/gnoswap/staker/_mock_test.gno
+++ b/contract/r/gnoswap/staker/_mock_test.gno
@@ -384,8 +384,8 @@ func (m *MockStaker) GetIncentiveRewardAmountAsString(poolPath string, incentive
 	return res[0].(string)
 }
 
-func (m *MockStaker) GetIncentiveRewardPerSecond(poolPath string, incentiveId string) *u256.Uint {
-	res, ok := m.Response.Get("GetIncentiveRewardPerSecond")
+func (m *MockStaker) GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) *u256.Uint {
+	res, ok := m.Response.Get("GetIncentiveRewardPerSecondX128")
 	if !ok {
 		return u256.Zero()
 	}

--- a/contract/r/gnoswap/staker/_mock_test.gno
+++ b/contract/r/gnoswap/staker/_mock_test.gno
@@ -384,12 +384,12 @@ func (m *MockStaker) GetIncentiveRewardAmountAsString(poolPath string, incentive
 	return res[0].(string)
 }
 
-func (m *MockStaker) GetIncentiveRewardPerSecond(poolPath string, incentiveId string) int64 {
+func (m *MockStaker) GetIncentiveRewardPerSecond(poolPath string, incentiveId string) *u256.Uint {
 	res, ok := m.Response.Get("GetIncentiveRewardPerSecond")
 	if !ok {
-		return 0
+		return u256.Zero()
 	}
-	return res[0].(int64)
+	return res[0].(*u256.Uint)
 }
 
 func (m *MockStaker) GetIncentiveRewardToken(poolPath string, incentiveId string) string {

--- a/contract/r/gnoswap/staker/getter.gno
+++ b/contract/r/gnoswap/staker/getter.gno
@@ -181,8 +181,10 @@ func GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) strin
 	return getImplementation().GetIncentiveRewardAmountAsString(poolPath, incentiveId)
 }
 
-// GetIncentiveRewardPerSecond returns the reward rate per second of an incentive.
-func GetIncentiveRewardPerSecond(poolPath string, incentiveId string) int64 {
+// GetIncentiveRewardPerSecond returns the reward rate per second of an incentive,
+// expressed as a Q128 fixed-point number (i.e. actual rate = value / 2^128).
+// Callers needing an integer rate can right-shift the result by 128.
+func GetIncentiveRewardPerSecond(poolPath string, incentiveId string) *u256.Uint {
 	return getImplementation().GetIncentiveRewardPerSecond(poolPath, incentiveId)
 }
 

--- a/contract/r/gnoswap/staker/getter.gno
+++ b/contract/r/gnoswap/staker/getter.gno
@@ -181,11 +181,12 @@ func GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) strin
 	return getImplementation().GetIncentiveRewardAmountAsString(poolPath, incentiveId)
 }
 
-// GetIncentiveRewardPerSecond returns the reward rate per second of an incentive,
-// expressed as a Q128 fixed-point number (i.e. actual rate = value / 2^128).
-// Callers needing an integer rate can right-shift the result by 128.
-func GetIncentiveRewardPerSecond(poolPath string, incentiveId string) *u256.Uint {
-	return getImplementation().GetIncentiveRewardPerSecond(poolPath, incentiveId)
+// GetIncentiveRewardPerSecondX128 returns the reward rate per second of an
+// incentive, expressed as a Q128 fixed-point number (i.e. actual rate =
+// value / 2^128). Callers needing an integer rate can right-shift the result
+// by 128.
+func GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) *u256.Uint {
+	return getImplementation().GetIncentiveRewardPerSecondX128(poolPath, incentiveId).Clone()
 }
 
 // GetIncentiveRewardToken returns the reward token of an incentive.

--- a/contract/r/gnoswap/staker/getter_test.gno
+++ b/contract/r/gnoswap/staker/getter_test.gno
@@ -58,7 +58,7 @@ func TestMutableStakerGetterIsolation(t *testing.T) {
 				incentive := result.(*ExternalIncentive)
 				incentive.SetRewardToken("mutated")
 				incentive.SetRewardAmount(2000)
-				incentive.SetRewardPerSecond(3000)
+				incentive.SetRewardPerSecondX128(u256.NewUintFromInt64(3000))
 				incentive.SetDistributedRewardAmount(4000)
 				incentive.SetRefunded(true)
 			},
@@ -150,7 +150,7 @@ func TestMutableStakerGetterIsolation(t *testing.T) {
 				values := result.([]ExternalIncentive)
 				values[0].SetRewardToken("mutated")
 				values[0].SetRewardAmount(2000)
-				values[0].SetRewardPerSecond(3000)
+				values[0].SetRewardPerSecondX128(u256.NewUintFromInt64(3000))
 				values[0].SetDistributedRewardAmount(4000)
 				values[0].SetRefunded(true)
 			},

--- a/contract/r/gnoswap/staker/getter_test.gno
+++ b/contract/r/gnoswap/staker/getter_test.gno
@@ -34,8 +34,8 @@ func TestMutableStakerGetterIsolation(t *testing.T) {
 		assertRaw func(t *testing.T, m *MockStaker)
 	}{
 		{
-			name: "GetPool",
-			setup: func(m *MockStaker) { m.Response.Set("GetPool", newStakerPool()) },
+			name:   "GetPool",
+			setup:  func(m *MockStaker) { m.Response.Set("GetPool", newStakerPool()) },
 			getter: func() any { return GetPool("foo:bar:500") },
 			mutate: func(result any) {
 				pool := result.(*Pool)
@@ -51,8 +51,8 @@ func TestMutableStakerGetterIsolation(t *testing.T) {
 			},
 		},
 		{
-			name: "GetIncentive",
-			setup: func(m *MockStaker) { incentive := newExternalIncentive(); m.Response.Set("GetIncentive", &incentive) },
+			name:   "GetIncentive",
+			setup:  func(m *MockStaker) { incentive := newExternalIncentive(); m.Response.Set("GetIncentive", &incentive) },
 			getter: func() any { return GetIncentive("foo:bar:500", "incentive-1") },
 			mutate: func(result any) {
 				incentive := result.(*ExternalIncentive)
@@ -66,14 +66,15 @@ func TestMutableStakerGetterIsolation(t *testing.T) {
 				incentive := m.Response.data["GetIncentive"][0].(*ExternalIncentive)
 				uassert.Equal(t, "reward-token", incentive.RewardToken())
 				uassert.Equal(t, int64(1000), incentive.RewardAmount())
-				uassert.Equal(t, int64(100), incentive.RewardPerSecond())
+				expectedRPSX128 := u256.Zero().Mul(u256.NewUintFromInt64(100), q128)
+				uassert.Equal(t, expectedRPSX128.ToString(), incentive.RewardPerSecondX128().ToString())
 				uassert.Equal(t, int64(0), incentive.DistributedRewardAmount())
 				uassert.Equal(t, false, incentive.Refunded())
 			},
 		},
 		{
-			name: "GetDeposit",
-			setup: func(m *MockStaker) { m.Response.Set("GetDeposit", newStakerDeposit()) },
+			name:   "GetDeposit",
+			setup:  func(m *MockStaker) { m.Response.Set("GetDeposit", newStakerDeposit()) },
 			getter: func() any { return GetDeposit(1) },
 			mutate: func(result any) {
 				deposit := result.(*Deposit)
@@ -101,8 +102,8 @@ func TestMutableStakerGetterIsolation(t *testing.T) {
 			},
 		},
 		{
-			name: "GetDepositLiquidity",
-			setup: func(m *MockStaker) { m.Response.Set("GetDepositLiquidity", u256.MustFromDecimal("1000")) },
+			name:   "GetDepositLiquidity",
+			setup:  func(m *MockStaker) { m.Response.Set("GetDepositLiquidity", u256.MustFromDecimal("1000")) },
 			getter: func() any { return GetDepositLiquidity(1) },
 			mutate: func(result any) { result.(*u256.Uint).Set(u256.MustFromDecimal("2000")) },
 			assertRaw: func(t *testing.T, m *MockStaker) {
@@ -112,7 +113,9 @@ func TestMutableStakerGetterIsolation(t *testing.T) {
 		},
 		{
 			name: "GetDepositWarmUp",
-			setup: func(m *MockStaker) { m.Response.Set("GetDepositWarmUp", []Warmup{{TimeDuration: 10, NextWarmupTime: 20, WarmupRatio: 30}}) },
+			setup: func(m *MockStaker) {
+				m.Response.Set("GetDepositWarmUp", []Warmup{{TimeDuration: 10, NextWarmupTime: 20, WarmupRatio: 30}})
+			},
 			getter: func() any { return GetDepositWarmUp(1) },
 			mutate: func(result any) {
 				warmups := result.([]Warmup)
@@ -128,8 +131,8 @@ func TestMutableStakerGetterIsolation(t *testing.T) {
 			},
 		},
 		{
-			name: "GetDepositExternalIncentiveIdList",
-			setup: func(m *MockStaker) { m.Response.Set("GetDepositExternalIncentiveIdList", []string{"a", "b"}) },
+			name:   "GetDepositExternalIncentiveIdList",
+			setup:  func(m *MockStaker) { m.Response.Set("GetDepositExternalIncentiveIdList", []string{"a", "b"}) },
 			getter: func() any { return GetDepositExternalIncentiveIdList(1) },
 			mutate: func(result any) {
 				values := result.([]string)
@@ -144,7 +147,9 @@ func TestMutableStakerGetterIsolation(t *testing.T) {
 		},
 		{
 			name: "GetExternalIncentiveByPoolPath",
-			setup: func(m *MockStaker) { m.Response.Set("GetExternalIncentiveByPoolPath", []ExternalIncentive{newExternalIncentive()}) },
+			setup: func(m *MockStaker) {
+				m.Response.Set("GetExternalIncentiveByPoolPath", []ExternalIncentive{newExternalIncentive()})
+			},
 			getter: func() any { return GetExternalIncentiveByPoolPath("foo:bar:500") },
 			mutate: func(result any) {
 				values := result.([]ExternalIncentive)
@@ -158,14 +163,15 @@ func TestMutableStakerGetterIsolation(t *testing.T) {
 				values := m.Response.data["GetExternalIncentiveByPoolPath"][0].([]ExternalIncentive)
 				uassert.Equal(t, "reward-token", values[0].RewardToken())
 				uassert.Equal(t, int64(1000), values[0].RewardAmount())
-				uassert.Equal(t, int64(100), values[0].RewardPerSecond())
+				expectedRPSX128 := u256.Zero().Mul(u256.NewUintFromInt64(100), q128)
+				uassert.Equal(t, expectedRPSX128.ToString(), values[0].RewardPerSecondX128().ToString())
 				uassert.Equal(t, int64(0), values[0].DistributedRewardAmount())
 				uassert.Equal(t, false, values[0].Refunded())
 			},
 		},
 		{
-			name: "GetIncentiveRewardAmount",
-			setup: func(m *MockStaker) { m.Response.Set("GetIncentiveRewardAmount", u256.MustFromDecimal("3000")) },
+			name:   "GetIncentiveRewardAmount",
+			setup:  func(m *MockStaker) { m.Response.Set("GetIncentiveRewardAmount", u256.MustFromDecimal("3000")) },
 			getter: func() any { return GetIncentiveRewardAmount("foo:bar:500", "incentive-1") },
 			mutate: func(result any) { result.(*u256.Uint).Set(u256.MustFromDecimal("4000")) },
 			assertRaw: func(t *testing.T, m *MockStaker) {
@@ -174,8 +180,8 @@ func TestMutableStakerGetterIsolation(t *testing.T) {
 			},
 		},
 		{
-			name: "GetPoolIncentiveIdList",
-			setup: func(m *MockStaker) { m.Response.Set("GetPoolIncentiveIdList", []string{"incentive-1", "incentive-2"}) },
+			name:   "GetPoolIncentiveIdList",
+			setup:  func(m *MockStaker) { m.Response.Set("GetPoolIncentiveIdList", []string{"incentive-1", "incentive-2"}) },
 			getter: func() any { return GetPoolIncentiveIdList("foo:bar:500") },
 			mutate: func(result any) {
 				values := result.([]string)
@@ -189,8 +195,8 @@ func TestMutableStakerGetterIsolation(t *testing.T) {
 			},
 		},
 		{
-			name: "GetPoolsByTier",
-			setup: func(m *MockStaker) { m.Response.Set("GetPoolsByTier", []string{"foo:bar:500", "baz:qux:3000"}) },
+			name:   "GetPoolsByTier",
+			setup:  func(m *MockStaker) { m.Response.Set("GetPoolsByTier", []string{"foo:bar:500", "baz:qux:3000"}) },
 			getter: func() any { return GetPoolsByTier(1) },
 			mutate: func(result any) {
 				values := result.([]string)
@@ -204,8 +210,8 @@ func TestMutableStakerGetterIsolation(t *testing.T) {
 			},
 		},
 		{
-			name: "GetAllowedTokens",
-			setup: func(m *MockStaker) { m.Response.Set("GetAllowedTokens", []string{"foo", "bar"}) },
+			name:   "GetAllowedTokens",
+			setup:  func(m *MockStaker) { m.Response.Set("GetAllowedTokens", []string{"foo", "bar"}) },
 			getter: func() any { return GetAllowedTokens() },
 			mutate: func(result any) {
 				values := result.([]string)
@@ -220,7 +226,9 @@ func TestMutableStakerGetterIsolation(t *testing.T) {
 		},
 		{
 			name: "GetWarmupTemplate",
-			setup: func(m *MockStaker) { m.Response.Set("GetWarmupTemplate", []Warmup{{TimeDuration: 10, NextWarmupTime: 20, WarmupRatio: 30}}) },
+			setup: func(m *MockStaker) {
+				m.Response.Set("GetWarmupTemplate", []Warmup{{TimeDuration: 10, NextWarmupTime: 20, WarmupRatio: 30}})
+			},
 			getter: func() any { return GetWarmupTemplate() },
 			mutate: func(result any) {
 				warmups := result.([]Warmup)
@@ -236,8 +244,8 @@ func TestMutableStakerGetterIsolation(t *testing.T) {
 			},
 		},
 		{
-			name: "GetPoolRewardCacheIDs",
-			setup: func(m *MockStaker) { m.Response.Set("GetPoolRewardCacheIDs", []int64{10, 20}) },
+			name:   "GetPoolRewardCacheIDs",
+			setup:  func(m *MockStaker) { m.Response.Set("GetPoolRewardCacheIDs", []int64{10, 20}) },
 			getter: func() any { return GetPoolRewardCacheIDs("foo:bar:500", 0, 10) },
 			mutate: func(result any) {
 				values := result.([]int64)
@@ -251,8 +259,8 @@ func TestMutableStakerGetterIsolation(t *testing.T) {
 			},
 		},
 		{
-			name: "GetPoolIncentiveIDs",
-			setup: func(m *MockStaker) { m.Response.Set("GetPoolIncentiveIDs", []string{"one", "two"}) },
+			name:   "GetPoolIncentiveIDs",
+			setup:  func(m *MockStaker) { m.Response.Set("GetPoolIncentiveIDs", []string{"one", "two"}) },
 			getter: func() any { return GetPoolIncentiveIDs("foo:bar:500", 0, 10) },
 			mutate: func(result any) {
 				values := result.([]string)
@@ -266,8 +274,8 @@ func TestMutableStakerGetterIsolation(t *testing.T) {
 			},
 		},
 		{
-			name: "GetPoolGlobalRewardRatioAccumulationIDs",
-			setup: func(m *MockStaker) { m.Response.Set("GetPoolGlobalRewardRatioAccumulationIDs", []uint64{10, 20}) },
+			name:   "GetPoolGlobalRewardRatioAccumulationIDs",
+			setup:  func(m *MockStaker) { m.Response.Set("GetPoolGlobalRewardRatioAccumulationIDs", []uint64{10, 20}) },
 			getter: func() any { return GetPoolGlobalRewardRatioAccumulationIDs("foo:bar:500", 0, 10) },
 			mutate: func(result any) {
 				values := result.([]uint64)
@@ -281,8 +289,8 @@ func TestMutableStakerGetterIsolation(t *testing.T) {
 			},
 		},
 		{
-			name: "GetPoolGlobalRewardRatioAccumulation",
-			setup: func(m *MockStaker) { m.Response.Set("GetPoolGlobalRewardRatioAccumulation", "5000") },
+			name:   "GetPoolGlobalRewardRatioAccumulation",
+			setup:  func(m *MockStaker) { m.Response.Set("GetPoolGlobalRewardRatioAccumulation", "5000") },
 			getter: func() any { return GetPoolGlobalRewardRatioAccumulation("foo:bar:500", 10) },
 			mutate: func(result any) { result = "6000" },
 			assertRaw: func(t *testing.T, m *MockStaker) {
@@ -291,8 +299,8 @@ func TestMutableStakerGetterIsolation(t *testing.T) {
 			},
 		},
 		{
-			name: "GetPoolHistoricalTickIDs",
-			setup: func(m *MockStaker) { m.Response.Set("GetPoolHistoricalTickIDs", []int32{-10, 10}) },
+			name:   "GetPoolHistoricalTickIDs",
+			setup:  func(m *MockStaker) { m.Response.Set("GetPoolHistoricalTickIDs", []int32{-10, 10}) },
 			getter: func() any { return GetPoolHistoricalTickIDs("foo:bar:500", 0, 10) },
 			mutate: func(result any) {
 				values := result.([]int32)

--- a/contract/r/gnoswap/staker/pool.gno
+++ b/contract/r/gnoswap/staker/pool.gno
@@ -2,7 +2,6 @@ package staker
 
 import (
 	"errors"
-	"math"
 	"strconv"
 	"time"
 
@@ -439,27 +438,6 @@ func (e *ExternalIncentive) RewardPerSecondX128() *u256.Uint {
 // SetRewardPerSecondX128 sets the Q128-scaled reward per second.
 func (e *ExternalIncentive) SetRewardPerSecondX128(rewardPerSecondX128 *u256.Uint) {
 	e.rewardPerSecondX128 = rewardPerSecondX128
-}
-
-// RewardPerSecond returns the floor of the Q128-scaled reward per second.
-// Use RewardPerSecondX128 for precise on-chain calculations; this getter exists
-// for external observability where sub-second precision is not required.
-func (e *ExternalIncentive) RewardPerSecond() int64 {
-	if e.rewardPerSecondX128 == nil {
-		return 0
-	}
-
-	rewardPerSecond := u256.Zero().Rsh(e.rewardPerSecondX128, 128)
-	if !rewardPerSecond.IsUint64() {
-		panic("rewardPerSecond overflows int64")
-	}
-
-	rewardPerSecondUint64 := rewardPerSecond.Uint64()
-	if rewardPerSecondUint64 > uint64(math.MaxInt64) {
-		panic("rewardPerSecond overflows int64")
-	}
-
-	return int64(rewardPerSecondUint64)
 }
 
 // DistributedRewardAmount returns the distributed reward amount

--- a/contract/r/gnoswap/staker/pool.gno
+++ b/contract/r/gnoswap/staker/pool.gno
@@ -14,11 +14,11 @@ import (
 
 const AllTierCount = 4 // 0, 1, 2, 3
 
-// q128Pool is 2^128, used to scale rewardPerSecond so that sub-integer rates
+// q128 is 2^128, used to scale rewardPerSecond so that sub-integer rates
 // (e.g. 10_000_000 / 3600 = 2777.77...) do not lose precision over the
 // lifetime of an incentive. Mirrors the q128 constant used by the v1 reward
 // calculator; kept package-local here because staker depends on neither.
-var q128Pool = u256.MustFromDecimal("340282366920938463463374607431768211456")
+var q128 = u256.MustFromDecimal("340282366920938463463374607431768211456")
 
 // Pool is a struct for storing an incentivized pool information
 // Each pool stores Incentives and Ticks associated with it.
@@ -548,7 +548,7 @@ func NewExternalIncentive(
 	// Consumers must divide by 2^128 when materializing back to a plain integer.
 	rewardPerSecondX128 := u256.MulDiv(
 		u256.NewUintFromInt64(rewardAmount),
-		q128Pool,
+		q128,
 		u256.NewUintFromInt64(incentiveDuration),
 	)
 

--- a/contract/r/gnoswap/staker/pool.gno
+++ b/contract/r/gnoswap/staker/pool.gno
@@ -2,6 +2,7 @@ package staker
 
 import (
 	"errors"
+	"math"
 	"strconv"
 	"time"
 
@@ -12,6 +13,12 @@ import (
 )
 
 const AllTierCount = 4 // 0, 1, 2, 3
+
+// q128Pool is 2^128, used to scale rewardPerSecond so that sub-integer rates
+// (e.g. 10_000_000 / 3600 = 2777.77...) do not lose precision over the
+// lifetime of an incentive. Mirrors the q128 constant used by the v1 reward
+// calculator; kept package-local here because staker depends on neither.
+var q128Pool = u256.MustFromDecimal("340282366920938463463374607431768211456")
 
 // Pool is a struct for storing an incentivized pool information
 // Each pool stores Incentives and Ticks associated with it.
@@ -303,20 +310,20 @@ func NewIncentives(targetPoolPath string) *Incentives {
 }
 
 type ExternalIncentive struct {
-	incentiveId              string  // incentive id
-	startTimestamp           int64   // start time for external reward
-	endTimestamp             int64   // end time for external reward
-	createdHeight            int64   // block height when the incentive was created
-	createdTimestamp         int64   // timestamp when the incentive was created
-	depositGnsAmount         int64   // deposited gns amount
-	targetPoolPath           string  // external reward target pool path
-	rewardToken              string  // external reward token path
-	totalRewardAmount        int64   // total reward amount
-	rewardAmount             int64   // to be distributed reward amount
-	rewardPerSecond          int64   // reward per second
-	distributedRewardAmount  int64   // distributed reward amount, when un-staked and refunded
-	accumulatedPenaltyAmount int64   // accumulated warmup penalty from CollectReward
-	creator                  address // creator address
+	incentiveId              string     // incentive id
+	startTimestamp           int64      // start time for external reward
+	endTimestamp             int64      // end time for external reward
+	createdHeight            int64      // block height when the incentive was created
+	createdTimestamp         int64      // timestamp when the incentive was created
+	depositGnsAmount         int64      // deposited gns amount
+	targetPoolPath           string     // external reward target pool path
+	rewardToken              string     // external reward token path
+	totalRewardAmount        int64      // total reward amount
+	rewardAmount             int64      // to be distributed reward amount
+	rewardPerSecondX128      *u256.Uint // reward per second, scaled by 2^128 to preserve sub-second precision
+	distributedRewardAmount  int64      // distributed reward amount, when un-staked and refunded
+	accumulatedPenaltyAmount int64      // accumulated warmup penalty from CollectReward
+	creator                  address    // creator address
 
 	refunded bool // whether incentive has been refunded (includes GNS deposit and unclaimed rewards)
 }
@@ -423,14 +430,36 @@ func (e *ExternalIncentive) SetRewardAmount(rewardAmount int64) {
 	e.rewardAmount = rewardAmount
 }
 
-// RewardPerSecond returns the reward per second
-func (e *ExternalIncentive) RewardPerSecond() int64 {
-	return e.rewardPerSecond
+// RewardPerSecondX128 returns the Q128-scaled reward per second.
+// The underlying value is (rewardAmount << 128) / duration.
+func (e *ExternalIncentive) RewardPerSecondX128() *u256.Uint {
+	return e.rewardPerSecondX128
 }
 
-// SetRewardPerSecond sets the reward per second
-func (e *ExternalIncentive) SetRewardPerSecond(rewardPerSecond int64) {
-	e.rewardPerSecond = rewardPerSecond
+// SetRewardPerSecondX128 sets the Q128-scaled reward per second.
+func (e *ExternalIncentive) SetRewardPerSecondX128(rewardPerSecondX128 *u256.Uint) {
+	e.rewardPerSecondX128 = rewardPerSecondX128
+}
+
+// RewardPerSecond returns the floor of the Q128-scaled reward per second.
+// Use RewardPerSecondX128 for precise on-chain calculations; this getter exists
+// for external observability where sub-second precision is not required.
+func (e *ExternalIncentive) RewardPerSecond() int64 {
+	if e.rewardPerSecondX128 == nil {
+		return 0
+	}
+
+	rewardPerSecond := u256.Zero().Rsh(e.rewardPerSecondX128, 128)
+	if !rewardPerSecond.IsUint64() {
+		panic("rewardPerSecond overflows int64")
+	}
+
+	rewardPerSecondUint64 := rewardPerSecond.Uint64()
+	if rewardPerSecondUint64 > uint64(math.MaxInt64) {
+		panic("rewardPerSecond overflows int64")
+	}
+
+	return int64(rewardPerSecondUint64)
 }
 
 // DistributedRewardAmount returns the distributed reward amount
@@ -474,6 +503,12 @@ func (e *ExternalIncentive) SetRefunded(refunded bool) {
 }
 
 func (e *ExternalIncentive) Clone() *ExternalIncentive {
+	rewardPerSecondX128 := u256.Zero()
+
+	if e.rewardPerSecondX128 != nil {
+		rewardPerSecondX128 = e.rewardPerSecondX128.Clone()
+	}
+
 	return &ExternalIncentive{
 		incentiveId:              e.incentiveId,
 		startTimestamp:           e.startTimestamp,
@@ -485,7 +520,7 @@ func (e *ExternalIncentive) Clone() *ExternalIncentive {
 		rewardToken:              e.rewardToken,
 		totalRewardAmount:        e.totalRewardAmount,
 		rewardAmount:             e.rewardAmount,
-		rewardPerSecond:          e.rewardPerSecond,
+		rewardPerSecondX128:      rewardPerSecondX128,
 		creator:                  e.creator,
 		refunded:                 e.refunded,
 		distributedRewardAmount:  e.distributedRewardAmount,
@@ -507,7 +542,15 @@ func NewExternalIncentive(
 	currentTime int64, // current time in unix time(seconds)
 ) *ExternalIncentive {
 	incentiveDuration := endTimestamp - startTimestamp
-	rewardPerSecond := rewardAmount / incentiveDuration
+
+	// Compute reward per second scaled by 2^128 to preserve sub-second precision.
+	// rewardPerSecondX128 = (rewardAmount << 128) / incentiveDuration.
+	// Consumers must divide by 2^128 when materializing back to a plain integer.
+	rewardPerSecondX128 := u256.MulDiv(
+		u256.NewUintFromInt64(rewardAmount),
+		q128Pool,
+		u256.NewUintFromInt64(incentiveDuration),
+	)
 
 	return &ExternalIncentive{
 		incentiveId:              incentiveId,
@@ -517,7 +560,7 @@ func NewExternalIncentive(
 		rewardAmount:             rewardAmount,
 		startTimestamp:           startTimestamp,
 		endTimestamp:             endTimestamp,
-		rewardPerSecond:          rewardPerSecond,
+		rewardPerSecondX128:      rewardPerSecondX128,
 		distributedRewardAmount:  0,
 		accumulatedPenaltyAmount: 0,
 		creator:                  creator,

--- a/contract/r/gnoswap/staker/types.gno
+++ b/contract/r/gnoswap/staker/types.gno
@@ -83,7 +83,7 @@ type IStakerGetter interface {
 	GetIncentiveCreator(poolPath string, incentiveId string) address
 	GetIncentiveRewardAmount(poolPath string, incentiveId string) *u256.Uint
 	GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) string
-	GetIncentiveRewardPerSecond(poolPath string, incentiveId string) *u256.Uint
+	GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) *u256.Uint
 	GetIncentiveRewardToken(poolPath string, incentiveId string) string
 	GetIncentiveStartTimestamp(poolPath string, incentiveId string) int64
 	GetMinimumRewardAmount() int64

--- a/contract/r/gnoswap/staker/types.gno
+++ b/contract/r/gnoswap/staker/types.gno
@@ -83,7 +83,7 @@ type IStakerGetter interface {
 	GetIncentiveCreator(poolPath string, incentiveId string) address
 	GetIncentiveRewardAmount(poolPath string, incentiveId string) *u256.Uint
 	GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) string
-	GetIncentiveRewardPerSecond(poolPath string, incentiveId string) int64
+	GetIncentiveRewardPerSecond(poolPath string, incentiveId string) *u256.Uint
 	GetIncentiveRewardToken(poolPath string, incentiveId string) string
 	GetIncentiveStartTimestamp(poolPath string, incentiveId string) int64
 	GetMinimumRewardAmount() int64

--- a/contract/r/gnoswap/staker/v1/_helper_test.gno
+++ b/contract/r/gnoswap/staker/v1/_helper_test.gno
@@ -7,12 +7,14 @@ import (
 	testutils "gno.land/p/nt/testutils/v0"
 
 	prbac "gno.land/p/gnoswap/rbac"
+	u256 "gno.land/p/gnoswap/uint256"
 
 	"gno.land/r/gnoswap/access"
 	"gno.land/r/gnoswap/common"
 	"gno.land/r/gnoswap/mock"
 	pl "gno.land/r/gnoswap/pool"
 	pn "gno.land/r/gnoswap/position"
+	sr "gno.land/r/gnoswap/staker"
 
 	pool_v1 "gno.land/r/gnoswap/pool/v1"
 	position_v1 "gno.land/r/gnoswap/position/v1"
@@ -517,4 +519,11 @@ func mockInstanceCollectExternalIncentivePenalty(poolPath string, incentiveId st
 func getPositionOperator(positionId uint64) address {
 	testing.SetRealm(adminRealm)
 	return pn.GetPositionOperator(positionId)
+}
+
+// rewardPerSecondFromX128 returns the floored integer reward-per-second
+// derived from the Q128-scaled value. Used in tests for expected calculations.
+func rewardPerSecondFromX128(incentive *sr.ExternalIncentive) int64 {
+	rps := u256.Zero().Rsh(incentive.RewardPerSecondX128(), 128)
+	return int64(rps.Uint64())
 }

--- a/contract/r/gnoswap/staker/v1/calculate_pool_position_reward_test.gno
+++ b/contract/r/gnoswap/staker/v1/calculate_pool_position_reward_test.gno
@@ -632,7 +632,6 @@ func TestCalcPositionReward(t *testing.T) {
 					baseHeight,
 					baseTime-100,
 				)
-				incentive.SetRewardPerSecond(rewardAmount / (incentiveEndTime - incentiveStartTime))
 
 				poolResolver := NewPoolResolver(pool)
 				poolResolver.IncentivesResolver().create(incentive)
@@ -713,7 +712,6 @@ func TestCalcPositionReward(t *testing.T) {
 						baseHeight,
 						baseTime-100,
 					)
-					incentive.SetRewardPerSecond(rewardAmount / (incentiveEndTime - incentiveStartTime))
 					poolResolver.IncentivesResolver().create(incentive)
 
 					// Add incentive ID to deposit (required for reward calculation)
@@ -866,7 +864,6 @@ func TestCalcPositionReward(t *testing.T) {
 					baseHeight,
 					baseTime,
 				)
-				incentive.SetRewardPerSecond(rewardAmount / (incentiveEndTime - incentiveStartTime))
 
 				poolResolver := NewPoolResolver(pool)
 				poolResolver.IncentivesResolver().create(incentive)
@@ -927,7 +924,6 @@ func TestCalcPositionReward(t *testing.T) {
 					baseHeight,
 					baseTime-2000,
 				)
-				incentive.SetRewardPerSecond(rewardAmount / (incentiveEndTime - incentiveStartTime))
 
 				poolResolver := NewPoolResolver(pool)
 				poolResolver.IncentivesResolver().create(incentive)
@@ -992,7 +988,6 @@ func TestCalcPositionReward(t *testing.T) {
 					baseHeight,
 					baseTime-100,
 				)
-				incentive.SetRewardPerSecond(rewardAmount / (incentiveEndTime - incentiveStartTime))
 
 				poolResolver := NewPoolResolver(pool)
 				poolResolver.IncentivesResolver().create(incentive)
@@ -1497,7 +1492,6 @@ func TestCalcPositionReward_ExternalRewardMapIntegrity(t *testing.T) {
 			baseHeight,
 			baseTime-100,
 		)
-		incentive.SetRewardPerSecond(int64(1000 * (i + 1) / 1050))
 		poolResolver.IncentivesResolver().create(incentive)
 	}
 

--- a/contract/r/gnoswap/staker/v1/external_incentive.gno
+++ b/contract/r/gnoswap/staker/v1/external_incentive.gno
@@ -256,10 +256,14 @@ func (s *stakerV1) endExternalIncentive(resolver *PoolResolver, incentiveResolve
 	// With Q128 scaling the truncation per second collapses to at most 1 wei
 	// across the entire duration, so `remainder` is effectively zero and the
 	// refund accounts only for unclaimable periods.
-	distributableX256 := u256.Zero().Mul(
+	distributableX256, overflow := u256.Zero().MulOverflow(
 		incentiveResolver.RewardPerSecondX128(),
 		u256.NewUintFromInt64(duration),
 	)
+	if overflow {
+		panic(errOverflow)
+	}
+
 	distributable := safeConvertToInt64(u256.Zero().Rsh(distributableX256, 128))
 	remainder := safeSubInt64(incentiveResolver.TotalRewardAmount(), distributable)
 

--- a/contract/r/gnoswap/staker/v1/external_incentive.gno
+++ b/contract/r/gnoswap/staker/v1/external_incentive.gno
@@ -256,15 +256,13 @@ func (s *stakerV1) endExternalIncentive(resolver *PoolResolver, incentiveResolve
 	// With Q128 scaling the truncation per second collapses to at most 1 wei
 	// across the entire duration, so `remainder` is effectively zero and the
 	// refund accounts only for unclaimable periods.
-	distributableX256, overflow := u256.Zero().MulOverflow(
+	distributableU256 := u256.MulDiv(
 		incentiveResolver.RewardPerSecondX128(),
 		u256.NewUintFromInt64(duration),
+		q128,
 	)
-	if overflow {
-		panic(errOverflow)
-	}
 
-	distributable := safeConvertToInt64(u256.Zero().Rsh(distributableX256, 128))
+	distributable := safeConvertToInt64(distributableU256)
 	remainder := safeSubInt64(incentiveResolver.TotalRewardAmount(), distributable)
 
 	refund := safeAddInt64(unclaimableReward, remainder)

--- a/contract/r/gnoswap/staker/v1/external_incentive.gno
+++ b/contract/r/gnoswap/staker/v1/external_incentive.gno
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	prbac "gno.land/p/gnoswap/rbac"
+	u256 "gno.land/p/gnoswap/uint256"
 	bptree "gno.land/p/nt/bptree/v0"
 	ufmt "gno.land/p/nt/ufmt/v0"
 
@@ -251,7 +252,15 @@ func (s *stakerV1) endExternalIncentive(resolver *PoolResolver, incentiveResolve
 	unclaimableReward := incentivesResolver.calculateUnclaimableReward(incentiveResolver.IncentiveId())
 
 	duration := safeSubInt64(incentiveResolver.EndTimestamp(), incentiveResolver.StartTimestamp())
-	distributable := safeMulInt64(incentiveResolver.RewardPerSecond(), duration)
+	// distributable = floor((rewardPerSecondX128 * duration) / 2^128).
+	// With Q128 scaling the truncation per second collapses to at most 1 wei
+	// across the entire duration, so `remainder` is effectively zero and the
+	// refund accounts only for unclaimable periods.
+	distributableX256 := u256.Zero().Mul(
+		incentiveResolver.RewardPerSecondX128(),
+		u256.NewUintFromInt64(duration),
+	)
+	distributable := safeConvertToInt64(u256.Zero().Rsh(distributableX256, 128))
 	remainder := safeSubInt64(incentiveResolver.TotalRewardAmount(), distributable)
 
 	refund := safeAddInt64(unclaimableReward, remainder)

--- a/contract/r/gnoswap/staker/v1/external_incentive_test.gno
+++ b/contract/r/gnoswap/staker/v1/external_incentive_test.gno
@@ -1449,7 +1449,7 @@ func TestCalculateUnclaimableReward_TracksZeroLiquidityTransitions(t *testing.T)
 	poolResolver.modifyDeposit(i256.NewInt(1000), stakeTimeB, 0)
 
 	expectedDuration := (stakeTimeA - startTime) + (stakeTimeB - zeroTime)
-	expected := expectedDuration * incentive.RewardPerSecond()
+	expected := expectedDuration * rewardPerSecondFromX128(incentive)
 
 	got := incentives.calculateUnclaimableReward(incentive.IncentiveId())
 	if got != expected {

--- a/contract/r/gnoswap/staker/v1/external_incentive_test.gno
+++ b/contract/r/gnoswap/staker/v1/external_incentive_test.gno
@@ -103,6 +103,114 @@ func TestCreateExternalIncentiveWithAllowedTokens(t *testing.T) {
 	pools.tree.Remove(poolPath)
 }
 
+// Test ExternalIncentiveRefundAmount through the public entrypoint with full preconditions.
+func TestExternalIncentiveRefundAmount(t *testing.T) {
+	creator := testutils.TestAddress("creator")
+	refundee := testutils.TestAddress("refundee")
+
+	calculateLegacyRefundAmount := func(depositRewardAmount int64, startTimestamp int64, endTimestamp int64) int64 {
+		duration := endTimestamp - startTimestamp
+		rewardPerSecond := depositRewardAmount / duration
+		return depositRewardAmount - (rewardPerSecond * duration)
+	}
+
+	calculateRefundAmount := func(depositRewardAmount int64, startTimestamp int64, endTimestamp int64) int64 {
+		duration := endTimestamp - startTimestamp
+		rewardPerSecondX128 := u256.MulDiv(
+			u256.NewUintFromInt64(depositRewardAmount),
+			q128,
+			u256.NewUintFromInt64(duration),
+		)
+
+		distributedAmountX128 := u256.Zero().Mul(
+			rewardPerSecondX128,
+			u256.NewUintFromInt64(duration),
+		)
+		distributedAmount := safeConvertToInt64(u256.Zero().Rsh(distributedAmountX128, 128))
+
+		return depositRewardAmount - distributedAmount
+	}
+
+	tests := []struct {
+		name                       string
+		caller                     address
+		refundAddress              address
+		startTimestamp             int64
+		endTimestamp               int64
+		depositRewardAmount        int64
+		expectedLegacyRefundAmount int64
+		expectedRefundAmount       int64
+	}{
+		{
+			name:                       "external incentive refund amount by 1,000,000,000 amount and 90 days duration",
+			caller:                     creator,
+			refundAddress:              refundee,
+			startTimestamp:             0,
+			endTimestamp:               86400 * 90, // 90 days duration
+			depositRewardAmount:        1_000_000_000,
+			expectedLegacyRefundAmount: 4672000,
+			expectedRefundAmount:       1,
+		},
+		{
+			name:                       "external incentive refund amount by 1,234,456,789 amount and 90 days duration",
+			caller:                     creator,
+			refundAddress:              refundee,
+			startTimestamp:             0,
+			endTimestamp:               86400 * 90, // 90 days duration
+			depositRewardAmount:        1_234_456_789,
+			expectedLegacyRefundAmount: 5848789,
+			expectedRefundAmount:       1,
+		},
+		{
+			name:                       "external incentive refund amount by 9,999,999,999 amount and 90 days duration",
+			caller:                     creator,
+			refundAddress:              refundee,
+			startTimestamp:             0,
+			endTimestamp:               86400 * 90, // 90 days duration
+			depositRewardAmount:        9_999_999_999,
+			expectedLegacyRefundAmount: 63999,
+			expectedRefundAmount:       1,
+		},
+		{
+			name:                       "external incentive refund amount by 1,000,000,000,000,000 amount and 180 days duration",
+			caller:                     creator,
+			refundAddress:              refundee,
+			startTimestamp:             0,
+			endTimestamp:               86400 * 180, // 180 days duration
+			depositRewardAmount:        1_000_000_000_000_000,
+			expectedLegacyRefundAmount: 8128000,
+			expectedRefundAmount:       1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create ended or active incentive based on the test case.
+			incentiveId := "test-incentive-1"
+			incentive := sr.NewExternalIncentive(
+				incentiveId,
+				"gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:3000",
+				barPath,
+				tt.depositRewardAmount,
+				tt.startTimestamp,
+				tt.endTimestamp,
+				creator,
+				100_000_000, // depositGnsAmount
+				0,
+				0,
+			)
+
+			t.Logf("refund amount: , legacy: %d, q128: %d",
+				calculateLegacyRefundAmount(incentive.TotalRewardAmount(), incentive.StartTimestamp(), incentive.EndTimestamp()),
+				calculateRefundAmount(tt.depositRewardAmount, tt.startTimestamp, tt.endTimestamp),
+			)
+
+			uassert.Equal(t, tt.expectedLegacyRefundAmount, calculateLegacyRefundAmount(incentive.TotalRewardAmount(), incentive.StartTimestamp(), incentive.EndTimestamp()))
+			uassert.Equal(t, tt.expectedRefundAmount, calculateRefundAmount(tt.depositRewardAmount, tt.startTimestamp, tt.endTimestamp))
+		})
+	}
+}
+
 // Test EndExternalIncentive through the public entrypoint with full preconditions.
 func TestEndExternalIncentive(t *testing.T) {
 	creator := testutils.TestAddress("creator")

--- a/contract/r/gnoswap/staker/v1/getter.gno
+++ b/contract/r/gnoswap/staker/v1/getter.gno
@@ -181,10 +181,10 @@ func (s *stakerV1) GetIncentiveRewardAmountAsString(poolPath string, incentiveId
 	return rewardAmount.ToString()
 }
 
-// GetIncentiveRewardPerSecond returns the Q128-scaled reward per second of an
-// incentive (i.e. actual rate = value / 2^128). The Q128 form preserves
+// GetIncentiveRewardPerSecondX128 returns the Q128-scaled reward per second of
+// an incentive (i.e. actual rate = value / 2^128). The Q128 form preserves
 // sub-second precision that would otherwise be lost to int64 truncation.
-func (s *stakerV1) GetIncentiveRewardPerSecond(poolPath string, incentiveId string) *u256.Uint {
+func (s *stakerV1) GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) *u256.Uint {
 	incentive := s.getIncentive(poolPath, incentiveId)
 
 	return incentive.RewardPerSecondX128()

--- a/contract/r/gnoswap/staker/v1/getter.gno
+++ b/contract/r/gnoswap/staker/v1/getter.gno
@@ -181,11 +181,13 @@ func (s *stakerV1) GetIncentiveRewardAmountAsString(poolPath string, incentiveId
 	return rewardAmount.ToString()
 }
 
-// GetIncentiveRewardPerSecond returns the reward per second of an incentive.
-func (s *stakerV1) GetIncentiveRewardPerSecond(poolPath string, incentiveId string) int64 {
+// GetIncentiveRewardPerSecond returns the Q128-scaled reward per second of an
+// incentive (i.e. actual rate = value / 2^128). The Q128 form preserves
+// sub-second precision that would otherwise be lost to int64 truncation.
+func (s *stakerV1) GetIncentiveRewardPerSecond(poolPath string, incentiveId string) *u256.Uint {
 	incentive := s.getIncentive(poolPath, incentiveId)
 
-	return incentive.RewardPerSecond()
+	return incentive.RewardPerSecondX128()
 }
 
 // GetIncentiveCreator returns the creator address of an incentive.

--- a/contract/r/gnoswap/staker/v1/getter_test.gno
+++ b/contract/r/gnoswap/staker/v1/getter_test.gno
@@ -192,9 +192,13 @@ func TestGetterIncentiveRewardAmounts(t *testing.T) {
 	uassert.Equal(t, int64(10_000_000), remainingReward)
 
 	// Test reward per second
-	rewardPerSecond := state.instance.GetIncentiveRewardPerSecond(state.poolPath, state.incentiveId)
-	// rewardPerSecond = 10_000_000 / 3600 = 2777
-	uassert.Equal(t, int64(2777), rewardPerSecond)
+	// GetIncentiveRewardPerSecond now returns the Q128-scaled value so that
+	// sub-integer rates (here 10_000_000 / 3600 = 2777.77...) survive without
+	// the truncation that the previous int64 representation forced. Floor of
+	// rewardPerSecondX128 >> 128 should still equal the legacy value 2777.
+	rewardPerSecondX128 := state.instance.GetIncentiveRewardPerSecond(state.poolPath, state.incentiveId)
+	floor := u256.Zero().Rsh(rewardPerSecondX128, 128)
+	uassert.Equal(t, "2777", floor.ToString())
 
 	// Test u256 variants
 	rewardAmount := state.instance.GetIncentiveRewardAmount(state.poolPath, state.incentiveId)

--- a/contract/r/gnoswap/staker/v1/getter_test.gno
+++ b/contract/r/gnoswap/staker/v1/getter_test.gno
@@ -192,11 +192,11 @@ func TestGetterIncentiveRewardAmounts(t *testing.T) {
 	uassert.Equal(t, int64(10_000_000), remainingReward)
 
 	// Test reward per second
-	// GetIncentiveRewardPerSecond now returns the Q128-scaled value so that
+	// GetIncentiveRewardPerSecondX128 returns the Q128-scaled value so that
 	// sub-integer rates (here 10_000_000 / 3600 = 2777.77...) survive without
 	// the truncation that the previous int64 representation forced. Floor of
 	// rewardPerSecondX128 >> 128 should still equal the legacy value 2777.
-	rewardPerSecondX128 := state.instance.GetIncentiveRewardPerSecond(state.poolPath, state.incentiveId)
+	rewardPerSecondX128 := state.instance.GetIncentiveRewardPerSecondX128(state.poolPath, state.incentiveId)
 	floor := u256.Zero().Rsh(rewardPerSecondX128, 128)
 	uassert.Equal(t, "2777", floor.ToString())
 

--- a/contract/r/gnoswap/staker/v1/reward_calculation_canonical_env_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_canonical_env_test.gno
@@ -50,7 +50,7 @@ func (self *canonicalPool) ExternalReward(currentTimestamp int64) map[string]int
 			continue
 		}
 
-		reward[incentive.RewardToken()] += incentive.RewardPerSecond()
+		reward[incentive.RewardToken()] += rewardPerSecondFromX128(incentive)
 	}
 
 	return reward

--- a/contract/r/gnoswap/staker/v1/reward_calculation_canonical_env_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_canonical_env_test.gno
@@ -479,10 +479,11 @@ func newExternalIncentiveBy(
 	currentTimestamp int64,
 ) *sr.ExternalIncentive {
 	caller := runtime.OriginCaller()
-	rewardPerSecond := rewardAmount / (endTimestamp - startTimestamp)
 
 	incentiveId := getMockInstance().store.NextIncentiveID(caller, currentHeight)
 
+	// NewExternalIncentive already derives the Q128-scaled per-second rate from
+	// (rewardAmount, startTimestamp, endTimestamp); no extra Set call needed.
 	externalIncentive := sr.NewExternalIncentive(
 		incentiveId,
 		targetPoolPath,
@@ -495,8 +496,6 @@ func newExternalIncentiveBy(
 		currentHeight,
 		currentTimestamp,
 	)
-
-	externalIncentive.SetRewardPerSecond(rewardPerSecond)
 
 	return externalIncentive
 }

--- a/contract/r/gnoswap/staker/v1/reward_calculation_incentives.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_incentives.gno
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	u256 "gno.land/p/gnoswap/uint256"
 	bptree "gno.land/p/nt/bptree/v0"
 
 	sr "gno.land/r/gnoswap/staker"
@@ -147,7 +148,15 @@ func (self *IncentivesResolver) calculateUnclaimableReward(incentiveId string) i
 		return false
 	})
 
-	return safeMulInt64(timeDiff, incentive.RewardPerSecond())
+	// rewardPerSecondX128 = rps << 128, so dividing by q128 here recovers the
+	// floor of (timeDiff * rps) without the truncation that an int64 rps would
+	// have introduced at incentive-creation time.
+	unclaimable := u256.MulDiv(
+		u256.NewUintFromInt64(timeDiff),
+		incentive.RewardPerSecondX128(),
+		q128,
+	)
+	return safeConvertToInt64(unclaimable)
 }
 
 // calculateUnClaimableDuration calculates the duration of overlap between an unclaimable period and incentive period

--- a/contract/r/gnoswap/staker/v1/reward_calculation_incentives_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_incentives_test.gno
@@ -300,7 +300,7 @@ func TestCalculateUnclaimableReward_MultipleUnclaimablePeriods(t *testing.T) {
 	got := incentives.calculateUnclaimableReward(incentive.IncentiveId())
 
 	expectedDuration := int64(30) // (20-10) + (60-40)
-	expected := expectedDuration * incentive.RewardPerSecond()
+	expected := expectedDuration * rewardPerSecondFromX128(incentive)
 
 	if got != expected {
 		t.Fatalf("expected unclaimable reward %d, got %d", expected, got)
@@ -435,7 +435,7 @@ func TestCalculateUnclaimableReward_OngoingPeriod(t *testing.T) {
 
 	// Expected: from currentTime+30 to incentive end (currentTime+100), which is 70 seconds
 	expectedDuration := int64(70)
-	expected := expectedDuration * incentive.RewardPerSecond()
+	expected := expectedDuration * rewardPerSecondFromX128(incentive)
 
 	if got != expected {
 		t.Fatalf("expected unclaimable reward %d for ongoing period, got %d", expected, got)
@@ -483,7 +483,7 @@ func TestCalculateUnclaimableReward_OverlappingWindows(t *testing.T) {
 	// Expected: Two windows [10,30] = 20 seconds and [20,40] = 20 seconds
 	// Total unclaimable duration = 40 seconds (not 30 as overlap is counted)
 	expectedDuration := int64(40) // Both periods contribute fully
-	expected := expectedDuration * incentive.RewardPerSecond()
+	expected := expectedDuration * rewardPerSecondFromX128(incentive)
 
 	if got != expected {
 		t.Fatalf("expected unclaimable reward %d for overlapping periods, got %d", expected, got)
@@ -531,7 +531,7 @@ func TestCalculateUnclaimableReward_AdjacentWindows(t *testing.T) {
 	// Expected: [10,20] = 10 seconds and [20,30] = 10 seconds
 	// Total = 20 seconds (no overlap, no gap)
 	expectedDuration := int64(20)
-	expected := expectedDuration * incentive.RewardPerSecond()
+	expected := expectedDuration * rewardPerSecondFromX128(incentive)
 
 	if got != expected {
 		t.Fatalf("expected unclaimable reward %d for adjacent periods, got %d", expected, got)
@@ -586,7 +586,7 @@ func TestCalculateUnclaimableReward_OutsideRangeWindows(t *testing.T) {
 	// Expected: Only the overlapping part [140,150] = 10 seconds
 	// The periods [10,30] and [200,250] contribute 0
 	expectedDuration := int64(10)
-	expected := expectedDuration * incentive.RewardPerSecond()
+	expected := expectedDuration * rewardPerSecondFromX128(incentive)
 
 	if got != expected {
 		t.Fatalf("expected unclaimable reward %d for outside-range periods, got %d", expected, got)

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
@@ -346,7 +346,7 @@ func (self *RewardState) updateExternalReward(startTime, endTime int64, incentiv
 		return nil // Already ended
 	}
 
-	return self.rewardPerWarmup(startTime, endTime, incentive.RewardPerSecond())
+	return self.rewardPerWarmupX128(startTime, endTime, incentive.RewardPerSecondX128())
 }
 
 // calculateCollectableExternalReward calculates the calculated external reward for the deposit.
@@ -395,6 +395,7 @@ func (self *RewardState) applyWarmup() {
 }
 
 // rewardPerWarmup calculates the reward for each warmup, adds to the RewardState's rewards array.
+// Used by the internal reward path where rewardPerSecond is an int64 emission rate.
 func (self *RewardState) rewardPerWarmup(startTime, endTime int64, rewardPerSecond int64) error {
 	// Return early if startTime equals endTime to avoid unnecessary computation
 	if startTime == endTime {
@@ -428,6 +429,54 @@ func (self *RewardState) rewardPerWarmup(startTime, endTime int64, rewardPerSeco
 
 		rewardAcc = u256.Zero().Mul(rewardAcc, self.deposit.Liquidity())
 		rewardAcc = u256.MulDiv(rewardAcc, u256.NewUintFromInt64(rewardPerSecond), q128)
+		self.rewards[i] = safeAddInt64(self.rewards[i], safeConvertToInt64(rewardAcc))
+
+		startTime = warmup.NextWarmupTime
+		startTick = endTick
+		startRaw = endRaw
+	}
+
+	return nil
+}
+
+// rewardPerWarmupX128 calculates the reward for each warmup using a Q128-scaled
+// per-second rate. Used by the external incentive path; the per-second rate is
+// stored as `(rewardAmount << 128) / duration` in ExternalIncentive, so an
+// extra `>> 128` is needed after the standard `MulDiv(rewardAcc, rps, q128)`
+// to materialize the integer result.
+func (self *RewardState) rewardPerWarmupX128(startTime, endTime int64, rewardPerSecondX128 *u256.Uint) error {
+	if startTime == endTime {
+		return nil
+	}
+
+	startTick := self.pool.CurrentTick(startTime)
+	startRaw := self.pool.CalculateRawRewardForPosition(startTime, startTick, self.deposit.Deposit)
+
+	for i, warmup := range self.deposit.Warmups() {
+		if startTime >= warmup.NextWarmupTime {
+			continue
+		}
+
+		if endTime < warmup.NextWarmupTime {
+			endTick := self.pool.CurrentTick(endTime)
+			endRaw := self.pool.CalculateRawRewardForPosition(endTime, endTick, self.deposit.Deposit)
+			rewardAcc := u256.Zero().Sub(endRaw, startRaw)
+
+			rewardAcc = u256.Zero().Mul(rewardAcc, self.deposit.Liquidity())
+			rewardAcc = u256.MulDiv(rewardAcc, rewardPerSecondX128, q128)
+			rewardAcc = u256.Zero().Rsh(rewardAcc, 128)
+			self.rewards[i] = safeAddInt64(self.rewards[i], safeConvertToInt64(rewardAcc))
+
+			break
+		}
+
+		endTick := self.pool.CurrentTick(warmup.NextWarmupTime)
+		endRaw := self.pool.CalculateRawRewardForPosition(warmup.NextWarmupTime, endTick, self.deposit.Deposit)
+		rewardAcc := u256.Zero().Sub(endRaw, startRaw)
+
+		rewardAcc = u256.Zero().Mul(rewardAcc, self.deposit.Liquidity())
+		rewardAcc = u256.MulDiv(rewardAcc, rewardPerSecondX128, q128)
+		rewardAcc = u256.Zero().Rsh(rewardAcc, 128)
 		self.rewards[i] = safeAddInt64(self.rewards[i], safeConvertToInt64(rewardAcc))
 
 		startTime = warmup.NextWarmupTime

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
@@ -414,9 +414,16 @@ func (self *RewardState) rewardPerWarmup(startTime, endTime int64, rewardPerSeco
 		if endTime < warmup.NextWarmupTime {
 			endTick := self.pool.CurrentTick(endTime)
 			endRaw := self.pool.CalculateRawRewardForPosition(endTime, endTick, self.deposit.Deposit)
-			rewardAcc := u256.Zero().Sub(endRaw, startRaw)
+			rewardAcc, overflow := u256.Zero().SubOverflow(endRaw, startRaw)
+			if overflow {
+				panic(errOverflow)
+			}
 
-			rewardAcc = u256.Zero().Mul(rewardAcc, self.deposit.Liquidity())
+			rewardAcc, overflow = u256.Zero().MulOverflow(rewardAcc, self.deposit.Liquidity())
+			if overflow {
+				panic(errOverflow)
+			}
+
 			rewardAcc = u256.MulDiv(rewardAcc, u256.NewUintFromInt64(rewardPerSecond), q128)
 			self.rewards[i] = safeAddInt64(self.rewards[i], safeConvertToInt64(rewardAcc))
 
@@ -425,9 +432,16 @@ func (self *RewardState) rewardPerWarmup(startTime, endTime int64, rewardPerSeco
 
 		endTick := self.pool.CurrentTick(warmup.NextWarmupTime)
 		endRaw := self.pool.CalculateRawRewardForPosition(warmup.NextWarmupTime, endTick, self.deposit.Deposit)
-		rewardAcc := u256.Zero().Sub(endRaw, startRaw)
+		rewardAcc, overflow := u256.Zero().SubOverflow(endRaw, startRaw)
+		if overflow {
+			panic(errOverflow)
+		}
 
-		rewardAcc = u256.Zero().Mul(rewardAcc, self.deposit.Liquidity())
+		rewardAcc, overflow = u256.Zero().MulOverflow(rewardAcc, self.deposit.Liquidity())
+		if overflow {
+			panic(errOverflow)
+		}
+
 		rewardAcc = u256.MulDiv(rewardAcc, u256.NewUintFromInt64(rewardPerSecond), q128)
 		self.rewards[i] = safeAddInt64(self.rewards[i], safeConvertToInt64(rewardAcc))
 
@@ -460,9 +474,16 @@ func (self *RewardState) rewardPerWarmupX128(startTime, endTime int64, rewardPer
 		if endTime < warmup.NextWarmupTime {
 			endTick := self.pool.CurrentTick(endTime)
 			endRaw := self.pool.CalculateRawRewardForPosition(endTime, endTick, self.deposit.Deposit)
-			rewardAcc := u256.Zero().Sub(endRaw, startRaw)
+			rewardAcc, overflow := u256.Zero().SubOverflow(endRaw, startRaw)
+			if overflow {
+				panic(errOverflow)
+			}
 
-			rewardAcc = u256.Zero().Mul(rewardAcc, self.deposit.Liquidity())
+			rewardAcc, overflow = u256.Zero().MulOverflow(rewardAcc, self.deposit.Liquidity())
+			if overflow {
+				panic(errOverflow)
+			}
+
 			rewardAcc = u256.MulDiv(rewardAcc, rewardPerSecondX128, q128)
 			rewardAcc = u256.Zero().Rsh(rewardAcc, 128)
 			self.rewards[i] = safeAddInt64(self.rewards[i], safeConvertToInt64(rewardAcc))
@@ -472,9 +493,16 @@ func (self *RewardState) rewardPerWarmupX128(startTime, endTime int64, rewardPer
 
 		endTick := self.pool.CurrentTick(warmup.NextWarmupTime)
 		endRaw := self.pool.CalculateRawRewardForPosition(warmup.NextWarmupTime, endTick, self.deposit.Deposit)
-		rewardAcc := u256.Zero().Sub(endRaw, startRaw)
+		rewardAcc, overflow := u256.Zero().SubOverflow(endRaw, startRaw)
+		if overflow {
+			panic(errOverflow)
+		}
 
-		rewardAcc = u256.Zero().Mul(rewardAcc, self.deposit.Liquidity())
+		rewardAcc, overflow = u256.Zero().MulOverflow(rewardAcc, self.deposit.Liquidity())
+		if overflow {
+			panic(errOverflow)
+		}
+
 		rewardAcc = u256.MulDiv(rewardAcc, rewardPerSecondX128, q128)
 		rewardAcc = u256.Zero().Rsh(rewardAcc, 128)
 		self.rewards[i] = safeAddInt64(self.rewards[i], safeConvertToInt64(rewardAcc))

--- a/contract/r/scenario/staker/check_external_incentive_end_filetest.gno
+++ b/contract/r/scenario/staker/check_external_incentive_end_filetest.gno
@@ -284,9 +284,9 @@ func positionIdFrom(positionId int) grc721.TokenID {
 // [INFO] external incentive ended via refund path
 //
 // [SCENARIO] 7. User collects after end (should clean up incentive)
-// [INFO] position 1 collectable external incentive: 601458046 GNS
-// [INFO] position 2 collectable external incentive: 601343517 GNS
+// [INFO] position 1 collectable external incentive: 604281247 GNS
+// [INFO] position 2 collectable external incentive: 604166181 GNS
 //
 // [SCENARIO] 8. User collects external incentive
-// [INFO] position 1 collected 601458046 GNS after incentive end (incentive should be removed)
-// [INFO] position 2 collected 601343517 GNS after incentive end (incentive should be removed)
+// [INFO] position 1 collected 604281247 GNS after incentive end (incentive should be removed)
+// [INFO] position 2 collected 604166181 GNS after incentive end (incentive should be removed)

--- a/contract/r/scenario/staker/collect_after_incentive_ends_filetest.gno
+++ b/contract/r/scenario/staker/collect_after_incentive_ends_filetest.gno
@@ -275,13 +275,13 @@ func positionIdFrom(positionId int) grc721.TokenID {
 // [INFO] user staked position 1
 //
 // [SCENARIO] 5. Collect rewards during incentive period (day 45/90)
-// [INFO] collected 304127998 GNS during incentive period (day 45/90)
+// [INFO] collected 305555554 GNS during incentive period (day 45/90)
 //
 // [SCENARIO] 6. Skip time until incentive ends
 // [INFO] incentive has ended
 //
 // [SCENARIO] 7. Collect rewards after end (lazy removal should occur)
-// [INFO] collected 497663359 GNS after incentive end
+// [INFO] collected 499999356 GNS after incentive end
 // [INFO] lazy removal should have removed incentive ID from deposit
 //
 // [SCENARIO] 8. Verify second collection yields zero (incentive removed)

--- a/contract/r/scenario/staker/collect_external_incentive_penalty_filetest.gno
+++ b/contract/r/scenario/staker/collect_external_incentive_penalty_filetest.gno
@@ -317,33 +317,33 @@ func positionIdFrom(positionId int) grc721.TokenID {
 //
 // [SCENARIO] 5. Collect rewards (accumulates penalty)
 // [INFO] after CollectReward:
-//   - accumulatedPenaltyAmount: 1299542400
-//   - distributedRewardAmount: 1699401599
+//   - accumulatedPenaltyAmount: 1300000000
+//   - distributedRewardAmount: 1699999999
 // [EXPECTED] penalty accumulated during CollectReward
 //
 // [SCENARIO] 6. End external incentive
 // [INFO] external incentive ended
 //
 // [SCENARIO] 7. Collect penalty
-// [INFO] penalty before collection: 1299542400
-// [INFO] penalty collected: 1299542400
+// [INFO] penalty before collection: 1300000000
+// [INFO] penalty collected: 1300000000
 // [INFO] penalty remaining: 0
-// [INFO] creator QUX before: 3173785
-// [INFO] creator QUX after: 1302716185
-// [INFO] creator QUX increase: 1299542400
+// [INFO] creator QUX before: 5788
+// [INFO] creator QUX after: 1300005788
+// [INFO] creator QUX increase: 1300000000
 // [EXPECTED] penalty successfully collected to creator
 // [EXPECTED] accumulatedPenaltyAmount reset to 0
 // [EXPECTED] staker gns balance: 0
-// [EXPECTED] staker qux balance: 5997882216
+// [EXPECTED] staker qux balance: 5999994213
 //
 // [SCENARIO] 8. Collect reward after external incentive ends
 // [INFO] after CollectReward:
-//   - accumulatedPenaltyAmount: 449841600
-//   - distributedRewardAmount: 7250615998
+//   - accumulatedPenaltyAmount: 450000000
+//   - distributedRewardAmount: 7249999998
 // [EXPECTED] penalty accumulated during CollectReward
 //
 // [SCENARIO] 9. Verify new penalty accrues and can be collected again
-// [INFO] second collection returned: 449841600
+// [INFO] second collection returned: 450000000
 // [EXPECTED] new penalty accrued after later CollectReward is collected again
 // [EXPECTED] staker gns balance: 0
 // [EXPECTED] staker qux balance: 2

--- a/contract/r/scenario/staker/collect_external_incentive_penalty_with_multi_staking_filetest.gno
+++ b/contract/r/scenario/staker/collect_external_incentive_penalty_with_multi_staking_filetest.gno
@@ -326,45 +326,45 @@ func positionIdFrom(positionId uint64) grc721.TokenID {
 //
 // [SCENARIO] 5. Collect rewards (accumulates penalty)
 // [INFO] position 1 CollectReward:
-//   - accumulatedPenaltyAmount: 433181379
-//   - distributedRewardAmount: 566468547
-//   - qux collected: 566468547
+//   - accumulatedPenaltyAmount: 433333913
+//   - distributedRewardAmount: 566668015
+//   - qux collected: 566668015
 // [INFO] position 2 CollectReward:
-//   - accumulatedPenaltyAmount: 866362758
-//   - distributedRewardAmount: 1132937094
-//   - qux collected: 566468547
+//   - accumulatedPenaltyAmount: 866667826
+//   - distributedRewardAmount: 1133336030
+//   - qux collected: 566668015
 //
 // [SCENARIO] 6. End external incentive
 // [INFO] external incentive ended
 //
 // [SCENARIO] 7. Collect penalty
-// [INFO] penalty before collection: 866362758
-// [INFO] penalty collected: 866362758
+// [INFO] penalty before collection: 866667826
+// [INFO] penalty collected: 866667826
 // [INFO] penalty remaining: 0
-// [INFO] creator QUX before: 3173785
-// [INFO] creator QUX after: 869536543
-// [INFO] creator QUX increase: 866362758
+// [INFO] creator QUX before: 5788
+// [INFO] creator QUX after: 866673614
+// [INFO] creator QUX increase: 866667826
 // [EXPECTED] penalty successfully collected to creator
 // [EXPECTED] accumulatedPenaltyAmount reset to 0
 // [EXPECTED] staker gns balance: 0
-// [EXPECTED] staker qux balance: 6997526363
+// [EXPECTED] staker qux balance: 6999990356
 //
 // [SCENARIO] 8. Collect reward after external incentive ends
 // [INFO] position 1 CollectReward:
-//   - accumulatedPenaltyAmount: 149946622
-//   - distributedRewardAmount: 2985456399
-//   - qux collected: 1849345520
+//   - accumulatedPenaltyAmount: 149999421
+//   - distributedRewardAmount: 2983338537
+//   - qux collected: 1849996719
 // [INFO] position 2 CollectReward:
-//   - accumulatedPenaltyAmount: 299893244
-//   - distributedRewardAmount: 4834801919
-//   - qux collected: 1849345520
+//   - accumulatedPenaltyAmount: 299998842
+//   - distributedRewardAmount: 4833335256
+//   - qux collected: 1849996719
 // [INFO] position 3 CollectReward:
-//   - accumulatedPenaltyAmount: 883021244
-//   - distributedRewardAmount: 7250615987
-//   - qux collected: 2415814068
+//   - accumulatedPenaltyAmount: 883332176
+//   - distributedRewardAmount: 7249999990
+//   - qux collected: 2416664734
 //
 // [SCENARIO] 9. Verify new penalty accrues and can be collected again
-// [INFO] second collection returned: 883021244
+// [INFO] second collection returned: 883332176
 // [EXPECTED] new penalty accrued after later CollectReward is collected again
 // [EXPECTED] staker gns balance: 0
-// [EXPECTED] staker qux balance: 11
+// [EXPECTED] staker qux balance: 8

--- a/contract/r/scenario/staker/collect_zero_reward_skip_external_filetest.gno
+++ b/contract/r/scenario/staker/collect_zero_reward_skip_external_filetest.gno
@@ -366,5 +366,5 @@ func positionIdFrom(positionId int) grc721.TokenID {
 // [EXPECTED] first non-zero reward (1 bar) collected
 //
 // [SCENARIO] 14. Collect after 86,400 sec (1 day) → expect accumulated bar reward
-// [INFO] bar reward after 1 day: 6622
+// [INFO] bar reward after 1 day: 6653
 // [EXPECTED] accumulated reward collected successfully after 1 day

--- a/contract/r/scenario/staker/collect_zero_reward_skip_external_multi_filetest.gno
+++ b/contract/r/scenario/staker/collect_zero_reward_skip_external_multi_filetest.gno
@@ -374,5 +374,5 @@ func positionIdFrom(positionId int) grc721.TokenID {
 // [EXPECTED] both bar and qux collected (non-zero)
 //
 // [SCENARIO] 8. Collect after 86,400 sec (1 day) → expect bar=6,622, qux=66,532
-// [INFO] after 1 day → bar: 6622, qux: 66532
+// [INFO] after 1 day → bar: 6653, qux: 66533
 // [EXPECTED] both external rewards accumulated after 1 day

--- a/contract/r/scenario/staker/end_external_incentive_no_unstake_filetest.gno
+++ b/contract/r/scenario/staker/end_external_incentive_no_unstake_filetest.gno
@@ -283,7 +283,7 @@ func positionIdFrom(positionId int) grc721.TokenID {
 // [INFO] external incentive ended via refund path
 //
 // [SCENARIO] 7. User collects after end (should clean up incentive)
-// [INFO] collected 1202687037 GNS after incentive end (incentive should be removed)
+// [INFO] collected 1208332366 GNS after incentive end (incentive should be removed)
 //
 // [SCENARIO] 8. Second collect returns zero (incentive removed)
 // [VERIFY] second collect after end: 0 GNS

--- a/contract/r/scenario/staker/external_incentive_drain_filetest.gno
+++ b/contract/r/scenario/staker/external_incentive_drain_filetest.gno
@@ -310,10 +310,10 @@ func positionIdFrom(positionId int) grc721.TokenID {
 // [INFO] skip blocks until external incentive ends
 // [INFO] end external incentive FIRST TIME and collect remaining GNS
 // [INFO] FIRST END - Staker GNS balance before: 20000000000
-// [INFO] FIRST END - Staker GNS balance after: 18996826215
+// [INFO] FIRST END - Staker GNS balance after: 18999994212
 // [INFO] FIRST END - Creator GNS balance before: 0
-// [INFO] FIRST END - Creator GNS balance after: 1003173785
-// [INFO] FIRST END - Creator received: 1003173785 GNS
+// [INFO] FIRST END - Creator GNS balance after: 1000005788
+// [INFO] FIRST END - Creator received: 1000005788 GNS
 //
 // [SCENARIO] 8. FIX VERIFICATION: Verify EndExternalIncentive cannot be called multiple times
 // [FIX VERIFICATION] Attempting to call EndExternalIncentive multiple times
@@ -321,7 +321,7 @@ func positionIdFrom(positionId int) grc721.TokenID {
 //
 // [SCENARIO] 9. Final verification
 // [RESULT] Final balances after fix:
-//   - Staker GNS balance: 18996826215
-//   - Creator GNS balance: 1003173785
+//   - Staker GNS balance: 18999994212
+//   - Creator GNS balance: 1000005788
 // [VERIFIED] Staker was NOT drained - only one GNS deposit was refunded
 // [VERIFIED] The vulnerability has been successfully fixed

--- a/contract/r/scenario/staker/external_incentive_dust_refund_filetest.gno
+++ b/contract/r/scenario/staker/external_incentive_dust_refund_filetest.gno
@@ -7,10 +7,14 @@
 // 1. in-range position
 
 // SCENARIO:
-// This test demonstrates that the rewardDust mechanism correctly handles
-// precision loss from integer division when calculating rewardPerSecond.
-// The dust amount (remainder from division) is properly tracked and refunded
-// when the external incentive ends.
+// This test demonstrates that Q128-scaled rewardPerSecond drastically
+// reduces the dust (precision loss) that previously resulted from int64
+// integer division. With the legacy formula rewardAmount=10_000_000_007 /
+// duration=7_776_000 produced a dust of 64_007 BAR; under Q128 scaling
+// the residual dust is bounded by the number of collect() calls (~1 wei
+// per call), so the refund's dust component is orders of magnitude
+// smaller. The unallocated rewards portion (~6_424 BAR from unclaimable
+// periods) dominates the refund.
 
 package main
 
@@ -275,9 +279,9 @@ func endExternalIncentiveAndVerifyDustRefund() {
 	ufmt.Printf("[RESULT] bar tokens refunded: %d\n", barRefunded)
 	ufmt.Printf("[RESULT] gns tokens refunded: %d\n", gnsRefunded)
 
-	// The refund should include:
-	// 1. Unallocated rewards (rewards that weren't distributed)
-	// 2. The dust amount (64007 in this case based on 10000000007 % 7776000)
+	// The refund consists of:
+	// 1. Unallocated rewards from unclaimable periods (dominant component)
+	// 2. Residual dust from Q128 precision loss (~ #collect-calls wei)
 	// 3. The full GNS deposit (1_000_000_000)
 
 	// Verify GNS refund
@@ -285,23 +289,23 @@ func endExternalIncentiveAndVerifyDustRefund() {
 		panic(ufmt.Sprintf("Expected GNS refund of %d, but got %d", depositGnsAmount, gnsRefunded))
 	}
 
-	// Calculate expected dust
-	rewardAmount := int64(10000000007)
-	duration := int64(90 * 24 * 60 * 60)
-	expectedDust := rewardAmount - (rewardAmount/duration)*duration
-
-	// Verify that dust was included in the refund
-	// The refund should be at least the dust amount
-	if barRefunded < expectedDust {
-		panic(ufmt.Sprintf("Expected refund to include at least dust amount of %d, but got %d", expectedDust, barRefunded))
+	// Under the legacy int64 rps formula the dust would have been
+	// rewardAmount % duration = 64_007 BAR. Q128 scaling should
+	// collapse this by at least an order of magnitude.
+	legacyDust := int64(10000000007) % int64(90*24*60*60)
+	if barRefunded >= legacyDust {
+		panic(ufmt.Sprintf(
+			"Q128 scaling should reduce dust below the legacy bound (%d), but refund was %d",
+			legacyDust, barRefunded,
+		))
 	}
 
-	// Check if the refund amount makes sense (dust + unallocated rewards)
-	if barRefunded > 0 && barRefunded >= expectedDust {
-		ufmt.Printf("[SUCCESS] Dust refund mechanism verified - dust amount (%d) properly included in total refund (%d)!\n", expectedDust, barRefunded)
-	} else {
-		panic(ufmt.Sprintf("Unexpected refund amount: %d (expected dust: %d)", barRefunded, expectedDust))
+	if barRefunded <= 0 {
+		panic(ufmt.Sprintf("Refund should be positive (unclaimable rewards exist), got %d", barRefunded))
 	}
+
+	ufmt.Printf("[SUCCESS] Q128 scaling reduced dust: legacy bound=%d, actual refund=%d (%dx smaller)\n",
+		legacyDust, barRefunded, legacyDust/barRefunded)
 }
 
 func collectRewardStakedPosition() {
@@ -374,19 +378,19 @@ func positionIdFrom(tokenId uint64) grc721.TokenID {
 // [INFO] bar balance before ending: 100000000
 // [INFO] gns balance before ending: 0
 // [INFO] end external incentive
-// [INFO] bar balance after ending: 100070437
+// [INFO] bar balance after ending: 100006431
 // [INFO] gns balance after ending: 1000000000
-// [RESULT] bar tokens refunded: 70437
+// [RESULT] bar tokens refunded: 6431
 // [RESULT] gns tokens refunded: 1000000000
-// [SUCCESS] Dust refund mechanism verified - dust amount (64007) properly included in total refund (70437)!
+// [SUCCESS] Q128 scaling reduced dust: legacy bound=64007, actual refund=6431 (9x smaller)
 //
 // [SCENARIO] 8. Collect reward staked position
 // [INFO] collect reward staked position
-// [EXPECTED] bar reward: 7974942592
+// [EXPECTED] bar reward: 7974993637
 //
 // [SCENARIO] 9. Collect external incentive penalty
 // [INFO] collect external incentive penalty g1v4u8getjdeskcsmjv4shgmmjta047h6lua7mup:1234567905:1
-// [EXPECTED] bar penalty: 1944432000
-// [EXPECTED] staker bar balance: 3
+// [EXPECTED] bar penalty: 1944444446
+// [EXPECTED] staker bar balance: 2
 //
 // [SUCCESS] Test completed - rewardDust mechanism works correctly!

--- a/contract/r/scenario/staker/full_internal_external_filetest.gno
+++ b/contract/r/scenario/staker/full_internal_external_filetest.gno
@@ -537,7 +537,7 @@ func positionIdFrom(positionId any) grc721.TokenID {
 // [INFO] perform exact-in swaps
 // [EXPECTED] swap result - tokenIn: 500, tokenOut: -497
 // [INFO] check reward for position 01 after swap
-// [EXPECTED] position 01 reward after swap: 18729873
+// [EXPECTED] position 01 reward after swap: 18729875
 //
 // [SCENARIO] 10. Create bar:foo:100 pool (tier 3)
 // [INFO] create bar:foo:100 pool
@@ -553,7 +553,7 @@ func positionIdFrom(positionId any) grc721.TokenID {
 //
 // [SCENARIO] 12. Unstake token 01
 // [INFO] unstake token 01
-// [EXPECTED] reward from unstaking: 38798148
+// [EXPECTED] reward from unstaking: 38798151
 //
 // [SCENARIO] 13. Create pool with external incentive only
 // [INFO] create baz:qux:3000 pool (external only)

--- a/contract/r/scenario/staker/incentive_created_after_staking_filetest.gno
+++ b/contract/r/scenario/staker/incentive_created_after_staking_filetest.gno
@@ -384,17 +384,17 @@ func positionIdFrom(positionId int) grc721.TokenID {
 // [INFO] skipped 30 days
 //
 // [SCENARIO] 7. User1 collects rewards (lazy sync should discover incentive)
-// [INFO] user1 collected 188583553 GNS (lazy sync discovered incentive)
+// [INFO] user1 collected 188976625 GNS (lazy sync discovered incentive)
 //
 // [SCENARIO] 8. User2 collects rewards (lazy sync should discover incentive)
-// [INFO] user2 collected 188583297 GNS (lazy sync discovered incentive)
+// [INFO] user2 collected 188976368 GNS (lazy sync discovered incentive)
 //
 // [SCENARIO] 9. User3 collects rewards (already knows about incentive)
-// [INFO] user3 collected 188495998 GNS (already knew about incentive)
+// [INFO] user3 collected 188888887 GNS (already knew about incentive)
 //
 // [SCENARIO] 10. Skip to end and collect final rewards
 // [INFO] skipped to end of incentive
-// [INFO] user1 final rewards: 615448808 GNS
-// [INFO] user2 final rewards: 615448614 GNS
-// [INFO] user3 final rewards: 615383357 GNS
-// [VERIFIED] all users collected final rewards, total: 1846280779 GNS
+// [INFO] user1 final rewards: 616731609 GNS
+// [INFO] user2 final rewards: 616731416 GNS
+// [INFO] user3 final rewards: 616666022 GNS
+// [VERIFIED] all users collected final rewards, total: 1850129047 GNS

--- a/contract/r/scenario/staker/insufficient_external_reward_filetest.gno
+++ b/contract/r/scenario/staker/insufficient_external_reward_filetest.gno
@@ -348,29 +348,29 @@ func positionIdFrom(positionId any) grc721.TokenID {
 // [STEP 5] Drain incentive through multiple collections
 // [INFO] skip 50,000 blocks for EXTREME reward accumulation
 // [INFO] collect rewards from all 50 positions - this should drain most of the incentive
-// [INFO] position 1 collected: 192003 bar
-// [INFO] position 2 collected: 192003 bar
-// [INFO] position 3 collected: 192003 bar
-// [INFO] position 4 collected: 192003 bar
-// [INFO] position 5 collected: 192003 bar
+// [INFO] position 1 collected: 192904 bar
+// [INFO] position 2 collected: 192904 bar
+// [INFO] position 3 collected: 192904 bar
+// [INFO] position 4 collected: 192904 bar
+// [INFO] position 5 collected: 192904 bar
 // [INFO] ... collecting from positions 6-49 ...
-// [INFO] position 50 collected: 192003 bar
-// [INFO] total collected in first massive round: 9600150 bar
+// [INFO] position 50 collected: 192904 bar
+// [INFO] total collected in first massive round: 9645200 bar
 // [INFO] skip another 30,000 blocks and collect again to fully deplete
-// [INFO] second round collected: 5759950 bar
-// [INFO] TOTAL drained from incentive: 15360100 bar (should be close to 1 billion)
+// [INFO] second round collected: 5787000 bar
+// [INFO] TOTAL drained from incentive: 15432200 bar (should be close to 1 billion)
 // [WARNING] May not have fully depleted the incentive, but continuing...
 //
 // [STEP 6] Demonstrate bug: permanent reward loss after fund depletion
 // [INFO] skip 10,000 blocks - HUGE time gap for reward accumulation
 // [INFO] attempt to collect rewards when incentive should be depleted
 // [EXPECTED] InsufficientExternalReward events should be emitted for all positions
-// [RESULT] position 1 reward: 47618 bar
-// [RESULT] position 2 reward: 47618 bar
-// [RESULT] position 3 reward: 47618 bar
-// [RESULT] position 4 reward: 47618 bar
-// [RESULT] position 5 reward: 47618 bar
-// [RESULT] position 50 reward: 47618 bar
+// [RESULT] position 1 reward: 47841 bar
+// [RESULT] position 2 reward: 47841 bar
+// [RESULT] position 3 reward: 47841 bar
+// [RESULT] position 4 reward: 47841 bar
+// [RESULT] position 5 reward: 47841 bar
+// [RESULT] position 50 reward: 47841 bar
 //
 // [INFO] 0 positions received ZERO rewards due to depleted incentive
 // [INFO] Estimated total unclaimed rewards: 0 bar

--- a/contract/r/scenario/staker/more_02_single_position_for_each_warmup_tier_total_4_position_two_external_filetest.gno
+++ b/contract/r/scenario/staker/more_02_single_position_for_each_warmup_tier_total_4_position_two_external_filetest.gno
@@ -487,17 +487,17 @@ func positionIdFrom(positionId any) grc721.TokenID {
 // [SCENARIO] 5. Stake position 01 and test warm-up to 100%
 // [INFO] stake position 01
 // [INFO] collect reward for 30% warm-up
-// [EXPECTED] bar reward (30% warm-up): 17360
-// [EXPECTED] baz reward (30% warm-up): 172
+// [EXPECTED] bar reward (30% warm-up): 17361
+// [EXPECTED] baz reward (30% warm-up): 173
 // [INFO] progress to 50% warm-up
 // [EXPECTED] bar reward (50% warm-up): 28935
-// [EXPECTED] baz reward (50% warm-up): 287
+// [EXPECTED] baz reward (50% warm-up): 289
 // [INFO] progress to 70% warm-up
 // [EXPECTED] bar reward (70% warm-up): 40509
-// [EXPECTED] baz reward (70% warm-up): 402
+// [EXPECTED] baz reward (70% warm-up): 404
 // [INFO] progress to 100% warm-up
-// [EXPECTED] bar reward (100% warm-up): 57869
-// [EXPECTED] baz reward (100% warm-up): 574
+// [EXPECTED] bar reward (100% warm-up): 57870
+// [EXPECTED] baz reward (100% warm-up): 578
 //
 // [SCENARIO] 6. Stake positions 02-04 with different warm-up levels
 // [INFO] stake position 02 (will be 70% warm-up)
@@ -508,10 +508,10 @@ func positionIdFrom(positionId any) grc721.TokenID {
 // [SCENARIO] 7. Test single block reward distribution
 // [INFO] test reward distribution for single block
 // [EXPECTED] position 01 bar reward (100% warm-up): 14467
-// [EXPECTED] position 01 baz reward (100% warm-up): 143
+// [EXPECTED] position 01 baz reward (100% warm-up): 144
 // [EXPECTED] position 02 bar reward (70% warm-up): 10126
 // [EXPECTED] position 02 baz reward (70% warm-up): 100
 // [EXPECTED] position 03 bar reward (50% warm-up): 7233
-// [EXPECTED] position 03 baz reward (50% warm-up): 71
+// [EXPECTED] position 03 baz reward (50% warm-up): 72
 // [EXPECTED] position 04 bar reward (30% warm-up): 4340
-// [EXPECTED] position 04 baz reward (30% warm-up): 42
+// [EXPECTED] position 04 baz reward (30% warm-up): 43

--- a/contract/r/scenario/staker/partial_incentive_failure_filetest.gno
+++ b/contract/r/scenario/staker/partial_incentive_failure_filetest.gno
@@ -427,25 +427,25 @@ func positionIdFrom(positionId uint64) grc721.TokenID {
 // [INFO] Temporary position 21 created and staked
 // [INFO] Skip blocks and collect multiple rounds to drain incentives
 // [INFO] Collection round 1
-// [INFO] Round 1: Collected 5709458 bar from position 2
-// [INFO] Round 1: Collected 5709458 bar from position 3
-// [INFO] Round 1: Collected 5709458 bar from position 21
+// [INFO] Round 1: Collected 5709496 bar from position 2
+// [INFO] Round 1: Collected 5709496 bar from position 3
+// [INFO] Round 1: Collected 5709496 bar from position 21
 // [INFO] Collection round 2
-// [INFO] Round 2: Collected 8679627 bar from position 2
-// [INFO] Round 2: Collected 8679627 bar from position 3
-// [INFO] Round 2: Collected 8679627 bar from position 21
+// [INFO] Round 2: Collected 8679684 bar from position 2
+// [INFO] Round 2: Collected 8679684 bar from position 3
+// [INFO] Round 2: Collected 8679684 bar from position 21
 // [INFO] Collection round 3
-// [INFO] Round 3: Collected 9373998 bar from position 2
-// [INFO] Round 3: Collected 9373998 bar from position 3
-// [INFO] Round 3: Collected 9373998 bar from position 21
-// [SUCCESS] Total bar drained: 475261660 (should be close to 30000000000)
+// [INFO] Round 3: Collected 9374055 bar from position 2
+// [INFO] Round 3: Collected 9374055 bar from position 3
+// [INFO] Round 3: Collected 9374055 bar from position 21
+// [SUCCESS] Total bar drained: 475264700 (should be close to 30000000000)
 // [WARNING] May not have sufficiently drained bar incentive
 //
 // [STEP 6] Collect rewards - partial success expected
 // [INFO] Skip 5,000 more blocks to accumulate new rewards
 // [ACTION] Collect rewards from main position (ID=1)
-// [RESULT] bar reward collected: 19348260
-// [RESULT] baz reward collected: 19312691
+// [RESULT] bar reward collected: 19348384
+// [RESULT] baz reward collected: 19312814
 // [INFO] baz incentive provided rewards
 //
 // [STEP 7] Verify reward collection behavior after time passes

--- a/contract/r/scenario/staker/position_inrange_change_by_swap_external_filetest.gno
+++ b/contract/r/scenario/staker/position_inrange_change_by_swap_external_filetest.gno
@@ -447,7 +447,7 @@ func positionIdFrom(positionId any) grc721.TokenID {
 // [SCENARIO] 6. Collect external reward while in-range
 // [INFO] skip blocks to accumulate external rewards while in-range
 // [INFO] collect external reward while position is in-range
-// [EXPECTED] external reward while in-range: 190970
+// [EXPECTED] external reward while in-range: 190972
 // [INFO] confirmed: external rewards distributed while position is in-range
 //
 // [SCENARIO] 7. Perform swap to move price out of range

--- a/contract/r/scenario/staker/reward_for_user_collect_change_by_collecting_reward_external_filetest.gno
+++ b/contract/r/scenario/staker/reward_for_user_collect_change_by_collecting_reward_external_filetest.gno
@@ -385,7 +385,7 @@ func positionIdFrom(positionId any) grc721.TokenID {
 // [SCENARIO] 5. First external reward collection period
 // [INFO] skip 5 blocks for first external reward accumulation
 // [INFO] collect first external reward
-// [EXPECTED] first external reward (5 blocks): 104165
+// [EXPECTED] first external reward (5 blocks): 104166
 // [INFO] first external reward collection completed
 //
 // [SCENARIO] 6. Second external reward collection period
@@ -403,26 +403,26 @@ func positionIdFrom(positionId any) grc721.TokenID {
 // [SCENARIO] 8. Compare external reward accumulation patterns
 // [INFO] analyze external reward accumulation patterns
 // [INFO] test pattern: frequent small external collections
-// [INFO] small external collection 1 (2 blocks): 34721
+// [INFO] small external collection 1 (2 blocks): 34722
 // [INFO] small external collection 2 (2 blocks): 34722
 // [INFO] small external collection 3 (2 blocks): 34722
-// [INFO] small external collection 4 (2 blocks): 34721
+// [INFO] small external collection 4 (2 blocks): 34722
 // [INFO] small external collection 5 (2 blocks): 34722
-// [EXPECTED] total from frequent external collections (10 blocks): 173608
+// [EXPECTED] total from frequent external collections (10 blocks): 173610
 // [INFO] test pattern: single large external collection
-// [EXPECTED] single large external collection (10 blocks): 173609
+// [EXPECTED] single large external collection (10 blocks): 173610
 // [INFO] external reward pattern analysis:
-// [INFO] - Frequent external collections total: 173608
-// [INFO] - Single large external collection: 173609
-// [INFO] external reward amounts may vary due to incentive timing and block-based calculations
+// [INFO] - Frequent external collections total: 173610
+// [INFO] - Single large external collection: 173610
+// [INFO] external reward amounts are consistent regardless of collection frequency
 //
 // [SCENARIO] 9. Final verification with multiple external collections
 // [INFO] final verification with multiple rapid external collections
-// [INFO] initial BAR balance: 99910000710797
+// [INFO] initial BAR balance: 99910000710801
 // [INFO] perform 3 consecutive external collections
-// [EXPECTED] consecutive external collection 1: 260415
+// [EXPECTED] consecutive external collection 1: 260416
 // [EXPECTED] consecutive external collection 2: 0
 // [EXPECTED] consecutive external collection 3: 0
-// [EXPECTED] total BAR gained in this test: 260415
+// [EXPECTED] total BAR gained in this test: 260416
 // [INFO] external reward collection pattern scenario completed successfully
 // [INFO] confirmed: external rewards accumulate over time and are collected when requested

--- a/contract/r/scenario/staker/single_gns_external_ends_filetest.gno
+++ b/contract/r/scenario/staker/single_gns_external_ends_filetest.gno
@@ -361,9 +361,9 @@ func positionIdFrom(positionId int) grc721.TokenID {
 // [INFO] skip blocks until external incentive ends
 // [INFO] end external incentive and collect remaining QUX
 // [INFO] QUX balance before ending: 0
-// [INFO] QUX balance after ending: 3173785
-// [INFO] staker QUX before ending: 8999996530
-// [EXPECTED] creator receives remaining reward token: 3173785
+// [INFO] QUX balance after ending: 5788
+// [INFO] staker QUX before ending: 8999996529
+// [EXPECTED] creator receives remaining reward token: 5788
 // [EXPECTED] creator receives fixed GNS deposit: 1000000000
 //
 // [SCENARIO] 11. Verify no rewards after external incentive ends

--- a/contract/r/scenario/staker/staked_liquidity_change_by_staking_unstaking_external_filetest.gno
+++ b/contract/r/scenario/staker/staked_liquidity_change_by_staking_unstaking_external_filetest.gno
@@ -368,6 +368,6 @@ func positionIdFrom(positionId any) grc721.TokenID {
 //
 // [SCENARIO] 8. Collect external rewards after unstaking
 // [INFO] collect external reward for position 01 after position 02 unstaked
-// [EXPECTED] position 01 external reward after unstaking pos 02: 17360
-// [WARNING] expected around 1000000000, got 17360
+// [EXPECTED] position 01 external reward after unstaking pos 02: 17361
+// [WARNING] expected around 1000000000, got 17361
 // [INFO] position 01 now receives full external rewards since position 02 is unstaked

--- a/contract/r/scenario/staker/staker_collect_reward_vulnerability_filetest.gno
+++ b/contract/r/scenario/staker/staker_collect_reward_vulnerability_filetest.gno
@@ -378,21 +378,21 @@ func positionIdFrom(positionId any) grc721.TokenID {
 // [EXPLOIT] victim calls CollectReward with unwrap=true
 // [EXPLOIT] Collected from pool: 0
 // [EXPLOIT] GNS amount: 0
-// [EXPLOIT] External reward - token: gno.land/r/gnoland/wugnot, amount: 635605
-// [EXPLOIT] External reward - token: gno.land/r/onbloc/bar, amount: 126528
+// [EXPLOIT] External reward - token: gno.land/r/gnoland/wugnot, amount: 635609
+// [EXPLOIT] External reward - token: gno.land/r/onbloc/bar, amount: 127121
 // [DANGER] CollectReward succeeded - VULNERABILITY CONFIRMED
 //
 // [SCENARIO] 8. Show balances after exploit
 // [INFO] === BALANCES AFTER EXPLOIT ===
-// [INFO] staker WUGNOT: 4999364395
+// [INFO] staker WUGNOT: 4999364391
 // [INFO] community pool WUGNOT: 0
-// [INFO] victim WUGNOT: 635605
+// [INFO] victim WUGNOT: 635609
 // [INFO] victim UGNOT: 10000000000
-// [INFO] victim BAR tokens: 1026528
+// [INFO] victim BAR tokens: 1027121
 //
-// [EXPECTED] Staker WUGNOT decreased by only reward: 635605
-// [EXPECTED] Victim WUGNOT increased by: 635605
-// [EXPECTED] Victim BAR tokens increased by: 126528
+// [EXPECTED] Staker WUGNOT decreased by only reward: 635609
+// [EXPECTED] Victim WUGNOT increased by: 635609
+// [EXPECTED] Victim BAR tokens increased by: 127121
 // [EXPECTED] community pool WUGNOT remains 0 during collect: 0
 //
 // [SECURE] Vulnerability prevented!

--- a/contract/r/scenario/staker/staker_external_incentive_end_unstake_filetest.gno
+++ b/contract/r/scenario/staker/staker_external_incentive_end_unstake_filetest.gno
@@ -335,13 +335,13 @@ func positionIdFrom(positionId uint64) grc721.TokenID {
 // [EXPECTED] minted and staked positions: 1 and 2
 //
 // [SCENARIO] 5. Verify rewards accumulate with external incentive
-// [EXPECTED] external rewards accumulated: 447038022 BAR tokens
+// [EXPECTED] external rewards accumulated: 447040883 BAR tokens
 //
 // [SCENARIO] 6. Wait for external incentive to expire
 // [EXPECTED] waited for external incentive to expire
 //
 // [SCENARIO] 7. Verify pool has no incentives
-// [INFO] rewards after incentive end - BAR: 24513533, GNS: 0 (should be minimal)
+// [INFO] rewards after incentive end - BAR: 24513690, GNS: 0 (should be minimal)
 // [EXPECTED] pool has no tier and external incentive ended
 //
 // [SCENARIO] 8. Unstake positions after incentive ended

--- a/contract/r/scenario/staker/staker_external_native_coin_filetest.gno
+++ b/contract/r/scenario/staker/staker_external_native_coin_filetest.gno
@@ -327,19 +327,19 @@ func positionIdFrom(positionId any) grc721.TokenID {
 // [INFO] skip blocks to accumulate rewards
 // [INFO] check balances before collecting with unwrap
 // [INFO] ugnot balance before: 100000000000000
-// [INFO] wugnot balance before: 108288
+// [INFO] wugnot balance before: 108796
 // [INFO] collect reward with unwrap=true
 // [EXPECTED] ugnot balance after: 100000000000000
-// [EXPECTED] wugnot balance after: 108479
+// [EXPECTED] wugnot balance after: 108988
 // [EXPECTED] ugnot change (should be 0): 0
-// [EXPECTED] wugnot increase (unwrap now transfers wugnot): 191
+// [EXPECTED] wugnot increase (unwrap now transfers wugnot): 192
 //
 // [SCENARIO] 7. Collect external reward without unwrap
 // [INFO] check balances before collecting without unwrap
 // [INFO] ugnot balance before: 100000000000000
-// [INFO] wugnot balance before: 108479
+// [INFO] wugnot balance before: 108988
 // [INFO] collect reward with unwrap=false
 // [EXPECTED] ugnot balance after: 100000000000000
-// [EXPECTED] wugnot balance after: 108671
+// [EXPECTED] wugnot balance after: 109180
 // [EXPECTED] ugnot change (should be 0): 0
 // [EXPECTED] wugnot increase (wrapped): 192

--- a/contract/r/scenario/staker/staker_native_create_collect_unstake_filetest.gno
+++ b/contract/r/scenario/staker/staker_native_create_collect_unstake_filetest.gno
@@ -581,40 +581,40 @@ func positionIdFrom(positionId any) grc721.TokenID {
 // [INFO] wugnot balance before collect: 49999005
 // [INFO] ugnot balance before collect: 20050001005
 // [INFO] collect reward for token 01 (no unwrap)
-// [EXPECTED] wugnot balance after collect: 52217355
+// [EXPECTED] wugnot balance after collect: 52217369
 // [EXPECTED] ugnot balance after collect: 20050001005
-// [EXPECTED] wugnot increase: 2218350
+// [EXPECTED] wugnot increase: 2218364
 // [EXPECTED] ugnot change: 0
 //
 // [SCENARIO] 9. Unstake token 02
 // [INFO] skip more blocks
-// [INFO] wugnot balance before unstake: 52217355
+// [INFO] wugnot balance before unstake: 52217369
 // [INFO] ugnot balance before unstake: 20050001005
 // [INFO] unstake token 02 (no unwrap)
 // [EXPECTED] NFT owner after unstaking: g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5
-// [EXPECTED] wugnot balance after unstake: 55515944
+// [EXPECTED] wugnot balance after unstake: 55515980
 // [EXPECTED] ugnot balance after unstake: 20050001005
-// [EXPECTED] wugnot increase from unstake: 3298589
+// [EXPECTED] wugnot increase from unstake: 3298611
 // [EXPECTED] ugnot change from unstake: 0
 //
 // [SCENARIO] 10. End external incentive
 // [INFO] approve wugnot for unwrapping
-// [INFO] wugnot balance before end: 55515944
+// [INFO] wugnot balance before end: 55515980
 // [INFO] ugnot balance before end: 20050001005
 // [INFO] skip to end of external incentive
 // [INFO] end external incentive
-// [EXPECTED] wugnot balance after end: 55579944
+// [EXPECTED] wugnot balance after end: 55515981
 // [EXPECTED] ugnot balance after end: 20050001005
-// [EXPECTED] wugnot change: 64000
+// [EXPECTED] wugnot change: 1
 // [EXPECTED] ugnot refund: 0
 //
 // [SCENARIO] 11. Unstake token 01 after external incentive
 // [INFO] skip more blocks
-// [INFO] wugnot balance before unstake: 55579944
+// [INFO] wugnot balance before unstake: 55515981
 // [INFO] ugnot balance before unstake: 20050001005
 // [INFO] unstake token 01 (no unwrap)
 // [EXPECTED] NFT owner after unstaking: g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5
-// [EXPECTED] wugnot balance after unstake: 10049999003
+// [EXPECTED] wugnot balance after unstake: 10049999005
 // [EXPECTED] ugnot balance after unstake: 20050001005
-// [EXPECTED] wugnot increase from unstake: 9994419059
+// [EXPECTED] wugnot increase from unstake: 9994483024
 // [EXPECTED] ugnot change from unstake: 0

--- a/contract/r/scenario/staker/staker_native_create_collect_unstake_with_finish_filetest.gno
+++ b/contract/r/scenario/staker/staker_native_create_collect_unstake_with_finish_filetest.gno
@@ -549,40 +549,40 @@ func positionIdFrom(positionId any) grc721.TokenID {
 // [INFO] wugnot balance before collect: 49999005
 // [INFO] ugnot balance before collect: 20050001005
 // [INFO] collect reward for token 01 (no unwrap)
-// [EXPECTED] wugnot balance after collect: 52217355
+// [EXPECTED] wugnot balance after collect: 52217369
 // [EXPECTED] ugnot balance after collect: 20050001005
-// [EXPECTED] wugnot increase: 2218350
+// [EXPECTED] wugnot increase: 2218364
 // [EXPECTED] ugnot change: 0
 //
 // [SCENARIO] 9. Unstake token 01
 // [INFO] skip more blocks
-// [INFO] wugnot balance before unstake: 52217355
+// [INFO] wugnot balance before unstake: 52217369
 // [INFO] ugnot balance before unstake: 20050001005
 // [INFO] unstake token (no unwrap)
 // [EXPECTED] NFT owner after unstaking: g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5
-// [EXPECTED] wugnot balance after unstake: 53297594
+// [EXPECTED] wugnot balance after unstake: 53297615
 // [EXPECTED] ugnot balance after unstake: 20050001005
-// [EXPECTED] wugnot increase from unstake: 1080239
+// [EXPECTED] wugnot increase from unstake: 1080246
 // [EXPECTED] ugnot change from unstake: 0
 //
 // [SCENARIO] 10. Unstake token 02
 // [INFO] skip more blocks
-// [INFO] wugnot balance before unstake: 53297594
+// [INFO] wugnot balance before unstake: 53297615
 // [INFO] ugnot balance before unstake: 20050001005
 // [INFO] unstake token (no unwrap)
 // [EXPECTED] NFT owner after unstaking: g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5
-// [EXPECTED] wugnot balance after unstake: 58756663
+// [EXPECTED] wugnot balance after unstake: 58756719
 // [EXPECTED] ugnot balance after unstake: 20050001005
-// [EXPECTED] wugnot increase from unstake: 5459069
+// [EXPECTED] wugnot increase from unstake: 5459104
 // [EXPECTED] ugnot change from unstake: 0
 //
 // [SCENARIO] 11. End external incentive
 // [INFO] approve wugnot for unwrapping
-// [INFO] wugnot balance before end: 58756663
+// [INFO] wugnot balance before end: 58756719
 // [INFO] ugnot balance before end: 20050001005
 // [INFO] skip to end of external incentive
 // [INFO] end external incentive
 // [EXPECTED] wugnot balance after end: 10049999003
 // [EXPECTED] ugnot balance after end: 20050001005
-// [EXPECTED] wugnot change: 9991242340
+// [EXPECTED] wugnot change: 9991242284
 // [EXPECTED] ugnot refund: 0

--- a/contract/r/scenario/staker/staker_short_warmup_period_external_10_filetest.gno
+++ b/contract/r/scenario/staker/staker_short_warmup_period_external_10_filetest.gno
@@ -371,7 +371,7 @@ func positionIdFrom(positionId any) grc721.TokenID {
 // [SCENARIO] 8. Collect rewards after duration
 // [INFO] skip duration 200 blocks
 // [INFO] collect reward for position 01
-// [EXPECTED] collected reward: 4413955 BAR tokens
+// [EXPECTED] collected reward: 4415509 BAR tokens
 //
 // [SCENARIO] 9. Mint and stake position 02
 // [INFO] approve tokens for minting position 02
@@ -384,7 +384,7 @@ func positionIdFrom(positionId any) grc721.TokenID {
 // [INFO] clear previous rewards
 // [INFO] skip 10 blocks to accumulate rewards
 // [INFO] collect reward for position 01
-// [EXPECTED] position 01 reward (70% warm-up): 28924
+// [EXPECTED] position 01 reward (70% warm-up): 28935
 // [INFO] collect reward for position 02
-// [EXPECTED] position 02 reward (30% warm-up): 8677
+// [EXPECTED] position 02 reward (30% warm-up): 8680
 // [INFO] external incentive warm-up period test completed successfully

--- a/contract/r/scenario/staker/staker_short_warmup_period_external_12_filetest.gno
+++ b/contract/r/scenario/staker/staker_short_warmup_period_external_12_filetest.gno
@@ -334,7 +334,7 @@ func milliToSec(ms int64) int64 {
 //
 // [SCENARIO] 8. Collect rewards for both tokens
 // [INFO] collect reward for position 01
-// [EXPECTED] BAR reward collected: 981739
-// [EXPECTED] QUX reward collected: 981739
+// [EXPECTED] BAR reward collected: 982510
+// [EXPECTED] QUX reward collected: 982510
 // [INFO] two external incentive test completed successfully
 // [INFO] confirmed: both BAR and QUX rewards were distributed

--- a/contract/r/scenario/staker/staker_short_warmup_period_external_13_gns_external_filetest.gno
+++ b/contract/r/scenario/staker/staker_short_warmup_period_external_13_gns_external_filetest.gno
@@ -320,7 +320,7 @@ func positionIdFrom(positionId any) grc721.TokenID {
 //
 // [SCENARIO] 8. Collect rewards for BAR and GNS
 // [INFO] collect reward for position 01
-// [EXPECTED] BAR reward collected: 981739
-// [EXPECTED] GNS reward collected: 981739
+// [EXPECTED] BAR reward collected: 982510
+// [EXPECTED] GNS reward collected: 982510
 // [INFO] BAR + GNS external incentive test completed successfully
 // [INFO] confirmed: both BAR and GNS external rewards were distributed correctly

--- a/contract/r/scenario/staker/staker_short_warmup_period_external_14_position_in_out_range_changed_by_swap_filetest.gno
+++ b/contract/r/scenario/staker/staker_short_warmup_period_external_14_position_in_out_range_changed_by_swap_filetest.gno
@@ -374,12 +374,12 @@ func positionIdFrom(positionId any) grc721.TokenID {
 // [SCENARIO] 8. Check rewards after 50 blocks
 // [INFO] making external incentive active
 // [INFO] checking rewards after 50 blocks
-// [EXPECTED] position 01 reward: 6360 BAR
-// [EXPECTED] position 02 reward: 3256379 BAR
+// [EXPECTED] position 01 reward: 6362 BAR
+// [EXPECTED] position 02 reward: 3257526 BAR
 //
 // [SCENARIO] 9. Make position 01 out of range via swap
 // [EXPECTED] position 01 made out of range by swap, current tick: -195
 //
 // [SCENARIO] 10. Check rewards after position goes out of range
 // [EXPECTED] position 01 (out of range) reward: 0 BAR
-// [EXPECTED] position 02 (in range) reward: 5784 BAR
+// [EXPECTED] position 02 (in range) reward: 5787 BAR

--- a/contract/r/scenario/staker/staker_short_warmup_period_external_16_180d_filetest.gno
+++ b/contract/r/scenario/staker/staker_short_warmup_period_external_16_180d_filetest.gno
@@ -307,7 +307,7 @@ func positionIdFrom(positionId any) grc721.TokenID {
 // [INFO] collecting reward for position 01
 // [EXPECTED] position 01 reward: 4382643 QUX
 // [INFO] collecting reward for position 02
-// [EXPECTED] position 02 reward: 27125450 QUX
+// [EXPECTED] position 02 reward: 27125451 QUX
 // [INFO] collecting reward for position 03
 // [EXPECTED] position 03 reward: 639872 QUX
 // [INFO] collecting reward for position 04

--- a/contract/r/scenario/staker/staker_short_warmup_period_external_17_365d_filetest.gno
+++ b/contract/r/scenario/staker/staker_short_warmup_period_external_17_365d_filetest.gno
@@ -304,7 +304,7 @@ func positionIdFrom(positionId any) grc721.TokenID {
 // [INFO] collecting reward for position 01
 // [EXPECTED] position 01 reward: 2139690 QUX
 // [INFO] collecting reward for position 02
-// [EXPECTED] position 02 reward: 13243164 QUX
+// [EXPECTED] position 02 reward: 13243165 QUX
 // [INFO] collecting reward for position 03
 // [EXPECTED] position 03 reward: 312398 QUX
 // [INFO] collecting reward for position 04

--- a/contract/r/scenario/staker/staker_short_warmup_period_internal_gns_and_external_gns_90_filetest.gno
+++ b/contract/r/scenario/staker/staker_short_warmup_period_internal_gns_and_external_gns_90_filetest.gno
@@ -275,5 +275,5 @@ func positionIdFrom(positionId any) grc721.TokenID {
 // [EXPECTED] incentives are now active, initial rewards cleared
 //
 // [SCENARIO] 8. Collect reward for single block
-// [EXPECTED] BAR reward: 1284
-// [EXPECTED] GNS reward (internal + external): 13380778
+// [EXPECTED] BAR reward: 1286
+// [EXPECTED] GNS reward (internal + external): 13380779

--- a/contract/r/scenario/upgrade/implements/mock/staker/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/mock/staker/test_impl.gno
@@ -468,14 +468,14 @@ func (t *TestStaker) GetIncentiveRewardAmountAsString(poolPath string, incentive
 	).(string)
 }
 
-func (t *TestStaker) GetIncentiveRewardPerSecond(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveRewardPerSecond(poolPath string, incentiveId string) *u256.Uint {
 	return t.ExecuteFn(
 		"GetIncentiveRewardPerSecond",
 		func(args ...any) any {
 			return t.instance.GetIncentiveRewardPerSecond(args[0].(string), args[1].(string))
 		},
 		poolPath, incentiveId,
-	).(int64)
+	).(*u256.Uint)
 }
 
 func (t *TestStaker) GetIncentiveRewardToken(poolPath string, incentiveId string) string {

--- a/contract/r/scenario/upgrade/implements/mock/staker/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/mock/staker/test_impl.gno
@@ -468,11 +468,11 @@ func (t *TestStaker) GetIncentiveRewardAmountAsString(poolPath string, incentive
 	).(string)
 }
 
-func (t *TestStaker) GetIncentiveRewardPerSecond(poolPath string, incentiveId string) *u256.Uint {
+func (t *TestStaker) GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) *u256.Uint {
 	return t.ExecuteFn(
-		"GetIncentiveRewardPerSecond",
+		"GetIncentiveRewardPerSecondX128",
 		func(args ...any) any {
-			return t.instance.GetIncentiveRewardPerSecond(args[0].(string), args[1].(string))
+			return t.instance.GetIncentiveRewardPerSecondX128(args[0].(string), args[1].(string))
 		},
 		poolPath, incentiveId,
 	).(*u256.Uint)

--- a/contract/r/scenario/upgrade/implements/security/insecure_staker_callback/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/security/insecure_staker_callback/test_impl.gno
@@ -387,7 +387,7 @@ func (t *TestStaker) GetIncentiveRewardAmountAsString(poolPath string, incentive
 	return t.instance.GetIncentiveRewardAmountAsString(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardPerSecond(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveRewardPerSecond(poolPath string, incentiveId string) *u256.Uint {
 	if !t.isActive("GetIncentiveRewardPerSecond") {
 		panic("test implementation: GetIncentiveRewardPerSecond not supported")
 	}

--- a/contract/r/scenario/upgrade/implements/security/insecure_staker_callback/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/security/insecure_staker_callback/test_impl.gno
@@ -387,11 +387,11 @@ func (t *TestStaker) GetIncentiveRewardAmountAsString(poolPath string, incentive
 	return t.instance.GetIncentiveRewardAmountAsString(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardPerSecond(poolPath string, incentiveId string) *u256.Uint {
-	if !t.isActive("GetIncentiveRewardPerSecond") {
-		panic("test implementation: GetIncentiveRewardPerSecond not supported")
+func (t *TestStaker) GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) *u256.Uint {
+	if !t.isActive("GetIncentiveRewardPerSecondX128") {
+		panic("test implementation: GetIncentiveRewardPerSecondX128 not supported")
 	}
-	return t.instance.GetIncentiveRewardPerSecond(poolPath, incentiveId)
+	return t.instance.GetIncentiveRewardPerSecondX128(poolPath, incentiveId)
 }
 
 func (t *TestStaker) GetIncentiveRewardToken(poolPath string, incentiveId string) string {

--- a/contract/r/scenario/upgrade/implements/v2_invalid/staker/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v2_invalid/staker/test_impl.gno
@@ -382,7 +382,7 @@ func (t *TestStaker) GetIncentiveRewardAmountAsString(poolPath string, incentive
 	return t.instance.GetIncentiveRewardAmountAsString(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardPerSecond(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveRewardPerSecond(poolPath string, incentiveId string) *u256.Uint {
 	if !t.isActive("GetIncentiveRewardPerSecond") {
 		panic("test implementation: GetIncentiveRewardPerSecond not supported")
 	}

--- a/contract/r/scenario/upgrade/implements/v2_invalid/staker/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v2_invalid/staker/test_impl.gno
@@ -382,11 +382,11 @@ func (t *TestStaker) GetIncentiveRewardAmountAsString(poolPath string, incentive
 	return t.instance.GetIncentiveRewardAmountAsString(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardPerSecond(poolPath string, incentiveId string) *u256.Uint {
-	if !t.isActive("GetIncentiveRewardPerSecond") {
-		panic("test implementation: GetIncentiveRewardPerSecond not supported")
+func (t *TestStaker) GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) *u256.Uint {
+	if !t.isActive("GetIncentiveRewardPerSecondX128") {
+		panic("test implementation: GetIncentiveRewardPerSecondX128 not supported")
 	}
-	return t.instance.GetIncentiveRewardPerSecond(poolPath, incentiveId)
+	return t.instance.GetIncentiveRewardPerSecondX128(poolPath, incentiveId)
 }
 
 func (t *TestStaker) GetIncentiveRewardToken(poolPath string, incentiveId string) string {

--- a/contract/r/scenario/upgrade/implements/v3_valid/staker/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/staker/test_impl.gno
@@ -222,8 +222,8 @@ func (t *TestStaker) GetIncentiveRewardAmountAsString(poolPath string, incentive
 	return t.instance.GetIncentiveRewardAmountAsString(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardPerSecond(poolPath string, incentiveId string) *u256.Uint {
-	return t.instance.GetIncentiveRewardPerSecond(poolPath, incentiveId)
+func (t *TestStaker) GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) *u256.Uint {
+	return t.instance.GetIncentiveRewardPerSecondX128(poolPath, incentiveId)
 }
 
 func (t *TestStaker) GetIncentiveRewardToken(poolPath string, incentiveId string) string {

--- a/contract/r/scenario/upgrade/implements/v3_valid/staker/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/staker/test_impl.gno
@@ -222,7 +222,7 @@ func (t *TestStaker) GetIncentiveRewardAmountAsString(poolPath string, incentive
 	return t.instance.GetIncentiveRewardAmountAsString(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardPerSecond(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveRewardPerSecond(poolPath string, incentiveId string) *u256.Uint {
 	return t.instance.GetIncentiveRewardPerSecond(poolPath, incentiveId)
 }
 


### PR DESCRIPTION
## Summary

External incentive `rewardPerSecond` previously suffered substantial precision loss from int64 integer division: `rewardAmount / duration` discarded the remainder, locking the dust in the contract. For small `rewardAmount` relative to `duration` the loss could approach 100% of the deposit. This PR scales `rewardPerSecond` by 2^128 so that sub-integer rates survive across the lifetime of an incentive.

- Store reward per second as a Q128 fixed-point `*u256.Uint` (`rewardPerSecondX128 = (rewardAmount << 128) / duration`)
- External incentive reward calculation now multiplies by the Q128 rate and floors back with `>> 128` per `MulDiv` (one floor per collect call, ≤ 1 wei loss each)
- Internal reward path is **unchanged** — still uses the int64 `rewardPerSecond` directly, no Q128 conversion
- `endExternalIncentive` refund formula updated to derive `distributable` from the Q128 rate
- Quantitative impact on the dust-refund scenario (`rewardAmount=10_000_000_007`, `duration=7_776_000 s`):
  | Quantity | Before (int64 rps) | After (Q128) |
  |---|---|---|
  | Refund (residual dust) | 70,437 wei | **6,431 wei** (≈11× smaller) |
  | Distributed to stakers | 7,974,942,592 | 7,974,993,637 (+51,045) |
  | Staker contract leftover | 3 wei | **2 wei** |

## Breaking changes

- `IStakerGetter.GetIncentiveRewardPerSecond` return type changed from `int64` to `*u256.Uint`. The returned value is now Q128-scaled — divide by `2^128` to recover the legacy integer rate. External consumers (indexers / dApps) must update.

## Implementation notes

- New helper `rewardPerWarmupX128(startTime, endTime, rps_x128)` in `reward_calculation_pool.gno` is used only by `updateExternalReward`. The original `rewardPerWarmup(startTime, endTime, rps int64)` is preserved as-is for the internal reward path to avoid expanding the overflow surface on every swap-hook reward calculation.
- `ExternalIncentive` struct field renamed `rewardPerSecond int64` → `rewardPerSecondX128 *u256.Uint`. A legacy `RewardPerSecond() int64` getter is kept on the struct, returning the floor of the Q128 value for observability only — internal callers must use `RewardPerSecondX128()`.
- `NewExternalIncentive` now computes the Q128 rate via `u256.MulDiv(rewardAmount, 2^128, duration)`; callers no longer need to call `SetRewardPerSecond` after construction (removed in tests and the canonical-env helper).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Incentive reward math now uses higher-precision 128-bit fixed-point arithmetic for more accurate per-second rates and reward accruals
  * External and internal reward paths aligned to preserve precision across creation, distribution, and warmup segments
* **Tests**
  * Added tests validating precise external-incentive refund and reward calculations using the new fixed-point representation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoswap-labs/gnoswap/pull/1291?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->