### PR TITLE
refactor(r/referral): migrate to interrealm v2

### DIFF
--- a/contract/r/gnoswap/referral/README.md
+++ b/contract/r/gnoswap/referral/README.md
@@ -37,8 +37,8 @@ import (
 
 // RegisterUserReferral registers a referral relationship for a user.
 // Must be called from an authorized realm (router, staker, etc.)
-func RegisterUserReferral(userAddr, referrerAddr address) bool {
-    return referral.TryRegister(cross, userAddr, referrerAddr.String())
+func RegisterUserReferral(cur realm, userAddr, referrerAddr address) bool {
+    return referral.TryRegister(cross(cur), userAddr, referrerAddr.String())
 }
 ```
 
@@ -53,8 +53,8 @@ import (
 
 // RemoveUserReferral removes the referral relationship for a user.
 // Pass the contract's own address as the referral to indicate removal.
-func RemoveUserReferral(userAddr address) bool {
-    return referral.TryRegister(cross, userAddr, referral.ContractAddress())
+func RemoveUserReferral(cur realm, userAddr address) bool {
+    return referral.TryRegister(cross(cur), userAddr, referral.ContractAddress())
 }
 ```
 

--- a/contract/r/gnoswap/referral/assert_test.gno
+++ b/contract/r/gnoswap/referral/assert_test.gno
@@ -11,7 +11,7 @@ import (
 	"gno.land/r/gnoswap/access"
 )
 
-func TestUtils_assertValidCaller_AllAuthorizedRoles(t *testing.T) {
+func TestUtils_assertValidCaller_AllAuthorizedRoles(cur realm, t *testing.T) {
 	tests := []struct {
 		name     string
 		roleName string
@@ -43,7 +43,7 @@ func TestUtils_assertValidCaller_AllAuthorizedRoles(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			// given
 			roleAddr, ok := access.GetAddress(tc.roleName)
 			if !ok {
@@ -59,7 +59,7 @@ func TestUtils_assertValidCaller_AllAuthorizedRoles(t *testing.T) {
 	}
 }
 
-func TestUtils_assertValidCaller_UnauthorizedCallers(t *testing.T) {
+func TestUtils_assertValidCaller_UnauthorizedCallers(cur realm, t *testing.T) {
 	tests := []struct {
 		name   string
 		caller address
@@ -79,16 +79,16 @@ func TestUtils_assertValidCaller_UnauthorizedCallers(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			// when
-			uassert.PanicsContains(t, "unauthorized", func() {
+			uassert.PanicsContains(t, cur, "unauthorized", func() {
 				assertValidCaller(tc.caller)
 			})
 		})
 	}
 }
 
-func TestUtils_assertValidCaller_EdgeCases(t *testing.T) {
+func TestUtils_assertValidCaller_EdgeCases(cur realm, t *testing.T) {
 	tests := []struct {
 		name   string
 		caller address
@@ -104,18 +104,18 @@ func TestUtils_assertValidCaller_EdgeCases(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			// when
-			uassert.PanicsContains(t, "unauthorized", func() {
+			uassert.PanicsContains(t, cur, "unauthorized", func() {
 				assertValidCaller(tc.caller)
 			})
 		})
 	}
 }
 
-func TestUtils_assertValidCaller_MultipleRolesConsistency(t *testing.T) {
+func TestUtils_assertValidCaller_MultipleRolesConsistency(cur realm, t *testing.T) {
 	// Test that multiple calls with the same authorized role return consistent results
-	t.Run("consistent authorization for same role", func(t *testing.T) {
+	t.Run("consistent authorization for same role", func(cur realm, t *testing.T) {
 		// given
 		routerAddr, ok := access.GetAddress(prabc.ROLE_ROUTER.String())
 		if !ok {
@@ -128,22 +128,22 @@ func TestUtils_assertValidCaller_MultipleRolesConsistency(t *testing.T) {
 		}
 	})
 
-	t.Run("consistent rejection for unauthorized caller", func(t *testing.T) {
+	t.Run("consistent rejection for unauthorized caller", func(cur realm, t *testing.T) {
 		// given
 		unauthorizedAddr := testutils.TestAddress("unauthorized")
 
 		// when & then - call multiple times
 		for i := 0; i < 5; i++ {
-			uassert.PanicsContains(t, "unauthorized", func() {
+			uassert.PanicsContains(t, cur, "unauthorized", func() {
 				assertValidCaller(unauthorizedAddr)
 			})
 		}
 	})
 }
 
-func TestUtils_assertValidCaller_RoleIsolation(t *testing.T) {
+func TestUtils_assertValidCaller_RoleIsolation(cur realm, t *testing.T) {
 	// Test that authorization is properly isolated by role
-	t.Run("different authorized roles all work", func(t *testing.T) {
+	t.Run("different authorized roles all work", func(cur realm, t *testing.T) {
 		roles := []string{
 			prabc.ROLE_GOVERNANCE.String(),
 			prabc.ROLE_ROUTER.String(),
@@ -160,7 +160,7 @@ func TestUtils_assertValidCaller_RoleIsolation(t *testing.T) {
 		}
 	})
 
-	t.Run("unauthorized address between authorized roles", func(t *testing.T) {
+	t.Run("unauthorized address between authorized roles", func(cur realm, t *testing.T) {
 		// given
 		routerAddr, ok1 := access.GetAddress(prabc.ROLE_ROUTER.String())
 		positionAddr, ok2 := access.GetAddress(prabc.ROLE_POSITION.String())
@@ -176,7 +176,7 @@ func TestUtils_assertValidCaller_RoleIsolation(t *testing.T) {
 		assertValidCaller(routerAddr)
 
 		// panic
-		uassert.PanicsContains(t, "unauthorized", func() {
+		uassert.PanicsContains(t, cur, "unauthorized", func() {
 			assertValidCaller(unauthorizedAddr)
 		})
 

--- a/contract/r/gnoswap/referral/doc.gno
+++ b/contract/r/gnoswap/referral/doc.gno
@@ -92,16 +92,14 @@
 // ```go
 //
 //	import (
-//	    "chain/runtime"
-//
 //	    "gno.land/r/gnoswap/referral"
 //	)
 //
 //	func SwapWithReferral(cur realm, referralCode string, ...) {
 //	    // Get the caller address
-//	    caller := runtime.PreviousRealm().Address()
+//	    caller := cur.Previous().Address()
 //
-//	    actualReferrer := referral.TryRegister(cross, caller, referralCode)
+//	    actualReferrer := referral.TryRegister(cross(cur), caller, referralCode)
 //
 //	    // Continue with swap logic...
 //	}

--- a/contract/r/gnoswap/referral/global_keeper.gno
+++ b/contract/r/gnoswap/referral/global_keeper.gno
@@ -2,7 +2,6 @@ package referral
 
 import (
 	"chain"
-	"chain/runtime"
 )
 
 var gReferralKeeper ReferralKeeper
@@ -62,7 +61,7 @@ func TryRegister(cur realm, addr address, referral string) string {
 		return GetReferral(addr.String())
 	}
 
-	caller := runtime.PreviousRealm().Address()
+	caller := cur.Previous().Address()
 	assertValidCaller(caller)
 
 	result, err := gReferralKeeper.register(addr, address(referral))

--- a/contract/r/gnoswap/referral/global_keeper_test.gno
+++ b/contract/r/gnoswap/referral/global_keeper_test.gno
@@ -18,7 +18,7 @@ var (
 	userRealm   = testing.NewCodeRealm("gno.land/r/demo/users")
 )
 
-func TestGlobalKeeper_TryRegister(t *testing.T) {
+func TestGlobalKeeper_TryRegister(cur realm, t *testing.T) {
 	tests := []struct {
 		name                 string
 		callerRealm          runtime.Realm
@@ -102,29 +102,29 @@ func TestGlobalKeeper_TryRegister(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			cleanup(t)
 
 			// given
 			testing.SetRealm(tc.callerRealm)
 
 			if tc.existingReferral != "" {
-				setupExistingReferral(t, tc.addr, address(tc.existingReferral))
+				setupExistingReferral(0, cur, t, tc.addr, address(tc.existingReferral))
 			}
 
 			if tc.expectedPanics {
-				uassert.AbortsContains(t, tc.expectedPanicMessage, func() {
-					TryRegister(cross, tc.addr, tc.referral)
+				uassert.AbortsContains(t, cur, tc.expectedPanicMessage, func() {
+					TryRegister(cross(cur), tc.addr, tc.referral)
 				})
 			} else {
-				result := TryRegister(cross, tc.addr, tc.referral)
+				result := TryRegister(cross(cur), tc.addr, tc.referral)
 				uassert.Equal(t, tc.expectedReferrer, result)
 			}
 		})
 	}
 }
 
-func TestGlobalKeeper_GetReferral(t *testing.T) {
+func TestGlobalKeeper_GetReferral(cur realm, t *testing.T) {
 	tests := []struct {
 		name             string
 		addr             string
@@ -164,14 +164,14 @@ func TestGlobalKeeper_GetReferral(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			cleanup(t)
 
 			// given
 			testing.SetRealm(testing.NewUserRealm(routerAddr))
 
 			if tc.setupReferral != "" {
-				setupExistingReferral(t, address(tc.addr), address(tc.setupReferral))
+				setupExistingReferral(0, cur, t, address(tc.addr), address(tc.setupReferral))
 			}
 
 			// when
@@ -183,7 +183,7 @@ func TestGlobalKeeper_GetReferral(t *testing.T) {
 	}
 }
 
-func TestGlobalKeeper_HasReferral(t *testing.T) {
+func TestGlobalKeeper_HasReferral(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
 		addr          string
@@ -223,14 +223,14 @@ func TestGlobalKeeper_HasReferral(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			cleanup(t)
 
 			// given
 			testing.SetRealm(testing.NewUserRealm(routerAddr))
 
 			if tc.setupReferral != "" {
-				setupExistingReferral(t, address(tc.addr), address(tc.setupReferral))
+				setupExistingReferral(0, cur, t, address(tc.addr), address(tc.setupReferral))
 			}
 
 			// when
@@ -242,7 +242,7 @@ func TestGlobalKeeper_HasReferral(t *testing.T) {
 	}
 }
 
-func TestGlobalKeeper_IsEmpty(t *testing.T) {
+func TestGlobalKeeper_IsEmpty(cur realm, t *testing.T) {
 	tests := []struct {
 		name            string
 		setupReferrals  map[string]string
@@ -271,14 +271,14 @@ func TestGlobalKeeper_IsEmpty(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			cleanup(t)
 
 			// given
 			testing.SetRealm(testing.NewUserRealm(routerAddr))
 
 			for addr, referral := range tc.setupReferrals {
-				setupExistingReferral(t, address(addr), address(referral))
+				setupExistingReferral(0, cur, t, address(addr), address(referral))
 			}
 
 			// when
@@ -290,7 +290,7 @@ func TestGlobalKeeper_IsEmpty(t *testing.T) {
 	}
 }
 
-func TestGlobalKeeper_GetLastOpTimestamp(t *testing.T) {
+func TestGlobalKeeper_GetLastOpTimestamp(cur realm, t *testing.T) {
 	tests := []struct {
 		name           string
 		addr           string
@@ -324,7 +324,7 @@ func TestGlobalKeeper_GetLastOpTimestamp(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			cleanup(t)
 
 			testing.SetRealm(routerRealm)
@@ -334,7 +334,7 @@ func TestGlobalKeeper_GetLastOpTimestamp(t *testing.T) {
 				userAddr := address(tc.addr)
 				refAddr := testutils.TestAddress("referrer1")
 				before = time.Now().Unix()
-				uassert.Equal(t, refAddr.String(), TryRegister(cross, userAddr, refAddr.String()))
+				uassert.Equal(t, refAddr.String(), TryRegister(cross(cur), userAddr, refAddr.String()))
 				after = time.Now().Unix()
 			}
 
@@ -350,7 +350,7 @@ func TestGlobalKeeper_GetLastOpTimestamp(t *testing.T) {
 	}
 }
 
-func TestGlobalKeeper_TryRegisterFallbacks(t *testing.T) {
+func TestGlobalKeeper_TryRegisterFallbacks(cur realm, t *testing.T) {
 	tests := []struct {
 		name             string
 		caller           address
@@ -386,15 +386,15 @@ func TestGlobalKeeper_TryRegisterFallbacks(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			cleanup(t)
 			testing.SetRealm(routerRealm)
 
 			if tc.setupReferral != "" {
-				setupExistingReferral(t, tc.caller, address(tc.setupReferral))
+				setupExistingReferral(0, cur, t, tc.caller, address(tc.setupReferral))
 			}
 
-			result := TryRegister(cross, tc.caller, tc.referrer)
+			result := TryRegister(cross(cur), tc.caller, tc.referrer)
 
 			uassert.Equal(t, tc.expectedReferrer, result)
 			uassert.Equal(t, tc.expectedHas, HasReferral(tc.caller.String()))
@@ -402,7 +402,7 @@ func TestGlobalKeeper_TryRegisterFallbacks(t *testing.T) {
 	}
 }
 
-func TestGlobalKeeper_getKeeper(t *testing.T) {
+func TestGlobalKeeper_getKeeper(cur realm, t *testing.T) {
 	tests := []struct {
 		name           string
 		expectedNotNil bool
@@ -414,7 +414,7 @@ func TestGlobalKeeper_getKeeper(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			cleanup(t)
 
 			// when
@@ -437,7 +437,7 @@ func cleanup(t *testing.T) {
 	gReferralKeeper = NewKeeper()
 }
 
-func setupExistingReferral(t *testing.T, addr, referralAddr address) {
+func setupExistingReferral(_ int, rlm realm, t *testing.T, addr, referralAddr address) {
 	t.Helper()
-	TryRegister(cross, addr, referralAddr.String())
+	TryRegister(cross(rlm), addr, referralAddr.String())
 }

--- a/contract/r/gnoswap/referral/keeper_test.gno
+++ b/contract/r/gnoswap/referral/keeper_test.gno
@@ -8,7 +8,7 @@ import (
 	uassert "gno.land/p/nt/uassert/v0"
 )
 
-func TestKeeper_Register(t *testing.T) {
+func TestKeeper_Register(cur realm, t *testing.T) {
 	var (
 		routerRealm = testing.NewCodeRealm("gno.land/r/gnoswap/router")
 		userRealm   = testing.NewCodeRealm("gno.land/r/demo/users")
@@ -54,7 +54,7 @@ func TestKeeper_Register(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			cleanup(t)
 
 			// given
@@ -62,11 +62,11 @@ func TestKeeper_Register(t *testing.T) {
 
 			// when/then
 			if tc.expectedPanicMessage != "" {
-				uassert.AbortsContains(t, tc.expectedPanicMessage, func() {
-					TryRegister(cross, tc.addr, tc.refAddr.String())
+				uassert.AbortsContains(t, cur, tc.expectedPanicMessage, func() {
+					TryRegister(cross(cur), tc.addr, tc.refAddr.String())
 				})
 			} else {
-				result := TryRegister(cross, tc.addr, tc.refAddr.String())
+				result := TryRegister(cross(cur), tc.addr, tc.refAddr.String())
 				uassert.Equal(t, tc.expectedReferrer, result)
 			}
 		})
@@ -77,7 +77,7 @@ func TestKeeper_Register(t *testing.T) {
 // these tests have been removed as they test internal implementation
 // that requires realm context not available in unit tests.
 
-func TestKeeper_Has(t *testing.T) {
+func TestKeeper_Has(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
 		addr          address
@@ -108,14 +108,14 @@ func TestKeeper_Has(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			cleanup(t)
 
 			// given
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/router"))
 
 			if tc.setupReferral {
-				TryRegister(cross, tc.addr, tc.refAddr.String())
+				TryRegister(cross(cur), tc.addr, tc.refAddr.String())
 			}
 
 			// when
@@ -127,7 +127,7 @@ func TestKeeper_Has(t *testing.T) {
 	}
 }
 
-func TestKeeper_Get(t *testing.T) {
+func TestKeeper_Get(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
 		addr          address
@@ -162,14 +162,14 @@ func TestKeeper_Get(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			cleanup(t)
 
 			// given
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/router"))
 
 			if tc.setupReferral {
-				TryRegister(cross, tc.addr, tc.refAddr.String())
+				TryRegister(cross(cur), tc.addr, tc.refAddr.String())
 			}
 
 			// when
@@ -181,7 +181,7 @@ func TestKeeper_Get(t *testing.T) {
 	}
 }
 
-func TestKeeper_IsEmpty(t *testing.T) {
+func TestKeeper_IsEmpty(cur realm, t *testing.T) {
 	tests := []struct {
 		name           string
 		setupReferrals []struct {
@@ -222,14 +222,14 @@ func TestKeeper_IsEmpty(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			cleanup(t)
 
 			// given
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/router"))
 
 			for _, ref := range tc.setupReferrals {
-				TryRegister(cross, ref.addr, ref.refAddr.String())
+				TryRegister(cross(cur), ref.addr, ref.refAddr.String())
 			}
 
 			// when
@@ -241,7 +241,7 @@ func TestKeeper_IsEmpty(t *testing.T) {
 	}
 }
 
-func TestKeeper_NewKeeper(t *testing.T) {
+func TestKeeper_NewKeeper(cur realm, t *testing.T) {
 	k := NewKeeper().(*keeper)
 	if k == nil {
 		t.Fatal("keeper should not be nil")
@@ -250,8 +250,8 @@ func TestKeeper_NewKeeper(t *testing.T) {
 	uassert.True(t, k.isEmpty())
 }
 
-func TestKeeper_ContractAddressRemoval(t *testing.T) {
-	t.Run("Remove existing referral with contract address", func(t *testing.T) {
+func TestKeeper_ContractAddressRemoval(cur realm, t *testing.T) {
+	t.Run("Remove existing referral with contract address", func(cur realm, t *testing.T) {
 		cleanup(t)
 		testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/router"))
 
@@ -259,7 +259,7 @@ func TestKeeper_ContractAddressRemoval(t *testing.T) {
 		referrer := testutils.TestAddress("referrer1")
 
 		// Register referral first
-		result := TryRegister(cross, user, referrer.String())
+		result := TryRegister(cross(cur), user, referrer.String())
 		uassert.Equal(t, referrer.String(), result, "Initial registration should succeed")
 		uassert.True(t, HasReferral(user.String()), "Referral should exist after registration")
 
@@ -268,12 +268,12 @@ func TestKeeper_ContractAddressRemoval(t *testing.T) {
 		k.lastOps.Set(user.String(), int64(0))
 
 		// Remove by registering with contract address
-		result = TryRegister(cross, user, contractAddress().String())
+		result = TryRegister(cross(cur), user, contractAddress().String())
 		uassert.Equal(t, "", result, "Removal with contract address should succeed")
 		uassert.False(t, HasReferral(user.String()), "Referral should not exist after removal")
 	})
 
-	t.Run("Contract address removal is not rate limited", func(t *testing.T) {
+	t.Run("Contract address removal is not rate limited", func(cur realm, t *testing.T) {
 		cleanup(t)
 		testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/router"))
 
@@ -281,18 +281,18 @@ func TestKeeper_ContractAddressRemoval(t *testing.T) {
 		referrer := testutils.TestAddress("referrer2")
 
 		// Register referral
-		result := TryRegister(cross, user, referrer.String())
+		result := TryRegister(cross(cur), user, referrer.String())
 		uassert.Equal(t, referrer.String(), result)
 		uassert.True(t, HasReferral(user.String()))
 
 		// Immediately try to remove with contract address (no time passage)
 		// This should succeed because contract address removal bypasses rate limit
-		result = TryRegister(cross, user, contractAddress().String())
+		result = TryRegister(cross(cur), user, contractAddress().String())
 		uassert.Equal(t, "", result, "Contract address removal should bypass rate limit")
 		uassert.False(t, HasReferral(user.String()))
 	})
 
-	t.Run("Re-register after contract address removal", func(t *testing.T) {
+	t.Run("Re-register after contract address removal", func(cur realm, t *testing.T) {
 		cleanup(t)
 		testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/router"))
 
@@ -301,34 +301,34 @@ func TestKeeper_ContractAddressRemoval(t *testing.T) {
 		referrer2 := testutils.TestAddress("referrer3b")
 
 		// Register first referral
-		result := TryRegister(cross, user, referrer1.String())
+		result := TryRegister(cross(cur), user, referrer1.String())
 		uassert.Equal(t, referrer1.String(), result)
 		uassert.Equal(t, referrer1.String(), GetReferral(user.String()))
 
 		// Remove with contract address (bypasses rate limit)
-		result = TryRegister(cross, user, contractAddress().String())
+		result = TryRegister(cross(cur), user, contractAddress().String())
 		uassert.Equal(t, "", result)
 		uassert.False(t, HasReferral(user.String()))
 
 		// Re-register with new referrer should be rate limited
 		// because lastOps was set during first registration
-		result = TryRegister(cross, user, referrer2.String())
+		result = TryRegister(cross(cur), user, referrer2.String())
 		uassert.Equal(t, "", result, "Re-registration should be rate limited")
 	})
 
-	t.Run("Contract address on non-existent referral is no-op", func(t *testing.T) {
+	t.Run("Contract address on non-existent referral is no-op", func(cur realm, t *testing.T) {
 		cleanup(t)
 		testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/router"))
 
 		user := testutils.TestAddress("user4")
 
 		// Try to remove non-existent referral
-		result := TryRegister(cross, user, contractAddress().String())
+		result := TryRegister(cross(cur), user, contractAddress().String())
 		uassert.Equal(t, "", result, "Contract address on non-existent should succeed (no-op)")
 		uassert.False(t, HasReferral(user.String()))
 	})
 
-	t.Run("Multiple contract address removals are allowed", func(t *testing.T) {
+	t.Run("Multiple contract address removals are allowed", func(cur realm, t *testing.T) {
 		cleanup(t)
 		testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/router"))
 
@@ -336,11 +336,11 @@ func TestKeeper_ContractAddressRemoval(t *testing.T) {
 		referrer := testutils.TestAddress("referrer5")
 
 		// Register
-		TryRegister(cross, user, referrer.String())
+		TryRegister(cross(cur), user, referrer.String())
 
 		// Multiple contract address calls should all succeed
 		for i := 0; i < 3; i++ {
-			result := TryRegister(cross, user, contractAddress().String())
+			result := TryRegister(cross(cur), user, contractAddress().String())
 			uassert.Equal(t, "", result, "Multiple contract address calls should succeed")
 		}
 	})

--- a/contract/r/gnoswap/referral/rate_limit_test.gno
+++ b/contract/r/gnoswap/referral/rate_limit_test.gno
@@ -1,7 +1,7 @@
 package referral
 
 import (
-	"chain/runtime"
+	"chain/runtime/unsafe"
 	"testing"
 	"time"
 
@@ -13,7 +13,7 @@ import (
 	"gno.land/r/gnoswap/access"
 )
 
-func TestRateLimit_AllowsFirstOperation(t *testing.T) {
+func TestRateLimit_AllowsFirstOperation(cur realm, t *testing.T) {
 	cleanup := setupValidCaller(t)
 	defer cleanup()
 
@@ -30,7 +30,7 @@ func TestRateLimit_AllowsFirstOperation(t *testing.T) {
 	uassert.Equal(t, referrerAddr.String(), ref.String())
 }
 
-func TestRateLimit_BlocksSecondOperationWithin24Hours(t *testing.T) {
+func TestRateLimit_BlocksSecondOperationWithin24Hours(cur realm, t *testing.T) {
 	cleanup := setupValidCaller(t)
 	defer cleanup()
 	k := setupRateLimitKeeper(t)
@@ -50,7 +50,7 @@ func TestRateLimit_BlocksSecondOperationWithin24Hours(t *testing.T) {
 	uassert.Equal(t, referrerAddr.String(), ref.String())
 }
 
-func TestRateLimit_IsAddressSpecific(t *testing.T) {
+func TestRateLimit_IsAddressSpecific(cur realm, t *testing.T) {
 	cleanup := setupValidCaller(t)
 	defer cleanup()
 
@@ -69,7 +69,7 @@ func TestRateLimit_IsAddressSpecific(t *testing.T) {
 	uassert.True(t, k.has(user2))
 }
 
-func TestRateLimit_ContractAddressNotRateLimited(t *testing.T) {
+func TestRateLimit_ContractAddressNotRateLimited(cur realm, t *testing.T) {
 	cleanup := setupValidCaller(t)
 	defer cleanup()
 	k := setupRateLimitKeeper(t)
@@ -85,7 +85,7 @@ func TestRateLimit_ContractAddressNotRateLimited(t *testing.T) {
 	uassert.False(t, k.has(userAddr))
 }
 
-func TestRateLimit_TimeBoundaries(t *testing.T) {
+func TestRateLimit_TimeBoundaries(cur realm, t *testing.T) {
 	tests := []struct {
 		name            string
 		prefix          string
@@ -113,7 +113,7 @@ func TestRateLimit_TimeBoundaries(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			cleanup := setupValidCaller(t)
 			defer cleanup()
 			k := setupRateLimitKeeper(t)
@@ -142,7 +142,7 @@ func TestRateLimit_TimeBoundaries(t *testing.T) {
 	}
 }
 
-func TestRateLimit_CheckRateLimitInternal(t *testing.T) {
+func TestRateLimit_CheckRateLimitInternal(cur realm, t *testing.T) {
 	tests := []struct {
 		name         string
 		setupLastOps func(k *keeper, addr string)
@@ -177,7 +177,7 @@ func TestRateLimit_CheckRateLimitInternal(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			k := setupRateLimitKeeper(t)
 			userAddr := testutils.TestAddress("user")
 			tc.setupLastOps(k, userAddr.String())
@@ -193,19 +193,19 @@ func TestRateLimit_CheckRateLimitInternal(t *testing.T) {
 	}
 }
 
-func TestRateLimit_UnauthorizedCallerTakesPrecedence(t *testing.T) {
+func TestRateLimit_UnauthorizedCallerTakesPrecedence(cur realm, t *testing.T) {
 	cleanup := setupRateLimitCaller(t, "unauthorized")
 	defer cleanup()
 
 	user := testutils.TestAddress("user")
 	referrer := testutils.TestAddress("referrer")
 
-	uassert.AbortsContains(t, "unauthorized caller", func() {
-		TryRegister(cross, user, referrer.String())
+	uassert.AbortsContains(t, cur, "unauthorized caller", func() {
+		TryRegister(cross(cur), user, referrer.String())
 	})
 }
 
-func TestRateLimit_SelfReferralTakesPrecedence(t *testing.T) {
+func TestRateLimit_SelfReferralTakesPrecedence(cur realm, t *testing.T) {
 	cleanup := setupValidCaller(t)
 	defer cleanup()
 	k := setupRateLimitKeeper(t)
@@ -224,7 +224,7 @@ func setupRateLimitKeeper(t *testing.T) *keeper {
 
 func setupValidCaller(t *testing.T) func() {
 	t.Helper()
-	origCaller := runtime.OriginCaller()
+	origCaller := unsafe.OriginCaller()
 	routerAddr, _ := access.GetAddress(prabc.ROLE_ROUTER.String())
 	testing.SetOriginCaller(routerAddr)
 	return func() {
@@ -234,7 +234,7 @@ func setupValidCaller(t *testing.T) func() {
 
 func setupRateLimitCaller(t *testing.T, caller string) func() {
 	t.Helper()
-	origCaller := runtime.OriginCaller()
+	origCaller := unsafe.OriginCaller()
 	switch caller {
 	case "router":
 		routerAddr, _ := access.GetAddress(prabc.ROLE_ROUTER.String())

--- a/contract/r/gnoswap/referral/type.gno
+++ b/contract/r/gnoswap/referral/type.gno
@@ -1,15 +1,13 @@
 package referral
 
-import "chain/runtime"
-
 var (
 	zeroAddress = address("")
 	// selfAddress is cached at package initialization to ensure consistent comparison.
 	selfAddress address
 )
 
-func init() {
-	selfAddress = runtime.CurrentRealm().Address()
+func init(cur realm) {
+	selfAddress = cur.Address()
 }
 
 // contractAddress returns the address of the referral contract.


### PR DESCRIPTION
## Descriptions

Migrates `r/gnoswap/referral` to the Interrealm v2 calling convention by threading `realm` explicitly through public entrypoints, tests, and docs.

### Motivation

The referral module previously depended on deprecated runtime-based caller/context symbols. Under Interrealm v2, the active `realm` frame should be passed explicitly so call context is clear at each site and caller derivation is performed from the live frame (`cur.Previous()`), not implicit globals.

### Changes

**`r/gnoswap/referral`**

- Updated referral APIs and usage examples to accept and propagate `cur realm` (for example, `TryRegister(cross(cur), ...)`).
- Replaced runtime-based caller derivation with frame-based derivation:
  - `runtime.PreviousRealm().Address()` → `cur.Previous().Address()`.
- Migrated realm initialization to v2 form:
  - `init()` → `init(cur realm)` and `selfAddress = cur.Address()`.
- Removed legacy `chain/runtime` usage where no longer needed.
- Updated docs/README examples to the v2 crossing style (`cross(cur)` and `cur.Previous()`).
- Updated referral test suite signatures and subtest closures to carry `cur realm`.
- Updated panic/assert helper calls to the new signatures that include `cur`.
- Replaced deprecated origin-caller accessor in tests:
  - `runtime.OriginCaller()` → `unsafe.OriginCaller()`.

### Security

Caller validation in registration now derives the caller from the live realm token (`cur.Previous().Address()`), reducing reliance on deprecated implicit runtime context and aligning authorization checks with Interrealm v2 execution semantics.

### Notes

- This PR is focused on referral-module Interrealm v2 migration and related test/doc updates.
- No referral business rules were intentionally changed (rate-limit/self-referral/removal behavior remains covered by existing tests).