### PR TITLE
refactor(p/version_manager): migrate to interrealm v2

### DIFF
--- a/contract/p/gnoswap/version_manager/types.gno
+++ b/contract/p/gnoswap/version_manager/types.gno
@@ -18,12 +18,22 @@ type VersionManager interface {
 	// Must be called by each version package during initialization.
 	// First registration becomes the active implementation with write access.
 	// Subsequent registrations are granted read-only access.
-	RegisterInitializer(initializer func(store any) any) error
+	//
+	// The leading `_ int, rlm realm` is the v2 interrealm-spec marker pattern:
+	// the `0` sentinel surfaces at every call site so the realm threading is
+	// visible to the reader, and rlm is the live crossing-frame token that
+	// the implementation validates via rlm.IsCurrent() and reads via
+	// rlm.Previous() to identify the version package.
+	RegisterInitializer(_ int, rlm realm, initializer func(store any) any) error
 
 	// ChangeImplementation switches the active version at runtime.
 	// The new active version gets write access, while others remain read-only.
 	// This enables hot-swapping without downtime or data migration.
-	ChangeImplementation(packagePath string) error
+	//
+	// The leading `_ int, rlm realm` is the v2 interrealm-spec marker pattern;
+	// rlm is validated via rlm.IsCurrent() to reject spoofed/stale tokens.
+	// Upgrade ACLs live in the wrapping /r/ realm, not here.
+	ChangeImplementation(_ int, rlm realm, packagePath string) error
 
 	// GetDomainPath returns the base domain path (e.g., "gno.land/r/gnoswap/protocol_fee")
 	GetDomainPath() string

--- a/contract/p/gnoswap/version_manager/version_manager.gno
+++ b/contract/p/gnoswap/version_manager/version_manager.gno
@@ -12,7 +12,6 @@ package version_manager
 
 import (
 	"chain"
-	"chain/runtime"
 	"errors"
 	"strings"
 
@@ -20,14 +19,19 @@ import (
 	ufmt "gno.land/p/nt/ufmt/v0"
 )
 
+// ErrSpoofedRealm is returned when the supplied realm token does not match the
+// live crossing frame (rlm.IsCurrent() == false). It signals a stale or
+// spoofed token captured in an earlier frame.
+var ErrSpoofedRealm = errors.New("rlm does not match the current crossing frame")
+
 // versionManager is the concrete implementation of VersionManager interface.
 // It manages multiple versioned implementations of a domain (e.g., protocol_fee/v1, protocol_fee/v2).
 //
 // Storage Access Model:
 // Implementation realms do NOT receive direct storage permissions. Instead, when calls flow
-// from the domain proxy to the implementation, runtime.CurrentRealm() remains the domain
-// (proxy) realm, which already has write permission to the KVStore. This design prevents
-// external callers from directly invoking implementation realms to modify storage.
+// from the domain proxy to the implementation, the proxy realm (which has write permission
+// to the KVStore) is the one that drives the storage. This design prevents external callers
+// from directly invoking implementation realms to modify storage.
 type versionManager struct {
 	// initializers stores registered initializer functions keyed by package path
 	// Each initializer bootstraps a specific version's implementation
@@ -57,24 +61,33 @@ type versionManager struct {
 // This method must be called by each version package (e.g., v1, v2) during initialization.
 //
 // The registration process:
-//  1. Validates the caller is within the authorized domain path
-//  2. Stores the initializer function for later version switching
+//  1. Validates the realm token is the live crossing frame (rejects spoofed tokens)
+//  2. Validates the caller is within the authorized domain path
+//  3. Stores the initializer function for later version switching
 //
 // Parameters:
+//   - rlm: the live realm token threaded in by the caller; rlm.Previous() identifies the
+//     version package that is registering. The leading `_ int` is a v2 sentinel that surfaces
+//     as a `0` at every call site so the realm-threading is visible to the reader.
 //   - initializer: A function that receives a storage interface and returns an implementation instance
 //
 // Returns:
-//   - error: If caller is unauthorized, already registered, or permission setup fails
+//   - error: If realm token is spoofed, caller is unauthorized, already registered, or initializer is nil
 //
-// Security: Only packages under the domainPath prefix can register (enforced by isContainDomainPath)
-func (vm *versionManager) RegisterInitializer(initializer func(store any) any) error {
+// Security: Only packages under the domainPath prefix can register (enforced by isContainDomainPath).
+func (vm *versionManager) RegisterInitializer(_ int, rlm realm, initializer func(store any) any) error {
+	if !rlm.IsCurrent() {
+		return ErrSpoofedRealm
+	}
+
 	// Validate initializer is not nil to prevent panic during initialization
 	if initializer == nil {
 		return errors.New("version_manager: initializer cannot be nil")
 	}
 
-	// Ensure the caller is within the domain path (e.g., protocol_fee/v1, protocol_fee/v2)
-	previousRealm := runtime.PreviousRealm()
+	// Ensure the caller is within the domain path (e.g., protocol_fee/v1, protocol_fee/v2).
+	// rlm.Previous() corresponds to v1's runtime.PreviousRealm().
+	previousRealm := rlm.Previous()
 	if previousRealm.IsUser() {
 		return errors.New("version_manager: caller cannot be user")
 	}
@@ -117,15 +130,26 @@ func (vm *versionManager) RegisterInitializer(initializer func(store any) any) e
 // This enables zero-downtime upgrades by switching the active implementation at runtime.
 //
 // The switching process:
-//  1. Validates the target version has been registered via RegisterInitializer
-//  2. Retrieves and executes the target version's initializer
+//  1. Validates the realm token is the live crossing frame (rejects spoofed tokens)
+//  2. Validates the target version has been registered via RegisterInitializer
+//  3. Retrieves and executes the target version's initializer
+//
+// Authorization is the caller realm's responsibility — version_manager only rejects
+// spoofed realm tokens. Upgrade ACLs (admin / governance) live in the wrapping /r/ realm
+// (see each module's upgrade.gno).
 //
 // Parameters:
+//   - rlm: the live realm token threaded in by the caller. The leading `_ int` is a v2
+//     sentinel that surfaces as a `0` at every call site so the realm-threading is visible.
 //   - packagePath: The full package path of the target version (e.g., "gno.land/r/gnoswap/protocol_fee/v2")
 //
 // Returns:
-//   - error: If target version is not registered or initializer is invalid
-func (vm *versionManager) ChangeImplementation(packagePath string) error {
+//   - error: If realm token is spoofed, target version is not registered, or initializer is invalid
+func (vm *versionManager) ChangeImplementation(_ int, rlm realm, packagePath string) error {
+	if !rlm.IsCurrent() {
+		return ErrSpoofedRealm
+	}
+
 	// Retrieve the registered initializer function
 	initializer, ok := vm.initializers[packagePath]
 	if !ok {
@@ -186,7 +210,7 @@ func (vm *versionManager) GetCurrentImplementation() any {
 //   - Valid callers: "gno.land/r/gnoswap/protocol_fee/v1", "gno.land/r/gnoswap/protocol_fee/v2"
 //   - Invalid callers: "gno.land/r/gnoswap/other", "gno.land/r/attacker/malicious"
 func (vm *versionManager) isContainDomainPath(targetPackagePath string) bool {
-	// `domainPath` is set via `runtime.CurrentRealm().PkgPath()` in each contract.
+	// `domainPath` is set via the current realm's PkgPath in each contract.
 	// Therefore, there is no need for a separate trailing slash check,
 	// and the prefix is determined by directly appending `/` for version detection.
 	prefix := vm.domainPath + "/"

--- a/contract/p/gnoswap/version_manager/version_manager_test.gno
+++ b/contract/p/gnoswap/version_manager/version_manager_test.gno
@@ -11,7 +11,7 @@ import (
 // Mock domain address for testing
 const mockDomainAddr = address("g1domain")
 
-func TestNewVersionManager(t *testing.T) {
+func TestNewVersionManager(cur realm, t *testing.T) {
 	tests := []struct {
 		name                    string
 		domainPath              string
@@ -47,7 +47,7 @@ func TestNewVersionManager(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			kvStore := store.NewKVStore(mockDomainAddr)
 			vm := NewVersionManager(
 				tt.domainPath,
@@ -88,7 +88,7 @@ func TestNewVersionManager(t *testing.T) {
 	}
 }
 
-func TestVersionManager_InitialState(t *testing.T) {
+func TestVersionManager_InitialState(cur realm, t *testing.T) {
 	tests := []struct {
 		name                      string
 		domainPath                string
@@ -136,7 +136,7 @@ func TestVersionManager_InitialState(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			kvStore := store.NewKVStore(mockDomainAddr)
 			vm := NewVersionManager(
 				tt.domainPath,
@@ -173,7 +173,7 @@ func TestVersionManager_InitialState(t *testing.T) {
 }
 
 // TestChangeImplementation_Errors tests all error cases in ChangeImplementation
-func TestChangeImplementation_Errors(t *testing.T) {
+func TestChangeImplementation_Errors(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
 		setupFunc     func() (*versionManager, string)
@@ -227,9 +227,9 @@ func TestChangeImplementation_Errors(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			vm, packagePath := tt.setupFunc()
-			err := vm.ChangeImplementation(packagePath)
+			err := vm.ChangeImplementation(0, cur, packagePath)
 			uassert.ErrorContains(t, err, tt.errorContains)
 		})
 	}
@@ -257,7 +257,7 @@ func mockInitializeDomainStoreFn(kvStore store.KVStore) any {
 }
 
 // TestVersionManager_StoragePermission verifies that only domain address has storage permission
-func TestVersionManager_StoragePermission(t *testing.T) {
+func TestVersionManager_StoragePermission(cur realm, t *testing.T) {
 	kvStore := store.NewKVStore(mockDomainAddr)
 	vm := NewVersionManager(
 		"gno.land/r/gnoswap/protocol_fee",
@@ -266,7 +266,7 @@ func TestVersionManager_StoragePermission(t *testing.T) {
 	)
 
 	// Attempt to change to non-existent package (should fail)
-	_ = vm.ChangeImplementation("gno.land/r/gnoswap/protocol_fee/v1")
+	_ = vm.ChangeImplementation(0, cur, "gno.land/r/gnoswap/protocol_fee/v1")
 
 	// Verify kvStore has only domain address as authorized caller
 	authorizedCallers, err := kvStore.GetAuthorizedCallers()
@@ -286,7 +286,7 @@ func TestVersionManager_StoragePermission(t *testing.T) {
 }
 
 // TestVersionManager_DomainPath tests edge cases for domain paths
-func TestVersionManager_GetDomainPath(t *testing.T) {
+func TestVersionManager_GetDomainPath(cur realm, t *testing.T) {
 	tests := []struct {
 		name       string
 		domainPath string
@@ -315,7 +315,7 @@ func TestVersionManager_GetDomainPath(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			defer func() {
 				r := recover()
 				if (r != nil) != tt.wantPanic {
@@ -338,7 +338,7 @@ func TestVersionManager_GetDomainPath(t *testing.T) {
 }
 
 // TestChangeImplementation_Success tests successful implementation changes
-func TestChangeImplementation_Success(t *testing.T) {
+func TestChangeImplementation_Success(cur realm, t *testing.T) {
 	tests := []struct {
 		name             string
 		domainPath       string
@@ -388,7 +388,7 @@ func TestChangeImplementation_Success(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			kvStore := store.NewKVStore(mockDomainAddr)
 			vmInternal := &versionManager{
 				domainPath:              tt.domainPath,
@@ -403,7 +403,7 @@ func TestChangeImplementation_Success(t *testing.T) {
 				vmInternal.initializers[pkg] = mockInitializer(pkg)
 			}
 
-			err := vmInternal.ChangeImplementation(tt.changeToPackage)
+			err := vmInternal.ChangeImplementation(0, cur, tt.changeToPackage)
 
 			if tt.expectError {
 				uassert.NotNil(t, err, "ChangeImplementation() should return error")
@@ -421,8 +421,8 @@ func TestChangeImplementation_Success(t *testing.T) {
 	}
 }
 
-func TestGetInitializers(t *testing.T) {
-	t.Run("single initializer", func(t *testing.T) {
+func TestGetInitializers(cur realm, t *testing.T) {
+	t.Run("single initializer", func(cur realm, t *testing.T) {
 		kvStore := store.NewKVStore(mockDomainAddr)
 		vm := &versionManager{
 			domainPath:              "gno.land/r/gnoswap/protocol_fee",
@@ -443,7 +443,7 @@ func TestGetInitializers(t *testing.T) {
 		uassert.NotNil(t, result, "initializer should not be nil")
 	})
 
-	t.Run("multiple initializers", func(t *testing.T) {
+	t.Run("multiple initializers", func(cur realm, t *testing.T) {
 		kvStore := store.NewKVStore(mockDomainAddr)
 		vm := &versionManager{
 			domainPath:              "gno.land/r/gnoswap/pool",
@@ -469,7 +469,7 @@ func TestGetInitializers(t *testing.T) {
 		}
 	})
 
-	t.Run("empty initializers", func(t *testing.T) {
+	t.Run("empty initializers", func(cur realm, t *testing.T) {
 		kvStore := store.NewKVStore(mockDomainAddr)
 		vm := &versionManager{
 			domainPath:              "gno.land/r/gnoswap/position",
@@ -485,7 +485,7 @@ func TestGetInitializers(t *testing.T) {
 }
 
 // TestMakeInitializerSafe_InvalidType tests panic on invalid type
-func TestMakeInitializerSafe_InvalidType(t *testing.T) {
+func TestMakeInitializerSafe_InvalidType(cur realm, t *testing.T) {
 	tests := []struct {
 		name      string
 		input     any
@@ -516,7 +516,7 @@ func TestMakeInitializerSafe_InvalidType(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			defer func() {
 				r := recover()
 				if (r != nil) != tt.wantPanic {
@@ -534,7 +534,7 @@ func TestMakeInitializerSafe_InvalidType(t *testing.T) {
 // Note: The previousRealm.IsUser() check in RegisterInitializer is tested in integration tests:
 //   - tests/integration/testdata/upgradable/initializer_security.txtar
 //   - tests/integration/testdata/upgradable/user_cannot_register_initializer.txtar
-func TestIsContainDomainPath(t *testing.T) {
+func TestIsContainDomainPath(cur realm, t *testing.T) {
 	tests := []struct {
 		name       string
 		domainPath string
@@ -622,7 +622,7 @@ func TestIsContainDomainPath(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			kvStore := store.NewKVStore(mockDomainAddr)
 			vm := &versionManager{
 				domainPath:              tt.domainPath,
@@ -639,7 +639,7 @@ func TestIsContainDomainPath(t *testing.T) {
 }
 
 // TestChangeImplementation_StateConsistency tests state consistency during changes
-func TestChangeImplementation_StateConsistency(t *testing.T) {
+func TestChangeImplementation_StateConsistency(cur realm, t *testing.T) {
 	tests := []struct {
 		name             string
 		domainPath       string
@@ -685,7 +685,7 @@ func TestChangeImplementation_StateConsistency(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			kvStore := store.NewKVStore(mockDomainAddr)
 			vmInternal := &versionManager{
 				domainPath:              tt.domainPath,
@@ -705,7 +705,7 @@ func TestChangeImplementation_StateConsistency(t *testing.T) {
 			// Execute change sequence
 			for _, pkg := range tt.changeSequence {
 				fullPath := tt.domainPath + "/" + pkg
-				err := vmInternal.ChangeImplementation(fullPath)
+				err := vmInternal.ChangeImplementation(0, cur, fullPath)
 				uassert.Nil(t, err,
 				    ufmt.Sprintf("unexpected error during change to %s: %v", pkg, err))
 			}
@@ -733,15 +733,15 @@ func TestChangeImplementation_StateConsistency(t *testing.T) {
 // See:
 //   - tests/integration/testdata/upgradable/initializer_security.txtar
 //   - tests/integration/testdata/upgradable/user_cannot_register_initializer.txtar
-func TestRegisterInitializer_ErrorBranches(t *testing.T) {
-	t.Run("nil initializer", func(t *testing.T) {
+func TestRegisterInitializer_ErrorBranches(cur realm, t *testing.T) {
+	t.Run("nil initializer", func(cur realm, t *testing.T) {
 		kvStore := store.NewKVStore(mockDomainAddr)
 		vm := NewVersionManager(
 			"gno.land/r/gnoswap/protocol_fee",
 			kvStore,
 			mockInitializeDomainStoreFn,
 		)
-		err := vm.RegisterInitializer(nil)
+		err := vm.RegisterInitializer(0, cur, nil)
 		uassert.ErrorContains(t, err, "initializer cannot be nil")
 	})
 }

--- a/contract/r/gnoswap/gov/governance/upgrade.gno
+++ b/contract/r/gnoswap/gov/governance/upgrade.gno
@@ -15,7 +15,7 @@ func RegisterInitializer(cur realm, initializer func(governanceStore IGovernance
 		return initializer(currentGovernanceStore, newGovStakerAccessor())
 	}
 
-	err := versionManager.RegisterInitializer(initializerFunc)
+	err := versionManager.RegisterInitializer(0, cur, initializerFunc)
 	if err != nil {
 		panic(err)
 	}
@@ -37,7 +37,7 @@ func UpgradeImpl(cur realm, targetPackagePath string) {
 	caller := runtime.PreviousRealm().Address()
 	access.AssertIsAdminOrGovernance(caller)
 
-	err := versionManager.ChangeImplementation(targetPackagePath)
+	err := versionManager.ChangeImplementation(0, cur, targetPackagePath)
 	if err != nil {
 		panic(err)
 	}

--- a/contract/r/gnoswap/gov/staker/upgrade.gno
+++ b/contract/r/gnoswap/gov/staker/upgrade.gno
@@ -18,7 +18,7 @@ func RegisterInitializer(cur realm, initializer func(govStakerStore IGovStakerSt
 		return initializer(currentGovStakerStore)
 	}
 
-	err := versionManager.RegisterInitializer(initializerFunc)
+	err := versionManager.RegisterInitializer(0, cur, initializerFunc)
 	if err != nil {
 		panic(err)
 	}
@@ -36,7 +36,7 @@ func UpgradeImpl(cur realm, packagePath string) {
 	caller := runtime.PreviousRealm().Address()
 	access.AssertIsAdminOrGovernance(caller)
 
-	err := versionManager.ChangeImplementation(packagePath)
+	err := versionManager.ChangeImplementation(0, cur, packagePath)
 	if err != nil {
 		panic(err)
 	}

--- a/contract/r/gnoswap/launchpad/upgrade.gno
+++ b/contract/r/gnoswap/launchpad/upgrade.gno
@@ -25,7 +25,7 @@ func RegisterInitializer(cur realm, initializer func(launchpadStore ILaunchpadSt
 		return initializer(currentLaunchpadStore)
 	}
 
-	err := versionManager.RegisterInitializer(initializerFunc)
+	err := versionManager.RegisterInitializer(0, cur, initializerFunc)
 	if err != nil {
 		panic(err)
 	}
@@ -47,7 +47,7 @@ func UpgradeImpl(cur realm, packagePath string) {
 	caller := runtime.PreviousRealm().Address()
 	access.AssertIsAdminOrGovernance(caller)
 
-	err := versionManager.ChangeImplementation(packagePath)
+	err := versionManager.ChangeImplementation(0, cur, packagePath)
 	if err != nil {
 		panic(err)
 	}

--- a/contract/r/gnoswap/pool/upgrade.gno
+++ b/contract/r/gnoswap/pool/upgrade.gno
@@ -27,7 +27,7 @@ func RegisterInitializer(cur realm, initializer func(poolStore IPoolStore) IPool
 		return initializer(currentPoolStore)
 	}
 
-	err := versionManager.RegisterInitializer(initializerFunc)
+	err := versionManager.RegisterInitializer(0, cur, initializerFunc)
 	if err != nil {
 		panic(err)
 	}
@@ -49,7 +49,7 @@ func UpgradeImpl(cur realm, packagePath string) {
 	caller := runtime.PreviousRealm().Address()
 	access.AssertIsAdminOrGovernance(caller)
 
-	err := versionManager.ChangeImplementation(packagePath)
+	err := versionManager.ChangeImplementation(0, cur, packagePath)
 	if err != nil {
 		panic(err)
 	}

--- a/contract/r/gnoswap/position/upgrade.gno
+++ b/contract/r/gnoswap/position/upgrade.gno
@@ -27,7 +27,7 @@ func RegisterInitializer(cur realm, initializer func(positionStore IPositionStor
 		return initializer(currentPositionStore)
 	}
 
-	err := versionManager.RegisterInitializer(initializerFunc)
+	err := versionManager.RegisterInitializer(0, cur, initializerFunc)
 	if err != nil {
 		panic(err)
 	}
@@ -49,7 +49,7 @@ func UpgradeImpl(cur realm, packagePath string) {
 	caller := runtime.PreviousRealm().Address()
 	access.AssertIsAdminOrGovernance(caller)
 
-	err := versionManager.ChangeImplementation(packagePath)
+	err := versionManager.ChangeImplementation(0, cur, packagePath)
 	if err != nil {
 		panic(err)
 	}

--- a/contract/r/gnoswap/protocol_fee/upgrade.gno
+++ b/contract/r/gnoswap/protocol_fee/upgrade.gno
@@ -27,7 +27,7 @@ func RegisterInitializer(cur realm, initializer func(protocolFeeStore IProtocolF
 		return initializer(currentProtocolFeeStore)
 	}
 
-	err := versionManager.RegisterInitializer(initializerFunc)
+	err := versionManager.RegisterInitializer(0, cur, initializerFunc)
 	if err != nil {
 		panic(err)
 	}
@@ -49,7 +49,7 @@ func UpgradeImpl(cur realm, packagePath string) {
 	caller := runtime.PreviousRealm().Address()
 	access.AssertIsAdminOrGovernance(caller)
 
-	err := versionManager.ChangeImplementation(packagePath)
+	err := versionManager.ChangeImplementation(0, cur, packagePath)
 	if err != nil {
 		panic(err)
 	}

--- a/contract/r/gnoswap/router/upgrade.gno
+++ b/contract/r/gnoswap/router/upgrade.gno
@@ -25,7 +25,7 @@ func RegisterInitializer(cur realm, initializer func(routerStore IRouterStore) I
 		return initializer(currentRouterStore)
 	}
 
-	err := versionManager.RegisterInitializer(initializerFunc)
+	err := versionManager.RegisterInitializer(0, cur, initializerFunc)
 	if err != nil {
 		panic(err)
 	}
@@ -47,7 +47,7 @@ func UpgradeImpl(cur realm, packagePath string) {
 	caller := runtime.PreviousRealm().Address()
 	access.AssertIsAdminOrGovernance(caller)
 
-	err := versionManager.ChangeImplementation(packagePath)
+	err := versionManager.ChangeImplementation(0, cur, packagePath)
 	if err != nil {
 		panic(err)
 	}

--- a/contract/r/gnoswap/staker/upgrade.gno
+++ b/contract/r/gnoswap/staker/upgrade.gno
@@ -25,7 +25,7 @@ func RegisterInitializer(cur realm, initializer func(stakerStore IStakerStore, p
 		return initializer(currentStakerStore, newPoolAccessor(), newEmissionAccessor(), newNFTAccessor())
 	}
 
-	err := versionManager.RegisterInitializer(initializerFunc)
+	err := versionManager.RegisterInitializer(0, cur, initializerFunc)
 	if err != nil {
 		panic(err)
 	}
@@ -47,7 +47,7 @@ func UpgradeImpl(cur realm, packagePath string) {
 	caller := runtime.PreviousRealm().Address()
 	access.AssertIsAdminOrGovernance(caller)
 
-	err := versionManager.ChangeImplementation(packagePath)
+	err := versionManager.ChangeImplementation(0, cur, packagePath)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Descriptions

Migrates `p/gnoswap/version_manager` to the Interrealm v2 calling convention and adds spoof-guard protection to all mutating interface methods.

### Motivation

The v1 convention relied on `runtime.CurrentRealm()` / `runtime.PreviousRealm()` to identify callers. In GnoVM's Interrealm v2 model these symbols are no longer the idiomatic choice for cross-realm identity; the live `realm` token threaded through the call frame is. Accepting the token explicitly makes realm-threading visible at every call site and allows the callee to reject stale or spoofed tokens via `rlm.IsCurrent()`.

### Changes

**`p/gnoswap/version_manager`**

- Added `ErrSpoofedRealm` sentinel error returned whenever `rlm.IsCurrent()` fails.
- Updated `VersionManager` interface: `RegisterInitializer` and `ChangeImplementation` now accept a leading `(_ int, rlm realm, ...)` parameter pair following the v2 sentinel pattern.
- Replaced `runtime.PreviousRealm()` with `rlm.Previous()` inside `RegisterInitializer` to identify the registering version package.
- Removed the `chain/runtime` import (no longer needed after the above substitution).
- Updated all test functions and `t.Run` closures to carry `cur realm` as their first parameter; call sites pass `(0, cur, ...)`.

**`r/gnoswap/*/upgrade.gno`** (gov/governance, gov/staker, launchpad, pool, position, protocol\_fee, router, staker)

- Updated every `RegisterInitializer` and `ChangeImplementation` call to pass `(0, cur, ...)` in line with the new interface.

### Security

`rlm.IsCurrent()` is evaluated before any business logic in both mutating methods. A caller that captures a `realm` token from a previous frame and replays it will receive `ErrSpoofedRealm` instead of silently succeeding.

### Notes

- Authorization policy (admin / governance ACLs) remains in each module's `upgrade.gno`; `version_manager` itself only enforces the anti-spoof check and the domain-path prefix rule.
- `make test PKG=gno.land/p/gnoswap/version_manager` is blocked until the sibling `refactor/interrealm-v2-store` branch (which migrates `p/gnoswap/store` off `runtime.CurrentRealm()`) is merged forward.
