### PR TITLE
refactor(r/halt): migrate to interrealm v2

### DIFF
--- a/contract/r/gnoswap/halt/README.md
+++ b/contract/r/gnoswap/halt/README.md
@@ -45,16 +45,16 @@ Checks if operation is halted.
 
 ```go
 // Set system to safe mode (beta mainnet)
-SetHaltLevel(HaltLevelSafeMode)
+SetHaltLevel(cross(cur), HaltLevelSafeMode)
 
 // Enable emergency mode
-SetHaltLevel(HaltLevelEmergency)
+SetHaltLevel(cross(cur), HaltLevelEmergency)
 
 // Halt specific operation
-SetOperationStatus(OpTypeRouter, true)
+SetOperationStatus(cross(cur), OpTypeRouter, true)
 
 // Resume specific operation
-SetOperationStatus(OpTypeRouter, false)
+SetOperationStatus(cross(cur), OpTypeRouter, false)
 
 // Check before operation
 halted, err := IsHalted(OpTypeWithdraw)

--- a/contract/r/gnoswap/halt/assert_test.gno
+++ b/contract/r/gnoswap/halt/assert_test.gno
@@ -6,7 +6,7 @@ import (
 	uassert "gno.land/p/nt/uassert/v0"
 )
 
-func TestAssert_AssertIsNotHaltedPool(t *testing.T) {
+func TestAssert_AssertIsNotHaltedPool(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		haltLevel   HaltLevel
@@ -19,17 +19,17 @@ func TestAssert_AssertIsNotHaltedPool(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Setup
 			err := setHaltLevel(tt.haltLevel)
 			uassert.NoError(t, err)
 
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, "halted: pool", func() {
+				uassert.PanicsWithMessage(t, cur, "halted: pool", func() {
 					AssertIsNotHaltedPool()
 				})
 			} else {
-				uassert.NotPanics(t, func() {
+				uassert.NotPanics(t, cur, func() {
 					AssertIsNotHaltedPool()
 				})
 			}
@@ -37,7 +37,7 @@ func TestAssert_AssertIsNotHaltedPool(t *testing.T) {
 	}
 }
 
-func TestAssert_AssertIsNotHaltedPosition(t *testing.T) {
+func TestAssert_AssertIsNotHaltedPosition(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		haltLevel   HaltLevel
@@ -50,16 +50,16 @@ func TestAssert_AssertIsNotHaltedPosition(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			err := setHaltLevel(tt.haltLevel)
 			uassert.NoError(t, err)
 
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, "halted: position", func() {
+				uassert.PanicsWithMessage(t, cur, "halted: position", func() {
 					AssertIsNotHaltedPosition()
 				})
 			} else {
-				uassert.NotPanics(t, func() {
+				uassert.NotPanics(t, cur, func() {
 					AssertIsNotHaltedPosition()
 				})
 			}
@@ -67,7 +67,7 @@ func TestAssert_AssertIsNotHaltedPosition(t *testing.T) {
 	}
 }
 
-func TestAssert_AssertIsNotHaltedProtocolFee(t *testing.T) {
+func TestAssert_AssertIsNotHaltedProtocolFee(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		haltLevel   HaltLevel
@@ -80,16 +80,16 @@ func TestAssert_AssertIsNotHaltedProtocolFee(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			err := setHaltLevel(tt.haltLevel)
 			uassert.NoError(t, err)
 
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, "halted: protocol_fee", func() {
+				uassert.PanicsWithMessage(t, cur, "halted: protocol_fee", func() {
 					AssertIsNotHaltedProtocolFee()
 				})
 			} else {
-				uassert.NotPanics(t, func() {
+				uassert.NotPanics(t, cur, func() {
 					AssertIsNotHaltedProtocolFee()
 				})
 			}
@@ -97,7 +97,7 @@ func TestAssert_AssertIsNotHaltedProtocolFee(t *testing.T) {
 	}
 }
 
-func TestAssert_AssertIsNotHaltedRouter(t *testing.T) {
+func TestAssert_AssertIsNotHaltedRouter(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		haltLevel   HaltLevel
@@ -110,16 +110,16 @@ func TestAssert_AssertIsNotHaltedRouter(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			err := setHaltLevel(tt.haltLevel)
 			uassert.NoError(t, err)
 
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, "halted: router", func() {
+				uassert.PanicsWithMessage(t, cur, "halted: router", func() {
 					AssertIsNotHaltedRouter()
 				})
 			} else {
-				uassert.NotPanics(t, func() {
+				uassert.NotPanics(t, cur, func() {
 					AssertIsNotHaltedRouter()
 				})
 			}
@@ -127,7 +127,7 @@ func TestAssert_AssertIsNotHaltedRouter(t *testing.T) {
 	}
 }
 
-func TestAssert_AssertIsNotHaltedStaker(t *testing.T) {
+func TestAssert_AssertIsNotHaltedStaker(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		haltLevel   HaltLevel
@@ -140,16 +140,16 @@ func TestAssert_AssertIsNotHaltedStaker(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			err := setHaltLevel(tt.haltLevel)
 			uassert.NoError(t, err)
 
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, "halted: staker", func() {
+				uassert.PanicsWithMessage(t, cur, "halted: staker", func() {
 					AssertIsNotHaltedStaker()
 				})
 			} else {
-				uassert.NotPanics(t, func() {
+				uassert.NotPanics(t, cur, func() {
 					AssertIsNotHaltedStaker()
 				})
 			}
@@ -157,7 +157,7 @@ func TestAssert_AssertIsNotHaltedStaker(t *testing.T) {
 	}
 }
 
-func TestAssert_AssertIsNotHaltedLaunchpad(t *testing.T) {
+func TestAssert_AssertIsNotHaltedLaunchpad(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		haltLevel   HaltLevel
@@ -170,16 +170,16 @@ func TestAssert_AssertIsNotHaltedLaunchpad(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			err := setHaltLevel(tt.haltLevel)
 			uassert.NoError(t, err)
 
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, "halted: launchpad", func() {
+				uassert.PanicsWithMessage(t, cur, "halted: launchpad", func() {
 					AssertIsNotHaltedLaunchpad()
 				})
 			} else {
-				uassert.NotPanics(t, func() {
+				uassert.NotPanics(t, cur, func() {
 					AssertIsNotHaltedLaunchpad()
 				})
 			}
@@ -187,7 +187,7 @@ func TestAssert_AssertIsNotHaltedLaunchpad(t *testing.T) {
 	}
 }
 
-func TestAssert_AssertIsNotHaltedGovernance(t *testing.T) {
+func TestAssert_AssertIsNotHaltedGovernance(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		haltLevel   HaltLevel
@@ -200,16 +200,16 @@ func TestAssert_AssertIsNotHaltedGovernance(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			err := setHaltLevel(tt.haltLevel)
 			uassert.NoError(t, err)
 
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, "halted: governance", func() {
+				uassert.PanicsWithMessage(t, cur, "halted: governance", func() {
 					AssertIsNotHaltedGovernance()
 				})
 			} else {
-				uassert.NotPanics(t, func() {
+				uassert.NotPanics(t, cur, func() {
 					AssertIsNotHaltedGovernance()
 				})
 			}
@@ -217,7 +217,7 @@ func TestAssert_AssertIsNotHaltedGovernance(t *testing.T) {
 	}
 }
 
-func TestAssert_AssertIsNotHaltedGovStaker(t *testing.T) {
+func TestAssert_AssertIsNotHaltedGovStaker(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		haltLevel   HaltLevel
@@ -230,16 +230,16 @@ func TestAssert_AssertIsNotHaltedGovStaker(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			err := setHaltLevel(tt.haltLevel)
 			uassert.NoError(t, err)
 
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, "halted: gov_staker", func() {
+				uassert.PanicsWithMessage(t, cur, "halted: gov_staker", func() {
 					AssertIsNotHaltedGovStaker()
 				})
 			} else {
-				uassert.NotPanics(t, func() {
+				uassert.NotPanics(t, cur, func() {
 					AssertIsNotHaltedGovStaker()
 				})
 			}
@@ -247,7 +247,7 @@ func TestAssert_AssertIsNotHaltedGovStaker(t *testing.T) {
 	}
 }
 
-func TestAssert_AssertIsNotHaltedXGns(t *testing.T) {
+func TestAssert_AssertIsNotHaltedXGns(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		haltLevel   HaltLevel
@@ -260,16 +260,16 @@ func TestAssert_AssertIsNotHaltedXGns(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			err := setHaltLevel(tt.haltLevel)
 			uassert.NoError(t, err)
 
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, "halted: xgns", func() {
+				uassert.PanicsWithMessage(t, cur, "halted: xgns", func() {
 					AssertIsNotHaltedXGns()
 				})
 			} else {
-				uassert.NotPanics(t, func() {
+				uassert.NotPanics(t, cur, func() {
 					AssertIsNotHaltedXGns()
 				})
 			}
@@ -277,7 +277,7 @@ func TestAssert_AssertIsNotHaltedXGns(t *testing.T) {
 	}
 }
 
-func TestAssert_AssertIsNotHaltedCommunityPool(t *testing.T) {
+func TestAssert_AssertIsNotHaltedCommunityPool(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		haltLevel   HaltLevel
@@ -290,16 +290,16 @@ func TestAssert_AssertIsNotHaltedCommunityPool(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			err := setHaltLevel(tt.haltLevel)
 			uassert.NoError(t, err)
 
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, "halted: community_pool", func() {
+				uassert.PanicsWithMessage(t, cur, "halted: community_pool", func() {
 					AssertIsNotHaltedCommunityPool()
 				})
 			} else {
-				uassert.NotPanics(t, func() {
+				uassert.NotPanics(t, cur, func() {
 					AssertIsNotHaltedCommunityPool()
 				})
 			}
@@ -307,7 +307,7 @@ func TestAssert_AssertIsNotHaltedCommunityPool(t *testing.T) {
 	}
 }
 
-func TestAssert_AssertIsNotHaltedEmission(t *testing.T) {
+func TestAssert_AssertIsNotHaltedEmission(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		haltLevel   HaltLevel
@@ -320,16 +320,16 @@ func TestAssert_AssertIsNotHaltedEmission(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			err := setHaltLevel(tt.haltLevel)
 			uassert.NoError(t, err)
 
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, "halted: emission", func() {
+				uassert.PanicsWithMessage(t, cur, "halted: emission", func() {
 					AssertIsNotHaltedEmission()
 				})
 			} else {
-				uassert.NotPanics(t, func() {
+				uassert.NotPanics(t, cur, func() {
 					AssertIsNotHaltedEmission()
 				})
 			}
@@ -337,7 +337,7 @@ func TestAssert_AssertIsNotHaltedEmission(t *testing.T) {
 	}
 }
 
-func TestAssert_AssertIsNotHaltedWithdraw(t *testing.T) {
+func TestAssert_AssertIsNotHaltedWithdraw(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		haltLevel   HaltLevel
@@ -350,16 +350,16 @@ func TestAssert_AssertIsNotHaltedWithdraw(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			err := setHaltLevel(tt.haltLevel)
 			uassert.NoError(t, err)
 
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, "halted: withdraw", func() {
+				uassert.PanicsWithMessage(t, cur, "halted: withdraw", func() {
 					AssertIsNotHaltedWithdraw()
 				})
 			} else {
-				uassert.NotPanics(t, func() {
+				uassert.NotPanics(t, cur, func() {
 					AssertIsNotHaltedWithdraw()
 				})
 			}
@@ -367,7 +367,7 @@ func TestAssert_AssertIsNotHaltedWithdraw(t *testing.T) {
 	}
 }
 
-func TestAssert_AssertIsNotHaltedOperation(t *testing.T) {
+func TestAssert_AssertIsNotHaltedOperation(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		opType      OpType
@@ -381,17 +381,17 @@ func TestAssert_AssertIsNotHaltedOperation(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			err := setHaltLevel(tt.haltLevel)
 			uassert.NoError(t, err)
 
 			if tt.shouldPanic {
 				expectedMsg := "halted: " + tt.opType.String()
-				uassert.PanicsWithMessage(t, expectedMsg, func() {
+				uassert.PanicsWithMessage(t, cur, expectedMsg, func() {
 					AssertIsNotHaltedOperation(tt.opType)
 				})
 			} else {
-				uassert.NotPanics(t, func() {
+				uassert.NotPanics(t, cur, func() {
 					AssertIsNotHaltedOperation(tt.opType)
 				})
 			}

--- a/contract/r/gnoswap/halt/config_test.gno
+++ b/contract/r/gnoswap/halt/config_test.gno
@@ -7,7 +7,7 @@ import (
 )
 
 // Test HaltConfig methods
-func TestHaltConfig_IsHalted(t *testing.T) {
+func TestHaltConfig_IsHalted(cur realm, t *testing.T) {
 	tests := []struct {
 		name     string
 		config   HaltConfig
@@ -35,7 +35,7 @@ func TestHaltConfig_IsHalted(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			// when
 			result := tc.config.IsHalted(tc.op)
 
@@ -45,7 +45,7 @@ func TestHaltConfig_IsHalted(t *testing.T) {
 	}
 }
 
-func TestHaltConfig_Get(t *testing.T) {
+func TestHaltConfig_Get(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
 		config        HaltConfig
@@ -77,7 +77,7 @@ func TestHaltConfig_Get(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			// when
 			result, err := tc.config.get(tc.op)
 
@@ -92,7 +92,7 @@ func TestHaltConfig_Get(t *testing.T) {
 	}
 }
 
-func TestHaltConfig_Set(t *testing.T) {
+func TestHaltConfig_Set(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
 		config        HaltConfig
@@ -124,7 +124,7 @@ func TestHaltConfig_Set(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			// when
 			err := tc.config.set(tc.op, tc.value)
 
@@ -143,7 +143,7 @@ func TestHaltConfig_Set(t *testing.T) {
 	}
 }
 
-func TestHaltConfig_Get_NotFound(t *testing.T) {
+func TestHaltConfig_Get_NotFound(cur realm, t *testing.T) {
 	tests := []struct {
 		name             string
 		config           HaltConfig
@@ -174,7 +174,7 @@ func TestHaltConfig_Get_NotFound(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			// when
 			_, err := tc.config.get(tc.op)
 
@@ -189,7 +189,7 @@ func TestHaltConfig_Get_NotFound(t *testing.T) {
 	}
 }
 
-func TestHaltConfig_Clone(t *testing.T) {
+func TestHaltConfig_Clone(cur realm, t *testing.T) {
 	// given
 	original := HaltConfig{
 		OpTypePool:   true,
@@ -219,7 +219,7 @@ func TestHaltConfig_Clone(t *testing.T) {
 }
 
 // Test config factory functions
-func TestNewNoneConfig(t *testing.T) {
+func TestNewNoneConfig(cur realm, t *testing.T) {
 	// when
 	config := newNoneConfig()
 
@@ -237,7 +237,7 @@ func TestNewNoneConfig(t *testing.T) {
 	}
 }
 
-func TestNewSafeModeConfig(t *testing.T) {
+func TestNewSafeModeConfig(cur realm, t *testing.T) {
 	// when
 	config := newSafeModeConfig()
 
@@ -261,7 +261,7 @@ func TestNewSafeModeConfig(t *testing.T) {
 	uassert.Equal(t, withdrawHalted, true)
 }
 
-func TestNewEmergencyConfig(t *testing.T) {
+func TestNewEmergencyConfig(cur realm, t *testing.T) {
 	// when
 	config := newEmergencyConfig()
 
@@ -295,7 +295,7 @@ func TestNewEmergencyConfig(t *testing.T) {
 	}
 }
 
-func TestNewCompleteConfig(t *testing.T) {
+func TestNewCompleteConfig(cur realm, t *testing.T) {
 	// when
 	config := newCompleteConfig()
 
@@ -313,7 +313,7 @@ func TestNewCompleteConfig(t *testing.T) {
 	}
 }
 
-func TestConfig_AllConfigLevelsIntegration(t *testing.T) {
+func TestConfig_AllConfigLevelsIntegration(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
 		configFunc    func() HaltConfig
@@ -363,7 +363,7 @@ func TestConfig_AllConfigLevelsIntegration(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			// when
 			config := tc.configFunc()
 
@@ -378,8 +378,8 @@ func TestConfig_AllConfigLevelsIntegration(t *testing.T) {
 }
 
 // Test edge cases and validation
-func TestHaltConfig_EdgeCases(t *testing.T) {
-	t.Run("Empty config", func(t *testing.T) {
+func TestHaltConfig_EdgeCases(cur realm, t *testing.T) {
+	t.Run("Empty config", func(cur realm, t *testing.T) {
 		config := make(HaltConfig)
 
 		// Non-existing operation should return false and error
@@ -388,7 +388,7 @@ func TestHaltConfig_EdgeCases(t *testing.T) {
 		uassert.Equal(t, halted, false)
 	})
 
-	t.Run("IsHalted with non-existing operation", func(t *testing.T) {
+	t.Run("IsHalted with non-existing operation", func(cur realm, t *testing.T) {
 		config := make(HaltConfig)
 
 		// IsHalted should return false for non-existing operations
@@ -396,7 +396,7 @@ func TestHaltConfig_EdgeCases(t *testing.T) {
 		uassert.Equal(t, halted, false)
 	})
 
-	t.Run("Set and get consistency", func(t *testing.T) {
+	t.Run("Set and get consistency", func(cur realm, t *testing.T) {
 		config := make(HaltConfig)
 
 		// Set a value to halted
@@ -412,7 +412,7 @@ func TestHaltConfig_EdgeCases(t *testing.T) {
 		uassert.Equal(t, config.IsHalted(OpTypePool), true)
 	})
 
-	t.Run("Override existing value", func(t *testing.T) {
+	t.Run("Override existing value", func(cur realm, t *testing.T) {
 		config := HaltConfig{OpTypePool: true}
 
 		// Override with false (not halted)
@@ -425,7 +425,7 @@ func TestHaltConfig_EdgeCases(t *testing.T) {
 		uassert.Equal(t, halted, false)
 	})
 
-	t.Run("Clone independence", func(t *testing.T) {
+	t.Run("Clone independence", func(cur realm, t *testing.T) {
 		original := HaltConfig{
 			OpTypePool:   true,
 			OpTypeRouter: false,

--- a/contract/r/gnoswap/halt/getters_test.gno
+++ b/contract/r/gnoswap/halt/getters_test.gno
@@ -6,7 +6,7 @@ import (
 	uassert "gno.land/p/nt/uassert/v0"
 )
 
-func TestGetters_IsHaltedPool(t *testing.T) {
+func TestGetters_IsHaltedPool(cur realm, t *testing.T) {
 	tests := []struct {
 		name      string
 		haltLevel HaltLevel
@@ -19,7 +19,7 @@ func TestGetters_IsHaltedPool(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			err := setHaltLevel(tt.haltLevel)
 			uassert.NoError(t, err)
 			result := IsHaltedPool()
@@ -28,7 +28,7 @@ func TestGetters_IsHaltedPool(t *testing.T) {
 	}
 }
 
-func TestGetters_IsHaltedPosition(t *testing.T) {
+func TestGetters_IsHaltedPosition(cur realm, t *testing.T) {
 	tests := []struct {
 		name      string
 		haltLevel HaltLevel
@@ -41,7 +41,7 @@ func TestGetters_IsHaltedPosition(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			err := setHaltLevel(tt.haltLevel)
 			uassert.NoError(t, err)
 			result := IsHaltedPosition()
@@ -50,7 +50,7 @@ func TestGetters_IsHaltedPosition(t *testing.T) {
 	}
 }
 
-func TestGetters_IsHaltedProtocolFee(t *testing.T) {
+func TestGetters_IsHaltedProtocolFee(cur realm, t *testing.T) {
 	tests := []struct {
 		name      string
 		haltLevel HaltLevel
@@ -63,7 +63,7 @@ func TestGetters_IsHaltedProtocolFee(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			err := setHaltLevel(tt.haltLevel)
 			uassert.NoError(t, err)
 			result := IsHaltedProtocolFee()
@@ -72,7 +72,7 @@ func TestGetters_IsHaltedProtocolFee(t *testing.T) {
 	}
 }
 
-func TestGetters_IsHaltedRouter(t *testing.T) {
+func TestGetters_IsHaltedRouter(cur realm, t *testing.T) {
 	tests := []struct {
 		name      string
 		haltLevel HaltLevel
@@ -85,7 +85,7 @@ func TestGetters_IsHaltedRouter(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			err := setHaltLevel(tt.haltLevel)
 			uassert.NoError(t, err)
 			result := IsHaltedRouter()
@@ -94,7 +94,7 @@ func TestGetters_IsHaltedRouter(t *testing.T) {
 	}
 }
 
-func TestGetters_IsHaltedStaker(t *testing.T) {
+func TestGetters_IsHaltedStaker(cur realm, t *testing.T) {
 	tests := []struct {
 		name      string
 		haltLevel HaltLevel
@@ -107,7 +107,7 @@ func TestGetters_IsHaltedStaker(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			err := setHaltLevel(tt.haltLevel)
 			uassert.NoError(t, err)
 			result := IsHaltedStaker()
@@ -116,7 +116,7 @@ func TestGetters_IsHaltedStaker(t *testing.T) {
 	}
 }
 
-func TestGetters_IsHaltedLaunchpad(t *testing.T) {
+func TestGetters_IsHaltedLaunchpad(cur realm, t *testing.T) {
 	tests := []struct {
 		name      string
 		haltLevel HaltLevel
@@ -129,7 +129,7 @@ func TestGetters_IsHaltedLaunchpad(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			err := setHaltLevel(tt.haltLevel)
 			uassert.NoError(t, err)
 			result := IsHaltedLaunchpad()
@@ -138,7 +138,7 @@ func TestGetters_IsHaltedLaunchpad(t *testing.T) {
 	}
 }
 
-func TestGetters_IsHaltedGovernance(t *testing.T) {
+func TestGetters_IsHaltedGovernance(cur realm, t *testing.T) {
 	tests := []struct {
 		name      string
 		haltLevel HaltLevel
@@ -151,7 +151,7 @@ func TestGetters_IsHaltedGovernance(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			err := setHaltLevel(tt.haltLevel)
 			uassert.NoError(t, err)
 			result := IsHaltedGovernance()
@@ -160,7 +160,7 @@ func TestGetters_IsHaltedGovernance(t *testing.T) {
 	}
 }
 
-func TestGetters_IsHaltedGovStaker(t *testing.T) {
+func TestGetters_IsHaltedGovStaker(cur realm, t *testing.T) {
 	tests := []struct {
 		name      string
 		haltLevel HaltLevel
@@ -173,7 +173,7 @@ func TestGetters_IsHaltedGovStaker(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			err := setHaltLevel(tt.haltLevel)
 			uassert.NoError(t, err)
 			result := IsHaltedGovStaker()
@@ -182,7 +182,7 @@ func TestGetters_IsHaltedGovStaker(t *testing.T) {
 	}
 }
 
-func TestGetters_IsHaltedXGns(t *testing.T) {
+func TestGetters_IsHaltedXGns(cur realm, t *testing.T) {
 	tests := []struct {
 		name      string
 		haltLevel HaltLevel
@@ -195,7 +195,7 @@ func TestGetters_IsHaltedXGns(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			err := setHaltLevel(tt.haltLevel)
 			uassert.NoError(t, err)
 			result := IsHaltedXGns()
@@ -204,7 +204,7 @@ func TestGetters_IsHaltedXGns(t *testing.T) {
 	}
 }
 
-func TestGetters_IsHaltedCommunityPool(t *testing.T) {
+func TestGetters_IsHaltedCommunityPool(cur realm, t *testing.T) {
 	tests := []struct {
 		name      string
 		haltLevel HaltLevel
@@ -217,7 +217,7 @@ func TestGetters_IsHaltedCommunityPool(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			err := setHaltLevel(tt.haltLevel)
 			uassert.NoError(t, err)
 			result := IsHaltedCommunityPool()
@@ -226,7 +226,7 @@ func TestGetters_IsHaltedCommunityPool(t *testing.T) {
 	}
 }
 
-func TestGetters_IsHaltedEmission(t *testing.T) {
+func TestGetters_IsHaltedEmission(cur realm, t *testing.T) {
 	tests := []struct {
 		name      string
 		haltLevel HaltLevel
@@ -239,7 +239,7 @@ func TestGetters_IsHaltedEmission(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			err := setHaltLevel(tt.haltLevel)
 			uassert.NoError(t, err)
 			result := IsHaltedEmission()
@@ -248,7 +248,7 @@ func TestGetters_IsHaltedEmission(t *testing.T) {
 	}
 }
 
-func TestGetters_IsHaltedWithdraw(t *testing.T) {
+func TestGetters_IsHaltedWithdraw(cur realm, t *testing.T) {
 	tests := []struct {
 		name      string
 		haltLevel HaltLevel
@@ -261,7 +261,7 @@ func TestGetters_IsHaltedWithdraw(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			err := setHaltLevel(tt.haltLevel)
 			uassert.NoError(t, err)
 			result := IsHaltedWithdraw()
@@ -270,7 +270,7 @@ func TestGetters_IsHaltedWithdraw(t *testing.T) {
 	}
 }
 
-func TestGetters_isHaltedOperation(t *testing.T) {
+func TestGetters_isHaltedOperation(cur realm, t *testing.T) {
 	tests := []struct {
 		name      string
 		opType    OpType
@@ -285,7 +285,7 @@ func TestGetters_isHaltedOperation(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			err := setHaltLevel(tt.haltLevel)
 			uassert.NoError(t, err)
 			result := isHaltedOperation(tt.opType)
@@ -294,16 +294,16 @@ func TestGetters_isHaltedOperation(t *testing.T) {
 	}
 }
 
-func TestGetters_isHaltedOperation_InvalidOpType(t *testing.T) {
+func TestGetters_isHaltedOperation_InvalidOpType(cur realm, t *testing.T) {
 	err := setHaltLevel(HaltLevelNone)
 	uassert.NoError(t, err)
 
-	uassert.PanicsWithMessage(t, "invalid operation type: invalid_op", func() {
+	uassert.PanicsWithMessage(t, cur, "invalid operation type: invalid_op", func() {
 		isHaltedOperation(OpType("invalid_op"))
 	})
 }
 
-func TestGetters_IsHalted_InvalidOpType(t *testing.T) {
+func TestGetters_IsHalted_InvalidOpType(cur realm, t *testing.T) {
 	tests := []struct {
 		name             string
 		opTypes          []OpType
@@ -340,7 +340,7 @@ func TestGetters_IsHalted_InvalidOpType(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			err := setHaltLevel(HaltLevelNone)
 			uassert.NoError(t, err)
 			halted, err := IsHalted(tt.opTypes...)

--- a/contract/r/gnoswap/halt/halt.gno
+++ b/contract/r/gnoswap/halt/halt.gno
@@ -2,7 +2,6 @@ package halt
 
 import (
 	"chain"
-	"chain/runtime"
 	"strconv"
 
 	"gno.land/r/gnoswap/access"
@@ -21,7 +20,7 @@ func init() {
 //
 // Only callable by admin or governance.
 func SetHaltLevel(cur realm, level HaltLevel) {
-	caller := runtime.PreviousRealm().Address()
+	caller := cur.Previous().Address()
 	access.AssertIsAdminOrGovernance(caller)
 
 	err := setHaltLevel(level)
@@ -45,7 +44,7 @@ func SetHaltLevel(cur realm, level HaltLevel) {
 //
 // Only callable by admin or governance.
 func SetOperationStatus(cur realm, op OpType, halted bool) {
-	caller := runtime.PreviousRealm().Address()
+	caller := cur.Previous().Address()
 	access.AssertIsAdminOrGovernance(caller)
 
 	if !op.IsValid() {

--- a/contract/r/gnoswap/halt/halt_test.gno
+++ b/contract/r/gnoswap/halt/halt_test.gno
@@ -10,7 +10,7 @@ import (
 	_ "gno.land/r/gnoswap/rbac"
 )
 
-func TestHalt_SetHaltLevel_Internal(t *testing.T) {
+func TestHalt_SetHaltLevel_Internal(cur realm, t *testing.T) {
 	tests := []struct {
 		name             string
 		inputLevel       HaltLevel
@@ -59,7 +59,7 @@ func TestHalt_SetHaltLevel_Internal(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			cleanup(t)
 
 			// when
@@ -83,7 +83,7 @@ func TestHalt_SetHaltLevel_Internal(t *testing.T) {
 	}
 }
 
-func TestHalt_SetHaltLevel_Idempotency(t *testing.T) {
+func TestHalt_SetHaltLevel_Idempotency(cur realm, t *testing.T) {
 	tests := []struct {
 		name  string
 		level HaltLevel
@@ -95,7 +95,7 @@ func TestHalt_SetHaltLevel_Idempotency(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			cleanup(t)
 
 			// given - set level once
@@ -118,7 +118,7 @@ func TestHalt_SetHaltLevel_Idempotency(t *testing.T) {
 	}
 }
 
-func TestHalt_GetHaltConfig(t *testing.T) {
+func TestHalt_GetHaltConfig(cur realm, t *testing.T) {
 	cleanup(t)
 
 	// given - set a specific configuration
@@ -148,7 +148,7 @@ func TestHalt_GetHaltConfig(t *testing.T) {
 	uassert.Equal(t, halted, false) // Should still be false (not halted) in the clone
 }
 
-func TestHalt_IsHalted(t *testing.T) {
+func TestHalt_IsHalted(cur realm, t *testing.T) {
 	tests := []struct {
 		name           string
 		initialLevel   HaltLevel
@@ -222,7 +222,7 @@ func TestHalt_IsHalted(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			cleanup(t)
 
 			// given
@@ -243,7 +243,7 @@ func TestHalt_IsHalted(t *testing.T) {
 	}
 }
 
-func TestHalt_IndividualOperationStatus(t *testing.T) {
+func TestHalt_IndividualOperationStatus(cur realm, t *testing.T) {
 	tests := []struct {
 		name             string
 		initialLevel     HaltLevel
@@ -297,7 +297,7 @@ func TestHalt_IndividualOperationStatus(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			cleanup(t)
 
 			// given
@@ -306,7 +306,7 @@ func TestHalt_IndividualOperationStatus(t *testing.T) {
 
 			// when/then
 			if tc.expectedPanic {
-				uassert.AbortsWithMessage(t, tc.expectedPanicMsg, func() {
+				uassert.AbortsWithMessage(t, cur, tc.expectedPanicMsg, func() {
 					isHaltedOperation(tc.operation)
 				})
 			} else {
@@ -317,7 +317,7 @@ func TestHalt_IndividualOperationStatus(t *testing.T) {
 	}
 }
 
-func TestHalt_GetHaltConfigJson(t *testing.T) {
+func TestHalt_GetHaltConfigJson(cur realm, t *testing.T) {
 	tests := []struct {
 		name                 string
 		initialLevel         HaltLevel
@@ -375,7 +375,7 @@ func TestHalt_GetHaltConfigJson(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			cleanup(t)
 
 			// given
@@ -406,7 +406,7 @@ func TestHalt_GetHaltConfigJson(t *testing.T) {
 	}
 }
 
-func TestHalt_SetHaltLevel_WithAuthorization(t *testing.T) {
+func TestHalt_SetHaltLevel_WithAuthorization(cur realm, t *testing.T) {
 	adminAddr := access.MustGetAddress(prbac.ROLE_ADMIN.String())
 	govAddr := access.MustGetAddress(prbac.ROLE_GOVERNANCE.String())
 
@@ -453,18 +453,18 @@ func TestHalt_SetHaltLevel_WithAuthorization(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			cleanup(t)
 
 			testing.SetRealm(testing.NewUserRealm(tc.callerAddress))
 
 			// when/then
 			if tc.expectedHasAbort {
-				uassert.AbortsWithMessage(t, tc.expectedAbortMessage, func() {
-					SetHaltLevel(cross, tc.inputLevel)
+				uassert.AbortsContains(t, cur, tc.expectedAbortMessage, func() {
+					SetHaltLevel(cross(cur), tc.inputLevel)
 				})
 			} else {
-				SetHaltLevel(cross, tc.inputLevel)
+				SetHaltLevel(cross(cur), tc.inputLevel)
 
 				// Verify the level was set correctly by checking specific operations
 				config := GetHaltConfig()
@@ -490,7 +490,7 @@ func TestHalt_SetHaltLevel_WithAuthorization(t *testing.T) {
 	}
 }
 
-func TestHalt_SetOperationStatus_WithAuthorization(t *testing.T) {
+func TestHalt_SetOperationStatus_WithAuthorization(cur realm, t *testing.T) {
 	adminAddr := access.MustGetAddress(prbac.ROLE_ADMIN.String())
 	govAddr := access.MustGetAddress(prbac.ROLE_GOVERNANCE.String())
 
@@ -537,18 +537,18 @@ func TestHalt_SetOperationStatus_WithAuthorization(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			cleanup(t)
 
 			testing.SetRealm(testing.NewUserRealm(tc.callerAddress))
 
 			// when/then
 			if tc.expectedHasAbort {
-				uassert.AbortsWithMessage(t, tc.expectedAbortMessage, func() {
-					SetOperationStatus(cross, tc.operationType, tc.halted)
+				uassert.AbortsContains(t, cur, tc.expectedAbortMessage, func() {
+					SetOperationStatus(cross(cur), tc.operationType, tc.halted)
 				})
 			} else {
-				SetOperationStatus(cross, tc.operationType, tc.halted)
+				SetOperationStatus(cross(cur), tc.operationType, tc.halted)
 
 				// Verify the operation status was set correctly
 				config := GetHaltConfig()
@@ -560,7 +560,7 @@ func TestHalt_SetOperationStatus_WithAuthorization(t *testing.T) {
 	}
 }
 
-func TestHalt_IntegrationScenarios(t *testing.T) {
+func TestHalt_IntegrationScenarios(cur realm, t *testing.T) {
 	tests := []struct {
 		name                 string
 		initialLevel         HaltLevel
@@ -598,7 +598,7 @@ func TestHalt_IntegrationScenarios(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			cleanup(t)
 
 			// Set initial level
@@ -625,8 +625,8 @@ func TestHalt_IntegrationScenarios(t *testing.T) {
 	}
 }
 
-func TestHalt_EdgeCases(t *testing.T) {
-	t.Run("GetHaltConfig independence", func(t *testing.T) {
+func TestHalt_EdgeCases(cur realm, t *testing.T) {
+	t.Run("GetHaltConfig independence", func(cur realm, t *testing.T) {
 		cleanup(t)
 
 		configByGetter := GetHaltConfig()
@@ -644,7 +644,7 @@ func TestHalt_EdgeCases(t *testing.T) {
 		uassert.Equal(t, getterHalted, false)
 	})
 
-	t.Run("IsHalted with no operations", func(t *testing.T) {
+	t.Run("IsHalted with no operations", func(cur realm, t *testing.T) {
 		cleanup(t)
 		err := setHaltLevel(HaltLevelComplete)
 		uassert.NoError(t, err)
@@ -655,7 +655,7 @@ func TestHalt_EdgeCases(t *testing.T) {
 		uassert.Equal(t, halted, false)
 	})
 
-	t.Run("Multiple halt level changes", func(t *testing.T) {
+	t.Run("Multiple halt level changes", func(cur realm, t *testing.T) {
 		cleanup(t)
 
 		// Start with emergency
@@ -675,7 +675,7 @@ func TestHalt_EdgeCases(t *testing.T) {
 		uassert.Equal(t, isHaltedOperation(OpTypeGovernance), true)
 	})
 
-	t.Run("HaltConfig Clone method", func(t *testing.T) {
+	t.Run("HaltConfig Clone method", func(cur realm, t *testing.T) {
 		cleanup(t)
 
 		original := newSafeModeConfig()
@@ -695,7 +695,7 @@ func TestHalt_EdgeCases(t *testing.T) {
 		uassert.Equal(t, clonedHalted, false)
 	})
 
-	t.Run("HaltConfig IsHalted method", func(t *testing.T) {
+	t.Run("HaltConfig IsHalted method", func(cur realm, t *testing.T) {
 		cleanup(t)
 
 		config := newNoneConfig()
@@ -709,7 +709,7 @@ func TestHalt_EdgeCases(t *testing.T) {
 	})
 }
 
-func TestHalt_NewHaltStateManagerByConfig(t *testing.T) {
+func TestHalt_NewHaltStateManagerByConfig(cur realm, t *testing.T) {
 	tests := []struct {
 		name                   string
 		configFunc             func() HaltConfig
@@ -815,7 +815,7 @@ func TestHalt_NewHaltStateManagerByConfig(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			// given
 			config := tc.configFunc()
 
@@ -853,7 +853,7 @@ func TestHalt_NewHaltStateManagerByConfig(t *testing.T) {
 	}
 }
 
-func TestHalt_NewHaltStateManagerByConfig_Independence(t *testing.T) {
+func TestHalt_NewHaltStateManagerByConfig_Independence(cur realm, t *testing.T) {
 	tests := []struct {
 		name               string
 		configFunc         func() HaltConfig
@@ -902,7 +902,7 @@ func TestHalt_NewHaltStateManagerByConfig_Independence(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			// given
 			config := tc.configFunc()
 			manager := newHaltStateManagerByConfig(config)
@@ -924,7 +924,7 @@ func TestHalt_NewHaltStateManagerByConfig_Independence(t *testing.T) {
 	}
 }
 
-func TestHaltStateManager_GetOperationHalted_NotFound(t *testing.T) {
+func TestHaltStateManager_GetOperationHalted_NotFound(cur realm, t *testing.T) {
 	tests := []struct {
 		name           string
 		manager        HaltStateManager
@@ -954,7 +954,7 @@ func TestHaltStateManager_GetOperationHalted_NotFound(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			// when
 			halted, err := tc.manager.getOperationHalted(tc.op)
 
@@ -966,7 +966,7 @@ func TestHaltStateManager_GetOperationHalted_NotFound(t *testing.T) {
 	}
 }
 
-func TestHaltStateManager_SetOperationHalted_InvalidOpType(t *testing.T) {
+func TestHaltStateManager_SetOperationHalted_InvalidOpType(cur realm, t *testing.T) {
 	tests := []struct {
 		name           string
 		op             OpType
@@ -994,7 +994,7 @@ func TestHaltStateManager_SetOperationHalted_InvalidOpType(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			// given
 			manager := newHaltStateManagerByConfig(newNoneConfig())
 

--- a/contract/r/gnoswap/halt/types_test.gno
+++ b/contract/r/gnoswap/halt/types_test.gno
@@ -6,7 +6,7 @@ import (
 	uassert "gno.land/p/nt/uassert/v0"
 )
 
-func TestTypes_HaltLevelString(t *testing.T) {
+func TestTypes_HaltLevelString(cur realm, t *testing.T) {
 	tests := []struct {
 		name     string
 		level    HaltLevel
@@ -45,7 +45,7 @@ func TestTypes_HaltLevelString(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			// when
 			result := tc.level.String()
 
@@ -55,7 +55,7 @@ func TestTypes_HaltLevelString(t *testing.T) {
 	}
 }
 
-func TestTypes_HaltLevelDescription(t *testing.T) {
+func TestTypes_HaltLevelDescription(cur realm, t *testing.T) {
 	tests := []struct {
 		name     string
 		level    HaltLevel
@@ -99,7 +99,7 @@ func TestTypes_HaltLevelDescription(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			// when
 			result := tc.level.Description()
 
@@ -109,7 +109,7 @@ func TestTypes_HaltLevelDescription(t *testing.T) {
 	}
 }
 
-func TestTypes_HaltLevelIsValid(t *testing.T) {
+func TestTypes_HaltLevelIsValid(cur realm, t *testing.T) {
 	tests := []struct {
 		name     string
 		level    HaltLevel
@@ -158,7 +158,7 @@ func TestTypes_HaltLevelIsValid(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			// when
 			result := tc.level.IsValid()
 
@@ -168,7 +168,7 @@ func TestTypes_HaltLevelIsValid(t *testing.T) {
 	}
 }
 
-func TestTypes_OpTypeString(t *testing.T) {
+func TestTypes_OpTypeString(cur realm, t *testing.T) {
 	tests := []struct {
 		name     string
 		op       OpType
@@ -247,7 +247,7 @@ func TestTypes_OpTypeString(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			// when
 			result := tc.op.String()
 
@@ -257,7 +257,7 @@ func TestTypes_OpTypeString(t *testing.T) {
 	}
 }
 
-func TestTypes_OpTypeIsValid(t *testing.T) {
+func TestTypes_OpTypeIsValid(cur realm, t *testing.T) {
 	tests := []struct {
 		name     string
 		op       OpType
@@ -346,7 +346,7 @@ func TestTypes_OpTypeIsValid(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			// when
 			result := tc.op.IsValid()
 


### PR DESCRIPTION
## Summary
- Migrate halt admin/governance caller checks to `cur.Previous()`
- Update halt tests to use `cur realm`, `cross(cur)`, and realm-aware `uassert` helpers
- Update halt README examples for the Interrealm v2 public call style

## Verification
- `make test PKG=gno.land/r/gnoswap/halt`
