### PR TITLE
refactor(r/gnft): migrate to interrealm v2

### DIFF
--- a/contract/r/gnoswap/gnft/README.md
+++ b/contract/r/gnoswap/gnft/README.md
@@ -32,7 +32,7 @@ GNFT represents each liquidity position as a unique NFT with dynamically generat
 
 - Position contract mints NFTs for new positions
 - Staker contract locks NFTs during staking
-- Access control via the position role mirrored from RBAC
+- GRC721 owner/approval checks for transfers and operator management
 
 ## Key Functions
 
@@ -136,25 +136,24 @@ Example: "10,12,125,123,#FF5733,#33B5FF"
 import "gno.land/r/gnoswap/gnft"
 
 // Mint NFT for new position
-tokenId := gnft.Mint(cross, ownerAddress, positionId)
+tokenId := gnft.Mint(cross(cur), ownerAddress, positionId)
 
 // Get token URI with SVG
 imageURI, err := gnft.TokenURI(tokenId)
 // Returns: "data:image/svg+xml;base64,..." for generated GNFT images
 
 // Transfer NFT
-gnft.TransferFrom(cross, fromAddress, toAddress, tokenId)
+gnft.TransferFrom(cross(cur), fromAddress, toAddress, tokenId)
 
 // Burn NFT when closing position
-gnft.Burn(cross, tokenId)
+gnft.Burn(cross(cur), tokenId)
 ```
 
 ## Security
 
-- Only position contract can mint NFTs
-- Only position contract can set token URIs and burn NFTs
+- Position contract mints NFTs for new positions
+- Transfers and approvals require the caller to be the owner or approved for the token
 - Tokens held by the staker contract can only be moved by the staker
-- RBAC-backed role access through the access realm
 - Validated parameter ranges
 - Secure random generation
 
@@ -173,6 +172,5 @@ gnft.Burn(cross, tokenId)
 
 ### Access Control
 
-- `access.AssertIsPosition(cur.Previous().Address())`: Only position contract
-- `cur.Previous().Address()`: Caller propagated to GRC721 transfer and approval checks
+- `owner.AssertOwnedByPrevious()`: Checks that the caller owns the GNFT before owner-only operations
 - `checkErr()`: Panic on errors

--- a/contract/r/gnoswap/gnft/README.md
+++ b/contract/r/gnoswap/gnft/README.md
@@ -32,8 +32,7 @@ GNFT represents each liquidity position as a unique NFT with dynamically generat
 
 - Position contract mints NFTs for new positions
 - Staker contract locks NFTs during staking
-- Access control via RBAC system
-- Halt mechanism for emergency stops
+- Access control via the position role mirrored from RBAC
 
 ## Key Functions
 
@@ -68,12 +67,12 @@ Transfers NFT ownership.
 
 ### `TokenURI`
 
-Returns token metadata with SVG image.
+Returns the token URI, rendering stored SVG parameters as a base64 image data URI.
 
 **Parameters:**
 - `tid grc721.TokenID`: Token ID
 
-**Returns:** Metadata JSON with base64-encoded SVG
+**Returns:** Token URI string, using a base64-encoded SVG data URI for generated GNFT images
 
 ### `Approve`
 
@@ -137,25 +136,25 @@ Example: "10,12,125,123,#FF5733,#33B5FF"
 import "gno.land/r/gnoswap/gnft"
 
 // Mint NFT for new position
-tokenId := gnft.Mint(cur, ownerAddress, positionId)
+tokenId := gnft.Mint(cross, ownerAddress, positionId)
 
-// Get token metadata with SVG
-metadata := gnft.TokenURI(tokenId)
-// Returns: {"name":"Position #1","image":"data:image/svg+xml;base64,..."}
+// Get token URI with SVG
+imageURI, err := gnft.TokenURI(tokenId)
+// Returns: "data:image/svg+xml;base64,..." for generated GNFT images
 
 // Transfer NFT
-gnft.TransferFrom(cur, fromAddress, toAddress, tokenId)
+gnft.TransferFrom(cross, fromAddress, toAddress, tokenId)
 
 // Burn NFT when closing position
-gnft.Burn(cur, tokenId)
+gnft.Burn(cross, tokenId)
 ```
 
 ## Security
 
 - Only position contract can mint NFTs
-- Transfers blocked during staking
-- RBAC-based access control
-- Halt mechanism for emergencies
+- Only position contract can set token URIs and burn NFTs
+- Tokens held by the staker contract can only be moved by the staker
+- RBAC-backed role access through the access realm
 - Validated parameter ranges
 - Secure random generation
 
@@ -163,17 +162,17 @@ gnft.Burn(cur, tokenId)
 
 ### Dependencies
 
-- `gno.land/p/demo/grc/grc721`: GRC721 interface
+- `gno.land/p/demo/tokens/grc721`: GRC721 implementation
 - `gno.land/r/gnoswap/rbac`: Access control
-- `gno.land/r/gnoswap/halt`: Emergency stops
+- `gno.land/r/gnoswap/access`: Position role mirror
 
 ### State Variables
 
-- `nft *grc721.AdminToken`: GRC721 token instance
-- `tokenURIs avl.Tree`: TokenID → parameter string mapping
+- `nft`: GRC721 token instance
+- Token URIs are stored by the GRC721 token as compact SVG parameter strings
 
 ### Access Control
 
-- `owner.AssertOwnedByPrevious()`: Only position contract
+- `access.AssertIsPosition(cur.Previous().Address())`: Only position contract
+- `cur.Previous().Address()`: Caller propagated to GRC721 transfer and approval checks
 - `checkErr()`: Panic on errors
-- `halt.AssertIsNotHalted*()`: Check halt status

--- a/contract/r/gnoswap/gnft/_helper_test.gno
+++ b/contract/r/gnoswap/gnft/_helper_test.gno
@@ -2,22 +2,13 @@ package gnft
 
 import (
 	"strconv"
-	"testing"
 
 	"gno.land/p/demo/tokens/grc721"
 	prbac "gno.land/p/gnoswap/rbac"
 	"gno.land/r/gnoswap/access"
-	"gno.land/r/gnoswap/halt"
 )
 
 var positionAddr = access.MustGetAddress(prbac.ROLE_POSITION.String())
-
-func setHalted(halted bool) {
-	adminAddr, _ := access.GetAddress(prbac.ROLE_ADMIN.String())
-	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	halt.SetOperationStatus(cross, halt.OpTypePosition, halted)
-	halt.SetOperationStatus(cross, halt.OpTypeWithdraw, halted)
-}
 
 // tid is a test helper function that converts uint64 to TokenID
 func tid(id uint64) grc721.TokenID {

--- a/contract/r/gnoswap/gnft/assert.gno
+++ b/contract/r/gnoswap/gnft/assert.gno
@@ -1,8 +1,6 @@
 package gnft
 
 import (
-	"chain/runtime"
-
 	"gno.land/p/demo/tokens/grc721"
 	prabc "gno.land/p/gnoswap/rbac"
 	ufmt "gno.land/p/nt/ufmt/v0"
@@ -41,7 +39,7 @@ func assertToIsValidAddress(to address) {
 // assertIsAllowedTransfer enforces that NFTs held
 // by the staker (i.e. currently staked) can only be moved by the staker itself.
 // Other tokens fall through to the standard GRC721 owner/approval checks performed inside nft.
-func assertIsAllowedTransfer(tid grc721.TokenID) {
+func assertIsAllowedTransfer(caller address, tid grc721.TokenID) {
 	owner, err := nft.OwnerOf(tid)
 	if err != nil {
 		// Surface the same not-found error as the standard transfer path.
@@ -53,7 +51,6 @@ func assertIsAllowedTransfer(tid grc721.TokenID) {
 		return
 	}
 
-	caller := runtime.PreviousRealm().Address()
 	if caller != stakerAddr {
 		panic(makeErrorWithDetails(
 			errStakedTokenLocked,

--- a/contract/r/gnoswap/gnft/assert_test.gno
+++ b/contract/r/gnoswap/gnft/assert_test.gno
@@ -13,10 +13,10 @@ import (
 // Policy: when the token's owner is the staker contract, only the staker
 // itself may move the token. For any other owner, this assertion is a no-op
 // and the underlying GRC721 ownership/approval checks apply.
-func TestAssertIsAllowedTransfer(t *testing.T) {
+func TestAssertIsAllowedTransfer(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
-		setup       func(t *testing.T)
+		setup       func(cur realm, t *testing.T)
 		callerRealm runtime.Realm
 		tokenId     uint64
 		shouldPanic bool
@@ -25,9 +25,9 @@ func TestAssertIsAllowedTransfer(t *testing.T) {
 		{
 			// Owner is a regular user. Lock does not apply, regardless of caller.
 			name: "non-staked token allows arbitrary caller",
-			setup: func(t *testing.T) {
+			setup: func(cur realm, t *testing.T) {
 				testing.SetRealm(positionRealm)
-				Mint(cross, addr01, tid(1))
+				Mint(cross(cur), addr01, tid(1))
 			},
 			callerRealm: addr02Realm,
 			tokenId:     1,
@@ -37,9 +37,9 @@ func TestAssertIsAllowedTransfer(t *testing.T) {
 			// Owner is a regular user. Lock does not apply even when the
 			// owner themselves is the caller.
 			name: "non-staked token allows owner caller",
-			setup: func(t *testing.T) {
+			setup: func(cur realm, t *testing.T) {
 				testing.SetRealm(positionRealm)
-				Mint(cross, addr01, tid(1))
+				Mint(cross(cur), addr01, tid(1))
 			},
 			callerRealm: addr01Realm,
 			tokenId:     1,
@@ -49,7 +49,7 @@ func TestAssertIsAllowedTransfer(t *testing.T) {
 			// Token does not exist. The assertion should surface the
 			// underlying GRC721 not-found error, not silently fail-open.
 			name:        "non-existent token panics with not-found",
-			setup:       func(t *testing.T) {},
+			setup:       func(cur realm, t *testing.T) {},
 			callerRealm: addr01Realm,
 			tokenId:     999,
 			shouldPanic: true,
@@ -59,7 +59,7 @@ func TestAssertIsAllowedTransfer(t *testing.T) {
 			// Edge case — token id 0. Same as any other non-existent id;
 			// must fail-closed.
 			name:        "token id zero panics with not-found",
-			setup:       func(t *testing.T) {},
+			setup:       func(cur realm, t *testing.T) {},
 			callerRealm: addr01Realm,
 			tokenId:     0,
 			shouldPanic: true,
@@ -68,21 +68,21 @@ func TestAssertIsAllowedTransfer(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			resetObject(t)
 
 			if tt.setup != nil {
-				tt.setup(t)
+				tt.setup(cur, t)
 			}
 
 			if tt.shouldPanic {
 				testing.SetRealm(tt.callerRealm)
-				uassert.PanicsWithMessage(t, tt.panicMsg, func() {
-					assertIsAllowedTransfer(tid(tt.tokenId))
+				uassert.PanicsWithMessage(t, cur, tt.panicMsg, func() {
+					assertIsAllowedTransfer(tt.callerRealm.Address(), tid(tt.tokenId))
 				})
 			} else {
 				testing.SetRealm(tt.callerRealm)
-				assertIsAllowedTransfer(tid(tt.tokenId))
+				assertIsAllowedTransfer(tt.callerRealm.Address(), tid(tt.tokenId))
 			}
 		})
 	}

--- a/contract/r/gnoswap/gnft/errors.gno
+++ b/contract/r/gnoswap/gnft/errors.gno
@@ -19,6 +19,7 @@ var (
 	errInvalidTokenParamsRange = errors.New("[GNOSWAP-GNFT-007] token parameters out of range")
 	errInvalidColorFormat      = errors.New("[GNOSWAP-GNFT-008] invalid color format")
 	errStakedTokenLocked       = errors.New("[GNOSWAP-GNFT-009] staked token is locked")
+	errSpoofedRealm            = errors.New("[GNOSWAP-GNFT-010] rlm does not match the current crossing frame")
 )
 
 // makeErrorWithDetails creates an error with additional context.

--- a/contract/r/gnoswap/gnft/gnft.gno
+++ b/contract/r/gnoswap/gnft/gnft.gno
@@ -104,7 +104,7 @@ func SafeTransferFrom(cur realm, from, to address, tid grc721.TokenID) error {
 	assertIsAllowedTransfer(caller, tid)
 
 	err := nft.SafeTransferFrom(caller, from, to, tid)
-	checkTransferErr(caller, err, from, to, tid)
+	checkTransferErr(err, caller, from, to, tid)
 	return nil
 }
 
@@ -130,7 +130,7 @@ func TransferFrom(cur realm, from, to address, tid grc721.TokenID) error {
 	assertIsAllowedTransfer(caller, tid)
 
 	err := nft.TransferFrom(caller, from, to, tid)
-	checkTransferErr(caller, err, from, to, tid)
+	checkTransferErr(err, caller, from, to, tid)
 	return nil
 }
 
@@ -146,7 +146,7 @@ func Approve(cur realm, approved address, tid grc721.TokenID) error {
 
 	caller := cur.Previous().Address()
 	err := nft.Approve(caller, approved, tid)
-	checkApproveErr(caller, err, approved, tid)
+	checkApproveErr(err, caller, approved, tid)
 	return nil
 }
 

--- a/contract/r/gnoswap/gnft/gnft.gno
+++ b/contract/r/gnoswap/gnft/gnft.gno
@@ -2,7 +2,6 @@ package gnft
 
 import (
 	"chain"
-	"chain/runtime"
 
 	"gno.land/p/demo/tokens/grc721"
 	ufmt "gno.land/p/nt/ufmt/v0"
@@ -73,12 +72,12 @@ func MustOwnerOf(tid grc721.TokenID) address {
 //
 // Only callable by position contract.
 func SetTokenURI(cur realm, tid grc721.TokenID, tURI grc721.TokenURI) (bool, error) {
-	caller := runtime.PreviousRealm().Address()
+	caller := cur.Previous().Address()
 	access.AssertIsPosition(caller)
 
 	assertIsValidTokenURI(tid)
 
-	checkErr(setTokenURI(tid, tURI))
+	checkErr(setTokenURI(0, cur, tid, tURI))
 
 	return true, nil
 }
@@ -101,10 +100,11 @@ func SetTokenURI(cur realm, tid grc721.TokenID, tURI grc721.TokenURI) (bool, err
 func SafeTransferFrom(cur realm, from, to address, tid grc721.TokenID) error {
 	assertFromIsValidAddress(from)
 	assertToIsValidAddress(to)
-	assertIsAllowedTransfer(tid)
+	caller := cur.Previous().Address()
+	assertIsAllowedTransfer(caller, tid)
 
-	err := nft.SafeTransferFrom(from, to, tid)
-	checkTransferErr(err, from, to, tid)
+	err := nft.SafeTransferFrom(caller, from, to, tid)
+	checkTransferErr(caller, err, from, to, tid)
 	return nil
 }
 
@@ -126,10 +126,11 @@ func SafeTransferFrom(cur realm, from, to address, tid grc721.TokenID) error {
 func TransferFrom(cur realm, from, to address, tid grc721.TokenID) error {
 	assertFromIsValidAddress(from)
 	assertToIsValidAddress(to)
-	assertIsAllowedTransfer(tid)
+	caller := cur.Previous().Address()
+	assertIsAllowedTransfer(caller, tid)
 
-	err := nft.TransferFrom(from, to, tid)
-	checkTransferErr(err, from, to, tid)
+	err := nft.TransferFrom(caller, from, to, tid)
+	checkTransferErr(caller, err, from, to, tid)
 	return nil
 }
 
@@ -140,12 +141,12 @@ func TransferFrom(cur realm, from, to address, tid grc721.TokenID) error {
 //   - tid: token ID to approve for transfer
 //
 // Returns error if approval fails.
-// Only callable when not halted.
 func Approve(cur realm, approved address, tid grc721.TokenID) error {
 	assertIsValidAddress(approved)
 
-	err := nft.Approve(approved, tid)
-	checkApproveErr(err, approved, tid)
+	caller := cur.Previous().Address()
+	err := nft.Approve(caller, approved, tid)
+	checkApproveErr(caller, err, approved, tid)
 	return nil
 }
 
@@ -156,11 +157,10 @@ func Approve(cur realm, approved address, tid grc721.TokenID) error {
 //   - approved: true to approve, false to revoke
 //
 // Returns error if operation fails.
-// Only callable when not halted.
 func SetApprovalForAll(cur realm, operator address, approved bool) error {
 	assertIsValidAddress(operator)
 
-	checkErr(nft.SetApprovalForAll(operator, approved))
+	checkErr(nft.SetApprovalForAll(cur.Previous().Address(), operator, approved))
 	return nil
 }
 
@@ -194,7 +194,7 @@ func IsApprovedForAll(owner, operator address) bool {
 // Returns minted token ID.
 // Only callable by position contract.
 func Mint(cur realm, to address, tid grc721.TokenID) grc721.TokenID {
-	caller := runtime.PreviousRealm().Address()
+	caller := cur.Previous().Address()
 	access.AssertIsPosition(caller)
 
 	positionAddr := access.MustGetAddress(prabc.ROLE_POSITION.String())
@@ -203,9 +203,9 @@ func Mint(cur realm, to address, tid grc721.TokenID) grc721.TokenID {
 	// Store only the gradient parameters instead of full base64 SVG to reduce storage costs.
 	// Parameters are converted to full SVG on read via TokenURI().
 	imageParams := genImageParamsString(generateRandInstance())
-	checkErr(setTokenURI(tid, grc721.TokenURI(imageParams)))
+	checkErr(setTokenURI(0, cur, tid, grc721.TokenURI(imageParams)))
 
-	checkErr(nft.TransferFrom(positionAddr, to, tid))
+	checkErr(nft.TransferFrom(positionAddr, positionAddr, to, tid))
 
 	return tid
 }
@@ -223,7 +223,7 @@ func Exists(tid grc721.TokenID) bool {
 //
 // Only callable by position.
 func Burn(cur realm, tid grc721.TokenID) {
-	caller := runtime.PreviousRealm().Address()
+	caller := cur.Previous().Address()
 	access.AssertIsPosition(caller)
 
 	checkErr(nft.Burn(tid))
@@ -238,16 +238,22 @@ func Render(path string) string {
 }
 
 // setTokenURI sets the metadata URI for a specific token ID.
-func setTokenURI(tid grc721.TokenID, tURI grc721.TokenURI) error {
-	_, err := nft.SetTokenURI(tid, tURI)
+func setTokenURI(_ int, rlm realm, tid grc721.TokenID, tURI grc721.TokenURI) error {
+	if !rlm.IsCurrent() {
+		return errSpoofedRealm
+	}
+
+	previousRealm := rlm.Previous()
+	previousAddr := previousRealm.Address()
+
+	_, err := nft.SetTokenURI(previousAddr, tid, tURI)
 	if err != nil {
 		return makeErrorWithDetails(err, ufmt.Sprintf("token id (%s)", tid))
 	}
 
-	previousRealm := runtime.PreviousRealm()
 	chain.Emit(
 		"SetTokenURI",
-		"prevAddr", previousRealm.Address().String(),
+		"prevAddr", previousAddr.String(),
 		"prevRealm", previousRealm.PkgPath(),
 		"tokenId", string(tid),
 	)

--- a/contract/r/gnoswap/gnft/gnft_test.gno
+++ b/contract/r/gnoswap/gnft/gnft_test.gno
@@ -31,7 +31,7 @@ var (
 	addr02Realm = testing.NewUserRealm(addr02)
 )
 
-func TestMetadata(t *testing.T) {
+func TestMetadata(cur realm, t *testing.T) {
 	tests := []struct {
 		name     string
 		fn       func() string
@@ -42,16 +42,16 @@ func TestMetadata(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			uassert.Equal(t, tt.expected, tt.fn())
 		})
 	}
 }
 
-func TestBalanceOf(t *testing.T) {
+func TestBalanceOf(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
-		setup       func()
+		setup       func(cur realm)
 		addr        address
 		expected    int64
 		shouldPanic bool
@@ -59,64 +59,64 @@ func TestBalanceOf(t *testing.T) {
 	}{
 		{
 			name: "balance with one NFT",
-			setup: func() {
+			setup: func(cur realm) {
 				resetObject(t)
 				testing.SetRealm(positionRealm)
-				Mint(cross, addr01, tid(100))
+				Mint(cross(cur), addr01, tid(100))
 			},
 			addr:     addr01,
 			expected: 1,
 		},
 		{
 			name: "balance with zero NFTs",
-			setup: func() {
+			setup: func(cur realm) {
 				resetObject(t)
 				testing.SetRealm(positionRealm)
-				Mint(cross, addr01, tid(100))
+				Mint(cross(cur), addr01, tid(100))
 			},
 			addr:     addr02,
 			expected: 0,
 		},
 		{
 			name: "balance with multiple NFTs",
-			setup: func() {
+			setup: func(cur realm) {
 				resetObject(t)
 				testing.SetRealm(positionRealm)
-				Mint(cross, addr01, tid(1))
-				Mint(cross, addr01, tid(2))
-				Mint(cross, addr01, tid(3))
+				Mint(cross(cur), addr01, tid(1))
+				Mint(cross(cur), addr01, tid(2))
+				Mint(cross(cur), addr01, tid(3))
 			},
 			addr:     addr01,
 			expected: 3,
 		},
 		{
 			name: "balance after transfer",
-			setup: func() {
+			setup: func(cur realm) {
 				resetObject(t)
 				testing.SetRealm(positionRealm)
-				Mint(cross, addr01, tid(1))
-				Mint(cross, addr01, tid(2))
+				Mint(cross(cur), addr01, tid(1))
+				Mint(cross(cur), addr01, tid(2))
 				// Transfer one NFT to addr02
 				testing.SetRealm(addr01Realm)
-				Approve(cross, stakerRealm.Address(), tid(1))
+				Approve(cross(cur), stakerRealm.Address(), tid(1))
 				testing.SetRealm(stakerRealm)
-				TransferFrom(cross, addr01, addr02, tid(1))
+				TransferFrom(cross(cur), addr01, addr02, tid(1))
 			},
 			addr:     addr01,
 			expected: 1,
 		},
 		{
 			name: "balance of recipient after transfer",
-			setup: func() {
+			setup: func(cur realm) {
 				resetObject(t)
 				testing.SetRealm(positionRealm)
-				Mint(cross, addr01, tid(1))
-				Mint(cross, addr01, tid(2))
+				Mint(cross(cur), addr01, tid(1))
+				Mint(cross(cur), addr01, tid(2))
 				// Transfer one NFT to addr02
 				testing.SetRealm(addr01Realm)
-				Approve(cross, stakerRealm.Address(), tid(1))
+				Approve(cross(cur), stakerRealm.Address(), tid(1))
 				testing.SetRealm(stakerRealm)
-				TransferFrom(cross, addr01, addr02, tid(1))
+				TransferFrom(cross(cur), addr01, addr02, tid(1))
 			},
 			addr:     addr02,
 			expected: 1,
@@ -124,9 +124,9 @@ func TestBalanceOf(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.setup != nil {
-				tt.setup()
+				tt.setup(cur)
 			}
 
 			balance, _ := BalanceOf(tt.addr)
@@ -135,7 +135,7 @@ func TestBalanceOf(t *testing.T) {
 	}
 }
 
-func TestTotalSupply(t *testing.T) {
+func TestTotalSupply(cur realm, t *testing.T) {
 	resetObject(t)
 	tests := []struct {
 		name     string
@@ -150,8 +150,8 @@ func TestTotalSupply(t *testing.T) {
 			name: "total supply after minting",
 			setup: func(cur realm) {
 				testing.SetRealm(positionRealm)
-				Mint(cur, addr01, tid(1))
-				Mint(cur, addr01, tid(2))
+				Mint(cross(cur), addr01, tid(1))
+				Mint(cross(cur), addr01, tid(2))
 			},
 			expected: 2,
 		},
@@ -159,32 +159,32 @@ func TestTotalSupply(t *testing.T) {
 			name: "total supply after burning",
 			setup: func(cur realm) {
 				testing.SetRealm(positionRealm)
-				Burn(cur, tid(2))
+				Burn(cross(cur), tid(2))
 			},
 			expected: 1,
 		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.setup != nil {
 				testing.SetRealm(positionRealm)
-				tt.setup(cross)
+				tt.setup(cur)
 			}
 			uassert.Equal(t, tt.expected, TotalSupply())
 		})
 	}
 }
 
-func TestOwnerOf(t *testing.T) {
+func TestOwnerOf(cur realm, t *testing.T) {
 	resetObject(t)
 	testing.SetRealm(positionRealm)
-	Mint(cross, addr01, tid(1))
-	Mint(cross, addr02, tid(2))
+	Mint(cross(cur), addr01, tid(1))
+	Mint(cross(cur), addr02, tid(2))
 
 	tests := []struct {
 		name        string
-		setup       func()
+		setup       func(cur realm)
 		tokenId     uint64
 		shouldError bool
 		errorMsg    string
@@ -204,9 +204,9 @@ func TestOwnerOf(t *testing.T) {
 		},
 		{
 			name: "burned token",
-			setup: func() {
+			setup: func(cur realm) {
 				testing.SetRealm(positionRealm)
-				Burn(cross, tid(2))
+				Burn(cross(cur), tid(2))
 			},
 			tokenId:     2,
 			shouldError: true,
@@ -215,9 +215,9 @@ func TestOwnerOf(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.setup != nil {
-				tt.setup()
+				tt.setup(cur)
 			}
 
 			ownerAddr, err := OwnerOf(tid(tt.tokenId))
@@ -234,10 +234,10 @@ func TestOwnerOf(t *testing.T) {
 	}
 }
 
-func TestSetApprovalForAll(t *testing.T) {
+func TestSetApprovalForAll(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
-		setup       func()
+		setup       func(cur realm)
 		callerRealm runtime.Realm
 		operator    address
 		approved    bool
@@ -246,7 +246,7 @@ func TestSetApprovalForAll(t *testing.T) {
 	}{
 		{
 			name: "approve operator for all tokens",
-			setup: func() {
+			setup: func(cur realm) {
 				resetObject(t)
 			},
 			callerRealm: addr01Realm,
@@ -256,10 +256,10 @@ func TestSetApprovalForAll(t *testing.T) {
 		},
 		{
 			name: "revoke operator approval for all tokens",
-			setup: func() {
+			setup: func(cur realm) {
 				resetObject(t)
 				testing.SetRealm(addr01Realm)
-				SetApprovalForAll(cross, addr02, true)
+				SetApprovalForAll(cross(cur), addr02, true)
 			},
 			callerRealm: addr01Realm,
 			operator:    addr02,
@@ -268,7 +268,7 @@ func TestSetApprovalForAll(t *testing.T) {
 		},
 		{
 			name: "approve invalid operator address",
-			setup: func() {
+			setup: func(cur realm) {
 				resetObject(t)
 			},
 			callerRealm: addr01Realm,
@@ -279,7 +279,7 @@ func TestSetApprovalForAll(t *testing.T) {
 		},
 		{
 			name: "approve self as operator",
-			setup: func() {
+			setup: func(cur realm) {
 				resetObject(t)
 			},
 			callerRealm: addr01Realm,
@@ -291,19 +291,19 @@ func TestSetApprovalForAll(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.setup != nil {
-				tt.setup()
+				tt.setup(cur)
 			}
 
 			testing.SetRealm(tt.callerRealm)
 
 			if tt.shouldPanic {
-				uassert.AbortsContains(t, tt.panicMsg, func() {
-					SetApprovalForAll(cross, tt.operator, tt.approved)
+				uassert.AbortsContains(t, cur, tt.panicMsg, func() {
+					SetApprovalForAll(cross(cur), tt.operator, tt.approved)
 				})
 			} else {
-				err := SetApprovalForAll(cross, tt.operator, tt.approved)
+				err := SetApprovalForAll(cross(cur), tt.operator, tt.approved)
 				uassert.NoError(t, err)
 
 				// Verify approval status
@@ -314,7 +314,7 @@ func TestSetApprovalForAll(t *testing.T) {
 	}
 }
 
-func TestIsApprovedForAll(t *testing.T) {
+func TestIsApprovedForAll(cur realm, t *testing.T) {
 	tests := []struct {
 		name             string
 		isApprovedForAll bool
@@ -333,20 +333,20 @@ func TestIsApprovedForAll(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			testing.SetRealm(addr01Realm)
 			if tt.isApprovedForAll {
-				SetApprovalForAll(cross, addr02, tt.isApprovedForAll)
+				SetApprovalForAll(cross(cur), addr02, tt.isApprovedForAll)
 			}
 			uassert.Equal(t, tt.expected, IsApprovedForAll(addr01, addr02))
 		})
 	}
 }
 
-func TestSetTokenURI(t *testing.T) {
+func TestSetTokenURI(cur realm, t *testing.T) {
 	tests := []struct {
 		name             string
-		setup            func(tokenId uint64)
+		setup            func(cur realm, tokenId uint64)
 		callerRealm      runtime.Realm
 		tokenId          uint64
 		expectedHasAbort bool
@@ -354,7 +354,7 @@ func TestSetTokenURI(t *testing.T) {
 	}{
 		{
 			name: "successfully set token uri by owner with token id 1",
-			setup: func(tokenId uint64) {
+			setup: func(cur realm, tokenId uint64) {
 				resetObject(t)
 				testing.SetRealm(positionRealm)
 				// Mint token without URI by directly calling nft.Mint
@@ -366,7 +366,7 @@ func TestSetTokenURI(t *testing.T) {
 		},
 		{
 			name: "successfully set token uri by owner with token id 2",
-			setup: func(tokenId uint64) {
+			setup: func(cur realm, tokenId uint64) {
 				resetObject(t)
 				testing.SetRealm(positionRealm)
 				checkErr(nft.Mint(positionAddr, tid(tokenId)))
@@ -377,7 +377,7 @@ func TestSetTokenURI(t *testing.T) {
 		},
 		{
 			name: "successfully set token uri by owner with token id 100",
-			setup: func(tokenId uint64) {
+			setup: func(cur realm, tokenId uint64) {
 				resetObject(t)
 				testing.SetRealm(positionRealm)
 				checkErr(nft.Mint(positionAddr, tid(tokenId)))
@@ -388,10 +388,10 @@ func TestSetTokenURI(t *testing.T) {
 		},
 		{
 			name: "fail to set token uri on already set token with token id 1",
-			setup: func(tokenId uint64) {
+			setup: func(cur realm, tokenId uint64) {
 				resetObject(t)
 				testing.SetRealm(positionRealm)
-				Mint(cross, addr01, tid(tokenId))
+				Mint(cross(cur), addr01, tid(tokenId))
 			},
 			callerRealm:      positionRealm,
 			tokenId:          1,
@@ -400,10 +400,10 @@ func TestSetTokenURI(t *testing.T) {
 		},
 		{
 			name: "fail to set token uri on already set token with token id 999",
-			setup: func(tokenId uint64) {
+			setup: func(cur realm, tokenId uint64) {
 				resetObject(t)
 				testing.SetRealm(positionRealm)
-				Mint(cross, addr01, tid(tokenId))
+				Mint(cross(cur), addr01, tid(tokenId))
 			},
 			callerRealm:      positionRealm,
 			tokenId:          999,
@@ -412,10 +412,10 @@ func TestSetTokenURI(t *testing.T) {
 		},
 		{
 			name: "fail to set token uri by unauthorized caller with token id 1",
-			setup: func(tokenId uint64) {
+			setup: func(cur realm, tokenId uint64) {
 				resetObject(t)
 				testing.SetRealm(positionRealm)
-				Mint(cross, addr01, tid(tokenId))
+				Mint(cross(cur), addr01, tid(tokenId))
 			},
 			callerRealm:      addr01Realm,
 			tokenId:          1,
@@ -424,10 +424,10 @@ func TestSetTokenURI(t *testing.T) {
 		},
 		{
 			name: "fail to set token uri by unauthorized caller with token id 50",
-			setup: func(tokenId uint64) {
+			setup: func(cur realm, tokenId uint64) {
 				resetObject(t)
 				testing.SetRealm(positionRealm)
-				Mint(cross, addr01, tid(tokenId))
+				Mint(cross(cur), addr01, tid(tokenId))
 			},
 			callerRealm:      addr01Realm,
 			tokenId:          50,
@@ -437,18 +437,18 @@ func TestSetTokenURI(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.setup != nil {
-				tt.setup(tt.tokenId)
+				tt.setup(cur, tt.tokenId)
 			}
 
 			testing.SetRealm(tt.callerRealm)
 			if tt.expectedHasAbort {
-				uassert.AbortsWithMessage(t, tt.expectedErrMsg, func() {
-					SetTokenURI(cross, tid(tt.tokenId), testURI)
+				uassert.AbortsWithMessage(t, cur, tt.expectedErrMsg, func() {
+					SetTokenURI(cross(cur), tid(tt.tokenId), testURI)
 				})
 			} else {
-				result, err := SetTokenURI(cross, tid(tt.tokenId), grc721.TokenURI(testURI))
+				result, err := SetTokenURI(cross(cur), tid(tt.tokenId), grc721.TokenURI(testURI))
 				uassert.NoError(t, err)
 				uassert.True(t, result)
 
@@ -460,10 +460,10 @@ func TestSetTokenURI(t *testing.T) {
 	}
 }
 
-func TestGetApproved(t *testing.T) {
+func TestGetApproved(cur realm, t *testing.T) {
 	resetObject(t)
 	testing.SetRealm(positionRealm)
-	Mint(cross, addr01, tid(1))
+	Mint(cross(cur), addr01, tid(1))
 
 	tests := []struct {
 		name         string
@@ -483,7 +483,7 @@ func TestGetApproved(t *testing.T) {
 			name: "GetApproved for token with approval",
 			setup: func(cur realm) {
 				testing.SetRealm(addr01Realm)
-				Approve(cross, addr02, tid(1))
+				Approve(cross(cur), addr02, tid(1))
 			},
 			tokenId:      1,
 			expectedAddr: addr02,
@@ -498,8 +498,8 @@ func TestGetApproved(t *testing.T) {
 			name: "GetApproved for token with different approval",
 			setup: func(cur realm) {
 				testing.SetRealm(addr01Realm)
-				Approve(cross, addr02, tid(1))
-				Approve(cross, testutils.TestAddress("addr03"), tid(1)) // change approval
+				Approve(cross(cur), addr02, tid(1))
+				Approve(cross(cur), testutils.TestAddress("addr03"), tid(1)) // change approval
 			},
 			tokenId:      1,
 			expectedAddr: testutils.TestAddress("addr03"),
@@ -507,9 +507,9 @@ func TestGetApproved(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.setup != nil {
-				tt.setup(cross)
+				tt.setup(cur)
 			}
 
 			addr, err := GetApproved(tid(tt.tokenId))
@@ -530,10 +530,10 @@ func TestGetApproved(t *testing.T) {
 	}
 }
 
-func TestTransferFrom(t *testing.T) {
+func TestTransferFrom(cur realm, t *testing.T) {
 	resetObject(t)
 	testing.SetRealm(positionRealm)
-	Mint(cross, addr01, tid(1))
+	Mint(cross(cur), addr01, tid(1))
 
 	tests := []struct {
 		name              string
@@ -568,7 +568,7 @@ func TestTransferFrom(t *testing.T) {
 			name: "transfer token owned by other user with approval",
 			setup: func(cur realm) {
 				testing.SetRealm(addr01Realm)
-				Approve(cross, stakerRealm.Address(), tid(1))
+				Approve(cross(cur), stakerRealm.Address(), tid(1))
 			},
 			callerRealm:       stakerRealm,
 			fromAddr:          addr01,
@@ -579,7 +579,7 @@ func TestTransferFrom(t *testing.T) {
 			name: "transfer token owned by caller",
 			setup: func(cur realm) {
 				testing.SetRealm(addr02Realm)
-				Approve(cross, stakerRealm.Address(), tid(1))
+				Approve(cross(cur), stakerRealm.Address(), tid(1))
 			},
 			callerRealm:       stakerRealm,
 			fromAddr:          addr02,
@@ -616,9 +616,9 @@ func TestTransferFrom(t *testing.T) {
 			name: "transfer to self",
 			setup: func(cur realm) {
 				testing.SetRealm(positionRealm)
-				Mint(cross, addr01, tid(100))
+				Mint(cross(cur), addr01, tid(100))
 				testing.SetRealm(addr01Realm)
-				Approve(cross, stakerRealm.Address(), tid(100))
+				Approve(cross(cur), stakerRealm.Address(), tid(100))
 			},
 			callerRealm:       stakerRealm,
 			fromAddr:          addr01,
@@ -633,11 +633,11 @@ func TestTransferFrom(t *testing.T) {
 			name: "third party cannot move staked token",
 			setup: func(cur realm) {
 				testing.SetRealm(positionRealm)
-				Mint(cross, addr01, tid(200))
+				Mint(cross(cur), addr01, tid(200))
 				testing.SetRealm(addr01Realm)
-				Approve(cross, stakerRealm.Address(), tid(200))
+				Approve(cross(cur), stakerRealm.Address(), tid(200))
 				testing.SetRealm(stakerRealm)
-				TransferFrom(cross, addr01, stakerRealm.Address(), tid(200))
+				TransferFrom(cross(cur), addr01, stakerRealm.Address(), tid(200))
 				// addr01 still has approval recorded, but token is now staked.
 			},
 			callerRealm:       addr01Realm,
@@ -652,11 +652,11 @@ func TestTransferFrom(t *testing.T) {
 			name: "staker can move staked token",
 			setup: func(cur realm) {
 				testing.SetRealm(positionRealm)
-				Mint(cross, addr01, tid(201))
+				Mint(cross(cur), addr01, tid(201))
 				testing.SetRealm(addr01Realm)
-				Approve(cross, stakerRealm.Address(), tid(201))
+				Approve(cross(cur), stakerRealm.Address(), tid(201))
 				testing.SetRealm(stakerRealm)
-				TransferFrom(cross, addr01, stakerRealm.Address(), tid(201))
+				TransferFrom(cross(cur), addr01, stakerRealm.Address(), tid(201))
 			},
 			callerRealm:       stakerRealm,
 			fromAddr:          stakerRealm.Address(),
@@ -667,25 +667,25 @@ func TestTransferFrom(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.setup != nil {
-				tt.setup(cross)
+				tt.setup(cur)
 			}
 
 			testing.SetRealm(tt.callerRealm)
 			if tt.shouldPanic {
-				uassert.AbortsWithMessage(t, tt.panicMsg, func() {
-					TransferFrom(cross, tt.fromAddr, tt.toAddr, tid(tt.tokenIdToTransfer))
+				uassert.AbortsWithMessage(t, cur, tt.panicMsg, func() {
+					TransferFrom(cross(cur), tt.fromAddr, tt.toAddr, tid(tt.tokenIdToTransfer))
 				})
 			} else {
 				testing.SetRealm(tt.callerRealm)
-				TransferFrom(cross, tt.fromAddr, tt.toAddr, tid(tt.tokenIdToTransfer))
+				TransferFrom(cross(cur), tt.fromAddr, tt.toAddr, tid(tt.tokenIdToTransfer))
 			}
 		})
 	}
 }
 
-func TestMint(t *testing.T) {
+func TestMint(cur realm, t *testing.T) {
 	tests := []struct {
 		name            string
 		callerRealm     runtime.Realm
@@ -737,24 +737,24 @@ func TestMint(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			resetObject(t)
 
 			// token id 0 is pre-minted
 			testing.SetRealm(positionRealm)
-			Mint(cross, testutils.TestAddress("human"), tid(0))
+			Mint(cross(cur), testutils.TestAddress("human"), tid(0))
+
+			testing.SetRealm(tt.callerRealm)
 
 			if tt.shouldPanic {
-				uassert.AbortsWithMessage(t, tt.panicMsg, func() {
-					testing.SetRealm(tt.callerRealm)
-					Mint(cross, tt.addressToMint, tid(tt.tokenIdToMint))
+				uassert.AbortsWithMessage(t, cur, tt.panicMsg, func() {
+					Mint(cross(cur), tt.addressToMint, tid(tt.tokenIdToMint))
 				})
 
 				balance, _ := BalanceOf(tt.addressToMint)
 				uassert.Equal(t, int64(0), balance)
 			} else {
-				testing.SetRealm(tt.callerRealm)
-				mintedTokenId := Mint(cross, tt.addressToMint, tid(tt.tokenIdToMint))
+				mintedTokenId := Mint(cross(cur), tt.addressToMint, tid(tt.tokenIdToMint))
 				uassert.Equal(t, tt.expected, string(mintedTokenId))
 				tt.verifyTokenList()
 
@@ -767,10 +767,10 @@ func TestMint(t *testing.T) {
 	}
 }
 
-func TestBurn(t *testing.T) {
+func TestBurn(cur realm, t *testing.T) {
 	tests := []struct {
 		name            string
-		setup           func()
+		setup           func(cur realm)
 		callerRealm     runtime.Realm
 		tokenIdToBurn   uint64
 		expectedBalance int64
@@ -802,9 +802,9 @@ func TestBurn(t *testing.T) {
 		},
 		{
 			name: "burn already burned token",
-			setup: func() {
+			setup: func(cur realm) {
 				testing.SetRealm(positionRealm)
-				Burn(cross, tid(1))
+				Burn(cross(cur), tid(1))
 			},
 			callerRealm:     positionRealm,
 			tokenIdToBurn:   1,
@@ -815,25 +815,25 @@ func TestBurn(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			resetObject(t)
 
 			// token id 1 is pre-minted
 			testing.SetRealm(positionRealm)
-			Mint(cross, testutils.TestAddress("human"), tid(1))
+			Mint(cross(cur), testutils.TestAddress("human"), tid(1))
 
 			if tt.setup != nil {
-				tt.setup()
+				tt.setup(cur)
 			}
 
 			testing.SetRealm(tt.callerRealm)
 
 			if tt.shouldPanic {
-				uassert.AbortsWithMessage(t, tt.panicMsg, func() {
-					Burn(cross, tid(tt.tokenIdToBurn))
+				uassert.AbortsWithMessage(t, cur, tt.panicMsg, func() {
+					Burn(cross(cur), tid(tt.tokenIdToBurn))
 				})
 			} else {
-				Burn(cross, tid(tt.tokenIdToBurn))
+				Burn(cross(cur), tid(tt.tokenIdToBurn))
 
 				// Verify complete tree cleanup after burn
 				// 1. OwnerOf should return error for burned token
@@ -856,10 +856,10 @@ func TestBurn(t *testing.T) {
 	}
 }
 
-func TestTokenURI(t *testing.T) {
+func TestTokenURI(cur realm, t *testing.T) {
 	resetObject(t)
 	testing.SetRealm(positionRealm)
-	Mint(cross, addr01, tid(1))
+	Mint(cross(cur), addr01, tid(1))
 
 	tests := []struct {
 		name        string
@@ -881,7 +881,7 @@ func TestTokenURI(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			uri, err := TokenURI(tid(tt.tokenId))
 
 			if tt.shouldError {
@@ -898,10 +898,10 @@ func TestTokenURI(t *testing.T) {
 	}
 }
 
-func TestMustOwnerOf(t *testing.T) {
+func TestMustOwnerOf(cur realm, t *testing.T) {
 	resetObject(t)
 	testing.SetRealm(positionRealm)
-	Mint(cross, addr01, tid(1))
+	Mint(cross(cur), addr01, tid(1))
 
 	tests := []struct {
 		name        string
@@ -925,9 +925,9 @@ func TestMustOwnerOf(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.panicMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.panicMsg, func() {
 					MustOwnerOf(tid(tt.tokenId))
 				})
 			} else {
@@ -938,10 +938,10 @@ func TestMustOwnerOf(t *testing.T) {
 	}
 }
 
-func TestSafeTransferFrom(t *testing.T) {
+func TestSafeTransferFrom(cur realm, t *testing.T) {
 	resetObject(t)
 	testing.SetRealm(positionRealm)
-	Mint(cross, addr01, tid(1))
+	Mint(cross(cur), addr01, tid(1))
 
 	tests := []struct {
 		name        string
@@ -957,7 +957,7 @@ func TestSafeTransferFrom(t *testing.T) {
 			name: "owner transfers own token",
 			setup: func(cur realm) {
 				testing.SetRealm(addr01Realm)
-				Approve(cross, stakerRealm.Address(), tid(1))
+				Approve(cross(cur), stakerRealm.Address(), tid(1))
 			},
 			callerRealm: stakerRealm,
 			from:        addr01,
@@ -969,7 +969,7 @@ func TestSafeTransferFrom(t *testing.T) {
 			name: "non-owner transfers without approval",
 			setup: func(cur realm) {
 				testing.SetRealm(addr02Realm)
-				Approve(cross, stakerRealm.Address(), tid(1))
+				Approve(cross(cur), stakerRealm.Address(), tid(1))
 			},
 			callerRealm: stakerRealm,
 			from:        addr01,
@@ -1010,9 +1010,9 @@ func TestSafeTransferFrom(t *testing.T) {
 			name: "safe transfer to self",
 			setup: func(cur realm) {
 				testing.SetRealm(positionRealm)
-				Mint(cross, addr01, tid(100))
+				Mint(cross(cur), addr01, tid(100))
 				testing.SetRealm(addr01Realm)
-				Approve(cross, stakerRealm.Address(), tid(100))
+				Approve(cross(cur), stakerRealm.Address(), tid(100))
 			},
 			callerRealm: stakerRealm,
 			from:        addr01,
@@ -1027,11 +1027,11 @@ func TestSafeTransferFrom(t *testing.T) {
 			name: "safe transfer blocked when token is staked",
 			setup: func(cur realm) {
 				testing.SetRealm(positionRealm)
-				Mint(cross, addr01, tid(202))
+				Mint(cross(cur), addr01, tid(202))
 				testing.SetRealm(addr01Realm)
-				Approve(cross, stakerRealm.Address(), tid(202))
+				Approve(cross(cur), stakerRealm.Address(), tid(202))
 				testing.SetRealm(stakerRealm)
-				TransferFrom(cross, addr01, stakerRealm.Address(), tid(202))
+				TransferFrom(cross(cur), addr01, stakerRealm.Address(), tid(202))
 			},
 			callerRealm: addr01Realm,
 			from:        stakerRealm.Address(),
@@ -1043,19 +1043,19 @@ func TestSafeTransferFrom(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.setup != nil {
-				tt.setup(cross)
+				tt.setup(cur)
 			}
 
 			testing.SetRealm(tt.callerRealm)
 
 			if tt.shouldPanic {
-				uassert.AbortsWithMessage(t, tt.panicMsg, func() {
-					SafeTransferFrom(cross, tt.from, tt.to, tid(tt.tokenId))
+				uassert.AbortsWithMessage(t, cur, tt.panicMsg, func() {
+					SafeTransferFrom(cross(cur), tt.from, tt.to, tid(tt.tokenId))
 				})
 			} else {
-				err := SafeTransferFrom(cross, tt.from, tt.to, tid(tt.tokenId))
+				err := SafeTransferFrom(cross(cur), tt.from, tt.to, tid(tt.tokenId))
 				uassert.NoError(t, err)
 
 				// Verify ownership transferred
@@ -1066,12 +1066,12 @@ func TestSafeTransferFrom(t *testing.T) {
 	}
 }
 
-func TestExists(t *testing.T) {
+func TestExists(cur realm, t *testing.T) {
 	resetObject(t)
 	testing.SetRealm(positionRealm)
-	Mint(cross, addr01, tid(1))
-	Mint(cross, addr01, tid(2))
-	Burn(cross, tid(2))
+	Mint(cross(cur), addr01, tid(1))
+	Mint(cross(cur), addr01, tid(2))
+	Burn(cross(cur), tid(2))
 
 	tests := []struct {
 		name     string
@@ -1096,14 +1096,14 @@ func TestExists(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			exists := Exists(tid(tt.tokenId))
 			uassert.Equal(t, tt.expected, exists)
 		})
 	}
 }
 
-func TestRender(t *testing.T) {
+func TestRender(cur realm, t *testing.T) {
 	tests := []struct {
 		name     string
 		path     string
@@ -1127,21 +1127,21 @@ func TestRender(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			result := Render(tt.path)
 			uassert.Equal(t, tt.expected, result)
 		})
 	}
 }
 
-func TestApprove(t *testing.T) {
+func TestApprove(cur realm, t *testing.T) {
 	resetObject(t)
 	testing.SetRealm(positionRealm)
-	Mint(cross, addr01, tid(1))
+	Mint(cross(cur), addr01, tid(1))
 
 	tests := []struct {
 		name        string
-		setup       func()
+		setup       func(cur realm)
 		callerRealm runtime.Realm
 		approved    address
 		tokenId     uint64
@@ -1189,9 +1189,9 @@ func TestApprove(t *testing.T) {
 		},
 		{
 			name: "re-approve same address (idempotency)",
-			setup: func() {
+			setup: func(cur realm) {
 				testing.SetRealm(addr01Realm)
-				Approve(cross, addr02, tid(1))
+				Approve(cross(cur), addr02, tid(1))
 			},
 			callerRealm: addr01Realm,
 			approved:    addr02,
@@ -1201,19 +1201,19 @@ func TestApprove(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.setup != nil {
-				tt.setup()
+				tt.setup(cur)
 			}
 
 			testing.SetRealm(tt.callerRealm)
 
 			if tt.shouldPanic {
-				uassert.AbortsWithMessage(t, tt.panicMsg, func() {
-					Approve(cross, tt.approved, tid(tt.tokenId))
+				uassert.AbortsWithMessage(t, cur, tt.panicMsg, func() {
+					Approve(cross(cur), tt.approved, tid(tt.tokenId))
 				})
 			} else {
-				err := Approve(cross, tt.approved, tid(tt.tokenId))
+				err := Approve(cross(cur), tt.approved, tid(tt.tokenId))
 				uassert.NoError(t, err)
 
 				// Verify approval
@@ -1224,10 +1224,10 @@ func TestApprove(t *testing.T) {
 	}
 }
 
-func Test_setTokenURI(t *testing.T) {
+func Test_setTokenURI(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
-		setup         func()
+		setup         func(cur realm)
 		ownerAddr     address
 		tokenId       uint64
 		tokenURI      string
@@ -1237,7 +1237,7 @@ func Test_setTokenURI(t *testing.T) {
 	}{
 		{
 			name: "successfully sets URI for token owned by caller",
-			setup: func() {
+			setup: func(cur realm) {
 				// Mint token to position owner
 				ownerAddr := positionAddr
 				nft.Mint(ownerAddr, tid(100))
@@ -1249,7 +1249,7 @@ func Test_setTokenURI(t *testing.T) {
 		},
 		{
 			name: "fails for non-existent token",
-			setup: func() {
+			setup: func(cur realm) {
 				// No token minted
 			},
 			ownerAddr:     positionAddr,
@@ -1260,15 +1260,11 @@ func Test_setTokenURI(t *testing.T) {
 		},
 		{
 			name: "overwrites URI when already set (private function allows this)",
-			setup: func() {
+			setup: func(cur realm) {
 				// Mint and set URI
 				nft.Mint(positionAddr, tid(200))
-				// Set URI first time using nested realms
 				testing.SetRealm(testing.NewUserRealm(positionAddr))
-				func() {
-					testing.SetRealm(testing.NewCodeRealm("gno.land/r/test"))
-					setTokenURI(tid(200), grc721.TokenURI("first-uri"))
-				}()
+				callSetTokenURI(cross(cur), tid(200), grc721.TokenURI("first-uri"))
 			},
 			ownerAddr:     positionAddr,
 			tokenId:       200,
@@ -1277,7 +1273,7 @@ func Test_setTokenURI(t *testing.T) {
 		},
 		{
 			name: "fails when caller is not token owner",
-			setup: func() {
+			setup: func(cur realm) {
 				// Mint token to addr01
 				nft.Mint(addr01, tid(300))
 			},
@@ -1289,7 +1285,7 @@ func Test_setTokenURI(t *testing.T) {
 		},
 		{
 			name: "sets image params URI and verifies conversion to base64 SVG",
-			setup: func() {
+			setup: func(cur realm) {
 				// Mint token to position owner
 				ownerAddr := positionAddr
 				nft.Mint(ownerAddr, tid(400))
@@ -1308,7 +1304,7 @@ func Test_setTokenURI(t *testing.T) {
 		},
 		{
 			name: "sets plain URI and verifies it returns unchanged",
-			setup: func() {
+			setup: func(cur realm) {
 				// Mint token to position owner
 				ownerAddr := positionAddr
 				nft.Mint(ownerAddr, tid(500))
@@ -1326,7 +1322,7 @@ func Test_setTokenURI(t *testing.T) {
 		},
 		{
 			name: "sets invalid image params URI and verifies it returns error",
-			setup: func() {
+			setup: func(cur realm) {
 				// Mint token to position owner
 				ownerAddr := positionAddr
 				nft.Mint(ownerAddr, tid(500))
@@ -1345,21 +1341,18 @@ func Test_setTokenURI(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			// given
 			resetObject(t)
 
 			if tc.setup != nil {
-				tc.setup()
+				tc.setup(cur)
 			}
 
+
 			// when
-			var err error
 			testing.SetRealm(testing.NewUserRealm(tc.ownerAddr))
-			func() {
-				testing.SetRealm(testing.NewCodeRealm("gno.land/r/test"))
-				err = setTokenURI(tid(tc.tokenId), grc721.TokenURI(tc.tokenURI))
-			}()
+			err := callSetTokenURI(cross(cur), tid(tc.tokenId), grc721.TokenURI(tc.tokenURI))
 
 			// then
 			if tc.expectedError {
@@ -1382,6 +1375,10 @@ func Test_setTokenURI(t *testing.T) {
 			}
 		})
 	}
+}
+
+func callSetTokenURI(cur realm, tid grc721.TokenID, tURI grc721.TokenURI) error {
+	return setTokenURI(0, cur, tid, tURI)
 }
 
 func resetObject(t *testing.T) {

--- a/contract/r/gnoswap/gnft/svg_generator_test.gno
+++ b/contract/r/gnoswap/gnft/svg_generator_test.gno
@@ -10,14 +10,14 @@ import (
 	uassert "gno.land/p/nt/uassert/v0"
 )
 
-func TestSvgGenerator_genImageParamsString(t *testing.T) {
+func TestSvgGenerator_genImageParamsString(cur realm, t *testing.T) {
 	seed1 := uint64(time.Now().Unix())
 	seed2 := uint64(time.Now().UnixNano())
 	pcg := rand.NewPCG(seed1, seed2)
 	r := rand.New(pcg)
 
 	var params string
-	uassert.NotPanics(t, func() {
+	uassert.NotPanics(t, cur, func() {
 		params = genImageParamsString(r)
 	})
 
@@ -30,7 +30,7 @@ func TestSvgGenerator_genImageParamsString(t *testing.T) {
 	uassert.True(t, strings.HasPrefix(parts[5], "#"))
 }
 
-func TestSvgGenerator_generateImageURI(t *testing.T) {
+func TestSvgGenerator_generateImageURI(cur realm, t *testing.T) {
 	tests := []struct {
 		name   string
 		params string
@@ -50,12 +50,12 @@ func TestSvgGenerator_generateImageURI(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			params, err := parseImageParams(tc.params)
 			uassert.NoError(t, err)
 
 			var uri string
-			uassert.NotPanics(t, func() {
+			uassert.NotPanics(t, cur, func() {
 				uri = params.generateImageURI()
 			})
 
@@ -77,7 +77,7 @@ func TestSvgGenerator_generateImageURI(t *testing.T) {
 	}
 }
 
-func TestSvgGenerator_generateSVG(t *testing.T) {
+func TestSvgGenerator_generateSVG(cur realm, t *testing.T) {
 	tests := []struct {
 		name   string
 		params string
@@ -97,7 +97,7 @@ func TestSvgGenerator_generateSVG(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			// Parse params first
 			p, err := parseImageParams(tc.params)
 			uassert.NoError(t, err)
@@ -115,7 +115,7 @@ func TestSvgGenerator_generateSVG(t *testing.T) {
 	}
 }
 
-func TestSvgGenerator_paramsToImageRaw_ColorFormat(t *testing.T) {
+func TestSvgGenerator_paramsToImageRaw_ColorFormat(cur realm, t *testing.T) {
 	params := "10,12,125,123,#AABBCC,#DDEEFF"
 	p, err := parseImageParams(params)
 	uassert.NoError(t, err)
@@ -144,7 +144,7 @@ func TestSvgGenerator_paramsToImageRaw_ColorFormat(t *testing.T) {
 	}
 }
 
-func TestSvgGenerator_paramsToImageRaw_CoordinateRanges(t *testing.T) {
+func TestSvgGenerator_paramsToImageRaw_CoordinateRanges(cur realm, t *testing.T) {
 	tests := []struct {
 		name   string
 		params string
@@ -180,7 +180,7 @@ func TestSvgGenerator_paramsToImageRaw_CoordinateRanges(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			p, err := parseImageParams(tc.params)
 			uassert.NoError(t, err)
 			svg := p.generateSVG()
@@ -199,7 +199,7 @@ func TestSvgGenerator_paramsToImageRaw_CoordinateRanges(t *testing.T) {
 	}
 }
 
-func TestSvgGenerator_genImageParamsString_CoordinateRanges(t *testing.T) {
+func TestSvgGenerator_genImageParamsString_CoordinateRanges(cur realm, t *testing.T) {
 	tests := []struct {
 		name  string
 		seed1 uint64
@@ -218,7 +218,7 @@ func TestSvgGenerator_genImageParamsString_CoordinateRanges(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			pcg := rand.NewPCG(tc.seed1, tc.seed2)
 			r := rand.New(pcg)
 
@@ -247,7 +247,7 @@ func TestSvgGenerator_genImageParamsString_CoordinateRanges(t *testing.T) {
 	}
 }
 
-func TestSvgGenerator_roundTrip(t *testing.T) {
+func TestSvgGenerator_roundTrip(cur realm, t *testing.T) {
 	tests := []struct {
 		name  string
 		seed1 uint64
@@ -266,7 +266,7 @@ func TestSvgGenerator_roundTrip(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			pcg := rand.NewPCG(tc.seed1, tc.seed2)
 			r := rand.New(pcg)
 
@@ -294,7 +294,7 @@ func TestSvgGenerator_roundTrip(t *testing.T) {
 	}
 }
 
-func TestSvgGenerator_paramsToImageRaw_InvalidParams(t *testing.T) {
+func TestSvgGenerator_paramsToImageRaw_InvalidParams(cur realm, t *testing.T) {
 	tests := []struct {
 		name   string
 		params string
@@ -326,7 +326,7 @@ func TestSvgGenerator_paramsToImageRaw_InvalidParams(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			_, err := parseImageParams(tc.params)
 			uassert.Error(t, err)
 			uassert.Equal(t, errInvalidTokenParams.Error(), err.Error())
@@ -334,7 +334,7 @@ func TestSvgGenerator_paramsToImageRaw_InvalidParams(t *testing.T) {
 	}
 }
 
-func TestSvgGenerator_uniqueness(t *testing.T) {
+func TestSvgGenerator_uniqueness(cur realm, t *testing.T) {
 	paramsMap := make(map[string]bool)
 
 	for i := 0; i < 5; i++ {
@@ -354,7 +354,7 @@ func TestSvgGenerator_uniqueness(t *testing.T) {
 
 // TestSvgGenerator_outputConsistency verifies that the new param-based approach
 // produces identical SVG output as the old direct generation approach.
-func TestSvgGenerator_outputConsistency(t *testing.T) {
+func TestSvgGenerator_outputConsistency(cur realm, t *testing.T) {
 	tests := []struct {
 		name  string
 		seed1 uint64
@@ -383,7 +383,7 @@ func TestSvgGenerator_outputConsistency(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			// Generate using old method (simulated)
 			pcg1 := rand.NewPCG(tc.seed1, tc.seed2)
 			r1 := rand.New(pcg1)
@@ -443,7 +443,7 @@ func itoa(n int) string {
 }
 
 // TestSvgGenerator_boundaryValues tests all boundary values for coordinates.
-func TestSvgGenerator_boundaryValues(t *testing.T) {
+func TestSvgGenerator_boundaryValues(cur realm, t *testing.T) {
 	tests := []struct {
 		name   string
 		params string
@@ -503,11 +503,11 @@ func TestSvgGenerator_boundaryValues(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			if tc.valid {
 				p, err := parseImageParams(tc.params)
 				uassert.NoError(t, err)
-				uassert.NotPanics(t, func() {
+				uassert.NotPanics(t, cur, func() {
 					p.generateSVG()
 				})
 			}
@@ -516,7 +516,7 @@ func TestSvgGenerator_boundaryValues(t *testing.T) {
 }
 
 // TestSvgGenerator_outOfRangeValues tests coordinates outside valid ranges.
-func TestSvgGenerator_outOfRangeValues(t *testing.T) {
+func TestSvgGenerator_outOfRangeValues(cur realm, t *testing.T) {
 	tests := []struct {
 		name   string
 		params string
@@ -573,7 +573,7 @@ func TestSvgGenerator_outOfRangeValues(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			_, err := parseImageParams(tc.params)
 			uassert.Error(t, err)
 			// Error now includes detailed coordinate info, check contains base error
@@ -584,7 +584,7 @@ func TestSvgGenerator_outOfRangeValues(t *testing.T) {
 
 // TestSvgGenerator_outOfRangeValues_DetailedErrors verifies that error messages
 // contain specific coordinate information for easier debugging.
-func TestSvgGenerator_outOfRangeValues_DetailedErrors(t *testing.T) {
+func TestSvgGenerator_outOfRangeValues_DetailedErrors(cur realm, t *testing.T) {
 	tests := []struct {
 		name              string
 		params            string
@@ -651,7 +651,7 @@ func TestSvgGenerator_outOfRangeValues_DetailedErrors(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			_, err := parseImageParams(tc.params)
 			uassert.Error(t, err)
 
@@ -669,7 +669,7 @@ func TestSvgGenerator_outOfRangeValues_DetailedErrors(t *testing.T) {
 }
 
 // TestSvgGenerator_invalidColorFormat tests invalid color formats.
-func TestSvgGenerator_invalidColorFormat(t *testing.T) {
+func TestSvgGenerator_invalidColorFormat(cur realm, t *testing.T) {
 	tests := []struct {
 		name   string
 		params string
@@ -717,7 +717,7 @@ func TestSvgGenerator_invalidColorFormat(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			_, err := parseImageParams(tc.params)
 			uassert.Error(t, err)
 			uassert.Equal(t, errInvalidColorFormat.Error(), err.Error())
@@ -726,7 +726,7 @@ func TestSvgGenerator_invalidColorFormat(t *testing.T) {
 }
 
 // TestSvgGenerator_isValidHexColor tests the hex color validation function.
-func TestSvgGenerator_isValidHexColor(t *testing.T) {
+func TestSvgGenerator_isValidHexColor(cur realm, t *testing.T) {
 	tests := []struct {
 		name     string
 		color    string
@@ -751,7 +751,7 @@ func TestSvgGenerator_isValidHexColor(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			result := isValidHexColor(tc.color)
 			uassert.Equal(t, tc.expected, result)
 		})
@@ -760,7 +760,7 @@ func TestSvgGenerator_isValidHexColor(t *testing.T) {
 
 // TestSvgGenerator_genImageParamsString_alwaysProducesValidOutput tests that genImageParamsString
 // always produces output that passes validation in paramsToImageRaw.
-func TestSvgGenerator_genImageParamsString_alwaysProducesValidOutput(t *testing.T) {
+func TestSvgGenerator_genImageParamsString_alwaysProducesValidOutput(cur realm, t *testing.T) {
 	// Test with many different seeds to ensure robustness
 	for i := 0; i < 100; i++ {
 		seed1 := uint64(i * 12345)
@@ -773,7 +773,7 @@ func TestSvgGenerator_genImageParamsString_alwaysProducesValidOutput(t *testing.
 		uassert.NoError(t, err)
 
 		// Should never panic
-		uassert.NotPanics(t, func() {
+		uassert.NotPanics(t, cur, func() {
 			svg := p.generateSVG()
 			// Verify basic SVG structure
 			uassert.True(t, strings.Contains(svg, "<svg"))
@@ -845,7 +845,7 @@ func extractIntValue(t *testing.T, text, prefix string) int {
 
 // TestSvgGenerator_parseImageParams tests the parseImageParams function
 // which validates and parses the expected parameter format.
-func TestSvgGenerator_parseImageParams(t *testing.T) {
+func TestSvgGenerator_parseImageParams(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
 		input         string
@@ -1009,7 +1009,7 @@ func TestSvgGenerator_parseImageParams(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			_, err := parseImageParams(tc.input)
 			if tc.expectedError == nil {
 				uassert.NoError(t, err)

--- a/contract/r/gnoswap/gnft/utils.gno
+++ b/contract/r/gnoswap/gnft/utils.gno
@@ -25,7 +25,7 @@ func checkErr(err error) {
 }
 
 // checkTransferErr wraps transfer errors with more specific context.
-func checkTransferErr(caller address, err error, from, to address, tid grc721.TokenID) {
+func checkTransferErr(err error, caller, from, to address, tid grc721.TokenID) {
 	if err == nil {
 		return
 	}
@@ -67,7 +67,7 @@ func checkTransferErr(caller address, err error, from, to address, tid grc721.To
 }
 
 // checkApproveErr wraps approve errors with more specific context.
-func checkApproveErr(caller address, err error, approved address, tid grc721.TokenID) {
+func checkApproveErr(err error, caller, approved address, tid grc721.TokenID) {
 	if err == nil {
 		return
 	}

--- a/contract/r/gnoswap/gnft/utils.gno
+++ b/contract/r/gnoswap/gnft/utils.gno
@@ -1,7 +1,6 @@
 package gnft
 
 import (
-	"chain/runtime"
 	"math/rand"
 	"time"
 
@@ -26,12 +25,10 @@ func checkErr(err error) {
 }
 
 // checkTransferErr wraps transfer errors with more specific context.
-func checkTransferErr(err error, from, to address, tid grc721.TokenID) {
+func checkTransferErr(caller address, err error, from, to address, tid grc721.TokenID) {
 	if err == nil {
 		return
 	}
-
-	caller := runtime.PreviousRealm().Address()
 
 	// Check if token exists
 	owner, ownerErr := nft.OwnerOf(tid)
@@ -70,13 +67,12 @@ func checkTransferErr(err error, from, to address, tid grc721.TokenID) {
 }
 
 // checkApproveErr wraps approve errors with more specific context.
-func checkApproveErr(err error, approved address, tid grc721.TokenID) {
+func checkApproveErr(caller address, err error, approved address, tid grc721.TokenID) {
 	if err == nil {
 		return
 	}
 
 	errMsg := err.Error()
-	caller := runtime.PreviousRealm().Address()
 
 	// Check if token exists
 	owner, ownerErr := nft.OwnerOf(tid)


### PR DESCRIPTION
## Summary
- Migrate GNFT realm entrypoints and tests to Interrealm v2.
- Keep GNFT transfer and approval behavior aligned with GRC721 owner/approved/approved-for-all checks.
- Refresh GNFT README examples to use `cross(cur)` and document staked-token movement rules.

## Verification
- `make test PKG=gno.land/r/gnoswap/gnft`
- `GIT_MASTER=1 git diff --check origin/refactor/interrealm-v2...HEAD`