### PR TITLE
refactor(gns): migrate to interrealm v2

### DIFF
--- a/contract/r/gnoswap/gns/_helper_test.gno
+++ b/contract/r/gnoswap/gns/_helper_test.gno
@@ -16,17 +16,18 @@ import (
 
 var adminAddr = access.MustGetAddress(prabc.ROLE_ADMIN.String())
 
-func resetObject(t *testing.T) {
+func resetObject(cur realm, t *testing.T) {
 	t.Helper()
 
-	resetGnsTokenObject(t)
+	resetGnsTokenObject(cur, t)
 	resetEmissionState(t)
 }
 
-func resetGnsTokenObject(t *testing.T) {
+func resetGnsTokenObject(cur realm, t *testing.T) {
 	t.Helper()
 
-	token, privateLedger = grc20.NewToken("Gnoswap", "GNS", 6)
+	token, privateLedger = grc20.NewToken(0, cur, "Gnoswap", "GNS", 6)
+	UserTeller = token.CallerTeller()
 
 	privateLedger.Mint(adminAddr, INITIAL_MINT_AMOUNT)
 }
@@ -42,7 +43,7 @@ func resetEmissionState(t *testing.T) {
 
 // InitGnsTest initializes GNS state for testing by resetting emission amounts and state.
 // Matches init() function: lastMintedTimestamp starts at 0 (never minted).
-func InitGnsTest(t *testing.T) {
+func InitGnsTest(cur realm, t *testing.T) {
 	t.Helper()
 
 	setLeftEmissionAmount(MAX_EMISSION_AMOUNT)

--- a/contract/r/gnoswap/gns/emission.gno
+++ b/contract/r/gnoswap/gns/emission.gno
@@ -2,7 +2,6 @@ package gns
 
 import (
 	"chain"
-	"chain/runtime"
 	"time"
 
 	"gno.land/r/gnoswap/access"
@@ -12,7 +11,7 @@ import (
 // Only callable by emission contract. Sets up 12-year emission schedule
 // with halving every 2 years. Panics if caller is not emission contract.
 func InitEmissionState(cur realm, createdHeight int64, startTimestamp int64) {
-	previousRealm := runtime.PreviousRealm()
+	previousRealm := cur.Previous()
 	caller := previousRealm.Address()
 	access.AssertIsEmission(caller)
 

--- a/contract/r/gnoswap/gns/emission_distribution_test.gno
+++ b/contract/r/gnoswap/gns/emission_distribution_test.gno
@@ -9,9 +9,9 @@ import (
 
 // TestEmissionDistributionAcrossYears verifies that emission distribution is correct
 // for each year based on the halving schedule
-func TestEmissionDistributionAcrossYears(t *testing.T) {
+func TestEmissionDistributionAcrossYears(cur realm, t *testing.T) {
 	resetEmissionState(t)
-	InitGnsTest(t)
+	InitGnsTest(cur, t)
 
 	// Test emission amounts for each year
 	scenarios := []struct {
@@ -47,7 +47,7 @@ func TestEmissionDistributionAcrossYears(t *testing.T) {
 	}
 
 	for _, sc := range scenarios {
-		t.Run(sc.name, func(t *testing.T) {
+		t.Run(sc.name, func(cur realm, t *testing.T) {
 			// Test emission rate at different points in the year
 			startTs := GetHalvingYearStartTimestamp(sc.year)
 			endTs := GetHalvingYearEndTimestamp(sc.year)
@@ -77,9 +77,9 @@ func TestEmissionDistributionAcrossYears(t *testing.T) {
 }
 
 // TestEmissionHalvingSchedule verifies the halving schedule is correct
-func TestEmissionHalvingSchedule(t *testing.T) {
+func TestEmissionHalvingSchedule(cur realm, t *testing.T) {
 	resetEmissionState(t)
-	InitGnsTest(t)
+	InitGnsTest(cur, t)
 
 	// Verify halving amounts
 	halvingTests := []struct {
@@ -97,7 +97,7 @@ func TestEmissionHalvingSchedule(t *testing.T) {
 	}
 
 	for _, tt := range halvingTests {
-		t.Run(tt.description, func(t *testing.T) {
+		t.Run(tt.description, func(cur realm, t *testing.T) {
 			amount1 := GetHalvingAmountsPerYear(tt.fromYear)
 			amount2 := GetHalvingAmountsPerYear(tt.toYear)
 

--- a/contract/r/gnoswap/gns/emission_state_test.gno
+++ b/contract/r/gnoswap/gns/emission_state_test.gno
@@ -7,7 +7,7 @@ import (
 	uassert "gno.land/p/nt/uassert/v0"
 )
 
-func TestNewEmissionState(t *testing.T) {
+func TestNewEmissionState(cur realm, t *testing.T) {
 	tests := []struct {
 		name           string
 		createdHeight  int64
@@ -71,9 +71,9 @@ func TestNewEmissionState(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.panicMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.panicMsg, func() {
 					NewEmissionState(tt.createdHeight, tt.startTimestamp)
 				})
 				return
@@ -89,7 +89,7 @@ func TestNewEmissionState(t *testing.T) {
 	}
 }
 
-func TestIsInitialized(t *testing.T) {
+func TestIsInitialized(cur realm, t *testing.T) {
 	tests := []struct {
 		name           string
 		createdHeight  int64
@@ -147,7 +147,7 @@ func TestIsInitialized(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			es := NewEmissionState(tt.createdHeight, tt.startTimestamp)
 			got := es.isInitialized()
 			uassert.Equal(t, tt.want, got)
@@ -155,7 +155,7 @@ func TestIsInitialized(t *testing.T) {
 	}
 }
 
-func TestIsActive(t *testing.T) {
+func TestIsActive(cur realm, t *testing.T) {
 	startTs := int64(10000)
 	es := NewEmissionState(1, startTs)
 	endTs := es.getEndTimestamp()
@@ -189,14 +189,14 @@ func TestIsActive(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			got := es.isActive(tt.timestamp)
 			uassert.Equal(t, tt.want, got)
 		})
 	}
 }
 
-func TestIsActive_UninitializedState(t *testing.T) {
+func TestIsActive_UninitializedState(cur realm, t *testing.T) {
 	es := NewEmissionState(0, 0) // uninitialized
 
 	tests := []struct {
@@ -211,13 +211,13 @@ func TestIsActive_UninitializedState(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			uassert.False(t, es.isActive(tt.timestamp), "uninitialized state should never be active")
 		})
 	}
 }
 
-func TestIsActive_NegativeStartTimestamp(t *testing.T) {
+func TestIsActive_NegativeStartTimestamp(cur realm, t *testing.T) {
 	es := NewEmissionState(1, -1000)
 
 	tests := []struct {
@@ -233,14 +233,14 @@ func TestIsActive_NegativeStartTimestamp(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			got := es.isActive(tt.timestamp)
 			uassert.Equal(t, tt.want, got)
 		})
 	}
 }
 
-func TestIsEnded(t *testing.T) {
+func TestIsEnded(cur realm, t *testing.T) {
 	startTs := int64(10000)
 	es := NewEmissionState(1, startTs)
 	endTs := es.getEndTimestamp()
@@ -266,14 +266,14 @@ func TestIsEnded(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			got := es.isEnded(tt.timestamp)
 			uassert.Equal(t, tt.want, got)
 		})
 	}
 }
 
-func TestGetCurrentYear(t *testing.T) {
+func TestGetCurrentYear(cur realm, t *testing.T) {
 	startTs := int64(10000)
 	es := NewEmissionState(1, startTs)
 
@@ -309,14 +309,14 @@ func TestGetCurrentYear(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			got := es.getCurrentYear(tt.timestamp)
 			uassert.Equal(t, tt.want, got)
 		})
 	}
 }
 
-func TestGetCurrentYear_AllYearBoundaries(t *testing.T) {
+func TestGetCurrentYear_AllYearBoundaries(cur realm, t *testing.T) {
 	startTs := int64(10000)
 	es := NewEmissionState(1, startTs)
 
@@ -336,7 +336,7 @@ func TestGetCurrentYear_AllYearBoundaries(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			t.Run("year_"+formatInt(year)+"_"+tt.name, func(t *testing.T) {
+			t.Run("year_"+formatInt(year)+"_"+tt.name, func(cur realm, t *testing.T) {
 				got := es.getCurrentYear(tt.ts)
 				uassert.Equal(t, year, got)
 			})
@@ -344,7 +344,7 @@ func TestGetCurrentYear_AllYearBoundaries(t *testing.T) {
 	}
 }
 
-func TestGetters(t *testing.T) {
+func TestGetters(cur realm, t *testing.T) {
 	tests := []struct {
 		name           string
 		createdHeight  int64
@@ -358,7 +358,7 @@ func TestGetters(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			es := NewEmissionState(tt.createdHeight, tt.startTimestamp)
 
 			uassert.Equal(t, tt.createdHeight, es.getCreatedHeight())
@@ -371,7 +371,7 @@ func TestGetters(t *testing.T) {
 	}
 }
 
-func TestGetHalvingYearStartTimestamp(t *testing.T) {
+func TestGetHalvingYearStartTimestamp(cur realm, t *testing.T) {
 	startTs := int64(10000)
 	es := NewEmissionState(1, startTs)
 
@@ -395,14 +395,14 @@ func TestGetHalvingYearStartTimestamp(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			got := es.getHalvingYearStartTimestamp(tt.year)
 			uassert.Equal(t, tt.expected, got)
 		})
 	}
 }
 
-func TestGetHalvingYearEndTimestamp(t *testing.T) {
+func TestGetHalvingYearEndTimestamp(cur realm, t *testing.T) {
 	startTs := int64(10000)
 	es := NewEmissionState(1, startTs)
 
@@ -425,20 +425,20 @@ func TestGetHalvingYearEndTimestamp(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			got := es.getHalvingYearEndTimestamp(tt.year)
 			uassert.Equal(t, tt.expected, got)
 		})
 	}
 }
 
-func TestHalvingYearTimestampContinuity(t *testing.T) {
+func TestHalvingYearTimestampContinuity(cur realm, t *testing.T) {
 	startTs := int64(10000)
 	es := NewEmissionState(1, startTs)
 
 	// Verify that year boundaries are continuous
 	for year := int64(1); year < HALVING_END_YEAR; year++ {
-		t.Run("year_"+formatInt(year)+"_to_"+formatInt(year+1), func(t *testing.T) {
+		t.Run("year_"+formatInt(year)+"_to_"+formatInt(year+1), func(cur realm, t *testing.T) {
 			endTs := es.getHalvingYearEndTimestamp(year)
 			nextStartTs := es.getHalvingYearStartTimestamp(year + 1)
 
@@ -447,7 +447,7 @@ func TestHalvingYearTimestampContinuity(t *testing.T) {
 	}
 }
 
-func TestGetHalvingYearAmountPerSecond(t *testing.T) {
+func TestGetHalvingYearAmountPerSecond(cur realm, t *testing.T) {
 	startTs := int64(10000)
 	es := NewEmissionState(1, startTs)
 
@@ -471,14 +471,14 @@ func TestGetHalvingYearAmountPerSecond(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			got := es.getHalvingYearAmountPerSecond(tt.year)
 			uassert.Equal(t, tt.expected, got)
 		})
 	}
 }
 
-func TestHalvingRates(t *testing.T) {
+func TestHalvingRates(cur realm, t *testing.T) {
 	startTs := int64(10000)
 	es := NewEmissionState(1, startTs)
 
@@ -499,7 +499,7 @@ func TestHalvingRates(t *testing.T) {
 	year1Rate := es.getHalvingYearAmountPerSecond(1)
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			got := es.getHalvingYearAmountPerSecond(tt.year)
 			expected := year1Rate / tt.multiplier
 			uassert.Equal(t, expected, got)
@@ -507,7 +507,7 @@ func TestHalvingRates(t *testing.T) {
 	}
 }
 
-func TestGetHalvingYearAccumulatedAmount(t *testing.T) {
+func TestGetHalvingYearAccumulatedAmount(cur realm, t *testing.T) {
 	startTs := int64(10000)
 	es := NewEmissionState(1, startTs)
 
@@ -529,14 +529,14 @@ func TestGetHalvingYearAccumulatedAmount(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			got := es.getHalvingYearAccumulatedAmount(tt.year)
 			uassert.Equal(t, tt.expected, got)
 		})
 	}
 }
 
-func TestGetHalvingYearLeftAmount(t *testing.T) {
+func TestGetHalvingYearLeftAmount(cur realm, t *testing.T) {
 	startTs := int64(10000)
 	es := NewEmissionState(1, startTs)
 
@@ -558,14 +558,14 @@ func TestGetHalvingYearLeftAmount(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			got := es.getHalvingYearLeftAmount(tt.year)
 			uassert.Equal(t, tt.expected, got)
 		})
 	}
 }
 
-func TestAddHalvingYearAccumulatedAmount(t *testing.T) {
+func TestAddHalvingYearAccumulatedAmount(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		year        int64
@@ -587,7 +587,7 @@ func TestAddHalvingYearAccumulatedAmount(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			es := NewEmissionState(1, 10000)
 			err := es.addHalvingYearAccumulatedAmount(tt.year, tt.amount)
 
@@ -602,7 +602,7 @@ func TestAddHalvingYearAccumulatedAmount(t *testing.T) {
 	}
 }
 
-func TestAddHalvingYearAccumulatedAmount_Cumulative(t *testing.T) {
+func TestAddHalvingYearAccumulatedAmount_Cumulative(cur realm, t *testing.T) {
 	tests := []struct {
 		name    string
 		amounts []int64
@@ -614,7 +614,7 @@ func TestAddHalvingYearAccumulatedAmount_Cumulative(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			es := NewEmissionState(1, 10000)
 			expectedTotal := int64(0)
 
@@ -629,7 +629,7 @@ func TestAddHalvingYearAccumulatedAmount_Cumulative(t *testing.T) {
 	}
 }
 
-func TestAddHalvingYearAccumulatedAmount_Overflow(t *testing.T) {
+func TestAddHalvingYearAccumulatedAmount_Overflow(cur realm, t *testing.T) {
 	tests := []struct {
 		name         string
 		initialValue int64
@@ -651,18 +651,18 @@ func TestAddHalvingYearAccumulatedAmount_Overflow(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			es := NewEmissionState(1, 10000)
 			es.halvingData.setAccumAmount(1, tt.initialValue)
 
-			uassert.PanicsWithMessage(t, tt.panicMsg, func() {
+			uassert.PanicsWithMessage(t, cur, tt.panicMsg, func() {
 				es.addHalvingYearAccumulatedAmount(1, tt.addAmount)
 			})
 		})
 	}
 }
 
-func TestSubHalvingYearLeftAmount(t *testing.T) {
+func TestSubHalvingYearLeftAmount(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		year        int64
@@ -681,7 +681,7 @@ func TestSubHalvingYearLeftAmount(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			es := NewEmissionState(1, 10000)
 			initialLeft := es.getHalvingYearLeftAmount(tt.year)
 			err := es.subHalvingYearLeftAmount(tt.year, tt.amount)
@@ -697,7 +697,7 @@ func TestSubHalvingYearLeftAmount(t *testing.T) {
 	}
 }
 
-func TestSubHalvingYearLeftAmount_Underflow(t *testing.T) {
+func TestSubHalvingYearLeftAmount_Underflow(cur realm, t *testing.T) {
 	tests := []struct {
 		name         string
 		initialValue int64
@@ -719,18 +719,18 @@ func TestSubHalvingYearLeftAmount_Underflow(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			es := NewEmissionState(1, 10000)
 			es.halvingData.setLeftAmount(1, tt.initialValue)
 
-			uassert.PanicsWithMessage(t, tt.panicMsg, func() {
+			uassert.PanicsWithMessage(t, cur, tt.panicMsg, func() {
 				es.subHalvingYearLeftAmount(1, tt.subAmount)
 			})
 		})
 	}
 }
 
-func TestAddSubConsistency(t *testing.T) {
+func TestAddSubConsistency(cur realm, t *testing.T) {
 	tests := []struct {
 		name       string
 		year       int64
@@ -742,7 +742,7 @@ func TestAddSubConsistency(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Reset emission state for each test
 			es := NewEmissionState(1, 10000)
 			maxAmount := GetHalvingAmountsPerYear(tt.year)
@@ -763,7 +763,7 @@ func TestAddSubConsistency(t *testing.T) {
 	}
 }
 
-func TestGetEmissionState(t *testing.T) {
+func TestGetEmissionState(cur realm, t *testing.T) {
 	tests := []struct {
 		name string
 	}{
@@ -772,7 +772,7 @@ func TestGetEmissionState(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			resetEmissionState(t)
 
 			es := getEmissionState()
@@ -787,13 +787,13 @@ func TestGetEmissionState(t *testing.T) {
 	}
 }
 
-func TestEmissionStateYearBoundaryPrecision(t *testing.T) {
+func TestEmissionStateYearBoundaryPrecision(cur realm, t *testing.T) {
 	startTs := int64(10000)
 	es := NewEmissionState(1, startTs)
 
 	// Test exact second transitions
 	for year := int64(1); year < HALVING_END_YEAR; year++ {
-		t.Run("year_"+formatInt(year)+"_to_"+formatInt(year+1), func(t *testing.T) {
+		t.Run("year_"+formatInt(year)+"_to_"+formatInt(year+1), func(cur realm, t *testing.T) {
 			lastSecondOfYear := es.getHalvingYearEndTimestamp(year)
 			firstSecondOfNextYear := es.getHalvingYearStartTimestamp(year + 1)
 
@@ -811,7 +811,7 @@ func TestEmissionStateYearBoundaryPrecision(t *testing.T) {
 	}
 }
 
-func TestEmissionStateTotalEmission(t *testing.T) {
+func TestEmissionStateTotalEmission(cur realm, t *testing.T) {
 	es := NewEmissionState(1, 10000)
 
 	// Sum of all years' left amounts should equal MAX_EMISSION_AMOUNT
@@ -822,7 +822,7 @@ func TestEmissionStateTotalEmission(t *testing.T) {
 	uassert.Equal(t, MAX_EMISSION_AMOUNT, totalLeft)
 }
 
-func TestEmissionStateHalvingDataIntegrity(t *testing.T) {
+func TestEmissionStateHalvingDataIntegrity(cur realm, t *testing.T) {
 	startTs := int64(10000)
 	es := NewEmissionState(1, startTs)
 	halvingData := es.getHalvingData()
@@ -831,7 +831,7 @@ func TestEmissionStateHalvingDataIntegrity(t *testing.T) {
 
 	// Verify halving data matches emission state getters for all years
 	for year := int64(1); year <= HALVING_END_YEAR; year++ {
-		t.Run("year_"+formatInt(year), func(t *testing.T) {
+		t.Run("year_"+formatInt(year), func(cur realm, t *testing.T) {
 			uassert.Equal(t, halvingData.getStartTimestamp(year), es.getHalvingYearStartTimestamp(year))
 			uassert.Equal(t, halvingData.getEndTimestamp(year), es.getHalvingYearEndTimestamp(year))
 			uassert.Equal(t, halvingData.getAmountPerSecond(year), es.getHalvingYearAmountPerSecond(year))
@@ -841,7 +841,7 @@ func TestEmissionStateHalvingDataIntegrity(t *testing.T) {
 	}
 }
 
-func TestEmissionStateEndTimestampCalculation(t *testing.T) {
+func TestEmissionStateEndTimestampCalculation(cur realm, t *testing.T) {
 	tests := []struct {
 		name           string
 		startTimestamp int64
@@ -853,7 +853,7 @@ func TestEmissionStateEndTimestampCalculation(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			es := NewEmissionState(1, tt.startTimestamp)
 
 			// End timestamp should be exactly 12 years - 1 second from start
@@ -867,7 +867,7 @@ func TestEmissionStateEndTimestampCalculation(t *testing.T) {
 	}
 }
 
-func TestEmissionStateRepeatedOperations(t *testing.T) {
+func TestEmissionStateRepeatedOperations(cur realm, t *testing.T) {
 	tests := []struct {
 		name       string
 		iterations int
@@ -878,7 +878,7 @@ func TestEmissionStateRepeatedOperations(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			es := NewEmissionState(1, 10000)
 
 			for i := 0; i < tt.iterations; i++ {
@@ -898,7 +898,7 @@ func TestEmissionStateRepeatedOperations(t *testing.T) {
 	}
 }
 
-func TestEmissionStateAllYearsIndependent(t *testing.T) {
+func TestEmissionStateAllYearsIndependent(cur realm, t *testing.T) {
 	es := NewEmissionState(1, 10000)
 
 	// Modify each year independently
@@ -910,7 +910,7 @@ func TestEmissionStateAllYearsIndependent(t *testing.T) {
 
 	// Verify each year was modified independently
 	for year := int64(1); year <= HALVING_END_YEAR; year++ {
-		t.Run("year_"+formatInt(year), func(t *testing.T) {
+		t.Run("year_"+formatInt(year), func(cur realm, t *testing.T) {
 			expected := year * 1000
 			got := es.getHalvingYearAccumulatedAmount(year)
 			uassert.Equal(t, expected, got)

--- a/contract/r/gnoswap/gns/emission_test.gno
+++ b/contract/r/gnoswap/gns/emission_test.gno
@@ -9,9 +9,9 @@ import (
 )
 
 // TestEmissionBoundaryConditions tests for emission at year boundaries
-func TestEmissionBoundaryConditions(t *testing.T) {
+func TestEmissionBoundaryConditions(cur realm, t *testing.T) {
 	resetEmissionState(t)
-	InitGnsTest(t)
+	InitGnsTest(cur, t)
 
 	tests := []struct {
 		name           string
@@ -64,7 +64,7 @@ func TestEmissionBoundaryConditions(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			amount := GetEmissionAmountPerSecondByTimestamp(tt.timestamp)
 			uassert.Equal(t, tt.expectedAmount, amount,
 				"%s: %s", tt.name, tt.description)
@@ -73,9 +73,9 @@ func TestEmissionBoundaryConditions(t *testing.T) {
 }
 
 // TestEmissionAmountCalculation tests emission amount calculation for different timestamps
-func TestEmissionAmountCalculation(t *testing.T) {
+func TestEmissionAmountCalculation(cur realm, t *testing.T) {
 	resetEmissionState(t)
-	InitGnsTest(t)
+	InitGnsTest(cur, t)
 
 	tests := []struct {
 		name           string
@@ -122,7 +122,7 @@ func TestEmissionAmountCalculation(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			startTs := GetHalvingYearStartTimestamp(tt.year)
 			endTs := GetHalvingYearEndTimestamp(tt.year)
 			duration := endTs - startTs
@@ -137,7 +137,7 @@ func TestEmissionAmountCalculation(t *testing.T) {
 }
 
 // TestEmissionStateConsistency tests that emission state remains consistent
-func TestEmissionStateConsistency(t *testing.T) {
+func TestEmissionStateConsistency(cur realm, t *testing.T) {
 	resetEmissionState(t)
 
 	tests := []struct {
@@ -149,7 +149,7 @@ func TestEmissionStateConsistency(t *testing.T) {
 		{
 			name: "Initial state consistency",
 			operation: func() {
-				resetObject(t)
+				resetObject(cur, t)
 			},
 			validation: func(t *testing.T) {
 				totalMaxAmount := int64(0)
@@ -191,7 +191,7 @@ func TestEmissionStateConsistency(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			tt.operation()
 			tt.validation(t)
 		})
@@ -199,9 +199,9 @@ func TestEmissionStateConsistency(t *testing.T) {
 }
 
 // TestYearTransitions tests emission calculations at year transitions
-func TestYearTransitions(t *testing.T) {
+func TestYearTransitions(cur realm, t *testing.T) {
 	resetEmissionState(t)
-	InitGnsTest(t)
+	InitGnsTest(cur, t)
 
 	tests := []struct {
 		name        string
@@ -230,7 +230,7 @@ func TestYearTransitions(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Test at the boundary
 			endTs := GetHalvingYearEndTimestamp(tt.fromYear)
 			nextStartTs := GetHalvingYearStartTimestamp(tt.toYear)
@@ -264,9 +264,9 @@ func TestYearTransitions(t *testing.T) {
 }
 
 // TestEmissionTotalAmount tests that total emission amounts are correct
-func TestEmissionTotalAmount(t *testing.T) {
+func TestEmissionTotalAmount(cur realm, t *testing.T) {
 	resetEmissionState(t)
-	InitGnsTest(t)
+	InitGnsTest(cur, t)
 
 	// Calculate total emission by summing all years
 	totalEmission := int64(0)
@@ -300,7 +300,7 @@ func TestEmissionTotalAmount(t *testing.T) {
 }
 
 // TestEmissionStateIsActiveBoundary tests isActive at exact boundary timestamps
-func TestEmissionStateIsActiveBoundary(t *testing.T) {
+func TestEmissionStateIsActiveBoundary(cur realm, t *testing.T) {
 	startTs := int64(1000)
 	es := NewEmissionState(1, startTs)
 	endTs := es.getEndTimestamp()
@@ -322,7 +322,7 @@ func TestEmissionStateIsActiveBoundary(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			result := es.isActive(tt.timestamp)
 			uassert.Equal(t, tt.expected, result, "isActive result mismatch for %s", tt.name)
 		})
@@ -330,7 +330,7 @@ func TestEmissionStateIsActiveBoundary(t *testing.T) {
 }
 
 // TestEmissionStateIsEndedBoundary tests isEnded at exact boundary timestamps
-func TestEmissionStateIsEndedBoundary(t *testing.T) {
+func TestEmissionStateIsEndedBoundary(cur realm, t *testing.T) {
 	startTs := int64(1000)
 	es := NewEmissionState(1, startTs)
 	endTs := es.getEndTimestamp()
@@ -350,7 +350,7 @@ func TestEmissionStateIsEndedBoundary(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			result := es.isEnded(tt.timestamp)
 			uassert.Equal(t, tt.expected, result, "isEnded result mismatch for %s", tt.name)
 		})
@@ -358,7 +358,7 @@ func TestEmissionStateIsEndedBoundary(t *testing.T) {
 }
 
 // TestEmissionStateGetCurrentYearBoundary tests getCurrentYear at year boundaries
-func TestEmissionStateGetCurrentYearBoundary(t *testing.T) {
+func TestEmissionStateGetCurrentYearBoundary(cur realm, t *testing.T) {
 	startTs := int64(10000)
 	es := NewEmissionState(1, startTs)
 
@@ -379,7 +379,7 @@ func TestEmissionStateGetCurrentYearBoundary(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			result := es.getCurrentYear(tt.timestamp)
 			uassert.Equal(t, tt.expected, result, "getCurrentYear result mismatch for %s", tt.name)
 		})
@@ -387,15 +387,15 @@ func TestEmissionStateGetCurrentYearBoundary(t *testing.T) {
 }
 
 // TestEmissionStateUninitializedBehavior tests behavior when EmissionState is not initialized
-func TestEmissionStateUninitializedBehavior(t *testing.T) {
+func TestEmissionStateUninitializedBehavior(cur realm, t *testing.T) {
 	// Create uninitialized state
 	es := NewEmissionState(0, 0)
 
-	t.Run("isInitialized should be false", func(t *testing.T) {
+	t.Run("isInitialized should be false", func(cur realm, t *testing.T) {
 		uassert.False(t, es.isInitialized())
 	})
 
-	t.Run("isActive should be false for any timestamp", func(t *testing.T) {
+	t.Run("isActive should be false for any timestamp", func(cur realm, t *testing.T) {
 		timestamps := []int64{-1000, 0, 1, 1000, 9999999}
 		for _, ts := range timestamps {
 			uassert.False(t, es.isActive(ts))
@@ -404,9 +404,9 @@ func TestEmissionStateUninitializedBehavior(t *testing.T) {
 }
 
 // TestEmissionStateAddSubHalvingYearAmounts tests add/sub operations with edge cases
-func TestEmissionStateAddSubHalvingYearAmounts(t *testing.T) {
+func TestEmissionStateAddSubHalvingYearAmounts(cur realm, t *testing.T) {
 	resetEmissionState(t)
-	InitGnsTest(t)
+	InitGnsTest(cur, t)
 
 	es := getEmissionState()
 
@@ -427,7 +427,7 @@ func TestEmissionStateAddSubHalvingYearAmounts(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			var err error
 			if tt.operation == "add" {
 				err = es.addHalvingYearAccumulatedAmount(tt.year, tt.amount)
@@ -445,14 +445,14 @@ func TestEmissionStateAddSubHalvingYearAmounts(t *testing.T) {
 }
 
 // TestEmissionStateAmountConsistency tests that accumulated and left amounts stay consistent
-func TestEmissionStateAmountConsistency(t *testing.T) {
+func TestEmissionStateAmountConsistency(cur realm, t *testing.T) {
 	resetEmissionState(t)
-	InitGnsTest(t)
+	InitGnsTest(cur, t)
 
 	es := getEmissionState()
 
 	for year := int64(1); year <= 12; year++ {
-		t.Run("Year consistency for year "+formatInt(year), func(t *testing.T) {
+		t.Run("Year consistency for year "+formatInt(year), func(cur realm, t *testing.T) {
 			initialAccum := es.getHalvingYearAccumulatedAmount(year)
 			initialLeft := es.getHalvingYearLeftAmount(year)
 			maxAmount := GetHalvingYearMaxAmount(year)
@@ -481,7 +481,7 @@ func TestEmissionStateAmountConsistency(t *testing.T) {
 }
 
 // TestEmissionStateTimestampEdgeCases tests edge cases with various timestamps
-func TestEmissionStateTimestampEdgeCases(t *testing.T) {
+func TestEmissionStateTimestampEdgeCases(cur realm, t *testing.T) {
 	tests := []struct {
 		name           string
 		createdHeight  int64
@@ -513,7 +513,7 @@ func TestEmissionStateTimestampEdgeCases(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			es := NewEmissionState(tt.createdHeight, tt.startTimestamp)
 			year := es.getCurrentYear(tt.testTimestamp)
 			uassert.Equal(t, tt.expectedYear, year, "Year mismatch for "+tt.name)
@@ -522,9 +522,9 @@ func TestEmissionStateTimestampEdgeCases(t *testing.T) {
 }
 
 // TestAddHalvingYearAccumulatedAmountOverflow tests overflow protection in addHalvingYearAccumulatedAmount
-func TestAddHalvingYearAccumulatedAmountOverflow(t *testing.T) {
-	resetObject(t)
-	InitGnsTest(t)
+func TestAddHalvingYearAccumulatedAmountOverflow(cur realm, t *testing.T) {
+	resetObject(cur, t)
+	InitGnsTest(cur, t)
 
 	es := getEmissionState()
 
@@ -577,12 +577,12 @@ func TestAddHalvingYearAccumulatedAmountOverflow(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Set initial accumulated amount
 			es.halvingData.setAccumAmount(tt.year, tt.initialValue)
 
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.panicMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.panicMsg, func() {
 					es.addHalvingYearAccumulatedAmount(tt.year, tt.addAmount)
 				})
 			} else {
@@ -599,9 +599,9 @@ func TestAddHalvingYearAccumulatedAmountOverflow(t *testing.T) {
 }
 
 // TestSubHalvingYearLeftAmountUnderflow tests underflow protection in subHalvingYearLeftAmount
-func TestSubHalvingYearLeftAmountUnderflow(t *testing.T) {
-	resetObject(t)
-	InitGnsTest(t)
+func TestSubHalvingYearLeftAmountUnderflow(cur realm, t *testing.T) {
+	resetObject(cur, t)
+	InitGnsTest(cur, t)
 
 	es := getEmissionState()
 
@@ -661,12 +661,12 @@ func TestSubHalvingYearLeftAmountUnderflow(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Set initial left amount
 			es.halvingData.setLeftAmount(tt.year, tt.initialValue)
 
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.panicMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.panicMsg, func() {
 					es.subHalvingYearLeftAmount(tt.year, tt.subAmount)
 				})
 			} else {
@@ -683,7 +683,7 @@ func TestSubHalvingYearLeftAmountUnderflow(t *testing.T) {
 }
 
 // TestNewEmissionStateOverflow tests overflow protection in NewEmissionState
-func TestNewEmissionStateOverflow(t *testing.T) {
+func TestNewEmissionStateOverflow(cur realm, t *testing.T) {
 	tests := []struct {
 		name           string
 		createdHeight  int64
@@ -726,9 +726,9 @@ func TestNewEmissionStateOverflow(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.panicMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.panicMsg, func() {
 					NewEmissionState(tt.createdHeight, tt.startTimestamp)
 				})
 			} else {

--- a/contract/r/gnoswap/gns/getter_test.gno
+++ b/contract/r/gnoswap/gns/getter_test.gno
@@ -9,7 +9,7 @@ import (
 
 // TestGetHalvingYearInfo verifies that GetHalvingYearInfo correctly calculates
 // year-specific start and end timestamps and maintains consistency with other functions.
-func TestGetHalvingYearInfo(t *testing.T) {
+func TestGetHalvingYearInfo(cur realm, t *testing.T) {
 	const testStartTimestamp = int64(1000)
 	emissionState = NewEmissionState(1, testStartTimestamp)
 	halvingData := emissionState.getHalvingData()
@@ -66,7 +66,7 @@ func TestGetHalvingYearInfo(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			year, startTime, endTime := GetHalvingYearInfo(tt.timestamp)
 
 			if year != tt.expectedYear {
@@ -112,7 +112,7 @@ func TestGetHalvingYearInfo(t *testing.T) {
 	}
 }
 
-func TestValidYearEdgeCases(t *testing.T) {
+func TestValidYearEdgeCases(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		year        int64
@@ -128,7 +128,7 @@ func TestValidYearEdgeCases(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			err := validYear(tt.year)
 
 			if tt.shouldError {
@@ -140,7 +140,7 @@ func TestValidYearEdgeCases(t *testing.T) {
 	}
 }
 
-func TestValidEmissionAmountEdgeCases(t *testing.T) {
+func TestValidEmissionAmountEdgeCases(cur realm, t *testing.T) {
 	tests := []struct {
 		name             string
 		currentMinted    int64
@@ -158,7 +158,7 @@ func TestValidEmissionAmountEdgeCases(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			setMintedEmissionAmount(tt.currentMinted)
 
 			err := validEmissionAmount(tt.amountToValidate)
@@ -172,9 +172,9 @@ func TestValidEmissionAmountEdgeCases(t *testing.T) {
 	}
 }
 
-func TestGetEmissionAmountPerSecondInRangeEdgeCases(t *testing.T) {
+func TestGetEmissionAmountPerSecondInRangeEdgeCases(cur realm, t *testing.T) {
 	resetEmissionState(t)
-	InitGnsTest(t)
+	InitGnsTest(cur, t)
 
 	year3Start := GetHalvingYearStartTimestamp(3)
 
@@ -193,7 +193,7 @@ func TestGetEmissionAmountPerSecondInRangeEdgeCases(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			times, emissions := GetEmissionAmountPerSecondInRange(tt.fromTime, tt.toTime)
 
 			uassert.Equal(t, tt.expectedLength, len(times))
@@ -211,9 +211,9 @@ func TestGetEmissionAmountPerSecondInRangeEdgeCases(t *testing.T) {
 	}
 }
 
-func TestGetEmissionAmountPerSecondInRangeBoundary(t *testing.T) {
+func TestGetEmissionAmountPerSecondInRangeBoundary(cur realm, t *testing.T) {
 	resetEmissionState(t)
-	InitGnsTest(t)
+	InitGnsTest(cur, t)
 
 	year3Start := GetHalvingYearStartTimestamp(3)
 	year4Start := GetHalvingYearStartTimestamp(4)
@@ -232,44 +232,44 @@ func TestGetEmissionAmountPerSecondInRangeBoundary(t *testing.T) {
 		}
 	}
 
-	t.Run("fromTime at year start includes that year", func(t *testing.T) {
+	t.Run("fromTime at year start includes that year", func(cur realm, t *testing.T) {
 		times, emissions := GetEmissionAmountPerSecondInRange(year3Start, year5End)
 		verifyResult(t, times, emissions, 3)
 		uassert.Equal(t, year3Start, times[0])
 	})
 
-	t.Run("fromTime after year start excludes that year", func(t *testing.T) {
+	t.Run("fromTime after year start excludes that year", func(cur realm, t *testing.T) {
 		times, emissions := GetEmissionAmountPerSecondInRange(year3Start+1, year5End)
 		verifyResult(t, times, emissions, 2)
 		uassert.Equal(t, year4Start, times[0])
 	})
 
-	t.Run("fromTime in middle of year to next year start-1 returns empty", func(t *testing.T) {
+	t.Run("fromTime in middle of year to next year start-1 returns empty", func(cur realm, t *testing.T) {
 		times, emissions := GetEmissionAmountPerSecondInRange(midYear3, year4Start-1)
 		verifyResult(t, times, emissions, 0)
 	})
 
-	t.Run("fromTime in middle of year to next year start includes only next year", func(t *testing.T) {
+	t.Run("fromTime in middle of year to next year start includes only next year", func(cur realm, t *testing.T) {
 		times, emissions := GetEmissionAmountPerSecondInRange(midYear3, year4Start)
 		verifyResult(t, times, emissions, 1)
 		uassert.Equal(t, year4Start, times[0])
 	})
 
-	t.Run("toTime at year start includes that year", func(t *testing.T) {
+	t.Run("toTime at year start includes that year", func(cur realm, t *testing.T) {
 		times, emissions := GetEmissionAmountPerSecondInRange(year3Start, year5Start)
 		verifyResult(t, times, emissions, 3)
 		uassert.Equal(t, year5Start, times[2])
 	})
 
-	t.Run("toTime one second before year start excludes that year", func(t *testing.T) {
+	t.Run("toTime one second before year start excludes that year", func(cur realm, t *testing.T) {
 		times, emissions := GetEmissionAmountPerSecondInRange(year3Start, year5Start-1)
 		verifyResult(t, times, emissions, 2)
 	})
 }
 
-func TestGetEmissionFunctionsWithInvalidTimestamps(t *testing.T) {
+func TestGetEmissionFunctionsWithInvalidTimestamps(cur realm, t *testing.T) {
 	resetEmissionState(t)
-	InitGnsTest(t)
+	InitGnsTest(cur, t)
 
 	tests := []struct {
 		name      string
@@ -284,24 +284,24 @@ func TestGetEmissionFunctionsWithInvalidTimestamps(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name+" - GetEmissionAmountPerSecondByTimestamp", func(t *testing.T) {
+		t.Run(tt.name+" - GetEmissionAmountPerSecondByTimestamp", func(cur realm, t *testing.T) {
 			result := GetEmissionAmountPerSecondByTimestamp(tt.timestamp)
 			uassert.Equal(t, int64(0), result)
 		})
 
-		t.Run(tt.name+" - GetEmissionLeftAmountByTimestamp", func(t *testing.T) {
+		t.Run(tt.name+" - GetEmissionLeftAmountByTimestamp", func(cur realm, t *testing.T) {
 			result := GetEmissionLeftAmountByTimestamp(tt.timestamp)
 			uassert.Equal(t, int64(0), result)
 		})
 
-		t.Run(tt.name+" - GetEmissionAccumulatedAmountByTimestamp", func(t *testing.T) {
+		t.Run(tt.name+" - GetEmissionAccumulatedAmountByTimestamp", func(cur realm, t *testing.T) {
 			result := GetEmissionAccumulatedAmountByTimestamp(tt.timestamp)
 			uassert.Equal(t, int64(0), result)
 		})
 	}
 }
 
-func TestEmissionActiveBoundaries(t *testing.T) {
+func TestEmissionActiveBoundaries(cur realm, t *testing.T) {
 	const testStartTimestamp = int64(1000000)
 	emissionState = NewEmissionState(1, testStartTimestamp)
 
@@ -359,7 +359,7 @@ func TestEmissionActiveBoundaries(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			es := getEmissionState()
 
 			actualActive := es.isActive(tt.timestamp)
@@ -382,7 +382,7 @@ func TestEmissionActiveBoundaries(t *testing.T) {
 // for timestamps >= 0 within the 12-year range because the calculation is:
 // (timestamp - startTimestamp) / SECONDS_IN_YEAR + 1 = (timestamp - 0) / SECONDS_IN_YEAR + 1
 // However, isActive returns false because isInitialized() is false (startBlock == 0).
-func TestEmissionStateUninitializedBoundaries(t *testing.T) {
+func TestEmissionStateUninitializedBoundaries(cur realm, t *testing.T) {
 	emissionState = NewEmissionState(0, 0)
 	endTimestamp := getEmissionState().getEndTimestamp()
 
@@ -424,7 +424,7 @@ func TestEmissionStateUninitializedBoundaries(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			es := getEmissionState()
 
 			uassert.Equal(t, tt.expectedActive, es.isActive(tt.timestamp),
@@ -437,7 +437,7 @@ func TestEmissionStateUninitializedBoundaries(t *testing.T) {
 	}
 }
 
-func TestYearTransitionBoundaries(t *testing.T) {
+func TestYearTransitionBoundaries(cur realm, t *testing.T) {
 	const testStartTimestamp = int64(1000000)
 	emissionState = NewEmissionState(1, testStartTimestamp)
 
@@ -445,7 +445,7 @@ func TestYearTransitionBoundaries(t *testing.T) {
 		yearEndTimestamp := testStartTimestamp + (SECONDS_IN_YEAR * year) - 1
 		nextYearStartTimestamp := testStartTimestamp + (SECONDS_IN_YEAR * year)
 
-		t.Run(ufmt.Sprintf("year %d to %d transition", year, year+1), func(t *testing.T) {
+		t.Run(ufmt.Sprintf("year %d to %d transition", year, year+1), func(cur realm, t *testing.T) {
 			es := getEmissionState()
 
 			// Last second of current year
@@ -465,9 +465,9 @@ func TestYearTransitionBoundaries(t *testing.T) {
 	}
 }
 
-func TestGetEmissionAmountPerSecondInRangeIsolation(t *testing.T) {
+func TestGetEmissionAmountPerSecondInRangeIsolation(cur realm, t *testing.T) {
 	resetEmissionState(t)
-	InitGnsTest(t)
+	InitGnsTest(cur, t)
 
 	fromTime := GetHalvingYearStartTimestamp(3)
 	toTime := GetHalvingYearEndTimestamp(5)
@@ -485,9 +485,9 @@ func TestGetEmissionAmountPerSecondInRangeIsolation(t *testing.T) {
 	uassert.Equal(t, 3, len(reFetchedEmissions))
 }
 
-func TestGetHalvingInfoIsolation(t *testing.T) {
+func TestGetHalvingInfoIsolation(cur realm, t *testing.T) {
 	resetEmissionState(t)
-	InitGnsTest(t)
+	InitGnsTest(cur, t)
 
 	halvingInfo := GetHalvingInfo()
 	halvingInfo.startTimestamps[0] = -1

--- a/contract/r/gnoswap/gns/gns.gno
+++ b/contract/r/gnoswap/gns/gns.gno
@@ -2,7 +2,6 @@ package gns
 
 import (
 	"chain"
-	"chain/runtime"
 	"strings"
 	"time"
 
@@ -23,22 +22,26 @@ const (
 )
 
 var (
-	token, privateLedger = grc20.NewToken("Gnoswap", "GNS", 6)
-	UserTeller           = token.CallerTeller()
+	token         *grc20.Token
+	privateLedger *grc20.PrivateLedger
+	UserTeller    grc20.Teller
 
 	leftEmissionAmount   int64 // amount of GNS can be minted for emission
 	mintedEmissionAmount int64 // amount of GNS that has been minted for emission
 	lastMintedTimestamp  int64 // last block time that gns was minted for emission
 )
 
-func init() {
+func init(cur realm) {
+	token, privateLedger = grc20.NewToken(0, cur, "Gnoswap", "GNS", 6)
+	UserTeller = token.CallerTeller()
+
 	adminAddr := access.MustGetAddress(prabc.ROLE_ADMIN.String())
 	err := privateLedger.Mint(adminAddr, INITIAL_MINT_AMOUNT)
 	if err != nil {
 		panic(err.Error())
 	}
 
-	grc20reg.Register(cross, token, "")
+	grc20reg.Register(cross(cur), token, "")
 
 	// Initial amount set to 900_000_000_000_000 (MAXIMUM_SUPPLY - INITIAL_MINT_AMOUNT).
 	// leftEmissionAmount will decrease as tokens are minted.
@@ -80,7 +83,7 @@ func Allowance(owner, spender address) int64 { return token.Allowance(owner, spe
 // to allow graceful handling. This function assumes caller has already verified
 // halt status before invoking.
 func MintGns(cur realm, address address) int64 {
-	previousRealm := runtime.PreviousRealm()
+	previousRealm := cur.Previous()
 	caller := previousRealm.Address()
 	access.AssertIsEmission(caller)
 
@@ -131,7 +134,7 @@ func MintGns(cur realm, address address) int64 {
 //   - amount: amount to transfer
 func Transfer(cur realm, to address, amount int64) {
 	userTeller := token.CallerTeller()
-	checkErr(userTeller.Transfer(to, amount))
+	checkErr(userTeller.Transfer(0, cur, to, amount))
 }
 
 // Approve allows spender to transfer GNS tokens from caller's account.
@@ -141,7 +144,7 @@ func Transfer(cur realm, to address, amount int64) {
 //   - amount: maximum amount spender can transfer
 func Approve(cur realm, spender address, amount int64) {
 	userTeller := token.CallerTeller()
-	checkErr(userTeller.Approve(spender, amount))
+	checkErr(userTeller.Approve(0, cur, spender, amount))
 }
 
 // TransferFrom transfers GNS tokens on behalf of owner.
@@ -152,7 +155,7 @@ func Approve(cur realm, spender address, amount int64) {
 //   - amount: amount to transfer
 func TransferFrom(cur realm, from, to address, amount int64) {
 	userTeller := token.CallerTeller()
-	checkErr(userTeller.TransferFrom(from, to, amount))
+	checkErr(userTeller.TransferFrom(0, cur, from, to, amount))
 }
 
 // Render returns token information for web interface.

--- a/contract/r/gnoswap/gns/gns.gno
+++ b/contract/r/gnoswap/gns/gns.gno
@@ -24,7 +24,7 @@ const (
 var (
 	token         *grc20.Token
 	privateLedger *grc20.PrivateLedger
-	UserTeller    grc20.Teller
+	userTeller    grc20.Teller
 
 	leftEmissionAmount   int64 // amount of GNS can be minted for emission
 	mintedEmissionAmount int64 // amount of GNS that has been minted for emission
@@ -33,7 +33,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken(0, cur, "Gnoswap", "GNS", 6)
-	UserTeller = token.CallerTeller()
+	userTeller = token.CallerTeller()
 
 	adminAddr := access.MustGetAddress(prabc.ROLE_ADMIN.String())
 	err := privateLedger.Mint(adminAddr, INITIAL_MINT_AMOUNT)
@@ -133,7 +133,6 @@ func MintGns(cur realm, address address) int64 {
 //   - to: recipient address
 //   - amount: amount to transfer
 func Transfer(cur realm, to address, amount int64) {
-	userTeller := token.CallerTeller()
 	checkErr(userTeller.Transfer(0, cur, to, amount))
 }
 
@@ -143,7 +142,6 @@ func Transfer(cur realm, to address, amount int64) {
 //   - spender: address authorized to spend
 //   - amount: maximum amount spender can transfer
 func Approve(cur realm, spender address, amount int64) {
-	userTeller := token.CallerTeller()
 	checkErr(userTeller.Approve(0, cur, spender, amount))
 }
 
@@ -154,7 +152,6 @@ func Approve(cur realm, spender address, amount int64) {
 //   - to: recipient address
 //   - amount: amount to transfer
 func TransferFrom(cur realm, from, to address, amount int64) {
-	userTeller := token.CallerTeller()
 	checkErr(userTeller.TransferFrom(0, cur, from, to, amount))
 }
 

--- a/contract/r/gnoswap/gns/gns_test.gno
+++ b/contract/r/gnoswap/gns/gns_test.gno
@@ -28,7 +28,7 @@ var (
 	userRealm = testing.NewUserRealm(testutils.TestAddress("user"))
 )
 
-func TestKnownAccounts(t *testing.T) {
+func TestKnownAccounts(cur realm, t *testing.T) {
 	testing.SetOriginCaller(alice)
 	testing.SetRealm(testing.NewUserRealm(alice))
 	func() {
@@ -37,15 +37,15 @@ func TestKnownAccounts(t *testing.T) {
 	}()
 }
 
-func TestTotalSupply(t *testing.T) {
+func TestTotalSupply(cur realm, t *testing.T) {
 	uassert.Equal(t, INITIAL_MINT_AMOUNT, TotalSupply())
 }
 
-func TestBalanceOf(t *testing.T) {
+func TestBalanceOf(cur realm, t *testing.T) {
 	uassert.Equal(t, INITIAL_MINT_AMOUNT, BalanceOf(adminAddr))
 }
 
-func TestValidEmissionAmount(t *testing.T) {
+func TestValidEmissionAmount(cur realm, t *testing.T) {
 	tests := []struct {
 		name         string
 		amount       int64
@@ -65,7 +65,7 @@ func TestValidEmissionAmount(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			err := validEmissionAmount(tt.amount)
 
 			if tt.shouldError {
@@ -77,7 +77,7 @@ func TestValidEmissionAmount(t *testing.T) {
 	}
 }
 
-func TestHandleLeftEmissionAmount(t *testing.T) {
+func TestHandleLeftEmissionAmount(cur realm, t *testing.T) {
 	type testdata struct {
 		name      string
 		year      int64
@@ -104,7 +104,7 @@ func TestHandleLeftEmissionAmount(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			resetEmissionState(t)
 
 			if tt.subAmount > 0 {
@@ -119,64 +119,64 @@ func TestHandleLeftEmissionAmount(t *testing.T) {
 	}
 }
 
-func TestGetterSetter(t *testing.T) {
-	t.Run("last minted timestamp", func(t *testing.T) {
+func TestGetterSetter(cur realm, t *testing.T) {
+	t.Run("last minted timestamp", func(cur realm, t *testing.T) {
 		value := int64(1234567890)
 		setLastMintedTimestamp(value)
 		uassert.Equal(t, value, LastMintedTimestamp())
 	})
 
-	t.Run("left emission amount", func(t *testing.T) {
+	t.Run("left emission amount", func(cur realm, t *testing.T) {
 		value := int64(0)
 		setLeftEmissionAmount(value)
 		uassert.Equal(t, value, LeftEmissionAmount())
 	})
 }
 
-func TestGrc20Methods(t *testing.T) {
+func TestGrc20Methods(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
-		fn            func()
+		fn            func(cur realm)
 		shouldPanic   bool
 		exceptionKind string // abort / panic
 		panicMsg      string
 	}{
 		{
 			name: "TotalSupply",
-			fn: func() {
+			fn: func(cur realm) {
 				uassert.Equal(t, INITIAL_MINT_AMOUNT, TotalSupply())
 			},
 		},
 		{
 			name: "BalanceOf(admin)",
-			fn: func() {
+			fn: func(cur realm) {
 				uassert.Equal(t, INITIAL_MINT_AMOUNT, BalanceOf(adminAddr))
 			},
 		},
 		{
 			name: "BalanceOf(alice)",
-			fn: func() {
+			fn: func(cur realm) {
 				uassert.Equal(t, int64(0), BalanceOf(alice))
 			},
 		},
 		{
 			name: "Allowance(admin, alice)",
-			fn: func() {
+			fn: func(cur realm) {
 				uassert.Equal(t, int64(0), Allowance(adminAddr, alice))
 			},
 		},
 		{
 			name: "MintGns success",
-			fn: func() {
+			fn: func(cur realm) {
 				testing.SetRealm(emissionRealm)
-				MintGns(cross, adminAddr)
+				MintGns(cross(cur), adminAddr)
 			},
 		},
 		{
 			name: "MintGns without permission should panic",
-			fn: func() {
+			fn: func(cur realm) {
 				testing.SkipHeights(1) // Skip 1 block = 5 seconds pass
-				MintGns(cross, adminAddr)
+				MintGns(cross(cur), adminAddr)
 			},
 			shouldPanic:   true,
 			exceptionKind: "abort",
@@ -184,18 +184,18 @@ func TestGrc20Methods(t *testing.T) {
 		},
 		{
 			name: "Transfer success",
-			fn: func() {
+			fn: func(cur realm) {
 				testing.SetOriginCaller(adminAddr)
 				testing.SetRealm(adminRealm)
-				Transfer(cross, alice, int64(1))
+				Transfer(cross(cur), alice, int64(1))
 			},
 		},
 		{
 			name: "Transfer without enough balance should panic",
-			fn: func() {
+			fn: func(cur realm) {
 				testing.SetOriginCaller(alice)
 				testing.SetRealm(testing.NewUserRealm(alice))
-				Transfer(cross, bob, int64(1))
+				Transfer(cross(cur), bob, int64(1))
 			},
 			shouldPanic:   true,
 			exceptionKind: "abort",
@@ -203,10 +203,10 @@ func TestGrc20Methods(t *testing.T) {
 		},
 		{
 			name: "Transfer to self should panic",
-			fn: func() {
+			fn: func(cur realm) {
 				testing.SetOriginCaller(adminAddr)
 				testing.SetRealm(adminRealm)
-				Transfer(cross, adminAddr, int64(1))
+				Transfer(cross(cur), adminAddr, int64(1))
 			},
 			shouldPanic:   true,
 			exceptionKind: "abort",
@@ -214,26 +214,26 @@ func TestGrc20Methods(t *testing.T) {
 		},
 		{
 			name: "TransferFrom success",
-			fn: func() {
+			fn: func(cur realm) {
 				// approve first
 				testing.SetRealm(adminRealm)
-				Approve(cross, alice, int64(1))
+				Approve(cross(cur), alice, int64(1))
 
 				// alice transfer admin's balance to bob
 				testing.SetOriginCaller(alice)
 				testing.SetRealm(testing.NewUserRealm(alice))
-				TransferFrom(cross, adminAddr, bob, int64(1))
+				TransferFrom(cross(cur), adminAddr, bob, int64(1))
 			},
 		},
 		{
 			name: "TransferFrom without enough allowance should panic",
-			fn: func() {
+			fn: func(cur realm) {
 				testing.SetRealm(adminRealm)
-				Approve(cross, alice, int64(1))
+				Approve(cross(cur), alice, int64(1))
 
 				testing.SetOriginCaller(alice)
 				testing.SetRealm(testing.NewUserRealm(alice))
-				TransferFrom(cross, adminAddr, bob, int64(2))
+				TransferFrom(cross(cur), adminAddr, bob, int64(2))
 			},
 			shouldPanic:   true,
 			exceptionKind: "abort",
@@ -242,28 +242,28 @@ func TestGrc20Methods(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			resetGnsTokenObject(t)
+		t.Run(tt.name, func(cur realm, t *testing.T) {
+			resetGnsTokenObject(cur, t)
 
 			if tt.shouldPanic {
 				switch tt.exceptionKind {
 				case "abort":
-					uassert.AbortsContains(t, tt.panicMsg, tt.fn)
+					uassert.AbortsContains(t, cur, tt.panicMsg, func() { tt.fn(cur) })
 				case "panic":
-					uassert.PanicsContains(t, tt.panicMsg, tt.fn)
+					uassert.PanicsContains(t, cur, tt.panicMsg, func() { tt.fn(cur) })
 				default:
 					t.Fatalf("unknown exception kind: %s", tt.exceptionKind)
 				}
 			} else {
-				uassert.NotPanics(t, func() { tt.fn() })
+				uassert.NotPanics(t, cur, func() { tt.fn(cur) })
 			}
 		})
 	}
 }
 
-func TestCalculateAmountToMint(t *testing.T) {
+func TestCalculateAmountToMint(cur realm, t *testing.T) {
 	resetEmissionState(t)
-	InitGnsTest(t)
+	InitGnsTest(cur, t)
 	startTimestamp := GetHalvingYearStartTimestamp(1)
 	endTimestamp := GetHalvingYearEndTimestamp(12)
 
@@ -373,8 +373,8 @@ func TestCalculateAmountToMint(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			InitGnsTest(t)
+		t.Run(tt.name, func(cur realm, t *testing.T) {
+			InitGnsTest(cur, t)
 
 			amount, err := calculateAmountToMint(getEmissionState(), tt.inputFromTimestamp, tt.inputToTimestamp)
 			uassert.NoError(t, err)
@@ -384,9 +384,9 @@ func TestCalculateAmountToMint(t *testing.T) {
 	}
 }
 
-func TestCalculateAmountToMintBoundary(t *testing.T) {
-	t.Run("toTimestamp clamp to emission end", func(t *testing.T) {
-		InitGnsTest(t)
+func TestCalculateAmountToMintBoundary(cur realm, t *testing.T) {
+	t.Run("toTimestamp clamp to emission end", func(cur realm, t *testing.T) {
+		InitGnsTest(cur, t)
 
 		emissionEnd := GetHalvingYearEndTimestamp(12)
 		year12Start := GetHalvingYearStartTimestamp(12)
@@ -395,7 +395,7 @@ func TestCalculateAmountToMintBoundary(t *testing.T) {
 		amountAtEnd, err := calculateAmountToMint(getEmissionState(), year12Start, emissionEnd)
 		uassert.NoError(t, err)
 
-		InitGnsTest(t)
+		InitGnsTest(cur, t)
 
 		// Calculate amount for year 12 with toTimestamp after emission end (should be clamped)
 		amountAfterEnd, err := calculateAmountToMint(getEmissionState(), year12Start, emissionEnd+1000)
@@ -406,8 +406,8 @@ func TestCalculateAmountToMintBoundary(t *testing.T) {
 		uassert.Equal(t, GetHalvingAmountsPerYear(12), amountAtEnd)
 	})
 
-	t.Run("year end last second vs second-to-last", func(t *testing.T) {
-		InitGnsTest(t)
+	t.Run("year end last second vs second-to-last", func(cur realm, t *testing.T) {
+		InitGnsTest(cur, t)
 
 		year1Start := GetHalvingYearStartTimestamp(1)
 		year1End := GetHalvingYearEndTimestamp(1)
@@ -417,7 +417,7 @@ func TestCalculateAmountToMintBoundary(t *testing.T) {
 		amountSecondToLast, err := calculateAmountToMint(getEmissionState(), year1Start, year1End-1)
 		uassert.NoError(t, err)
 
-		InitGnsTest(t)
+		InitGnsTest(cur, t)
 
 		// Amount up to last second of year 1 (includes leftover)
 		amountLastSecond, err := calculateAmountToMint(getEmissionState(), year1Start, year1End)
@@ -432,8 +432,8 @@ func TestCalculateAmountToMintBoundary(t *testing.T) {
 			"last second should include leftover, not just 1 second of emission")
 	})
 
-	t.Run("fromTimestamp at emission start boundary", func(t *testing.T) {
-		InitGnsTest(t)
+	t.Run("fromTimestamp at emission start boundary", func(cur realm, t *testing.T) {
+		InitGnsTest(cur, t)
 
 		emissionStart := GetHalvingYearStartTimestamp(1)
 		amountPerSecond := GetAmountPerSecondPerHalvingYear(1)
@@ -443,7 +443,7 @@ func TestCalculateAmountToMintBoundary(t *testing.T) {
 		uassert.NoError(t, err)
 		uassert.Equal(t, amountPerSecond, amountAtStart)
 
-		InitGnsTest(t)
+		InitGnsTest(cur, t)
 
 		// fromTimestamp before emission start (should be clamped to start)
 		amountBeforeStart, err := calculateAmountToMint(getEmissionState(), emissionStart-100, emissionStart)
@@ -451,8 +451,8 @@ func TestCalculateAmountToMintBoundary(t *testing.T) {
 		uassert.Equal(t, amountPerSecond, amountBeforeStart)
 	})
 
-	t.Run("year transition boundary", func(t *testing.T) {
-		InitGnsTest(t)
+	t.Run("year transition boundary", func(cur realm, t *testing.T) {
+		InitGnsTest(cur, t)
 
 		year1End := GetHalvingYearEndTimestamp(1)
 		year2Start := GetHalvingYearStartTimestamp(2)
@@ -476,8 +476,8 @@ func TestCalculateAmountToMintBoundary(t *testing.T) {
 	})
 }
 
-func TestMintGns_WithZeroLastMintedTimestamp(t *testing.T) {
-	InitGnsTest(t)
+func TestMintGns_WithZeroLastMintedTimestamp(cur realm, t *testing.T) {
+	InitGnsTest(cur, t)
 	resetEmissionState(t)
 
 	// Verify lastMintedTimestamp is initialized to 0
@@ -489,7 +489,7 @@ func TestMintGns_WithZeroLastMintedTimestamp(t *testing.T) {
 	// Result: 1 second worth of emission (due to +1 in seconds calculation)
 	testing.SetRealm(emissionRealm)
 	currentTime := time.Now().Unix()
-	firstMintAmount := MintGns(cross, adminAddr)
+	firstMintAmount := MintGns(cross(cur), adminAddr)
 
 	uassert.Equal(t, int64(7134703), firstMintAmount)
 
@@ -497,7 +497,7 @@ func TestMintGns_WithZeroLastMintedTimestamp(t *testing.T) {
 	uassert.Equal(t, currentTime, LastMintedTimestamp())
 }
 
-func TestMintGns(t *testing.T) {
+func TestMintGns(cur realm, t *testing.T) {
 	tests := []struct {
 		name                  string
 		inputRealm            runtime.Realm
@@ -537,25 +537,25 @@ func TestMintGns(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			InitGnsTest(t)
+		t.Run(tt.name, func(cur realm, t *testing.T) {
+			InitGnsTest(cur, t)
 			resetEmissionState(t)
 
 			var firstMintedAmount int64
 			var secondMintedAmount int64
 
-			mintGnsFn := func() {
-				testing.SetRealm(tt.inputRealm)
-
-				firstMintedAmount = MintGns(cross, adminAddr)
-				testing.SkipHeights(tt.inputSkipHeight)
-				secondMintedAmount = MintGns(cross, adminAddr)
-			}
+			testing.SetRealm(tt.inputRealm)
 
 			if tt.expectedHasAbort {
-				uassert.AbortsWithMessage(t, tt.expectedAbortMessage, mintGnsFn)
+				uassert.AbortsWithMessage(t, cur, tt.expectedAbortMessage, func() {
+					firstMintedAmount = MintGns(cross(cur), adminAddr)
+					testing.SkipHeights(tt.inputSkipHeight)
+					secondMintedAmount = MintGns(cross(cur), adminAddr)
+				})
 			} else {
-				uassert.NotPanics(t, mintGnsFn)
+				firstMintedAmount = MintGns(cross(cur), adminAddr)
+				testing.SkipHeights(tt.inputSkipHeight)
+				secondMintedAmount = MintGns(cross(cur), adminAddr)
 			}
 
 			// Validate individual minted amounts
@@ -567,16 +567,16 @@ func TestMintGns(t *testing.T) {
 	}
 }
 
-func TestMintGns_EdgeCases(t *testing.T) {
+func TestMintGns_EdgeCases(cur realm, t *testing.T) {
 	tests := []struct {
 		name                 string
-		setup                func()
+		setup                func(cur realm)
 		expectedMintedAmount int64
 	}{
 		{
 			name: "returns zero when lastMintedTimestamp equals currentTime",
-			setup: func() {
-				InitGnsTest(t)
+			setup: func(cur realm) {
+				InitGnsTest(cur, t)
 				resetEmissionState(t)
 				// Set lastMintedTimestamp to current time
 				setLastMintedTimestamp(time.Now().Unix())
@@ -585,8 +585,8 @@ func TestMintGns_EdgeCases(t *testing.T) {
 		},
 		{
 			name: "returns zero when lastMintedTimestamp >= emissionEndTimestamp",
-			setup: func() {
-				InitGnsTest(t)
+			setup: func(cur realm) {
+				InitGnsTest(cur, t)
 				resetEmissionState(t)
 				// Set lastMintedTimestamp past emission end
 				setLastMintedTimestamp(GetEmissionEndTimestamp() + 1)
@@ -595,16 +595,16 @@ func TestMintGns_EdgeCases(t *testing.T) {
 		},
 		{
 			name: "mints correctly after skipping multiple blocks",
-			setup: func() {
-				InitGnsTest(t)
+			setup: func(cur realm) {
+				InitGnsTest(cur, t)
 				resetEmissionState(t)
 			},
 			expectedMintedAmount: 7134703, // 1 second worth
 		},
 		{
 			name: "updates MintedEmissionAmount correctly",
-			setup: func() {
-				InitGnsTest(t)
+			setup: func(cur realm) {
+				InitGnsTest(cur, t)
 				resetEmissionState(t)
 				uassert.Equal(t, int64(0), MintedEmissionAmount())
 			},
@@ -612,8 +612,8 @@ func TestMintGns_EdgeCases(t *testing.T) {
 		},
 		{
 			name: "updates LeftEmissionAmount correctly",
-			setup: func() {
-				InitGnsTest(t)
+			setup: func(cur realm) {
+				InitGnsTest(cur, t)
 				resetEmissionState(t)
 				uassert.Equal(t, MAX_EMISSION_AMOUNT, LeftEmissionAmount())
 			},
@@ -622,15 +622,13 @@ func TestMintGns_EdgeCases(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tt.setup()
+		t.Run(tt.name, func(cur realm, t *testing.T) {
+			tt.setup(cur)
 
 			balanceBefore := BalanceOf(adminAddr)
 			var mintedAmount int64
-			uassert.NotPanics(t, func() {
-				testing.SetRealm(emissionRealm)
-				mintedAmount = MintGns(cross, adminAddr)
-			})
+			testing.SetRealm(emissionRealm)
+			mintedAmount = MintGns(cross(cur), adminAddr)
 			balanceAfter := BalanceOf(adminAddr)
 			uassert.Equal(t, tt.expectedMintedAmount, mintedAmount)
 			uassert.Equal(t, mintedAmount, balanceAfter-balanceBefore)
@@ -638,7 +636,7 @@ func TestMintGns_EdgeCases(t *testing.T) {
 	}
 }
 
-func TestMintGns_StateUpdates(t *testing.T) {
+func TestMintGns_StateUpdates(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
 		validateState func(t *testing.T, mintedAmount int64)
@@ -676,17 +674,15 @@ func TestMintGns_StateUpdates(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			resetObject(t)
-			InitGnsTest(t)
+		t.Run(tt.name, func(cur realm, t *testing.T) {
+			resetObject(cur, t)
+			InitGnsTest(cur, t)
 
 			balanceBefore := BalanceOf(adminAddr)
 
 			var mintedAmount int64
-			uassert.NotPanics(t, func() {
-				testing.SetRealm(emissionRealm)
-				mintedAmount = MintGns(cross, adminAddr)
-			})
+			testing.SetRealm(emissionRealm)
+			mintedAmount = MintGns(cross(cur), adminAddr)
 
 			balanceAfter := BalanceOf(adminAddr)
 
@@ -696,7 +692,7 @@ func TestMintGns_StateUpdates(t *testing.T) {
 	}
 }
 
-func TestInitEmissionState(t *testing.T) {
+func TestInitEmissionState(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
 		realm         runtime.Realm
@@ -765,19 +761,17 @@ func TestInitEmissionState(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			resetObject(t)
+		t.Run(tt.name, func(cur realm, t *testing.T) {
+			resetObject(cur, t)
+
+			testing.SetRealm(tt.realm)
 
 			if tt.shouldAbort {
-				uassert.AbortsContains(t, tt.abortContains, func() {
-					testing.SetRealm(tt.realm)
-					InitEmissionState(cross, tt.height, tt.timestamp)
+				uassert.AbortsContains(t, cur, tt.abortContains, func() {
+					InitEmissionState(cross(cur), tt.height, tt.timestamp)
 				})
 			} else {
-				uassert.NotPanics(t, func() {
-					testing.SetRealm(tt.realm)
-					InitEmissionState(cross, tt.height, tt.timestamp)
-				})
+				InitEmissionState(cross(cur), tt.height, tt.timestamp)
 
 				if tt.validateState != nil {
 					tt.validateState(t)
@@ -787,28 +781,24 @@ func TestInitEmissionState(t *testing.T) {
 	}
 }
 
-func TestInitEmissionState_Reinitialize(t *testing.T) {
-	resetObject(t)
+func TestInitEmissionState_Reinitialize(cur realm, t *testing.T) {
+	resetObject(cur, t)
 
 	// First initialization
-	uassert.NotPanics(t, func() {
-		testing.SetRealm(emissionRealm)
-		InitEmissionState(cross, 50, 500)
-	})
+	testing.SetRealm(emissionRealm)
+	InitEmissionState(cross(cur), 50, 500)
 	uassert.Equal(t, int64(50), GetEmissionCreatedHeight())
 	uassert.Equal(t, int64(500), GetEmissionStartTimestamp())
 
 	// Reinitialize with new values
-	uassert.NotPanics(t, func() {
-		testing.SetRealm(emissionRealm)
-		InitEmissionState(cross, 200, 2000)
-	})
+	testing.SetRealm(emissionRealm)
+	InitEmissionState(cross(cur), 200, 2000)
 	// Should be overwritten with new values
 	uassert.Equal(t, int64(200), GetEmissionCreatedHeight())
 	uassert.Equal(t, int64(2000), GetEmissionStartTimestamp())
 }
 
-func TestInitEmissionState_HalvingDataInitialization(t *testing.T) {
+func TestInitEmissionState_HalvingDataInitialization(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
 		timestamp     int64
@@ -840,13 +830,11 @@ func TestInitEmissionState_HalvingDataInitialization(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			resetObject(t)
+		t.Run(tt.name, func(cur realm, t *testing.T) {
+			resetObject(cur, t)
 
-			uassert.NotPanics(t, func() {
-				testing.SetRealm(emissionRealm)
-				InitEmissionState(cross, 100, tt.timestamp)
-			})
+			testing.SetRealm(emissionRealm)
+			InitEmissionState(cross(cur), 100, tt.timestamp)
 
 			actualStart := GetHalvingYearStartTimestamp(tt.validateYear)
 			actualEnd := GetHalvingYearEndTimestamp(tt.validateYear)

--- a/contract/r/gnoswap/gns/halving_emission_scenario_test.gno
+++ b/contract/r/gnoswap/gns/halving_emission_scenario_test.gno
@@ -7,10 +7,10 @@ import (
 )
 
 // TestHalvingEmissionScenarios tests various scenarios for halving emission behavior
-func TestHalvingEmissionScenarios(t *testing.T) {
+func TestHalvingEmissionScenarios(cur realm, t *testing.T) {
 	tests := []struct {
 		name     string
-		testFunc func(t *testing.T)
+		testFunc func(cur realm, t *testing.T)
 	}{
 		{
 			name:     "Basic Emission Update Flow",
@@ -48,9 +48,9 @@ Expected behavior:
 - Emission values should be based on timestamp
 - Different years should have different emission rates
 */
-func testBasicEmissionUpdateFlow(t *testing.T) {
-	resetObject(t)
-	InitGnsTest(t)
+func testBasicEmissionUpdateFlow(cur realm, t *testing.T) {
+	resetObject(cur, t)
+	InitGnsTest(cur, t)
 
 	// Setup initial state
 	testing.SetRealm(adminRealm)
@@ -83,9 +83,9 @@ Expected behavior:
 - Emissions for years should use the correct year's emission rate
 - Different years should return same emission rates for years 1-2
 */
-func testHistoricalBlockEmissionAccuracy(t *testing.T) {
-	resetObject(t)
-	InitGnsTest(t)
+func testHistoricalBlockEmissionAccuracy(cur realm, t *testing.T) {
+	resetObject(cur, t)
+	InitGnsTest(cur, t)
 
 	testing.SetRealm(adminRealm)
 	testing.SetOriginCaller(adminAddr)
@@ -121,9 +121,9 @@ Expected behavior:
 - Years 1-2 should have same emission rates
 - Both emission rates should be positive
 */
-func testCacheRewardIntegration(t *testing.T) {
-	resetObject(t)
-	InitGnsTest(t)
+func testCacheRewardIntegration(cur realm, t *testing.T) {
+	resetObject(cur, t)
+	InitGnsTest(cur, t)
 
 	testing.SetRealm(adminRealm)
 	testing.SetOriginCaller(adminAddr)
@@ -159,9 +159,9 @@ Expected behavior:
 
 Note: Halving reduces emission rate by half every 2 years
 */
-func testMultipleBlockTimeChanges(t *testing.T) {
-	resetObject(t)
-	InitGnsTest(t)
+func testMultipleBlockTimeChanges(cur realm, t *testing.T) {
+	resetObject(cur, t)
+	InitGnsTest(cur, t)
 
 	testing.SetRealm(adminRealm)
 	testing.SetOriginCaller(adminAddr)

--- a/contract/r/gnoswap/gns/halving_test.gno
+++ b/contract/r/gnoswap/gns/halving_test.gno
@@ -20,25 +20,25 @@ var (
 	startTimestamp int64 = time.Now().Unix() + 2 // blockTime in seconds
 )
 
-func TestGetHalvingYear(t *testing.T) {
-	resetObject(t)
-	InitGnsTest(t)
+func TestGetHalvingYear(cur realm, t *testing.T) {
+	resetObject(cur, t)
+	InitGnsTest(cur, t)
 
-	t.Run("during halving years", func(t *testing.T) {
+	t.Run("during halving years", func(cur realm, t *testing.T) {
 		for year := HALVING_START_YEAR; year <= HALVING_END_YEAR; year++ {
 			firstTimestampOfYear := GetHalvingYearStartTimestamp(year)
 			uassert.Equal(t, year, GetHalvingYear(firstTimestampOfYear))
 		}
 	})
 
-	t.Run("no year after 12 years", func(t *testing.T) {
+	t.Run("no year after 12 years", func(cur realm, t *testing.T) {
 		uassert.Equal(t, int64(0), GetHalvingYear(GetEmissionEndTimestamp()+1))
 	})
 }
 
-func TestEmissionState_CalculateAmountPerSeconds(t *testing.T) {
-	resetObject(t)
-	InitGnsTest(t)
+func TestEmissionState_CalculateAmountPerSeconds(cur realm, t *testing.T) {
+	resetObject(cur, t)
+	InitGnsTest(cur, t)
 
 	// Test emission state basic functions
 	uassert.True(t, IsEmissionInitialized())
@@ -66,11 +66,11 @@ func TestEmissionState_CalculateAmountPerSeconds(t *testing.T) {
 	}
 }
 
-func TestHalvingYearGetters(t *testing.T) {
-	resetObject(t)
-	InitGnsTest(t)
+func TestHalvingYearGetters(cur realm, t *testing.T) {
+	resetObject(cur, t)
+	InitGnsTest(cur, t)
 
-	t.Run("valid years (1-12)", func(t *testing.T) {
+	t.Run("valid years (1-12)", func(cur realm, t *testing.T) {
 		var prevendTimestamp int64
 
 		for year := int64(1); year <= HALVING_END_YEAR; year++ {
@@ -102,7 +102,7 @@ func TestHalvingYearGetters(t *testing.T) {
 		}
 	})
 
-	t.Run("invalid year 0", func(t *testing.T) {
+	t.Run("invalid year 0", func(cur realm, t *testing.T) {
 		uassert.Equal(t, int64(0), GetHalvingYearStartTimestamp(0))
 		uassert.Equal(t, int64(0), GetHalvingYearEndTimestamp(0))
 		uassert.Equal(t, int64(0), GetHalvingYearMaxAmount(0))
@@ -110,7 +110,7 @@ func TestHalvingYearGetters(t *testing.T) {
 		uassert.Equal(t, int64(0), GetHalvingYearAccuAmount(0))
 	})
 
-	t.Run("invalid year 13", func(t *testing.T) {
+	t.Run("invalid year 13", func(cur realm, t *testing.T) {
 		uassert.Equal(t, int64(0), GetHalvingYearStartTimestamp(13))
 		uassert.Equal(t, int64(0), GetHalvingYearEndTimestamp(13))
 		uassert.Equal(t, int64(0), GetHalvingYearMaxAmount(13))
@@ -119,9 +119,9 @@ func TestHalvingYearGetters(t *testing.T) {
 	})
 }
 
-func TestAmountPerSecondsPerHalvingYear(t *testing.T) {
-	resetObject(t)
-	InitGnsTest(t)
+func TestAmountPerSecondsPerHalvingYear(cur realm, t *testing.T) {
+	resetObject(cur, t)
+	InitGnsTest(cur, t)
 
 	// Test that we can get the amount per seconds for a valid year
 	amountPerSeconds := GetAmountPerSecondPerHalvingYear(6)
@@ -130,9 +130,9 @@ func TestAmountPerSecondsPerHalvingYear(t *testing.T) {
 
 // TestGetHalvingYearInfoValidation tests various scenarios for GetHalvingYearInfo
 // to ensure proper validation and handling of edge cases
-func TestGetHalvingYearInfoValidation(t *testing.T) {
-	resetObject(t)
-	InitGnsTest(t)
+func TestGetHalvingYearInfoValidation(cur realm, t *testing.T) {
+	resetObject(cur, t)
+	InitGnsTest(cur, t)
 
 	es := getEmissionState()
 
@@ -205,7 +205,7 @@ func TestGetHalvingYearInfoValidation(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			timestamp := es.getStartTimestamp() + tt.timestampOffset
 			year, _, _ := GetHalvingYearInfo(timestamp)
 
@@ -216,9 +216,9 @@ func TestGetHalvingYearInfoValidation(t *testing.T) {
 }
 
 // TestHalvingDataGettersWithInvalidYear tests that HalvingData getters handle invalid years properly
-func TestHalvingDataGettersWithInvalidYear(t *testing.T) {
-	resetObject(t)
-	InitGnsTest(t)
+func TestHalvingDataGettersWithInvalidYear(cur realm, t *testing.T) {
+	resetObject(cur, t)
+	InitGnsTest(cur, t)
 
 	hd := &HalvingData{
 		startTimestamps: make([]int64, HALVING_END_YEAR),
@@ -289,7 +289,7 @@ func TestHalvingDataGettersWithInvalidYear(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			result := tt.getter(tt.year)
 			uassert.Equal(t, tt.expected, result,
 				"Unexpected result for %s", tt.name)
@@ -298,7 +298,7 @@ func TestHalvingDataGettersWithInvalidYear(t *testing.T) {
 }
 
 // TestHalvingDataSettersWithInvalidYear tests all HalvingData setters with invalid years
-func TestHalvingDataSettersWithInvalidYear(t *testing.T) {
+func TestHalvingDataSettersWithInvalidYear(cur realm, t *testing.T) {
 	hd := NewHalvingData(1000)
 
 	tests := []struct {
@@ -339,7 +339,7 @@ func TestHalvingDataSettersWithInvalidYear(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			err := tt.setter(tt.year)
 
 			if tt.shouldError {
@@ -352,7 +352,7 @@ func TestHalvingDataSettersWithInvalidYear(t *testing.T) {
 }
 
 // TestHalvingDataBoundaryTimestamps tests HalvingData with boundary timestamp values
-func TestHalvingDataBoundaryTimestamps(t *testing.T) {
+func TestHalvingDataBoundaryTimestamps(cur realm, t *testing.T) {
 	tests := []struct {
 		name           string
 		startTimestamp int64
@@ -391,7 +391,7 @@ func TestHalvingDataBoundaryTimestamps(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			hd := NewHalvingData(tt.startTimestamp)
 
 			startTimestamp := hd.getStartTimestamp(tt.year)
@@ -404,7 +404,7 @@ func TestHalvingDataBoundaryTimestamps(t *testing.T) {
 }
 
 // TestHalvingDataAmountOperations tests amount calculations with edge values
-func TestHalvingDataAmountOperations(t *testing.T) {
+func TestHalvingDataAmountOperations(cur realm, t *testing.T) {
 	hd := NewHalvingData(1000)
 
 	tests := []struct {
@@ -461,7 +461,7 @@ func TestHalvingDataAmountOperations(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			tt.operation()
 			tt.validateAmount(t)
 		})
@@ -469,7 +469,7 @@ func TestHalvingDataAmountOperations(t *testing.T) {
 }
 
 // TestHalvingDataAddAccumAmountOverflow tests overflow protection in HalvingData.addAccumAmount
-func TestHalvingDataAddAccumAmountOverflow(t *testing.T) {
+func TestHalvingDataAddAccumAmountOverflow(cur realm, t *testing.T) {
 	tests := []struct {
 		name         string
 		year         int64
@@ -533,14 +533,14 @@ func TestHalvingDataAddAccumAmountOverflow(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			hd := NewHalvingData(1000)
 
 			// Set initial accumulated amount
 			hd.setAccumAmount(tt.year, tt.initialValue)
 
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.panicMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.panicMsg, func() {
 					hd.addAccumAmount(tt.year, tt.addAmount)
 				})
 			} else {

--- a/contract/r/gnoswap/gns/utils_test.gno
+++ b/contract/r/gnoswap/gns/utils_test.gno
@@ -7,7 +7,7 @@ import (
 	uassert "gno.land/p/nt/uassert/v0"
 )
 
-func TestSafeAddInt64(t *testing.T) {
+func TestSafeAddInt64(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		a           int64
@@ -143,9 +143,9 @@ func TestSafeAddInt64(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.panicMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.panicMsg, func() {
 					safeAddInt64(tt.a, tt.b)
 				})
 			} else {
@@ -156,7 +156,7 @@ func TestSafeAddInt64(t *testing.T) {
 	}
 }
 
-func TestSafeSubInt64(t *testing.T) {
+func TestSafeSubInt64(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		a           int64
@@ -300,9 +300,9 @@ func TestSafeSubInt64(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.panicMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.panicMsg, func() {
 					safeSubInt64(tt.a, tt.b)
 				})
 			} else {
@@ -313,7 +313,7 @@ func TestSafeSubInt64(t *testing.T) {
 	}
 }
 
-func TestSafeMulInt64(t *testing.T) {
+func TestSafeMulInt64(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		a           int64
@@ -523,9 +523,9 @@ func TestSafeMulInt64(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.panicMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.panicMsg, func() {
 					safeMulInt64(tt.a, tt.b)
 				})
 			} else {
@@ -537,7 +537,7 @@ func TestSafeMulInt64(t *testing.T) {
 }
 
 // TestValidEmissionAmountOverflow tests overflow protection in validEmissionAmount
-func TestValidEmissionAmountOverflow(t *testing.T) {
+func TestValidEmissionAmountOverflow(cur realm, t *testing.T) {
 	// Save original values to restore after test
 	originalMinted := mintedEmissionAmount
 
@@ -587,12 +587,12 @@ func TestValidEmissionAmountOverflow(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Set minted amount for test
 			mintedEmissionAmount = tt.mintedAmount
 
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.panicMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.panicMsg, func() {
 					validEmissionAmount(tt.amount)
 				})
 			} else {
@@ -612,7 +612,7 @@ func TestValidEmissionAmountOverflow(t *testing.T) {
 }
 
 // TestSafeMulInt64InCalculateAmountToMint tests safeMulInt64 with realistic emission values
-func TestSafeMulInt64InCalculateAmountToMint(t *testing.T) {
+func TestSafeMulInt64InCalculateAmountToMint(cur realm, t *testing.T) {
 	tests := []struct {
 		name            string
 		amountPerSecond int64
@@ -655,9 +655,9 @@ func TestSafeMulInt64InCalculateAmountToMint(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.panicMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.panicMsg, func() {
 					safeMulInt64(tt.amountPerSecond, tt.seconds)
 				})
 			} else {


### PR DESCRIPTION
## Summary
- Migrate the GNS realm and package tests to Interrealm v2 cur realm / cross(cur) call patterns.
- Update GNS token/emission entrypoints to use cur.Previous() and v2 GRC20 APIs.
- Keep abort expectations unchanged while adjusting assertion callback shape for v2 caller frames.

## Dependencies
- Depends on https://github.com/gnoswap-labs/gnoswap/pull/1296 for access Interrealm v2 migration.
- Depends on https://github.com/gnoswap-labs/gnoswap/pull/1297 for rbac Interrealm v2 migration.

## Validation
- make test PKG=gno.land/r/gnoswap/gns passed with local direct dependency migrations applied.
- GNS-only PR scope intentionally excludes contract/r/gnoswap/access and contract/r/gnoswap/rbac; without those dependency migrations, make test PKG=gno.land/r/gnoswap/gns currently fails at access.gno with name PreviousRealm not declared.
