### PR TITLE
refactor(r/access): migrate to interrealm v2

### DIFF
--- a/contract/r/gnoswap/access/access.gno
+++ b/contract/r/gnoswap/access/access.gno
@@ -2,7 +2,6 @@ package access
 
 import (
     "chain"
-	"chain/runtime"
 	"strings"
 
 	ufmt "gno.land/p/nt/ufmt/v0"
@@ -24,8 +23,8 @@ func init() {
 //
 // Only callable by RBAC contract.
 func SetRoleAddress(cur realm, roleName string, roleAddress address) {
-	caller := runtime.PreviousRealm().Address()
-	assertIsRBAC(caller)
+	prev := cur.Previous()
+	assertIsRBAC(prev.Address())
 
 	// capture old value for event
 	oldAddr, _ := roleAddresses[strings.TrimSpace(roleName)]
@@ -36,7 +35,7 @@ func SetRoleAddress(cur realm, roleName string, roleAddress address) {
 
 	chain.Emit(
 	    "SetRoleAddress",
-		"prevAddr", caller.String(),
+		"prevAddr", prev.Address().String(),
 		"role", roleName,
 		"prevRoleAddr", oldAddr.String(),
 		"roleAddress", roleAddress.String(),
@@ -67,8 +66,8 @@ func setRoleAddress(roleName string, roleAddress address) error {
 //
 // Only callable by RBAC contract.
 func RemoveRole(cur realm, roleName string) {
-	caller := runtime.PreviousRealm().Address()
-	assertIsRBAC(caller)
+	prev := cur.Previous()
+	assertIsRBAC(prev.Address())
 
 	// Validate role name
 	roleName = strings.TrimSpace(roleName)
@@ -84,7 +83,7 @@ func RemoveRole(cur realm, roleName string) {
 
 	chain.Emit(
 		"RemoveRole",
-		"prevAddr", caller.String(),
+		"prevAddr", prev.Address().String(),
 		"role", roleName,
 	)
 }

--- a/contract/r/gnoswap/access/access_test.gno
+++ b/contract/r/gnoswap/access/access_test.gno
@@ -73,7 +73,7 @@ func TestGetAddress(cur realm, t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			roleAddresses = make(map[string]address)
 
 			// Setup
@@ -145,7 +145,7 @@ func TestGetRoleAddresses(cur realm, t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Setup
 			roleAddresses = make(map[string]address)
 			for role, addrs := range tt.setupRoles {
@@ -246,7 +246,7 @@ func TestIsAuthorized(cur realm, t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Reset state at start of each test case
 			roleAddresses = make(map[string]address)
 
@@ -583,7 +583,7 @@ func TestAccess_MustGetAddress(cur realm, t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Setup
 			roleAddresses = make(map[string]address)
 			if tt.setupRole != "" {

--- a/contract/r/gnoswap/access/access_test.gno
+++ b/contract/r/gnoswap/access/access_test.gno
@@ -8,7 +8,7 @@ import (
 	ufmt "gno.land/p/nt/ufmt/v0"
 )
 
-func TestGetAddress(t *testing.T) {
+func TestGetAddress(cur realm, t *testing.T) {
 	// Setup test data
 	testAddr := testutils.TestAddress("test")
 	testRole := "test_role"
@@ -100,7 +100,7 @@ func TestGetAddress(t *testing.T) {
 	}
 }
 
-func TestGetRoleAddresses(t *testing.T) {
+func TestGetRoleAddresses(cur realm, t *testing.T) {
 	// Save original state
 	originalRoles := make(map[string]address)
 	for k, v := range roleAddresses {
@@ -181,7 +181,7 @@ func TestGetRoleAddresses(t *testing.T) {
 	}
 }
 
-func TestIsAuthorized(t *testing.T) {
+func TestIsAuthorized(cur realm, t *testing.T) {
 	testAddr := testutils.TestAddress("test")
 	otherAddr := testutils.TestAddress("other")
 	testRole := "test_role"
@@ -262,7 +262,7 @@ func TestIsAuthorized(t *testing.T) {
 	}
 }
 
-func TestSetRoleAddress(t *testing.T) {
+func TestSetRoleAddress(cur realm, t *testing.T) {
 	// Save original state
 	originalRoles := make(map[string]address)
 	for k, v := range roleAddresses {
@@ -377,7 +377,7 @@ func TestSetRoleAddress(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Setup initial roles
 			roleAddresses = make(map[string]address)
 			for k, v := range tt.setupRoles {
@@ -392,11 +392,11 @@ func TestSetRoleAddress(t *testing.T) {
 			}
 
 			if tt.shouldAbort {
-				uassert.AbortsContains(t, tt.abortMsg, func() {
-					SetRoleAddress(cross, tt.roleName, tt.roleAddress)
+				uassert.AbortsContains(t, cur, tt.abortMsg, func() {
+					SetRoleAddress(cross(cur), tt.roleName, tt.roleAddress)
 				})
 			} else {
-				SetRoleAddress(cross, tt.roleName, tt.roleAddress)
+				SetRoleAddress(cross(cur), tt.roleName, tt.roleAddress)
 				addr, ok := GetAddress(tt.roleName)
 				uassert.True(t, ok, ufmt.Sprintf("Role %s should exist after set", tt.roleName))
 				uassert.True(t, addr == tt.roleAddress, ufmt.Sprintf("Expected %s for role %s, got %s", tt.roleAddress, tt.roleName, addr))
@@ -405,7 +405,7 @@ func TestSetRoleAddress(t *testing.T) {
 	}
 }
 
-func TestRemoveRole(t *testing.T) {
+func TestRemoveRole(cur realm, t *testing.T) {
 	// Save original state
 	originalRoles := make(map[string]address)
 	for k, v := range roleAddresses {
@@ -499,7 +499,7 @@ func TestRemoveRole(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Setup roles
 			roleAddresses = make(map[string]address)
 			for k, v := range tt.setupRoles {
@@ -514,11 +514,11 @@ func TestRemoveRole(t *testing.T) {
 			}
 
 			if tt.shouldAbort {
-				uassert.AbortsContains(t, tt.abortMsg, func() {
-					RemoveRole(cross, tt.roleName)
+				uassert.AbortsContains(t, cur, tt.abortMsg, func() {
+					RemoveRole(cross(cur), tt.roleName)
 				})
 			} else {
-				RemoveRole(cross, tt.roleName)
+				RemoveRole(cross(cur), tt.roleName)
 				_, ok := GetAddress(tt.roleName)
 				uassert.False(t, ok, ufmt.Sprintf("Role %s should not exist after removal", tt.roleName))
 			}
@@ -526,7 +526,7 @@ func TestRemoveRole(t *testing.T) {
 	}
 }
 
-func TestAccess_MustGetAddress(t *testing.T) {
+func TestAccess_MustGetAddress(cur realm, t *testing.T) {
 	testRole := "test_role"
 	testAddr := testutils.TestAddress("test")
 
@@ -591,7 +591,7 @@ func TestAccess_MustGetAddress(t *testing.T) {
 			}
 
 			if tt.shouldPanic {
-				uassert.PanicsContains(t, tt.panicMsg, func() {
+				uassert.PanicsContains(t, cur, tt.panicMsg, func() {
 					MustGetAddress(tt.queryRole)
 				})
 			} else {

--- a/contract/r/gnoswap/access/assert_test.gno
+++ b/contract/r/gnoswap/access/assert_test.gno
@@ -71,7 +71,7 @@ func TestAssertIsAdminOrGovernance(cur realm, t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Setup
 			roleAddresses = make(map[string]address)
 			for role, addrs := range tt.setupRoles {
@@ -284,7 +284,7 @@ func TestAssertFunctions(cur realm, t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Setup role - now using []std.Address
 			roleAddresses = make(map[string]address)
 			roleAddresses[tt.role] = tt.authorizedAddr
@@ -367,7 +367,7 @@ func TestAssertIsAuthorized(cur realm, t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Setup
 			roleAddresses = make(map[string]address)
 			for role, addrs := range tt.setupRoles {
@@ -509,7 +509,7 @@ func TestAssertHasAnyRole(cur realm, t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Setup
 			roleAddresses = make(map[string]address)
 			for role, addrs := range tt.setupRoles {
@@ -582,7 +582,7 @@ func TestAssertHasAnyRole_EdgeCases(cur realm, t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Setup
 			roleAddresses = make(map[string]address)
 			for role, addrs := range tt.setupRoles {
@@ -675,7 +675,7 @@ func TestAssertIsAuthorized_EdgeCases(cur realm, t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Setup
 			roleAddresses = make(map[string]address)
 			for role, addrs := range tt.setupRoles {
@@ -723,7 +723,7 @@ func TestAssertIsValidAddress(cur realm, t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.shouldPanic {
 				uassert.PanicsWithMessage(t, cur, tt.expectedMsg, func() {
 					AssertIsValidAddress(tt.addr)
@@ -758,7 +758,7 @@ func TestAssertIsUser(cur realm, t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.shouldPanic {
 				uassert.PanicsWithMessage(t, cur, tt.expectedMsg, func() {
 					AssertIsUser(tt.realm)
@@ -786,7 +786,7 @@ func TestAssert_assertIsRBAC(cur realm, t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.shouldPanic {
 				expectedMsg := ufmt.Sprintf("unauthorized: caller %s is not rbac", tt.caller.String())
 				uassert.PanicsWithMessage(t, cur, expectedMsg, func() {

--- a/contract/r/gnoswap/access/assert_test.gno
+++ b/contract/r/gnoswap/access/assert_test.gno
@@ -12,7 +12,7 @@ import (
 	prbac "gno.land/p/gnoswap/rbac"
 )
 
-func TestAssertIsAdminOrGovernance(t *testing.T) {
+func TestAssertIsAdminOrGovernance(cur realm, t *testing.T) {
 	// Save original state
 	originalRoles := make(map[string]address)
 	for k, v := range roleAddresses {
@@ -80,11 +80,11 @@ func TestAssertIsAdminOrGovernance(t *testing.T) {
 
 			// Test
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.expectedMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.expectedMsg, func() {
 					AssertIsAdminOrGovernance(tt.testAddr)
 				})
 			} else {
-				uassert.NotPanics(t, func() {
+				uassert.NotPanics(t, cur, func() {
 					AssertIsAdminOrGovernance(tt.testAddr)
 				})
 			}
@@ -92,7 +92,7 @@ func TestAssertIsAdminOrGovernance(t *testing.T) {
 	}
 }
 
-func TestAssertFunctions(t *testing.T) {
+func TestAssertFunctions(cur realm, t *testing.T) {
 	// Save original state
 	originalRoles := make(map[string]address)
 	for k, v := range roleAddresses {
@@ -292,11 +292,11 @@ func TestAssertFunctions(t *testing.T) {
 			for _, tc := range tt.testCases {
 				if tc.shouldPanic {
 					expectedMsg := "unauthorized: caller " + tc.testAddr.String() + " is not " + tt.role
-					uassert.PanicsWithMessage(t, expectedMsg, func() {
+					uassert.PanicsWithMessage(t, cur, expectedMsg, func() {
 						tt.assertFunc(tc.testAddr)
 					})
 				} else {
-					uassert.NotPanics(t, func() {
+					uassert.NotPanics(t, cur, func() {
 						tt.assertFunc(tc.testAddr)
 					})
 				}
@@ -305,7 +305,7 @@ func TestAssertFunctions(t *testing.T) {
 	}
 }
 
-func TestAssertIsAuthorized(t *testing.T) {
+func TestAssertIsAuthorized(cur realm, t *testing.T) {
 	// Save original state
 	originalRoles := make(map[string]address)
 	for k, v := range roleAddresses {
@@ -376,11 +376,11 @@ func TestAssertIsAuthorized(t *testing.T) {
 
 			// Test
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.expectedMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.expectedMsg, func() {
 					AssertIsAuthorized(tt.testRole, tt.testAddr)
 				})
 			} else {
-				uassert.NotPanics(t, func() {
+				uassert.NotPanics(t, cur, func() {
 					AssertIsAuthorized(tt.testRole, tt.testAddr)
 				})
 			}
@@ -388,7 +388,7 @@ func TestAssertIsAuthorized(t *testing.T) {
 	}
 }
 
-func TestAssertIsAdminReflectsRoleUpdate(t *testing.T) {
+func TestAssertIsAdminReflectsRoleUpdate(cur realm, t *testing.T) {
 	// Save original state
 	originalRoles := make(map[string]address)
 	for k, v := range roleAddresses {
@@ -405,24 +405,24 @@ func TestAssertIsAdminReflectsRoleUpdate(t *testing.T) {
 	err := setRoleAddress(prbac.ROLE_ADMIN.String(), adminAddr)
 	uassert.NoError(t, err)
 
-	uassert.NotPanics(t, func() {
+	uassert.NotPanics(t, cur, func() {
 		AssertIsAdmin(adminAddr)
 	})
 
 	err = setRoleAddress(prbac.ROLE_ADMIN.String(), newAdminAddr)
 	uassert.NoError(t, err)
 
-	uassert.NotPanics(t, func() {
+	uassert.NotPanics(t, cur, func() {
 		AssertIsAdmin(newAdminAddr)
 	})
 
 	expectedMsg := "unauthorized: caller " + adminAddr.String() + " is not " + prbac.ROLE_ADMIN.String()
-	uassert.PanicsWithMessage(t, expectedMsg, func() {
+	uassert.PanicsWithMessage(t, cur, expectedMsg, func() {
 		AssertIsAdmin(adminAddr)
 	})
 }
 
-func TestAssertHasAnyRole(t *testing.T) {
+func TestAssertHasAnyRole(cur realm, t *testing.T) {
 	// Save original state
 	originalRoles := make(map[string]address)
 	for k, v := range roleAddresses {
@@ -518,11 +518,11 @@ func TestAssertHasAnyRole(t *testing.T) {
 
 			// Test
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.expectedMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.expectedMsg, func() {
 					AssertHasAnyRole(tt.testAddr, tt.roleNames...)
 				})
 			} else {
-				uassert.NotPanics(t, func() {
+				uassert.NotPanics(t, cur, func() {
 					AssertHasAnyRole(tt.testAddr, tt.roleNames...)
 				})
 			}
@@ -530,7 +530,7 @@ func TestAssertHasAnyRole(t *testing.T) {
 	}
 }
 
-func TestAssertHasAnyRole_EdgeCases(t *testing.T) {
+func TestAssertHasAnyRole_EdgeCases(cur realm, t *testing.T) {
 	// Save original state
 	originalRoles := make(map[string]address)
 	for k, v := range roleAddresses {
@@ -591,11 +591,11 @@ func TestAssertHasAnyRole_EdgeCases(t *testing.T) {
 
 			// Test
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.expectedMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.expectedMsg, func() {
 					AssertHasAnyRole(tt.testAddr, tt.roleNames...)
 				})
 			} else {
-				uassert.NotPanics(t, func() {
+				uassert.NotPanics(t, cur, func() {
 					AssertHasAnyRole(tt.testAddr, tt.roleNames...)
 				})
 			}
@@ -603,7 +603,7 @@ func TestAssertHasAnyRole_EdgeCases(t *testing.T) {
 	}
 }
 
-func TestAssertIsAuthorized_EdgeCases(t *testing.T) {
+func TestAssertIsAuthorized_EdgeCases(cur realm, t *testing.T) {
 	// Save original state
 	originalRoles := make(map[string]address)
 	for k, v := range roleAddresses {
@@ -684,11 +684,11 @@ func TestAssertIsAuthorized_EdgeCases(t *testing.T) {
 
 			// Test
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.expectedMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.expectedMsg, func() {
 					AssertIsAuthorized(tt.testRole, tt.testAddr)
 				})
 			} else {
-				uassert.NotPanics(t, func() {
+				uassert.NotPanics(t, cur, func() {
 					AssertIsAuthorized(tt.testRole, tt.testAddr)
 				})
 			}
@@ -696,7 +696,7 @@ func TestAssertIsAuthorized_EdgeCases(t *testing.T) {
 	}
 }
 
-func TestAssertIsValidAddress(t *testing.T) {
+func TestAssertIsValidAddress(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		addr        address
@@ -725,11 +725,11 @@ func TestAssertIsValidAddress(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.expectedMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.expectedMsg, func() {
 					AssertIsValidAddress(tt.addr)
 				})
 			} else {
-				uassert.NotPanics(t, func() {
+				uassert.NotPanics(t, cur, func() {
 					AssertIsValidAddress(tt.addr)
 				})
 			}
@@ -737,7 +737,7 @@ func TestAssertIsValidAddress(t *testing.T) {
 	}
 }
 
-func TestAssertIsUser(t *testing.T) {
+func TestAssertIsUser(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		realm       runtime.Realm
@@ -760,11 +760,11 @@ func TestAssertIsUser(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.expectedMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.expectedMsg, func() {
 					AssertIsUser(tt.realm)
 				})
 			} else {
-				uassert.NotPanics(t, func() {
+				uassert.NotPanics(t, cur, func() {
 					AssertIsUser(tt.realm)
 				})
 			}
@@ -772,7 +772,7 @@ func TestAssertIsUser(t *testing.T) {
 	}
 }
 
-func TestAssert_assertIsRBAC(t *testing.T) {
+func TestAssert_assertIsRBAC(cur realm, t *testing.T) {
 	rbacAddress := chain.PackageAddress("gno.land/r/gnoswap/rbac")
 	unauthorizedAddr := testutils.TestAddress("unauthorized")
 
@@ -789,11 +789,11 @@ func TestAssert_assertIsRBAC(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.shouldPanic {
 				expectedMsg := ufmt.Sprintf("unauthorized: caller %s is not rbac", tt.caller.String())
-				uassert.PanicsWithMessage(t, expectedMsg, func() {
+				uassert.PanicsWithMessage(t, cur, expectedMsg, func() {
 					assertIsRBAC(tt.caller)
 				})
 			} else {
-				uassert.NotPanics(t, func() {
+				uassert.NotPanics(t, cur, func() {
 					assertIsRBAC(tt.caller)
 				})
 			}


### PR DESCRIPTION
## Summary

Migrate the `r/gnoswap/access` realm to the Interrealm v2 calling model.

This PR is split out from the broader Interrealm v2 migration and focuses only on the access-control realm surface.

## Changes

- Replace `runtime.PreviousRealm()` usage in RBAC-only entrypoints with `cur.Previous()`.
- Thread the current realm through RBAC-to-access calls with `cross(cur)`.
- Preserve the existing role-address registry behavior for setting, removing, looking up, and authorizing roles.
- Keep emitted event fields aligned with the previous behavior while sourcing caller information from the Interrealm v2 `cur` realm.
- Update access tests to pass `cur realm` through test functions, subtests, and panic/abort assertion helpers.

## Scope

- `contract/r/gnoswap/access/access.gno`
- `contract/r/gnoswap/access/access_test.gno`
- `contract/r/gnoswap/access/assert_test.gno`