### PR TITLE
refactor(r/rbac): migrate to interrealm v2

### DIFF
--- a/contract/r/gnoswap/rbac/assert_test.gno
+++ b/contract/r/gnoswap/rbac/assert_test.gno
@@ -10,7 +10,7 @@ import (
 	prbac "gno.land/p/gnoswap/rbac"
 )
 
-func TestAssert_assertIsOwner(t *testing.T) {
+func TestAssert_assertIsOwner(cur realm, t *testing.T) {
 	// Reset manager for test
 	manager = prbac.NewRBACWithAddress(ADMIN)
 
@@ -40,7 +40,7 @@ func TestAssert_assertIsOwner(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.shouldPanic {
 				defer func() {
 					r := recover()
@@ -65,7 +65,7 @@ func TestAssert_assertIsOwner(t *testing.T) {
 	}
 }
 
-func TestAssert_assertIsPendingOwner(t *testing.T) {
+func TestAssert_assertIsPendingOwner(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		addr        address
@@ -98,7 +98,7 @@ func TestAssert_assertIsPendingOwner(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			testing.SetRealm(testing.NewUserRealm(ADMIN))
 
 			// Reset manager for test
@@ -113,7 +113,7 @@ func TestAssert_assertIsPendingOwner(t *testing.T) {
 			testing.SetRealm(testing.NewUserRealm(tt.addr))
 
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.expectedMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.expectedMsg, func() {
 					assertIsPendingOwner(tt.addr)
 				})
 			} else {
@@ -123,13 +123,13 @@ func TestAssert_assertIsPendingOwner(t *testing.T) {
 	}
 }
 
-func TestAssert_assertIsAdmin(t *testing.T) {
+func TestAssert_assertIsAdmin(cur realm, t *testing.T) {
 	testing.SetRealm(testing.NewUserRealm(ADMIN))
 	// Reset manager for test
 	manager = prbac.NewRBACWithAddress(ADMIN)
 
 	testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/rbac"))
-	initRbac()
+	initRbac(cur)
 
 	tests := []struct {
 		name        string
@@ -157,11 +157,11 @@ func TestAssert_assertIsAdmin(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			testing.SetRealm(testing.NewUserRealm(tt.addr))
 
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.expectedMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.expectedMsg, func() {
 					assertIsAdmin(tt.addr)
 				})
 			} else {
@@ -171,17 +171,17 @@ func TestAssert_assertIsAdmin(t *testing.T) {
 	}
 }
 
-func TestAssert_assertIsAdminWithRoleUpdate(t *testing.T) {
+func TestAssert_assertIsAdminWithRoleUpdate(cur realm, t *testing.T) {
 	// Reset manager for test
 	manager = prbac.NewRBACWithAddress(ADMIN)
-	initRbac()
+	initRbac(cur)
 
 	// Change admin role via ownership transfer
 	testing.SetRealm(testing.NewUserRealm(ADMIN))
-	TransferOwnership(cross, DEV_OPS)
+	TransferOwnership(cross(cur), DEV_OPS)
 
 	testing.SetRealm(testing.NewUserRealm(DEV_OPS))
-	AcceptOwnership(cross)
+	AcceptOwnership(cross(cur))
 
 	tests := []struct {
 		name        string
@@ -203,11 +203,11 @@ func TestAssert_assertIsAdminWithRoleUpdate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			testing.SetRealm(testing.NewUserRealm(tt.addr))
 
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.expectedMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.expectedMsg, func() {
 					assertIsAdmin(tt.addr)
 				})
 			} else {
@@ -217,30 +217,30 @@ func TestAssert_assertIsAdminWithRoleUpdate(t *testing.T) {
 	}
 }
 
-func TestAssert_assertFunctionsIntegration(t *testing.T) {
+func TestAssert_assertFunctionsIntegration(cur realm, t *testing.T) {
 	// Reset manager for test
 	manager = prbac.NewRBACWithAddress(ADMIN)
 	testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/rbac"))
-	initRbac()
+	initRbac(cur)
 
 	// Test complete ownership transfer workflow with assertions
-	t.Run("Ownership transfer workflow with assertions", func(t *testing.T) {
+	t.Run("Ownership transfer workflow with assertions", func(cur realm, t *testing.T) {
 		// Initially, ADMIN should be owner
 		assertIsOwner(ADMIN)
 
 		// DEV_OPS should not be owner or pending owner
-		uassert.PanicsWithMessage(t, "caller is not owner || caller: g1mjvd83nnjee3z2g7683er55me9f09688pd4mj9", func() {
+		uassert.PanicsWithMessage(t, cur, "caller is not owner || caller: g1mjvd83nnjee3z2g7683er55me9f09688pd4mj9", func() {
 			assertIsOwner(DEV_OPS)
 		})
 
 		// Clear the panic and continue with next test
 	})
 
-	t.Run("Pending owner assertions after transfer", func(t *testing.T) {
+	t.Run("Pending owner assertions after transfer", func(cur realm, t *testing.T) {
 		// Transfer ownership
 		manager = prbac.NewRBACWithAddress(ADMIN)
 		testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/rbac"))
-		initRbac()
+		initRbac(cur)
 
 		testing.SetRealm(testing.NewUserRealm(ADMIN))
 		err := manager.TransferOwnershipBy(DEV_OPS, ADMIN)
@@ -252,28 +252,28 @@ func TestAssert_assertFunctionsIntegration(t *testing.T) {
 		assertIsPendingOwner(DEV_OPS)
 
 		// ADMIN should not be pending owner
-		uassert.PanicsWithMessage(t, "caller is not pending owner || caller: g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5", func() {
+		uassert.PanicsWithMessage(t, cur, "caller is not pending owner || caller: g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5", func() {
 			assertIsPendingOwner(ADMIN)
 		})
 	})
 
-	t.Run("Admin assertions", func(t *testing.T) {
+	t.Run("Admin assertions", func(cur realm, t *testing.T) {
 		// Reset for clean admin test
 		manager = prbac.NewRBACWithAddress(ADMIN)
 		testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/rbac"))
-		initRbac()
+		initRbac(cur)
 
 		// ADMIN should pass admin assertion
 		assertIsAdmin(ADMIN)
 
 		// Non-admin should fail
-		uassert.PanicsWithMessage(t, "caller is not admin || caller: g1mjvd83nnjee3z2g7683er55me9f09688pd4mj9", func() {
+		uassert.PanicsWithMessage(t, cur, "caller is not admin || caller: g1mjvd83nnjee3z2g7683er55me9f09688pd4mj9", func() {
 			assertIsAdmin(DEV_OPS)
 		})
 	})
 }
 
-func TestAssert_assertIsValidRoleName(t *testing.T) {
+func TestAssert_assertIsValidRoleName(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		roleName    string
@@ -305,9 +305,9 @@ func TestAssert_assertIsValidRoleName(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.expectedMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.expectedMsg, func() {
 					assertIsValidRoleName(tt.roleName)
 				})
 			} else {
@@ -317,7 +317,7 @@ func TestAssert_assertIsValidRoleName(t *testing.T) {
 	}
 }
 
-func TestAssert_assertNotAdminRole(t *testing.T) {
+func TestAssert_assertNotAdminRole(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		roleName    string
@@ -344,9 +344,9 @@ func TestAssert_assertNotAdminRole(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.expectedMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.expectedMsg, func() {
 					assertNotAdminRole(tt.roleName)
 				})
 			} else {
@@ -356,7 +356,7 @@ func TestAssert_assertNotAdminRole(t *testing.T) {
 	}
 }
 
-func TestAssert_assertIsValidAddress(t *testing.T) {
+func TestAssert_assertIsValidAddress(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		addr        address
@@ -394,9 +394,9 @@ func TestAssert_assertIsValidAddress(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.expectedMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.expectedMsg, func() {
 					assertIsValidAddress(tt.addr)
 				})
 			} else {
@@ -406,11 +406,11 @@ func TestAssert_assertIsValidAddress(t *testing.T) {
 	}
 }
 
-func TestAssert_assertIsAdminOrGovernance(t *testing.T) {
+func TestAssert_assertIsAdminOrGovernance(cur realm, t *testing.T) {
 	// Reset manager for test
 	manager = prbac.NewRBACWithAddress(ADMIN)
 	testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/rbac"))
-	initRbac()
+	initRbac(cur)
 
 	tests := []struct {
 		name        string
@@ -449,9 +449,9 @@ func TestAssert_assertIsAdminOrGovernance(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.expectedMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.expectedMsg, func() {
 					assertIsAdminOrGovernance(tt.addr)
 				})
 			} else {

--- a/contract/r/gnoswap/rbac/ownership.gno
+++ b/contract/r/gnoswap/rbac/ownership.gno
@@ -1,8 +1,6 @@
 package rbac
 
 import (
-	"chain/runtime"
-
 	ufmt "gno.land/p/nt/ufmt/v0"
 
 	prbac "gno.land/p/gnoswap/rbac"
@@ -32,7 +30,7 @@ func GetPendingOwner() address {
 // AcceptOwnership completes the ownership transfer process.
 // Only callable by pending owner.
 func AcceptOwnership(cur realm) {
-	caller := runtime.PreviousRealm().Address()
+	caller := cur.Previous().Address()
 	assertIsPendingOwner(caller)
 
 	err := manager.AcceptOwnershipBy(caller)
@@ -50,7 +48,7 @@ func AcceptOwnership(cur realm) {
 				prbac.ROLE_ADMIN.String(), newOwner.String()),
 		))
 	}
-	access.SetRoleAddress(cross, prbac.ROLE_ADMIN.String(), newOwner)
+	access.SetRoleAddress(cross(cur), prbac.ROLE_ADMIN.String(), newOwner)
 }
 
 // TransferOwnership initiates the ownership transfer process.
@@ -60,7 +58,7 @@ func AcceptOwnership(cur realm) {
 //
 // Only callable by current owner.
 func TransferOwnership(cur realm, addr address) {
-	caller := runtime.PreviousRealm().Address()
+	caller := cur.Previous().Address()
 	assertIsOwner(caller)
 	assertIsValidAddress(addr)
 

--- a/contract/r/gnoswap/rbac/ownership_test.gno
+++ b/contract/r/gnoswap/rbac/ownership_test.gno
@@ -12,7 +12,7 @@ import (
 	prbac "gno.land/p/gnoswap/rbac"
 )
 
-func TestIsOwner(t *testing.T) {
+func TestIsOwner(cur realm, t *testing.T) {
 	// Reset manager for test
 	manager = prbac.NewRBACWithAddress(ADMIN)
 
@@ -39,7 +39,7 @@ func TestIsOwner(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			result := IsOwner(tt.addr)
 			if result != tt.expected {
 				t.Errorf("IsOwner(%s) = %v, want %v", tt.addr, result, tt.expected)
@@ -48,7 +48,7 @@ func TestIsOwner(t *testing.T) {
 	}
 }
 
-func TestIsPendingOwner(t *testing.T) {
+func TestIsPendingOwner(cur realm, t *testing.T) {
 	tests := []struct {
 		name             string
 		setupPending     bool
@@ -105,7 +105,7 @@ func TestIsPendingOwner(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Reset manager for each test
 			manager = prbac.NewRBACWithAddress(ADMIN)
 
@@ -127,7 +127,7 @@ func TestIsPendingOwner(t *testing.T) {
 	}
 }
 
-func TestGetOwner(t *testing.T) {
+func TestGetOwner(cur realm, t *testing.T) {
 	// Reset manager for test
 	manager = prbac.NewRBACWithAddress(ADMIN)
 
@@ -137,7 +137,7 @@ func TestGetOwner(t *testing.T) {
 	}
 }
 
-func TestGetPendingOwner(t *testing.T) {
+func TestGetPendingOwner(cur realm, t *testing.T) {
 	// Reset manager for test
 	manager = prbac.NewRBACWithAddress(ADMIN)
 
@@ -160,7 +160,7 @@ func TestGetPendingOwner(t *testing.T) {
 	}
 }
 
-func TestTransferOwnership(t *testing.T) {
+func TestTransferOwnership(cur realm, t *testing.T) {
 	tests := []struct {
 		name                   string
 		ownerAddr              address
@@ -228,7 +228,7 @@ func TestTransferOwnership(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// reset manager for test
 			manager = prbac.NewRBACWithAddress(ADMIN)
 
@@ -241,23 +241,23 @@ func TestTransferOwnership(t *testing.T) {
 			}()
 
 			if tt.expectedHasAborted {
-				uassert.AbortsContains(t, tt.expectedAbortedMessage, func() {
-					TransferOwnership(cross, tt.transferAddr)
+				uassert.AbortsContains(t, cur, tt.expectedAbortedMessage, func() {
+					TransferOwnership(cross(cur), tt.transferAddr)
 				})
 			} else {
-				TransferOwnership(cross, tt.transferAddr)
+				TransferOwnership(cross(cur), tt.transferAddr)
 			}
 		})
 	}
 }
 
-func TestOwnership_TransferOwnershipTwice(t *testing.T) {
+func TestOwnership_TransferOwnershipTwice(cur realm, t *testing.T) {
 	// Reset manager for test
 	manager = prbac.NewRBACWithAddress(ADMIN)
 
 	// First transfer
 	testing.SetOriginCaller(ADMIN)
-	TransferOwnership(cross, DEV_OPS)
+	TransferOwnership(cross(cur), DEV_OPS)
 
 	// Verify first pending owner
 	if GetPendingOwner() != DEV_OPS {
@@ -266,7 +266,7 @@ func TestOwnership_TransferOwnershipTwice(t *testing.T) {
 
 	// Second transfer to different address
 	testing.SetOriginCaller(ADMIN)
-	TransferOwnership(cross, COMMUNITY_POOL_ADDR)
+	TransferOwnership(cross(cur), COMMUNITY_POOL_ADDR)
 
 	// Verify pending owner updated
 	if GetPendingOwner() != COMMUNITY_POOL_ADDR {
@@ -279,7 +279,7 @@ func TestOwnership_TransferOwnershipTwice(t *testing.T) {
 	}
 }
 
-func TestAcceptOwnership(t *testing.T) {
+func TestAcceptOwnership(cur realm, t *testing.T) {
 	tests := []struct {
 		name                   string
 		ownerAddr              address
@@ -323,7 +323,7 @@ func TestAcceptOwnership(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// reset manager for test
 			manager = prbac.NewRBACWithAddress(tt.ownerAddr)
 			err := manager.RegisterRole(prbac.ROLE_ADMIN.String(), tt.ownerAddr)
@@ -333,7 +333,7 @@ func TestAcceptOwnership(t *testing.T) {
 
 			// setup transfer ownership
 			testing.SetOriginCaller(tt.ownerAddr)
-			TransferOwnership(cross, tt.transferAddr)
+			TransferOwnership(cross(cur), tt.transferAddr)
 
 			// setup current realm and origin caller
 			func() {
@@ -344,11 +344,11 @@ func TestAcceptOwnership(t *testing.T) {
 			}()
 
 			if tt.expectedHasAborted {
-				uassert.AbortsContains(t, tt.expectedAbortedMessage, func() {
-					AcceptOwnership(cross)
+				uassert.AbortsContains(t, cur, tt.expectedAbortedMessage, func() {
+					AcceptOwnership(cross(cur))
 				})
 			} else {
-				AcceptOwnership(cross)
+				AcceptOwnership(cross(cur))
 			}
 
 			if GetOwner() != tt.expectedOwner {
@@ -376,15 +376,15 @@ func TestAcceptOwnership(t *testing.T) {
 	}
 }
 
-func TestOwnership_AcceptOwnershipWithoutPendingOwner(t *testing.T) {
+func TestOwnership_AcceptOwnershipWithoutPendingOwner(cur realm, t *testing.T) {
 	// Reset manager for test
 	manager = prbac.NewRBACWithAddress(ADMIN)
 
 	// Try to accept ownership without setting pending owner
 	testing.SetOriginCaller(DEV_OPS)
 
-	uassert.AbortsContains(t, "caller is not pending owner", func() {
-		AcceptOwnership(cross)
+	uassert.AbortsContains(t, cur, "caller is not pending owner", func() {
+		AcceptOwnership(cross(cur))
 	})
 
 	// Owner should remain unchanged
@@ -398,7 +398,7 @@ func TestOwnership_AcceptOwnershipWithoutPendingOwner(t *testing.T) {
 	}
 }
 
-func TestOwnershipWorkflow(t *testing.T) {
+func TestOwnershipWorkflow(cur realm, t *testing.T) {
 	// Reset manager for test
 	manager = prbac.NewRBACWithAddress(ADMIN)
 

--- a/contract/r/gnoswap/rbac/rbac.gno
+++ b/contract/r/gnoswap/rbac/rbac.gno
@@ -2,7 +2,6 @@ package rbac
 
 import (
 	"chain"
-	"chain/runtime"
 
 	"gno.land/r/gnoswap/access"
 
@@ -12,12 +11,12 @@ import (
 
 var manager *prbac.RBAC
 
-func init() {
-	initRbac()
+func init(cur realm) {
+	initRbac(cur)
 }
 
 // initRbac initializes RBAC manager with default admin and role mappings.
-func initRbac() {
+func initRbac(cur realm) {
 	manager = prbac.NewRBACWithAddress(ADMIN)
 
 	// Prepare initial roles for one-time initialization
@@ -32,7 +31,7 @@ func initRbac() {
 		}
 
 		// Update access package with the role address
-		access.SetRoleAddress(cross, roleName, addr)
+		access.SetRoleAddress(cross(cur), roleName, addr)
 	}
 }
 
@@ -44,8 +43,8 @@ func initRbac() {
 //
 // Only callable by admin or governance.
 func RegisterRole(cur realm, roleName string, roleAddress address) {
-	prevRealm := runtime.PreviousRealm()
-	caller := prevRealm.Address()
+	prev := cur.Previous()
+	caller := prev.Address()
 	assertIsAdminOrGovernance(caller)
 	assertIsValidRoleName(roleName)
 	assertIsValidAddress(roleAddress)
@@ -62,11 +61,11 @@ func RegisterRole(cur realm, roleName string, roleAddress address) {
 	}
 
 	// Set the role in access control
-	access.SetRoleAddress(cross, roleName, roleAddress)
+	access.SetRoleAddress(cross(cur), roleName, roleAddress)
 	chain.Emit(
 		"RegisterRole",
 		"prevAddr", caller.String(),
-		"prevRealm", prevRealm.PkgPath(),
+		"prevRealm", prev.PkgPath(),
 		"roleName", roleName,
 		"roleAddress", roleAddress.String(),
 	)
@@ -80,8 +79,8 @@ func RegisterRole(cur realm, roleName string, roleAddress address) {
 //
 // Only callable by admin or governance.
 func UpdateRoleAddress(cur realm, roleName string, addr address) {
-	prevRealm := runtime.PreviousRealm()
-	caller := prevRealm.Address()
+	prev := cur.Previous()
+	caller := prev.Address()
 	assertIsAdminOrGovernance(caller)
 
 	assertIsValidRoleName(roleName)
@@ -97,12 +96,12 @@ func UpdateRoleAddress(cur realm, roleName string, addr address) {
 	}
 
 	// Set the role address in access control
-	access.SetRoleAddress(cross, roleName, addr)
+	access.SetRoleAddress(cross(cur), roleName, addr)
 
 	chain.Emit(
 		"UpdateRoleAddress",
 		"prevAddr", caller.String(),
-		"prevRealm", prevRealm.PkgPath(),
+		"prevRealm", prev.PkgPath(),
 		"roleName", roleName,
 		"roleAddress", addr.String(),
 	)
@@ -115,8 +114,8 @@ func UpdateRoleAddress(cur realm, roleName string, addr address) {
 //
 // Only callable by admin or governance.
 func RemoveRole(cur realm, roleName string) {
-	prevRealm := runtime.PreviousRealm()
-	caller := prevRealm.Address()
+	prev := cur.Previous()
+	caller := prev.Address()
 	assertIsAdminOrGovernance(caller)
 	assertIsValidRoleName(roleName)
 	assertNotAdminRole(roleName)
@@ -130,11 +129,11 @@ func RemoveRole(cur realm, roleName string) {
 	}
 
 	// Remove the role from access control
-	access.RemoveRole(cross, roleName)
+	access.RemoveRole(cross(cur), roleName)
 	chain.Emit(
 		"RemoveRole",
 		"prevAddr", caller.String(),
-		"prevRealm", prevRealm.PkgPath(),
+		"prevRealm", prev.PkgPath(),
 		"roleName", roleName,
 		"roleAddress", "",
 	)

--- a/contract/r/gnoswap/rbac/rbac_test.gno
+++ b/contract/r/gnoswap/rbac/rbac_test.gno
@@ -9,7 +9,7 @@ import (
 	prbac "gno.land/p/gnoswap/rbac"
 )
 
-func TestRbac_RegisterRole(t *testing.T) {
+func TestRbac_RegisterRole(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
 		setup         func()
@@ -23,7 +23,7 @@ func TestRbac_RegisterRole(t *testing.T) {
 			name: "Register role with valid address succeeds (ADMIN)",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 			},
 			roleName:    "custom_role_with_addr",
 			roleAddress: testutils.TestAddress("custom_role_address"),
@@ -34,7 +34,7 @@ func TestRbac_RegisterRole(t *testing.T) {
 			name: "Register role with valid address succeeds (GOVERNANCE)",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 			},
 			roleName:    "custom_role_governance",
 			roleAddress: testutils.TestAddress("custom_gov_address"),
@@ -45,7 +45,7 @@ func TestRbac_RegisterRole(t *testing.T) {
 			name: "Register role with different valid address succeeds (ADMIN)",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 			},
 			roleName:    "another_custom_role",
 			roleAddress: testutils.TestAddress("another_address"),
@@ -56,7 +56,7 @@ func TestRbac_RegisterRole(t *testing.T) {
 			name: "Register role with empty address fails (ADMIN)",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 			},
 			roleName:      "invalid_role_empty",
 			roleAddress:   address(""),
@@ -68,7 +68,7 @@ func TestRbac_RegisterRole(t *testing.T) {
 			name: "Register role with empty address fails (GOVERNANCE)",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 			},
 			roleName:      "invalid_role_empty_gov",
 			roleAddress:   address(""),
@@ -80,7 +80,7 @@ func TestRbac_RegisterRole(t *testing.T) {
 			name: "Register duplicate role with different address fails (ADMIN)",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 				// Pre-register a role
 				manager.RegisterRole("duplicate_role", testutils.TestAddress("original"))
 				manager.UpdateRoleAddress("duplicate_role", testutils.TestAddress("original"))
@@ -95,7 +95,7 @@ func TestRbac_RegisterRole(t *testing.T) {
 			name: "Register system role with new address fails (GOVERNANCE)",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 			},
 			roleName:      prbac.ROLE_ADMIN.String(),
 			roleAddress:   testutils.TestAddress("new_admin"),
@@ -107,7 +107,7 @@ func TestRbac_RegisterRole(t *testing.T) {
 			name: "Register role with unauthorized caller fails",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 			},
 			roleName:      "unauthorized_role",
 			roleAddress:   testutils.TestAddress("some_address"),
@@ -119,7 +119,7 @@ func TestRbac_RegisterRole(t *testing.T) {
 			name: "Register role with devops caller fails (not admin or governance)",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 			},
 			roleName:      "devops_role_attempt",
 			roleAddress:   testutils.TestAddress("devops_address"),
@@ -131,7 +131,7 @@ func TestRbac_RegisterRole(t *testing.T) {
 			name: "Register role with empty role name fails",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 			},
 			roleName:      "",
 			roleAddress:   testutils.TestAddress("valid_address"),
@@ -143,7 +143,7 @@ func TestRbac_RegisterRole(t *testing.T) {
 			name: "Register role with whitespace-only name fails",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 			},
 			roleName:      "   ",
 			roleAddress:   testutils.TestAddress("valid_address"),
@@ -155,7 +155,7 @@ func TestRbac_RegisterRole(t *testing.T) {
 			name: "Register role with tab and space name fails",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 			},
 			roleName:      " \t ",
 			roleAddress:   testutils.TestAddress("valid_address"),
@@ -167,7 +167,7 @@ func TestRbac_RegisterRole(t *testing.T) {
 			name: "Register role with invalid address format fails",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 			},
 			roleName:      "valid_role_invalid_addr",
 			roleAddress:   address("invalid"),
@@ -179,7 +179,7 @@ func TestRbac_RegisterRole(t *testing.T) {
 			name: "Register role with malformed address fails",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 			},
 			roleName:      "valid_role_malformed",
 			roleAddress:   address("g1"),
@@ -190,18 +190,18 @@ func TestRbac_RegisterRole(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			tt.setup()
 
 			// Set realm to the specified caller for authorization testing
 			testing.SetRealm(testing.NewUserRealm(tt.callerRealm))
 
 			if tt.shouldPanic {
-				uassert.AbortsContains(t, tt.panicContains, func() {
-					RegisterRole(cross, tt.roleName, tt.roleAddress)
+				uassert.AbortsContains(t, cur, tt.panicContains, func() {
+					RegisterRole(cross(cur), tt.roleName, tt.roleAddress)
 				})
 			} else {
-				RegisterRole(cross, tt.roleName, tt.roleAddress)
+				RegisterRole(cross(cur), tt.roleName, tt.roleAddress)
 
 				// Verify the role was registered with correct address
 				addr, err := manager.GetRoleAddress(tt.roleName)
@@ -212,7 +212,7 @@ func TestRbac_RegisterRole(t *testing.T) {
 	}
 }
 
-func TestRbac_RemoveRole(t *testing.T) {
+func TestRbac_RemoveRole(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		setup       func()
@@ -224,7 +224,7 @@ func TestRbac_RemoveRole(t *testing.T) {
 			name: "Remove custom role should succeed",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 				manager.RegisterRole("removable_role", testutils.TestAddress("removable_address"))
 			},
 			roleName:    "removable_role",
@@ -234,7 +234,7 @@ func TestRbac_RemoveRole(t *testing.T) {
 			name: "Remove system role should error",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 			},
 			roleName:    prbac.ROLE_ADMIN.String(),
 			shouldError: true,
@@ -244,7 +244,7 @@ func TestRbac_RemoveRole(t *testing.T) {
 			name: "Remove non-existent role should error",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 			},
 			roleName:    "non_existent_role",
 			shouldError: true,
@@ -254,7 +254,7 @@ func TestRbac_RemoveRole(t *testing.T) {
 			name: "Remove role with empty string should error",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 			},
 			roleName:    "",
 			shouldError: true,
@@ -264,7 +264,7 @@ func TestRbac_RemoveRole(t *testing.T) {
 			name: "Remove role multiple times should error on second attempt",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 				manager.RegisterRole("remove_twice_role", testutils.TestAddress("remove_twice_address"))
 				manager.RemoveRole("remove_twice_role") // First removal
 			},
@@ -275,7 +275,7 @@ func TestRbac_RemoveRole(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			tt.setup()
 			testing.SetRealm(testing.NewUserRealm(ADMIN))
 			err := manager.RemoveRole(tt.roleName)
@@ -295,10 +295,10 @@ func TestRbac_RemoveRole(t *testing.T) {
 	}
 }
 
-func TestRbac_GetRoleAddress(t *testing.T) {
+func TestRbac_GetRoleAddress(cur realm, t *testing.T) {
 	// Reset manager for test
 	manager = prbac.NewRBACWithAddress(ADMIN)
-	initRbac()
+	initRbac(cur)
 
 	tests := []struct {
 		name      string
@@ -323,7 +323,7 @@ func TestRbac_GetRoleAddress(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			addr, err := GetRoleAddress(tt.roleName)
 
 			if tt.shouldErr {
@@ -342,10 +342,10 @@ func TestRbac_GetRoleAddress(t *testing.T) {
 	}
 }
 
-func TestRbac_UpdateRoleAddress_Basic(t *testing.T) {
+func TestRbac_UpdateRoleAddress_Basic(cur realm, t *testing.T) {
 	// Reset manager for test
 	manager = prbac.NewRBACWithAddress(ADMIN)
-	initRbac()
+	initRbac(cur)
 
 	// Register a test role
 	testRole := "test_update_role"
@@ -381,7 +381,7 @@ func TestRbac_UpdateRoleAddress_Basic(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Test manager functionality directly
 			err := manager.UpdateRoleAddress(tt.roleName, tt.addr)
 
@@ -406,10 +406,10 @@ func TestRbac_UpdateRoleAddress_Basic(t *testing.T) {
 	}
 }
 
-func TestUpdateAccessRoleAddresses(t *testing.T) {
+func TestUpdateAccessRoleAddresses(cur realm, t *testing.T) {
 	// Reset manager for test
 	manager = prbac.NewRBACWithAddress(ADMIN)
-	initRbac()
+	initRbac(cur)
 
 	// This function is private, but we can test its effect indirectly
 	// by calling functions that invoke it and checking if access package is updated
@@ -432,7 +432,7 @@ func TestUpdateAccessRoleAddresses(t *testing.T) {
 	t.Log("updateAccessRoleAddresses executed successfully")
 }
 
-func TestAddressChangeComplete(t *testing.T) {
+func TestAddressChangeComplete(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
 		setup         func()
@@ -446,7 +446,7 @@ func TestAddressChangeComplete(t *testing.T) {
 			name: "Change admin role address",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 			},
 			roleName:      prbac.ROLE_ADMIN.String(),
 			oldAddress:    ADMIN,
@@ -467,7 +467,7 @@ func TestAddressChangeComplete(t *testing.T) {
 			name: "Change custom role address",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 				manager.RegisterRole("custom_role", testutils.TestAddress("custom_address"))
 				manager.UpdateRoleAddress("custom_role", testutils.TestAddress("custom"))
 			},
@@ -490,7 +490,7 @@ func TestAddressChangeComplete(t *testing.T) {
 			name: "Change multiple role addresses sequentially",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 			},
 			roleName:      prbac.ROLE_ROUTER.String(),
 			oldAddress:    ROUTER_ADDR,
@@ -526,7 +526,7 @@ func TestAddressChangeComplete(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Set realm to rbac for access package calls
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/rbac"))
 
@@ -558,7 +558,7 @@ func TestAddressChangeComplete(t *testing.T) {
 	}
 }
 
-func TestRBACToAccessSync(t *testing.T) {
+func TestRBACToAccessSync(cur realm, t *testing.T) {
 	tests := []struct {
 		name       string
 		operations []struct {
@@ -664,13 +664,13 @@ func TestRBACToAccessSync(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Set realm to rbac for access package calls
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/rbac"))
 
 			// Reset manager
 			manager = prbac.NewRBACWithAddress(ADMIN)
-			initRbac()
+			initRbac(cur)
 
 			// Execute operations
 			for _, op := range tt.operations {
@@ -717,7 +717,7 @@ func TestRBACToAccessSync(t *testing.T) {
 	}
 }
 
-func TestRbac_UpdateRoleAddress_WithAuthorization(t *testing.T) {
+func TestRbac_UpdateRoleAddress_WithAuthorization(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
 		setup         func()
@@ -731,9 +731,9 @@ func TestRbac_UpdateRoleAddress_WithAuthorization(t *testing.T) {
 			name: "Update role with admin caller succeeds",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 				testing.SetRealm(testing.NewUserRealm(ADMIN))
-				RegisterRole(cross, "test_update_role_admin", testutils.TestAddress("old_addr"))
+				RegisterRole(cross(cur), "test_update_role_admin", testutils.TestAddress("old_addr"))
 			},
 			roleName:    "test_update_role_admin",
 			newAddr:     testutils.TestAddress("new_addr"),
@@ -744,9 +744,9 @@ func TestRbac_UpdateRoleAddress_WithAuthorization(t *testing.T) {
 			name: "Update role with governance caller succeeds",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 				testing.SetRealm(testing.NewUserRealm(ADMIN))
-				RegisterRole(cross, "test_update_role_gov", testutils.TestAddress("old_addr"))
+				RegisterRole(cross(cur), "test_update_role_gov", testutils.TestAddress("old_addr"))
 			},
 			roleName:    "test_update_role_gov",
 			newAddr:     testutils.TestAddress("new_addr_gov"),
@@ -757,9 +757,9 @@ func TestRbac_UpdateRoleAddress_WithAuthorization(t *testing.T) {
 			name: "Update role with unauthorized caller fails",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 				testing.SetRealm(testing.NewUserRealm(ADMIN))
-				RegisterRole(cross, "test_update_role_unauth", testutils.TestAddress("old_addr"))
+				RegisterRole(cross(cur), "test_update_role_unauth", testutils.TestAddress("old_addr"))
 			},
 			roleName:      "test_update_role_unauth",
 			newAddr:       testutils.TestAddress("new_addr_unauth"),
@@ -771,9 +771,9 @@ func TestRbac_UpdateRoleAddress_WithAuthorization(t *testing.T) {
 			name: "Update role with devops caller fails",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 				testing.SetRealm(testing.NewUserRealm(ADMIN))
-				RegisterRole(cross, "test_update_role_devops", testutils.TestAddress("old_addr"))
+				RegisterRole(cross(cur), "test_update_role_devops", testutils.TestAddress("old_addr"))
 			},
 			roleName:      "test_update_role_devops",
 			newAddr:       testutils.TestAddress("new_addr_devops"),
@@ -785,7 +785,7 @@ func TestRbac_UpdateRoleAddress_WithAuthorization(t *testing.T) {
 			name: "Update role with empty role name fails",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 			},
 			roleName:      "",
 			newAddr:       testutils.TestAddress("new_addr"),
@@ -797,9 +797,9 @@ func TestRbac_UpdateRoleAddress_WithAuthorization(t *testing.T) {
 			name: "Update role with empty address fails",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 				testing.SetRealm(testing.NewUserRealm(ADMIN))
-				RegisterRole(cross, "test_update_role_empty_addr", testutils.TestAddress("old_addr"))
+				RegisterRole(cross(cur), "test_update_role_empty_addr", testutils.TestAddress("old_addr"))
 			},
 			roleName:      "test_update_role_empty_addr",
 			newAddr:       address(""),
@@ -811,9 +811,9 @@ func TestRbac_UpdateRoleAddress_WithAuthorization(t *testing.T) {
 			name: "Update role with invalid address format fails",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 				testing.SetRealm(testing.NewUserRealm(ADMIN))
-				RegisterRole(cross, "test_update_role_invalid_addr", testutils.TestAddress("old_addr"))
+				RegisterRole(cross(cur), "test_update_role_invalid_addr", testutils.TestAddress("old_addr"))
 			},
 			roleName:      "test_update_role_invalid_addr",
 			newAddr:       address("invalid"),
@@ -825,9 +825,9 @@ func TestRbac_UpdateRoleAddress_WithAuthorization(t *testing.T) {
 			name: "Update role with malformed address fails",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 				testing.SetRealm(testing.NewUserRealm(ADMIN))
-				RegisterRole(cross, "test_update_role_malformed", testutils.TestAddress("old_addr"))
+				RegisterRole(cross(cur), "test_update_role_malformed", testutils.TestAddress("old_addr"))
 			},
 			roleName:      "test_update_role_malformed",
 			newAddr:       address("g1"),
@@ -839,7 +839,7 @@ func TestRbac_UpdateRoleAddress_WithAuthorization(t *testing.T) {
 			name: "Update non-existent role fails",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 			},
 			roleName:      "non_existent_role",
 			newAddr:       testutils.TestAddress("new_addr"),
@@ -851,9 +851,9 @@ func TestRbac_UpdateRoleAddress_WithAuthorization(t *testing.T) {
 			name: "Update role with same address succeeds (idempotent)",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 				testing.SetRealm(testing.NewUserRealm(ADMIN))
-				RegisterRole(cross, "test_idempotent_role", testutils.TestAddress("same_addr"))
+				RegisterRole(cross(cur), "test_idempotent_role", testutils.TestAddress("same_addr"))
 			},
 			roleName:    "test_idempotent_role",
 			newAddr:     testutils.TestAddress("same_addr"),
@@ -864,7 +864,7 @@ func TestRbac_UpdateRoleAddress_WithAuthorization(t *testing.T) {
 			name: "Update admin role via UpdateRoleAddress fails",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 			},
 			roleName:      prbac.ROLE_ADMIN.String(),
 			newAddr:       testutils.TestAddress("new_admin"),
@@ -876,7 +876,7 @@ func TestRbac_UpdateRoleAddress_WithAuthorization(t *testing.T) {
 			name: "Update whitespace padded admin role via UpdateRoleAddress fails",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 			},
 			roleName:      " admin ",
 			newAddr:       testutils.TestAddress("new_admin_with_space"),
@@ -887,18 +887,18 @@ func TestRbac_UpdateRoleAddress_WithAuthorization(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			tt.setup()
 
 			// Set realm to the specified caller for authorization testing
 			testing.SetRealm(testing.NewUserRealm(tt.callerRealm))
 
 			if tt.shouldPanic {
-				uassert.AbortsContains(t, tt.panicContains, func() {
-					UpdateRoleAddress(cross, tt.roleName, tt.newAddr)
+				uassert.AbortsContains(t, cur, tt.panicContains, func() {
+					UpdateRoleAddress(cross(cur), tt.roleName, tt.newAddr)
 				})
 			} else {
-				UpdateRoleAddress(cross, tt.roleName, tt.newAddr)
+				UpdateRoleAddress(cross(cur), tt.roleName, tt.newAddr)
 
 				// Verify the role address was updated
 				addr, err := manager.GetRoleAddress(tt.roleName)
@@ -909,7 +909,7 @@ func TestRbac_UpdateRoleAddress_WithAuthorization(t *testing.T) {
 	}
 }
 
-func TestRbac_RemoveRole_WithAuthorization(t *testing.T) {
+func TestRbac_RemoveRole_WithAuthorization(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
 		setup         func()
@@ -922,9 +922,9 @@ func TestRbac_RemoveRole_WithAuthorization(t *testing.T) {
 			name: "Remove role with admin caller succeeds",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 				testing.SetRealm(testing.NewUserRealm(ADMIN))
-				RegisterRole(cross, "test_remove_role_admin", testutils.TestAddress("test_addr"))
+				RegisterRole(cross(cur), "test_remove_role_admin", testutils.TestAddress("test_addr"))
 			},
 			roleName:    "test_remove_role_admin",
 			callerRealm: ADMIN,
@@ -934,9 +934,9 @@ func TestRbac_RemoveRole_WithAuthorization(t *testing.T) {
 			name: "Remove role with governance caller succeeds",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 				testing.SetRealm(testing.NewUserRealm(ADMIN))
-				RegisterRole(cross, "test_remove_role_gov", testutils.TestAddress("test_addr"))
+				RegisterRole(cross(cur), "test_remove_role_gov", testutils.TestAddress("test_addr"))
 			},
 			roleName:    "test_remove_role_gov",
 			callerRealm: GOV_GOVERNANCE_ADDR,
@@ -946,9 +946,9 @@ func TestRbac_RemoveRole_WithAuthorization(t *testing.T) {
 			name: "Remove role with unauthorized caller fails",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 				testing.SetRealm(testing.NewUserRealm(ADMIN))
-				RegisterRole(cross, "test_remove_role_unauth", testutils.TestAddress("test_addr"))
+				RegisterRole(cross(cur), "test_remove_role_unauth", testutils.TestAddress("test_addr"))
 			},
 			roleName:      "test_remove_role_unauth",
 			callerRealm:   testutils.TestAddress("random_user"),
@@ -959,9 +959,9 @@ func TestRbac_RemoveRole_WithAuthorization(t *testing.T) {
 			name: "Remove role with devops caller fails",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 				testing.SetRealm(testing.NewUserRealm(ADMIN))
-				RegisterRole(cross, "test_remove_role_devops", testutils.TestAddress("test_addr"))
+				RegisterRole(cross(cur), "test_remove_role_devops", testutils.TestAddress("test_addr"))
 			},
 			roleName:      "test_remove_role_devops",
 			callerRealm:   DEV_OPS,
@@ -972,7 +972,7 @@ func TestRbac_RemoveRole_WithAuthorization(t *testing.T) {
 			name: "Remove role with empty role name fails",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 			},
 			roleName:      "",
 			callerRealm:   ADMIN,
@@ -983,7 +983,7 @@ func TestRbac_RemoveRole_WithAuthorization(t *testing.T) {
 			name: "Remove admin role fails",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 			},
 			roleName:      prbac.ROLE_ADMIN.String(),
 			callerRealm:   ADMIN,
@@ -994,7 +994,7 @@ func TestRbac_RemoveRole_WithAuthorization(t *testing.T) {
 			name: "Remove whitespace padded admin role fails",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 			},
 			roleName:      " admin ",
 			callerRealm:   ADMIN,
@@ -1005,7 +1005,7 @@ func TestRbac_RemoveRole_WithAuthorization(t *testing.T) {
 			name: "Remove non-existent role fails",
 			setup: func() {
 				manager = prbac.NewRBACWithAddress(ADMIN)
-				initRbac()
+				initRbac(cur)
 			},
 			roleName:      "non_existent_role",
 			callerRealm:   ADMIN,
@@ -1015,18 +1015,18 @@ func TestRbac_RemoveRole_WithAuthorization(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			tt.setup()
 
 			// Set realm to the specified caller for authorization testing
 			testing.SetRealm(testing.NewUserRealm(tt.callerRealm))
 
 			if tt.shouldPanic {
-				uassert.AbortsContains(t, tt.panicContains, func() {
-					RemoveRole(cross, tt.roleName)
+				uassert.AbortsContains(t, cur, tt.panicContains, func() {
+					RemoveRole(cross(cur), tt.roleName)
 				})
 			} else {
-				RemoveRole(cross, tt.roleName)
+				RemoveRole(cross(cur), tt.roleName)
 
 				// Verify the role was actually removed
 				_, err := manager.GetRoleAddress(tt.roleName)

--- a/contract/r/gnoswap/rbac/role_test.gno
+++ b/contract/r/gnoswap/rbac/role_test.gno
@@ -6,7 +6,7 @@ import (
 	prbac "gno.land/p/gnoswap/rbac"
 )
 
-func TestDefaultRoleAddresses(t *testing.T) {
+func TestDefaultRoleAddresses(cur realm, t *testing.T) {
 	// Test that all default role addresses are properly defined
 	expectedRoles := []prbac.SystemRole{
 		prbac.ROLE_ADMIN,
@@ -62,7 +62,7 @@ func TestDefaultRoleAddresses(t *testing.T) {
 	}
 }
 
-func TestDefaultRoleAddressesCompleteness(t *testing.T) {
+func TestDefaultRoleAddressesCompleteness(cur realm, t *testing.T) {
 	// Test that all addresses are valid (non-empty)
 	for role, addr := range DefaultRoleAddresses {
 		if addr == "" {
@@ -75,7 +75,7 @@ func TestDefaultRoleAddressesCompleteness(t *testing.T) {
 	}
 }
 
-func TestDefaultRoleAddressesMapping(t *testing.T) {
+func TestDefaultRoleAddressesMapping(cur realm, t *testing.T) {
 	// Test specific role-address mappings
 	tests := []struct {
 		role         prbac.SystemRole
@@ -150,7 +150,7 @@ func TestDefaultRoleAddressesMapping(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.description, func(t *testing.T) {
+		t.Run(tt.description, func(cur realm, t *testing.T) {
 			actualAddr, exists := DefaultRoleAddresses[tt.role]
 			if !exists {
 				t.Errorf("Role %s not found in DefaultRoleAddresses", tt.role.String())
@@ -165,7 +165,7 @@ func TestDefaultRoleAddressesMapping(t *testing.T) {
 	}
 }
 
-func TestRoleStringRepresentation(t *testing.T) {
+func TestRoleStringRepresentation(cur realm, t *testing.T) {
 	// Test that all roles have proper string representation
 	expectedStrings := map[prbac.SystemRole]string{
 		prbac.ROLE_ADMIN:          "admin",
@@ -194,7 +194,7 @@ func TestRoleStringRepresentation(t *testing.T) {
 	}
 }
 
-func TestSystemRoleValidation(t *testing.T) {
+func TestSystemRoleValidation(cur realm, t *testing.T) {
 	// Test that all roles in DefaultRoleAddresses are system roles
 	for role := range DefaultRoleAddresses {
 		if !prbac.IsSystemRole(role.String()) {
@@ -219,7 +219,7 @@ func TestSystemRoleValidation(t *testing.T) {
 	}
 }
 
-func TestRoleAddressUniqueness(t *testing.T) {
+func TestRoleAddressUniqueness(cur realm, t *testing.T) {
 	// Test that all role addresses are unique (no two roles share the same address)
 	addressToRole := make(map[address]prbac.SystemRole)
 
@@ -233,10 +233,10 @@ func TestRoleAddressUniqueness(t *testing.T) {
 	}
 }
 
-func TestDefaultRoleAddressesIntegrationWithManager(t *testing.T) {
+func TestDefaultRoleAddressesIntegrationWithManager(cur realm, t *testing.T) {
 	// Test that DefaultRoleAddresses works correctly with RBAC manager
 	manager = prbac.NewRBACWithAddress(ADMIN)
-	initRbac()
+	initRbac(cur)
 
 	// Test that all roles from DefaultRoleAddresses are properly registered in manager
 	for role, expectedAddr := range DefaultRoleAddresses {


### PR DESCRIPTION
## Summary

Migrate the `r/gnoswap/rbac` realm to the Interrealm v2 calling model.

This PR is split out from the broader Interrealm v2 migration and focuses on RBAC ownership, role management, and access-role synchronization.

## Changes

- Convert RBAC initialization from `init()` / `initRbac()` to `init(cur realm)` / `initRbac(cur realm)` so default role registration can call access through `cross(cur)`.
- Replace `runtime.PreviousRealm()` usage in role-management and ownership entrypoints with `cur.Previous()`.
- Thread `cross(cur)` into access synchronization calls for role registration, role address updates, role removal, and ownership acceptance.
- Preserve existing admin/governance authorization, system-role protection, role-address updates, and ownership transfer semantics.
- Update RBAC tests to pass `cur realm` through test functions, subtests, initialization helpers, cross calls, and panic/abort assertion helpers.

## Dependencies
- Depends on https://github.com/gnoswap-labs/gnoswap/pull/1296 for access Interrealm v2 migration.

## Scope

- `contract/r/gnoswap/rbac/rbac.gno`
- `contract/r/gnoswap/rbac/ownership.gno`
- `contract/r/gnoswap/rbac/rbac_test.gno`
- `contract/r/gnoswap/rbac/ownership_test.gno`
- `contract/r/gnoswap/rbac/assert_test.gno`
- `contract/r/gnoswap/rbac/role_test.gno`