### PR TITLE
refactor(common): migrate to interrealm v2

### DIFF
--- a/contract/r/gnoswap/common/README.md
+++ b/contract/r/gnoswap/common/README.md
@@ -58,9 +58,19 @@ Liquidity (L) represents the relationship between token amounts and price:
 
 ### GRC20 Registry Helpers
 
+The write helpers are crossing adapters and should be called as
+`common.Transfer(cross(cur), ...)`, `common.SafeGRC20Transfer(cross(cur), ...)`,
+and so on. They intentionally keep `cur realm` as the first parameter so the
+helper runs in common's crossing frame, then forward that live `cur` to
+`grc20.Teller` as `Transfer(0, cur, ...)`. Because `GetTokenTeller` returns a
+`CallerTeller`, the token actor is derived from `cur.Previous()`, which is the
+realm that crossed into common. Do not convert these helpers to
+`_ int, rlm realm`; that would remove the common crossing boundary and change
+which realm `CallerTeller` treats as the actor.
+
 **Token Operations:**
 - **GetToken**: Retrieves GRC20 token instance
-- **GetTokenTeller**: Gets teller interface for token operations
+- **GetTokenTeller**: Gets a CallerTeller for token operations
 - **IsRegistered**: Checks token registration status
 - **MustRegistered**: Validates multiple tokens are registered
 

--- a/contract/r/gnoswap/common/assert.gno
+++ b/contract/r/gnoswap/common/assert.gno
@@ -1,13 +1,13 @@
 package common
 
-import "chain/banker"
+import "chain/runtime/unsafe"
 
 // AssertIsNotHandleNativeCoin validates that no native coins were sent with the transaction.
 // Panics with errNotHandleNativeCoin if any native coins were sent.
 //
 // Use this when a function should only work with GRC20 tokens and not accept native coins.
 func AssertIsNotHandleNativeCoin() {
-	if len(banker.OriginSend()) > 0 {
+	if len(unsafe.OriginSend()) > 0 {
 		panic(errNotHandleNativeCoin)
 	}
 }

--- a/contract/r/gnoswap/common/assert_test.gno
+++ b/contract/r/gnoswap/common/assert_test.gno
@@ -8,7 +8,7 @@ import (
 )
 
 // TestAssert_IsNotHandleNativeCoin tests the AssertIsNotHandleNativeCoin function with various scenarios
-func TestAssert_IsNotHandleNativeCoin(t *testing.T) {
+func TestAssert_IsNotHandleNativeCoin(cur realm, t *testing.T) {
 	tests := []struct {
 		name             string
 		sendCoins        map[string]int64
@@ -75,7 +75,7 @@ func TestAssert_IsNotHandleNativeCoin(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Setup banker environment
 			coins := make(chain.Coins, 0)
 			for denom, amount := range tt.sendCoins {
@@ -85,11 +85,11 @@ func TestAssert_IsNotHandleNativeCoin(t *testing.T) {
 
 			// Test
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.expectedPanicMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.expectedPanicMsg, func() {
 					AssertIsNotHandleNativeCoin()
 				}, tt.description)
 			} else {
-				uassert.NotPanics(t, func() {
+				uassert.NotPanics(t, cur, func() {
 					AssertIsNotHandleNativeCoin()
 				}, tt.description)
 			}

--- a/contract/r/gnoswap/common/grc20reg_helper.gno
+++ b/contract/r/gnoswap/common/grc20reg_helper.gno
@@ -104,7 +104,7 @@ func Allowance(path string, owner, spender address) int64 {
 //
 // Returns an error if the transfer fails, nil otherwise.
 func Transfer(cur realm, path string, to address, amount int64) error {
-	return GetTokenTeller(path).Transfer(to, amount)
+	return GetTokenTeller(path).Transfer(0, cur, to, amount)
 }
 
 // TransferFrom transfers tokens from one address to another using grc20.Teller.TransferFrom.
@@ -118,7 +118,7 @@ func Transfer(cur realm, path string, to address, amount int64) error {
 //
 // Returns an error if the transfer fails, nil otherwise.
 func TransferFrom(cur realm, path string, from, to address, amount int64) error {
-	return GetTokenTeller(path).TransferFrom(from, to, amount)
+	return GetTokenTeller(path).TransferFrom(0, cur, from, to, amount)
 }
 
 // Approve approves tokens for the specified spender using grc20.Teller.Approve.
@@ -131,7 +131,7 @@ func TransferFrom(cur realm, path string, from, to address, amount int64) error 
 //
 // Returns an error if the approval fails, nil otherwise.
 func Approve(cur realm, path string, spender address, amount int64) error {
-	return GetTokenTeller(path).Approve(spender, amount)
+	return GetTokenTeller(path).Approve(0, cur, spender, amount)
 }
 
 // SafeGRC20Transfer performs a token transfer and panics if it fails.
@@ -144,7 +144,7 @@ func Approve(cur realm, path string, spender address, amount int64) error {
 //
 // Panics if the transfer fails.
 func SafeGRC20Transfer(cur realm, path string, to address, amount int64) {
-	if err := GetTokenTeller(path).Transfer(to, amount); err != nil {
+	if err := GetTokenTeller(path).Transfer(0, cur, to, amount); err != nil {
 		panic(err)
 	}
 }
@@ -160,7 +160,7 @@ func SafeGRC20Transfer(cur realm, path string, to address, amount int64) {
 //
 // Panics if the transfer fails.
 func SafeGRC20TransferFrom(cur realm, path string, from, to address, amount int64) {
-	if err := GetTokenTeller(path).TransferFrom(from, to, amount); err != nil {
+	if err := GetTokenTeller(path).TransferFrom(0, cur, from, to, amount); err != nil {
 		panic(err)
 	}
 }
@@ -175,7 +175,7 @@ func SafeGRC20TransferFrom(cur realm, path string, from, to address, amount int6
 //
 // Panics if the approval fails.
 func SafeGRC20Approve(cur realm, path string, spender address, amount int64) {
-	if err := GetTokenTeller(path).Approve(spender, amount); err != nil {
+	if err := GetTokenTeller(path).Approve(0, cur, spender, amount); err != nil {
 		panic(err)
 	}
 }

--- a/contract/r/gnoswap/common/grc20reg_helper.gno
+++ b/contract/r/gnoswap/common/grc20reg_helper.gno
@@ -18,12 +18,13 @@ func GetToken(path string) *grc20.Token {
 	return grc20reg.MustGet(path)
 }
 
-// GetTokenTeller returns a grc20.Teller instance for the specified path, panicking if not registered.
+// GetTokenTeller returns a CallerTeller for the specified path, panicking if not registered.
 //
 // Parameters:
 //   - path: GRC20 token path
 //
-// Returns a grc20.Teller instance for making token operations.
+// Returns a grc20.Teller whose write methods derive the actor from the caller
+// realm.
 //
 // Panics if the token is not registered in grc20reg.
 func GetTokenTeller(path string) grc20.Teller {
@@ -94,10 +95,12 @@ func Allowance(path string, owner, spender address) int64 {
 	return GetToken(path).Allowance(owner, spender)
 }
 
-// Transfer transfers tokens to the specified address using grc20.Teller.Transfer.
+// Transfer crosses into common before forwarding to grc20.Teller.Transfer.
+// CallerTeller uses cur.Previous() as the token actor, so this helper must
+// remain a crossing adapter called with cross(cur).
 //
 // Parameters:
-//   - cur: current realm (unused, reserved for future use)
+//   - cur: current realm
 //   - path: GRC20 token path
 //   - to: recipient address
 //   - amount: amount of tokens to transfer
@@ -107,10 +110,12 @@ func Transfer(cur realm, path string, to address, amount int64) error {
 	return GetTokenTeller(path).Transfer(0, cur, to, amount)
 }
 
-// TransferFrom transfers tokens from one address to another using grc20.Teller.TransferFrom.
+// TransferFrom crosses into common before forwarding to grc20.Teller.TransferFrom.
+// CallerTeller uses cur.Previous() as the spender, so this helper must remain
+// a crossing adapter called with cross(cur).
 //
 // Parameters:
-//   - cur: current realm (unused, reserved for future use)
+//   - cur: current realm
 //   - path: GRC20 token path
 //   - from: sender address
 //   - to: recipient address
@@ -121,10 +126,12 @@ func TransferFrom(cur realm, path string, from, to address, amount int64) error 
 	return GetTokenTeller(path).TransferFrom(0, cur, from, to, amount)
 }
 
-// Approve approves tokens for the specified spender using grc20.Teller.Approve.
+// Approve crosses into common before forwarding to grc20.Teller.Approve.
+// CallerTeller uses cur.Previous() as the approver, so this helper must
+// remain a crossing adapter called with cross(cur).
 //
 // Parameters:
-//   - cur: current realm (unused, reserved for future use)
+//   - cur: current realm
 //   - path: GRC20 token path
 //   - spender: address allowed to spend the tokens
 //   - amount: amount of tokens to approve
@@ -134,10 +141,12 @@ func Approve(cur realm, path string, spender address, amount int64) error {
 	return GetTokenTeller(path).Approve(0, cur, spender, amount)
 }
 
-// SafeGRC20Transfer performs a token transfer and panics if it fails.
+// SafeGRC20Transfer crosses into common, transfers tokens, and panics if it fails.
+// CallerTeller uses cur.Previous() as the token actor, so this helper must
+// remain a crossing adapter called with cross(cur).
 //
 // Parameters:
-//   - cur: current realm (unused, reserved for future use)
+//   - cur: current realm
 //   - path: GRC20 token path
 //   - to: recipient address
 //   - amount: amount of tokens to transfer
@@ -149,10 +158,12 @@ func SafeGRC20Transfer(cur realm, path string, to address, amount int64) {
 	}
 }
 
-// SafeGRC20TransferFrom performs a token transfer from one address to another and panics if it fails.
+// SafeGRC20TransferFrom crosses into common, transfers tokens, and panics if it fails.
+// CallerTeller uses cur.Previous() as the spender, so this helper must remain
+// a crossing adapter called with cross(cur).
 //
 // Parameters:
-//   - cur: current realm (unused, reserved for future use)
+//   - cur: current realm
 //   - path: GRC20 token path
 //   - from: sender address
 //   - to: recipient address
@@ -165,10 +176,12 @@ func SafeGRC20TransferFrom(cur realm, path string, from, to address, amount int6
 	}
 }
 
-// SafeGRC20Approve performs a token approval and panics if it fails.
+// SafeGRC20Approve crosses into common, approves tokens, and panics if it fails.
+// CallerTeller uses cur.Previous() as the approver, so this helper must remain
+// a crossing adapter called with cross(cur).
 //
 // Parameters:
-//   - cur: current realm (unused, reserved for future use)
+//   - cur: current realm
 //   - path: GRC20 token path
 //   - spender: address allowed to spend the tokens
 //   - amount: amount of tokens to approve

--- a/contract/r/gnoswap/common/grc20reg_helper_test.gno
+++ b/contract/r/gnoswap/common/grc20reg_helper_test.gno
@@ -48,18 +48,16 @@ func TestGrc20regHelper_GetToken(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.shouldPanic {
-				defer func() {
-					if r := recover(); r == nil {
-						t.Errorf("Expected panic for %s", tt.name)
-					}
-				}()
+				uassert.AbortsContains(t, cur, "unknown token", func() {
+					GetToken(tt.path)
+				})
+				return
 			}
 
 			token := GetToken(tt.path)
-
-			if !tt.shouldPanic && token == nil {
+			if token == nil {
 				t.Error("Expected non-nil token")
 			}
 		})
@@ -69,35 +67,35 @@ func TestGrc20regHelper_GetToken(t *testing.T) {
 func TestGrc20regHelper_TokenMethod(t *testing.T) {
 	token := GetToken(tokenPath)
 
-	t.Run("GetName()", func(t *testing.T) {
+	t.Run("GetName()", func(cur realm, t *testing.T) {
 		uassert.Equal(t, "Foo", token.GetName())
 	})
 
-	t.Run("GetSymbol()", func(t *testing.T) {
+	t.Run("GetSymbol()", func(cur realm, t *testing.T) {
 		uassert.Equal(t, "FOO", token.GetSymbol())
 	})
 
-	t.Run("GetDecimals()", func(t *testing.T) {
+	t.Run("GetDecimals()", func(cur realm, t *testing.T) {
 		uassert.Equal(t, int(4), token.GetDecimals())
 	})
 
-	t.Run("TotalSupply()", func(t *testing.T) {
+	t.Run("TotalSupply()", func(cur realm, t *testing.T) {
 		uassert.Equal(t, int64(10000000000), token.TotalSupply())
 	})
 
-	t.Run("KnownAccounts()", func(t *testing.T) {
+	t.Run("KnownAccounts()", func(cur realm, t *testing.T) {
 		uassert.Equal(t, int(1), token.KnownAccounts())
 	})
 
-	t.Run("BalanceOf()", func(t *testing.T) {
+	t.Run("BalanceOf()", func(cur realm, t *testing.T) {
 		uassert.Equal(t, int64(10000000000), token.BalanceOf(address("g1rp7cmetn27eqlpjpc4vuusf8kaj746tysc0qgh")))
 	})
 
-	t.Run("Allowance()", func(t *testing.T) {
+	t.Run("Allowance()", func(cur realm, t *testing.T) {
 		uassert.Equal(t, int64(0), token.Allowance(address("g1rp7cmetn27eqlpjpc4vuusf8kaj746tysc0qgh"), address("g15vj5q08amlvyd0nx6zjgcvwq2d0gt9fcchrvum")))
 	})
 
-	t.Run("RenderHome()", func(t *testing.T) {
+	t.Run("RenderHome()", func(cur realm, t *testing.T) {
 		expected := ""
 		expected += ufmt.Sprintf("# %s ($%s)\n\n", "Foo", "FOO")
 		expected += ufmt.Sprintf("* **Decimals**: %d\n", 4)
@@ -131,25 +129,23 @@ func TestGrc20regHelper_GetTokenTeller(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.shouldPanic {
-				defer func() {
-					if r := recover(); r == nil {
-						t.Errorf("Expected panic for %s", tt.name)
-					}
-				}()
+				uassert.AbortsContains(t, cur, "unknown token", func() {
+					GetTokenTeller(tt.path)
+				})
+				return
 			}
 
 			teller := GetTokenTeller(tt.path)
-
-			if !tt.shouldPanic && teller == nil {
+			if teller == nil {
 				t.Error("Expected non-nil teller")
 			}
 		})
 	}
 }
 
-func TestGrc20regHelper_Transfer(t *testing.T) {
+func TestGrc20regHelper_Transfer(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
 		caller        address
@@ -229,15 +225,15 @@ func TestGrc20regHelper_Transfer(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			testing.SetRealm(testing.NewUserRealm(tt.caller))
 
 			if tt.shouldAbort {
-				uassert.AbortsContains(t, tt.abortContains, func() {
-					Transfer(cross, tt.path, tt.to, tt.amount)
+				uassert.AbortsContains(t, cur, tt.abortContains, func() {
+					Transfer(cross(cur), tt.path, tt.to, tt.amount)
 				})
 			} else {
-				err := Transfer(cross, tt.path, tt.to, tt.amount)
+				err := Transfer(cross(cur), tt.path, tt.to, tt.amount)
 				if tt.expectedError {
 					uassert.Error(t, err)
 				} else {
@@ -248,7 +244,7 @@ func TestGrc20regHelper_Transfer(t *testing.T) {
 	}
 }
 
-func TestGrc20regHelper_TransferFrom(t *testing.T) {
+func TestGrc20regHelper_TransferFrom(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
 		caller        address
@@ -335,22 +331,22 @@ func TestGrc20regHelper_TransferFrom(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Setup approval if needed - as the token owner (from address)
 			if tt.setupApproval {
 				testing.SetRealm(testing.NewUserRealm(tt.from))
-				Approve(cross, tt.path, tt.caller, tt.approvalAmt)
+				Approve(cross(cur), tt.path, tt.caller, tt.approvalAmt)
 			}
 
 			// Now perform TransferFrom as the caller
 			testing.SetRealm(testing.NewUserRealm(tt.caller))
 
 			if tt.shouldAbort {
-				uassert.AbortsContains(t, tt.abortContains, func() {
-					TransferFrom(cross, tt.path, tt.from, tt.to, tt.amount)
+				uassert.AbortsContains(t, cur, tt.abortContains, func() {
+					TransferFrom(cross(cur), tt.path, tt.from, tt.to, tt.amount)
 				})
 			} else {
-				err := TransferFrom(cross, tt.path, tt.from, tt.to, tt.amount)
+				err := TransferFrom(cross(cur), tt.path, tt.from, tt.to, tt.amount)
 				if tt.expectedError {
 					uassert.Error(t, err)
 				} else {
@@ -361,7 +357,7 @@ func TestGrc20regHelper_TransferFrom(t *testing.T) {
 	}
 }
 
-func TestGrc20regHelper_Approve(t *testing.T) {
+func TestGrc20regHelper_Approve(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
 		caller        address
@@ -424,15 +420,15 @@ func TestGrc20regHelper_Approve(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			testing.SetRealm(testing.NewUserRealm(tt.caller))
 
 			if tt.shouldAbort {
-				uassert.AbortsContains(t, tt.abortContains, func() {
-					Approve(cross, tt.path, tt.spender, tt.amount)
+				uassert.AbortsContains(t, cur, tt.abortContains, func() {
+					Approve(cross(cur), tt.path, tt.spender, tt.amount)
 				})
 			} else {
-				err := Approve(cross, tt.path, tt.spender, tt.amount)
+				err := Approve(cross(cur), tt.path, tt.spender, tt.amount)
 				if tt.expectedError {
 					uassert.Error(t, err)
 				} else {
@@ -443,7 +439,7 @@ func TestGrc20regHelper_Approve(t *testing.T) {
 	}
 }
 
-func TestGrc20regHelper_SafeGRC20Transfer(t *testing.T) {
+func TestGrc20regHelper_SafeGRC20Transfer(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
 		caller        address
@@ -491,23 +487,23 @@ func TestGrc20regHelper_SafeGRC20Transfer(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			testing.SetRealm(testing.NewUserRealm(tt.caller))
 
 			if tt.shouldAbort {
-				uassert.AbortsContains(t, tt.abortContains, func() {
-					SafeGRC20Transfer(cross, tt.path, tt.to, tt.amount)
+				uassert.AbortsContains(t, cur, tt.abortContains, func() {
+					SafeGRC20Transfer(cross(cur), tt.path, tt.to, tt.amount)
 				})
 			} else {
-				uassert.NotPanics(t, func() {
-					SafeGRC20Transfer(cross, tt.path, tt.to, tt.amount)
+				uassert.NotPanics(t, cur, func() {
+					SafeGRC20Transfer(cross(cur), tt.path, tt.to, tt.amount)
 				})
 			}
 		})
 	}
 }
 
-func TestGrc20regHelper_SafeGRC20TransferFrom(t *testing.T) {
+func TestGrc20regHelper_SafeGRC20TransferFrom(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
 		caller        address
@@ -567,30 +563,30 @@ func TestGrc20regHelper_SafeGRC20TransferFrom(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Setup approval if needed
 			if tt.setupApproval {
 				testing.SetRealm(testing.NewUserRealm(tt.from))
-				Approve(cross, tt.path, tt.caller, tt.approvalAmt)
+				Approve(cross(cur), tt.path, tt.caller, tt.approvalAmt)
 			}
 
 			// Now perform SafeGRC20TransferFrom as the caller
 			testing.SetRealm(testing.NewUserRealm(tt.caller))
 
 			if tt.shouldAbort {
-				uassert.AbortsContains(t, tt.abortContains, func() {
-					SafeGRC20TransferFrom(cross, tt.path, tt.from, tt.to, tt.amount)
+				uassert.AbortsContains(t, cur, tt.abortContains, func() {
+					SafeGRC20TransferFrom(cross(cur), tt.path, tt.from, tt.to, tt.amount)
 				})
 			} else {
-				uassert.NotPanics(t, func() {
-					SafeGRC20TransferFrom(cross, tt.path, tt.from, tt.to, tt.amount)
+				uassert.NotPanics(t, cur, func() {
+					SafeGRC20TransferFrom(cross(cur), tt.path, tt.from, tt.to, tt.amount)
 				})
 			}
 		})
 	}
 }
 
-func TestGrc20regHelper_SafeGRC20Approve(t *testing.T) {
+func TestGrc20regHelper_SafeGRC20Approve(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
 		caller        address
@@ -637,16 +633,16 @@ func TestGrc20regHelper_SafeGRC20Approve(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			testing.SetRealm(testing.NewUserRealm(tt.caller))
 
 			if tt.shouldAbort {
-				uassert.AbortsContains(t, tt.abortContains, func() {
-					SafeGRC20Approve(cross, tt.path, tt.spender, tt.amount)
+				uassert.AbortsContains(t, cur, tt.abortContains, func() {
+					SafeGRC20Approve(cross(cur), tt.path, tt.spender, tt.amount)
 				})
 			} else {
-				uassert.NotPanics(t, func() {
-					SafeGRC20Approve(cross, tt.path, tt.spender, tt.amount)
+				uassert.NotPanics(t, cur, func() {
+					SafeGRC20Approve(cross(cur), tt.path, tt.spender, tt.amount)
 				})
 			}
 		})
@@ -682,7 +678,7 @@ func TestGrc20regHelper_IsRegistered(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			err := IsRegistered(tt.path)
 			if tt.expectedError {
 				uassert.Error(t, err)
@@ -737,13 +733,12 @@ func TestGrc20regHelper_MustRegistered(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.shouldPanic {
-				defer func() {
-					if r := recover(); r == nil {
-						t.Errorf("Expected panic for %s", tt.name)
-					}
-				}()
+				uassert.PanicsContains(t, cur, "token(", func() {
+					MustRegistered(tt.paths...)
+				})
+				return
 			}
 			MustRegistered(tt.paths...)
 		})
@@ -776,20 +771,16 @@ func TestGrc20regHelper_TotalSupply(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.shouldPanic {
-				defer func() {
-					if r := recover(); r == nil {
-						t.Errorf("Expected panic for %s", tt.name)
-					}
-				}()
+				uassert.AbortsContains(t, cur, "unknown token", func() {
+					TotalSupply(tt.path)
+				})
+				return
 			}
 
 			supply := TotalSupply(tt.path)
-
-			if !tt.shouldPanic {
-				uassert.Equal(t, tt.expectedSupply, supply)
-			}
+			uassert.Equal(t, tt.expectedSupply, supply)
 		})
 	}
 }
@@ -833,20 +824,16 @@ func TestGrc20regHelper_BalanceOf(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.shouldPanic {
-				defer func() {
-					if r := recover(); r == nil {
-						t.Errorf("Expected panic for %s", tt.name)
-					}
-				}()
+				uassert.AbortsContains(t, cur, "unknown token", func() {
+					BalanceOf(tt.path, tt.addr)
+				})
+				return
 			}
 
 			balance := BalanceOf(tt.path, tt.addr)
-
-			if !tt.shouldPanic {
-				uassert.Equal(t, tt.expectedBalance, balance)
-			}
+			uassert.Equal(t, tt.expectedBalance, balance)
 		})
 	}
 }
@@ -904,20 +891,16 @@ func TestGrc20regHelper_Allowance(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.shouldPanic {
-				defer func() {
-					if r := recover(); r == nil {
-						t.Errorf("Expected panic for %s", tt.name)
-					}
-				}()
+				uassert.AbortsContains(t, cur, "unknown token", func() {
+					Allowance(tt.path, tt.owner, tt.spender)
+				})
+				return
 			}
 
 			allowance := Allowance(tt.path, tt.owner, tt.spender)
-
-			if !tt.shouldPanic {
-				uassert.Equal(t, tt.expectedAllowance, allowance)
-			}
+			uassert.Equal(t, tt.expectedAllowance, allowance)
 		})
 	}
 }

--- a/contract/r/gnoswap/common/grc20reg_helper_test.gno
+++ b/contract/r/gnoswap/common/grc20reg_helper_test.gno
@@ -226,6 +226,12 @@ func TestGrc20regHelper_Transfer(cur realm, t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
+			var beforeCallerBalance, beforeRecipientBalance int64
+			if !tt.expectedError && !tt.shouldAbort {
+				beforeCallerBalance = BalanceOf(tt.path, tt.caller)
+				beforeRecipientBalance = BalanceOf(tt.path, tt.to)
+			}
+
 			testing.SetRealm(testing.NewUserRealm(tt.caller))
 
 			if tt.shouldAbort {
@@ -238,6 +244,8 @@ func TestGrc20regHelper_Transfer(cur realm, t *testing.T) {
 					uassert.Error(t, err)
 				} else {
 					uassert.NoError(t, err)
+					uassert.Equal(t, beforeCallerBalance-tt.amount, BalanceOf(tt.path, tt.caller))
+					uassert.Equal(t, beforeRecipientBalance+tt.amount, BalanceOf(tt.path, tt.to))
 				}
 			}
 		})
@@ -335,7 +343,15 @@ func TestGrc20regHelper_TransferFrom(cur realm, t *testing.T) {
 			// Setup approval if needed - as the token owner (from address)
 			if tt.setupApproval {
 				testing.SetRealm(testing.NewUserRealm(tt.from))
-				Approve(cross(cur), tt.path, tt.caller, tt.approvalAmt)
+				err := Approve(cross(cur), tt.path, tt.caller, tt.approvalAmt)
+				uassert.NoError(t, err)
+			}
+
+			var beforeOwnerBalance, beforeRecipientBalance, beforeAllowance int64
+			if !tt.expectedError && !tt.shouldAbort {
+				beforeOwnerBalance = BalanceOf(tt.path, tt.from)
+				beforeRecipientBalance = BalanceOf(tt.path, tt.to)
+				beforeAllowance = Allowance(tt.path, tt.from, tt.caller)
 			}
 
 			// Now perform TransferFrom as the caller
@@ -351,6 +367,9 @@ func TestGrc20regHelper_TransferFrom(cur realm, t *testing.T) {
 					uassert.Error(t, err)
 				} else {
 					uassert.NoError(t, err)
+					uassert.Equal(t, beforeOwnerBalance-tt.amount, BalanceOf(tt.path, tt.from))
+					uassert.Equal(t, beforeRecipientBalance+tt.amount, BalanceOf(tt.path, tt.to))
+					uassert.Equal(t, beforeAllowance-tt.amount, Allowance(tt.path, tt.from, tt.caller))
 				}
 			}
 		})
@@ -433,6 +452,7 @@ func TestGrc20regHelper_Approve(cur realm, t *testing.T) {
 					uassert.Error(t, err)
 				} else {
 					uassert.NoError(t, err)
+					uassert.Equal(t, tt.amount, Allowance(tt.path, tt.caller, tt.spender))
 				}
 			}
 		})

--- a/contract/r/gnoswap/common/liquidity_amounts_test.gno
+++ b/contract/r/gnoswap/common/liquidity_amounts_test.gno
@@ -49,7 +49,7 @@ func TestLiquidityAmounts_ToAscendingOrder(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			min, max := toAscendingOrder(tt.a, tt.b)
 
 			if min.ToString() != tt.expectedA {
@@ -90,7 +90,7 @@ func TestLiquidityAmounts_SafeConvertToUint128(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.shouldPanic {
 				defer func() {
 					if r := recover(); r == nil {
@@ -163,7 +163,7 @@ func TestLiquidityAmounts_ComputeLiquidityForAmount0(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			defer func() {
 				if r := recover(); r != nil {
 					if !tc.expectPanic {
@@ -186,7 +186,7 @@ func TestLiquidityAmounts_ComputeLiquidityForAmount0(t *testing.T) {
 	}
 }
 
-func TestLiquidityAmounts_ComputeLiquidityForAmount1(t *testing.T) {
+func TestLiquidityAmounts_ComputeLiquidityForAmount1(cur realm, t *testing.T) {
 	q96 := u256.MustFromDecimal(Q96)
 
 	tests := []struct {
@@ -242,9 +242,9 @@ func TestLiquidityAmounts_ComputeLiquidityForAmount1(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.expectedPanic {
-				uassert.PanicsWithMessage(t, tt.expectedPanicMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.expectedPanicMsg, func() {
 					_ = computeLiquidityForAmount1(tt.sqrtRatioAX96, tt.sqrtRatioBX96, tt.amount1)
 				})
 			} else {
@@ -318,7 +318,7 @@ func TestLiquidityAmounts_GetLiquidityForAmounts(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			sqrtRatioX96 := u256.MustFromDecimal(tc.sqrtRatioX96)
 			sqrtRatioAX96 := u256.MustFromDecimal(tc.sqrtRatioAX96)
 			sqrtRatioBX96 := u256.MustFromDecimal(tc.sqrtRatioBX96)
@@ -381,7 +381,7 @@ func TestLiquidityAmounts_ComputeAmount0ForLiquidity(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			sqrtRatioAX96 := u256.MustFromDecimal(tc.sqrtRatioAX96)
 			sqrtRatioBX96 := u256.MustFromDecimal(tc.sqrtRatioBX96)
 			liquidity := u256.MustFromDecimal(tc.liquidity)
@@ -444,7 +444,7 @@ func TestLiquidityAmounts_ComputeAmount1ForLiquidity(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			result := computeAmount1ForLiquidity(tt.sqrtRatioAX96, tt.sqrtRatioBX96, tt.liquidity)
 			uassert.Equal(t, tt.expectedAmount, result.ToString(), ufmt.Sprintf("expected %s but got %s", tt.expectedAmount, result.ToString()))
 		})
@@ -538,7 +538,7 @@ func TestLiquidityAmounts_GetAmountsForLiquidity(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			amount0, amount1 := GetAmountsForLiquidity(tt.sqrtRatioX96, tt.sqrtRatioAX96, tt.sqrtRatioBX96, tt.liquidity)
 			uassert.Equal(t, tt.expectedAmount0, amount0.ToString(), ufmt.Sprintf("expected %s but got %s for amount0", tt.expectedAmount0, amount0))
 			uassert.Equal(t, tt.expectedAmount1, amount1.ToString(), ufmt.Sprintf("expected %s but got %s for amount1", tt.expectedAmount1, amount1))
@@ -582,7 +582,7 @@ func TestLiquidityAmounts_ExtremeRatioValues(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			result := tt.testFunc()
 			if tt.expected != "" {
 				uassert.Equal(t, tt.expected, result)
@@ -591,7 +591,7 @@ func TestLiquidityAmounts_ExtremeRatioValues(t *testing.T) {
 	}
 }
 
-func TestLiquidityAmounts_MulDivOverflowProtection(t *testing.T) {
+func TestLiquidityAmounts_MulDivOverflowProtection(cur realm, t *testing.T) {
 	tests := []struct {
 		name             string
 		value            *u256.Uint
@@ -618,9 +618,9 @@ func TestLiquidityAmounts_MulDivOverflowProtection(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.expectedPanic {
-				uassert.PanicsWithMessage(t, tt.expectedPanicMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.expectedPanicMsg, func() {
 					_ = computeLiquidityForAmount0(tt.sqrtRatioA, tt.sqrtRatioB, tt.value)
 				})
 			} else {
@@ -633,7 +633,7 @@ func TestLiquidityAmounts_MulDivOverflowProtection(t *testing.T) {
 	}
 }
 
-func TestLiquidityAmounts_LiquidityMathAddDelta(t *testing.T) {
+func TestLiquidityAmounts_LiquidityMathAddDelta(cur realm, t *testing.T) {
 	tests := []struct {
 		name      string
 		fn        func()
@@ -721,9 +721,9 @@ func TestLiquidityAmounts_LiquidityMathAddDelta(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.wantPanic != "" {
-				uassert.PanicsContains(t, tt.wantPanic, tt.fn)
+				uassert.PanicsContains(t, cur, tt.wantPanic, tt.fn)
 			} else {
 				tt.fn()
 			}
@@ -797,7 +797,7 @@ func TestLiquidityAmounts_NilParameterHandling(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.wantPanic {
 				defer func() {
 					if r := recover(); r == nil {

--- a/contract/r/gnoswap/common/tick_math_test.gno
+++ b/contract/r/gnoswap/common/tick_math_test.gno
@@ -17,7 +17,7 @@ var (
 	MAX_SQRT_RATIO = "1461446703485210103287273052203988822378723970342"
 )
 
-func TestTickMath_GetSqrtRatioAtTick(t *testing.T) {
+func TestTickMath_GetSqrtRatioAtTick(cur realm, t *testing.T) {
 	tests := []struct {
 		name                 string
 		tick                 int32
@@ -182,9 +182,9 @@ func TestTickMath_GetSqrtRatioAtTick(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.expectedHasPanic {
-				uassert.PanicsWithMessage(t, tt.expectedPanicMessage, func() {
+				uassert.PanicsWithMessage(t, cur, tt.expectedPanicMessage, func() {
 					TickMathGetSqrtRatioAtTick(tt.tick)
 				})
 			} else {
@@ -195,7 +195,7 @@ func TestTickMath_GetSqrtRatioAtTick(t *testing.T) {
 	}
 }
 
-func TestTickMath_GetTickAtSqrtRatio(t *testing.T) {
+func TestTickMath_GetTickAtSqrtRatio(cur realm, t *testing.T) {
 	tests := []struct {
 		name                 string
 		sqrtPriceX96         string
@@ -346,14 +346,14 @@ func TestTickMath_GetTickAtSqrtRatio(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			var sqrtPriceX96 *u256.Uint
 			if tt.sqrtPriceX96 != "" {
 				sqrtPriceX96 = u256.MustFromDecimal(tt.sqrtPriceX96)
 			}
 
 			if tt.expectedHasPanic {
-				uassert.PanicsContains(t, tt.expectedPanicMessage, func() {
+				uassert.PanicsContains(t, cur, tt.expectedPanicMessage, func() {
 					TickMathGetTickAtSqrtRatio(sqrtPriceX96)
 				})
 			} else {
@@ -378,7 +378,7 @@ func TestTickMath_PrecisionValidation(t *testing.T) {
 				continue
 			}
 
-			t.Run(ufmt.Sprintf("precision_tick_%d", tick), func(t *testing.T) {
+			t.Run(ufmt.Sprintf("precision_tick_%d", tick), func(cur realm, t *testing.T) {
 				result := TickMathGetSqrtRatioAtTick(tick)
 
 				// Basic validation: result should be within valid range
@@ -416,7 +416,7 @@ func TestTickMath_Constants(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			sqrtRatio := TickMathGetSqrtRatioAtTick(tt.tick)
 			expectedSqrtRatio := u256.MustFromDecimal(tt.expectedRatio)
 
@@ -492,7 +492,7 @@ func TestTickMath_RatioValidation(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		t.Run(test.name, func(cur realm, t *testing.T) {
 			sqrtRatio := u256.MustFromDecimal(test.sqrtRatio)
 
 			if test.expectValid {
@@ -520,7 +520,7 @@ func TestTickMath_RatioValidation(t *testing.T) {
 	}
 }
 
-func TestTickMath_BoundaryConditions(t *testing.T) {
+func TestTickMath_BoundaryConditions(cur realm, t *testing.T) {
 	tests := []struct {
 		name             string
 		tick             int32
@@ -552,9 +552,9 @@ func TestTickMath_BoundaryConditions(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		t.Run(test.name, func(cur realm, t *testing.T) {
 			if test.expectedPanic {
-				uassert.PanicsWithMessage(t, test.expectedPanicMsg, func() {
+				uassert.PanicsWithMessage(t, cur, test.expectedPanicMsg, func() {
 					TickMathGetSqrtRatioAtTick(test.tick)
 				})
 			} else {
@@ -569,7 +569,7 @@ func TestTickMath_BoundaryConditions(t *testing.T) {
 	}
 }
 
-func TestTickMath_SqrtRatioBoundaryConditions(t *testing.T) {
+func TestTickMath_SqrtRatioBoundaryConditions(cur realm, t *testing.T) {
 	tests := []struct {
 		name             string
 		sqrtRatio        string
@@ -601,11 +601,11 @@ func TestTickMath_SqrtRatioBoundaryConditions(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		t.Run(test.name, func(cur realm, t *testing.T) {
 			sqrtRatio := u256.MustFromDecimal(test.sqrtRatio)
 
 			if test.expectedPanic {
-				uassert.PanicsWithMessage(t, test.expectedPanicMsg, func() {
+				uassert.PanicsWithMessage(t, cur, test.expectedPanicMsg, func() {
 					TickMathGetTickAtSqrtRatio(sqrtRatio)
 				})
 			} else {
@@ -619,7 +619,7 @@ func TestTickMath_SqrtRatioBoundaryConditions(t *testing.T) {
 }
 
 // TestTickMath_MaxTickBoundaryBehavior explicitly tests MAX_TICK boundary behavior
-func TestTickMath_MaxTickBoundaryBehavior(t *testing.T) {
+func TestTickMath_MaxTickBoundaryBehavior(cur realm, t *testing.T) {
 	tests := []struct {
 		name             string
 		tick             int32
@@ -642,9 +642,9 @@ func TestTickMath_MaxTickBoundaryBehavior(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.expectPanic {
-				uassert.PanicsWithMessage(t, tt.expectedPanicMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.expectedPanicMsg, func() {
 					TickMathGetSqrtRatioAtTick(tt.tick)
 				})
 			} else {
@@ -668,22 +668,22 @@ func TestTickMath_MaxTickBoundaryBehavior(t *testing.T) {
 	}
 
 	// Explicitly test that MAX_SQRT_RATIO is rejected by TickMathGetTickAtSqrtRatio
-	t.Run("MAX_SQRT_RATIO_rejected_by_GetTickAtSqrtRatio", func(t *testing.T) {
+	t.Run("MAX_SQRT_RATIO_rejected_by_GetTickAtSqrtRatio", func(cur realm, t *testing.T) {
 		maxSqrtRatio := u256.MustFromDecimal(MAX_SQRT_RATIO)
 
 		// This should panic because TickMathGetTickAtSqrtRatio uses strict inequality (sqrtPriceX96 >= maxSqrtPriceX96)
-		uassert.PanicsContains(t, "out of range", func() {
+		uassert.PanicsContains(t, cur, "out of range", func() {
 			TickMathGetTickAtSqrtRatio(maxSqrtRatio)
 		})
 	})
 
 	// Test that MAX_SQRT_RATIO - 1 is accepted
-	t.Run("MAX_SQRT_RATIO_minus_1_accepted", func(t *testing.T) {
+	t.Run("MAX_SQRT_RATIO_minus_1_accepted", func(cur realm, t *testing.T) {
 		maxSqrtRatio := u256.MustFromDecimal(MAX_SQRT_RATIO)
 		almostMaxSqrtRatio := u256.Zero().Sub(maxSqrtRatio, u256.One())
 
 		// This should NOT panic
-		uassert.NotPanics(t, func() {
+		uassert.NotPanics(t, cur, func() {
 			tick := TickMathGetTickAtSqrtRatio(almostMaxSqrtRatio)
 			// Should return MAX_TICK - 1
 			uassert.Equal(t, MAX_TICK-1, tick,
@@ -735,7 +735,7 @@ func TestTickMath_ExtendedRoundtripAccuracy(t *testing.T) {
 	}
 
 	for _, tick := range testTicks {
-		t.Run(ufmt.Sprintf("tick_%d", tick), func(t *testing.T) {
+		t.Run(ufmt.Sprintf("tick_%d", tick), func(cur realm, t *testing.T) {
 			// Convert tick to sqrt ratio
 			sqrtRatio := TickMathGetSqrtRatioAtTick(tick)
 


### PR DESCRIPTION
## Summary
- Migrates common helper realm calls to Interrealm v2 conventions.
- Updates common package tests to use realm-aware test and uassert signatures.
- Refreshes GRC20 Teller wrapper calls to pass the current realm explicitly.

## Changes
- Replaced native coin assertion dependency with the Interrealm v2 unsafe runtime API.
- Updated common GRC20 helper wrappers to call Teller write methods with `(0, cur, ...)`.
- Converted common tests and subtests to pass `cur realm`, including `cross(cur)` call sites and realm-aware `uassert` helpers.

## Verification
- `make test PKG=gno.land/r/gnoswap/common`
