### PR TITLE
refactor(p/version_manager): migrate initializer to interrealm v2

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -425,6 +425,7 @@ No data migration required
 - Role-based storage permissions
 - Namespace isolation
 - Admin-only upgrade functions
+- Realm tokens are threaded explicitly into the version manager and validated via `rlm.IsCurrent()`, rejecting spoofed or stale crossing-frame tokens
 
 ### 3. Emergency Halt
 
@@ -459,14 +460,18 @@ func init() {
 // In pool/upgrade.gno
 func UpgradeImpl(cur realm, packagePath string) {
     caller := runtime.PreviousRealm().Address()
-    access.AssertIsAdmin(caller)
+    access.AssertIsAdminOrGovernance(caller)
 
-    if _, ok := initializers[packagePath]; !ok {
-        panic("Initializer not found")
+    // Thread the live crossing-frame token into the version manager. The
+    // leading 0 is the v2 interrealm sentinel; the manager validates
+    // rlm.IsCurrent() to reject spoofed/stale tokens before switching.
+    if err := versionManager.ChangeImplementation(0, cur, packagePath); err != nil {
+        panic(err)
     }
 
-    poolImpl = initializers[packagePath](NewPoolStore(kvStore))
-    // Update storage permissions...
+    if err := updateImplementation(); err != nil {
+        panic(err)
+    }
 }
 ```
 

--- a/contract/p/gnoswap/version_manager/README.md
+++ b/contract/p/gnoswap/version_manager/README.md
@@ -47,7 +47,9 @@ func init() {
     manager = version_manager.NewVersionManager(
         "gno.land/r/gnoswap/protocol_fee",
         kvStore,
-        func(kv store.KVStore) any {
+        // initializeDomainStoreFn carries the v2 interrealm marker (`_ int, rlm realm`):
+        // the leading 0 surfaces realm-threading at the call site.
+        func(_ int, rlm realm, kv store.KVStore) any {
             return NewProtocolFeeStore(kv)
         },
     )
@@ -55,6 +57,24 @@ func init() {
 
 func GetManager() version_manager.VersionManager {
     return manager
+}
+
+// RegisterInitializer is the crossing entry point each version package calls.
+// `cur` is the live crossing-frame realm token; it is threaded straight into the
+// version manager (the leading 0 is the v2 sentinel) so the manager can reject
+// spoofed/stale tokens via rlm.IsCurrent() and identify the caller via rlm.Previous().
+func RegisterInitializer(cur realm, initializer func(_ int, rlm realm, store any) any) {
+    if err := manager.RegisterInitializer(0, cur, initializer); err != nil {
+        panic(err)
+    }
+}
+
+// UpgradeImpl switches the active version. Authorization (admin / governance) is
+// enforced here in the /r/ realm; version_manager only rejects spoofed tokens.
+func UpgradeImpl(cur realm, packagePath string) {
+    if err := manager.ChangeImplementation(0, cur, packagePath); err != nil {
+        panic(err)
+    }
 }
 ```
 
@@ -71,9 +91,10 @@ type protocolFeeV1 struct {
 }
 
 func init() {
-    // Register this version during package initialization
-    manager := protocol_fee.GetManager()
-    manager.RegisterInitializer(func(store any) any {
+    // Register this version during package initialization.
+    // `cross` invokes the domain's crossing entry point, which threads the
+    // live realm token into the version manager.
+    protocol_fee.RegisterInitializer(cross, func(_ int, rlm realm, store any) any {
         return &protocolFeeV1{store: store}
     })
 }
@@ -96,9 +117,8 @@ type protocolFeeV2 struct {
 }
 
 func init() {
-    // Register v2
-    manager := protocol_fee.GetManager()
-    manager.RegisterInitializer(func(store any) any {
+    // Register v2 — read-only until explicitly activated.
+    protocol_fee.RegisterInitializer(cross, func(_ int, rlm realm, store any) any {
         return &protocolFeeV2{store: store}
     })
 }
@@ -130,12 +150,11 @@ func UseFee() {
 ### Step 5: Switch Versions at Runtime
 
 ```go
-// governance or admin function
-func UpgradeToV2() error {
-    manager := protocol_fee.GetManager()
-
-    // Hot-swap to v2 - zero downtime
-    return manager.ChangeImplementation("gno.land/r/gnoswap/protocol_fee/v2")
+// governance or admin entry point
+func UpgradeToV2(cur realm) {
+    // Hot-swap to v2 — zero downtime. `cross` enters UpgradeImpl's crossing
+    // frame; UpgradeImpl threads the realm token into the version manager.
+    protocol_fee.UpgradeImpl(cross, "gno.land/r/gnoswap/protocol_fee/v2")
 }
 ```
 
@@ -146,11 +165,12 @@ func UpgradeToV2() error {
 ```
 1. Domain package initializes version manager with KVStore
    ↓
-2. v1 package calls RegisterInitializer during init()
+2. v1 package calls RegisterInitializer (via the domain's crossing wrapper) during init()
+   → Manager validates the realm token (rlm.IsCurrent()) and caller domain path
    → Becomes active implementation
    ↓
 3. v2 package calls RegisterInitializer during init()
-   → Registered
+   → Registered (read-only until activated)
    ↓
 4. v3 package calls RegisterInitializer during init()
    → Registered
@@ -159,22 +179,25 @@ func UpgradeToV2() error {
 ### Version Switching Flow
 
 ```
-1. Admin calls ChangeImplementation("path/to/v2")
+1. Admin/governance calls ChangeImplementation (via the domain's UpgradeImpl wrapper)
+   → Authorization is enforced in the /r/ wrapper
    ↓
-2. Version Manager retrieves v2's initializer
+2. Version Manager validates the realm token (rlm.IsCurrent()), rejecting spoofed/stale tokens
    ↓
-3. Executes v2 initializer with shared KVStore
+3. Version Manager retrieves v2's initializer
    ↓
-4. Updates currentImplementation pointer to v2
+4. Executes v2 initializer with shared KVStore
    ↓
-5. v2 is now the active implementation
+5. Updates currentImplementation pointer to v2
+   ↓
+6. v2 is now the active implementation
 ```
 
 ### Storage Access Model
 
 - **Domain Ownership**: The domain (proxy) realm owns the KVStore and has write permission
-- **Realm Context Preservation**: When domain calls implementation, `runtime.CurrentRealm()` remains the domain realm
-- **No Direct Permission Grants**: Implementation realms do not receive storage permissions directly
+- **Explicit Realm Threading**: Registration/upgrade calls thread the live crossing-frame token (`rlm`) into the manager instead of relying on `runtime.CurrentRealm()`. The manager validates it with `rlm.IsCurrent()` (rejecting spoofed/stale tokens) and identifies the registering version package via `rlm.Previous()`
+- **No Direct Permission Grants**: Implementation realms do not receive storage permissions directly; the proxy realm drives all storage access
 - **Security by Design**: External callers cannot invoke implementation realms to modify storage
 
 ### Best Practices
@@ -189,6 +212,7 @@ func UpgradeToV2() error {
 
 The package returns errors for:
 
+- A spoofed or stale realm token (`rlm.IsCurrent() == false` → `ErrSpoofedRealm`)
 - Unauthorized caller attempting to register (not in domain path)
 - Duplicate registration of the same package path
 - Attempting to switch to an unregistered version
@@ -202,7 +226,7 @@ Upgrade DeFi protocol logic without disrupting active users:
 
 ```go
 // Upgrade fee calculation algorithm
-manager.ChangeImplementation("gno.land/r/gnoswap/protocol_fee/v2")
+protocol_fee.UpgradeImpl(cross, "gno.land/r/gnoswap/protocol_fee/v2")
 ```
 
 ### A/B Testing
@@ -211,10 +235,10 @@ Test new implementations before full rollout:
 
 ```go
 // Switch to experimental version
-manager.ChangeImplementation("gno.land/r/gnoswap/protocol_fee/experimental")
+protocol_fee.UpgradeImpl(cross, "gno.land/r/gnoswap/protocol_fee/experimental")
 
 // Rollback if issues detected
-manager.ChangeImplementation("gno.land/r/gnoswap/protocol_fee/v1")
+protocol_fee.UpgradeImpl(cross, "gno.land/r/gnoswap/protocol_fee/v1")
 ```
 
 ### Emergency Response
@@ -223,14 +247,14 @@ Quickly switch to a patched version during security incidents:
 
 ```go
 // Deploy fixed version and immediately activate
-manager.ChangeImplementation("gno.land/r/gnoswap/protocol_fee/v1_hotfix")
+protocol_fee.UpgradeImpl(cross, "gno.land/r/gnoswap/protocol_fee/v1_hotfix")
 ```
 
 ## Implementation Notes
 
 - Built on Strategy Pattern for runtime algorithm swapping
 - Uses Plugin Architecture for dynamic version loading
-- Storage access controlled via realm context (`runtime.CurrentRealm()`)
+- Storage access is driven by the proxy realm; the live realm token is threaded explicitly (the v2 `_ int, rlm realm` marker) and validated via `rlm.IsCurrent()`
 - No data migration required - all versions share the same storage
 - Type assertions required when retrieving current implementation
 - Map used for efficient initializer storage and lookup

--- a/contract/p/gnoswap/version_manager/doc.gno
+++ b/contract/p/gnoswap/version_manager/doc.gno
@@ -119,7 +119,7 @@
 //	func init() {
 //	    // Register this version during package initialization
 //	    manager := protocol_fee.GetManager()
-//	    manager.RegisterInitializer(func(store any) any {
+//	    manager.RegisterInitializer(func(_ int, rlm realm, store any) any {
 //	        return &protocolFeeV1{store: store}
 //	    })
 //	}
@@ -153,7 +153,7 @@
 //	func init() {
 //	    // Register v2 - will be read-only until explicitly activated
 //	    manager := protocol_fee.GetManager()
-//	    manager.RegisterInitializer(func(store any) any {
+//	    manager.RegisterInitializer(func(_ int, rlm realm, store any) any {
 //	        return &protocolFeeV2{store: store}
 //	    })
 //	}

--- a/contract/p/gnoswap/version_manager/types.gno
+++ b/contract/p/gnoswap/version_manager/types.gno
@@ -24,7 +24,7 @@ type VersionManager interface {
 	// visible to the reader, and rlm is the live crossing-frame token that
 	// the implementation validates via rlm.IsCurrent() and reads via
 	// rlm.Previous() to identify the version package.
-	RegisterInitializer(_ int, rlm realm, initializer func(store any) any) error
+	RegisterInitializer(_ int, rlm realm, initializer func(_ int, rlm realm, store any) any) error
 
 	// ChangeImplementation switches the active version at runtime.
 	// The new active version gets write access, while others remain read-only.
@@ -39,7 +39,7 @@ type VersionManager interface {
 	GetDomainPath() string
 
 	// GetInitializers returns all registered version initializers
-	GetInitializers() map[string]func(store any) any
+	GetInitializers() map[string]func(_ int, rlm realm, store any) any
 
 	// GetCurrentPackagePath returns the package path of the active implementation
 	GetCurrentPackagePath() string

--- a/contract/p/gnoswap/version_manager/version_manager.gno
+++ b/contract/p/gnoswap/version_manager/version_manager.gno
@@ -35,7 +35,7 @@ var ErrSpoofedRealm = errors.New("rlm does not match the current crossing frame"
 type versionManager struct {
 	// initializers stores registered initializer functions keyed by package path
 	// Each initializer bootstraps a specific version's implementation
-	initializers map[string]func(store any) any
+	initializers map[string]func(_ int, rlm realm, store any) any
 
 	// domainKVStore is the shared storage layer accessible by all versions
 	// The domain (proxy) realm is the owner and has write permission
@@ -43,7 +43,7 @@ type versionManager struct {
 
 	// initializeDomainStoreFn wraps the KVStore into domain-specific storage interface
 	// This abstraction decouples the version manager from domain-specific storage implementations
-	initializeDomainStoreFn func(kvStore store.KVStore) any
+	initializeDomainStoreFn func(_ int, rlm realm, kvStore store.KVStore) any
 
 	// domainPath defines the base path for this domain (e.g., "gno.land/r/gnoswap/protocol_fee")
 	// Used for security validation to ensure only authorized packages can register
@@ -75,7 +75,7 @@ type versionManager struct {
 //   - error: If realm token is spoofed, caller is unauthorized, already registered, or initializer is nil
 //
 // Security: Only packages under the domainPath prefix can register (enforced by isContainDomainPath).
-func (vm *versionManager) RegisterInitializer(_ int, rlm realm, initializer func(store any) any) error {
+func (vm *versionManager) RegisterInitializer(_ int, rlm realm, initializer func(_ int, rlm realm, store any) any) error {
 	if !rlm.IsCurrent() {
 		return ErrSpoofedRealm
 	}
@@ -114,7 +114,7 @@ func (vm *versionManager) RegisterInitializer(_ int, rlm realm, initializer func
 	// Initialize the current implementation if it hasn't been done yet
 	if vm.currentPackagePath == "" || vm.currentImplementation == nil {
 		vm.currentPackagePath = targetPackagePath
-		vm.currentImplementation = initializer(vm.initializeDomainStoreFn(vm.domainKVStore))
+		vm.currentImplementation = initializer(0, rlm, vm.initializeDomainStoreFn(0, rlm, vm.domainKVStore))
 
 		chain.Emit(
 			"InitializeImplementation",
@@ -162,7 +162,7 @@ func (vm *versionManager) ChangeImplementation(_ int, rlm realm, packagePath str
 
 	prevPackagePath := vm.currentPackagePath
 	vm.currentPackagePath = packagePath
-	vm.currentImplementation = initializer(vm.initializeDomainStoreFn(vm.domainKVStore))
+	vm.currentImplementation = initializer(0, rlm, vm.initializeDomainStoreFn(0, rlm, vm.domainKVStore))
 
 	chain.Emit(
 		"ChangeImplementation",
@@ -183,7 +183,7 @@ func (vm *versionManager) GetDomainPath() string {
 // GetInitializers returns the map containing all registered initializer functions.
 // Keys are package paths, values are initializer functions.
 // Useful for inspecting which versions are available.
-func (vm *versionManager) GetInitializers() map[string]func(store any) any {
+func (vm *versionManager) GetInitializers() map[string]func(_ int, rlm realm, store any) any {
 	return vm.initializers
 }
 
@@ -243,13 +243,13 @@ func (vm *versionManager) isContainDomainPath(targetPackagePath string) bool {
 func NewVersionManager(
 	domainPath string,
 	kvStore store.KVStore,
-	initializeDomainStoreFn func(kvStore store.KVStore) any,
+	initializeDomainStoreFn func(_ int, rlm realm, kvStore store.KVStore) any,
 ) VersionManager {
 	return &versionManager{
 		domainPath:              domainPath,
 		domainKVStore:           kvStore,
 		initializeDomainStoreFn: initializeDomainStoreFn,
-		initializers:            make(map[string]func(store any) any),
+		initializers:            make(map[string]func(_ int, rlm realm, store any) any),
 		currentPackagePath:      "",
 		currentImplementation:   nil,
 	}
@@ -258,13 +258,13 @@ func NewVersionManager(
 // makeInitializerSafe creates a safe copy of an initializer function.
 // Used to verify stored initializer types during inspection.
 func makeInitializerSafe(data any) any {
-	fn, ok := data.(func(store any) any)
+	fn, ok := data.(func(_ int, rlm realm, store any) any)
 	if !ok {
-		panic(ufmt.Sprintf("expected func(store any) any, got %T", data))
+		panic(ufmt.Sprintf("expected func(_ int, rlm realm, store any) any, got %T", data))
 	}
 
-	cpy := func(store any) any {
-		return fn(store)
+	cpy := func(_ int, rlm realm, store any) any {
+		return fn(0, rlm, store)
 	}
 
 	return cpy

--- a/contract/p/gnoswap/version_manager/version_manager_test.gno
+++ b/contract/p/gnoswap/version_manager/version_manager_test.gno
@@ -188,7 +188,7 @@ func TestChangeImplementation_Errors(cur realm, t *testing.T) {
 					domainPath:              "gno.land/r/gnoswap/protocol_fee",
 					domainKVStore:           kvStore,
 					initializeDomainStoreFn: mockInitializeDomainStoreFn,
-					initializers:            make(map[string]func(store any) any),
+					initializers:            make(map[string]func(_ int, rlm realm, store any) any),
 				}
 				return vm, "gno.land/r/gnoswap/protocol_fee/v999"
 			},
@@ -202,7 +202,7 @@ func TestChangeImplementation_Errors(cur realm, t *testing.T) {
 					domainPath:              "gno.land/r/gnoswap/pool",
 					domainKVStore:           kvStore,
 					initializeDomainStoreFn: mockInitializeDomainStoreFn,
-					initializers:            make(map[string]func(store any) any),
+					initializers:            make(map[string]func(_ int, rlm realm, store any) any),
 				}
 				return vm, ""
 			},
@@ -217,7 +217,7 @@ func TestChangeImplementation_Errors(cur realm, t *testing.T) {
 					domainPath:              "gno.land/r/gnoswap/position",
 					domainKVStore:           kvStore,
 					initializeDomainStoreFn: mockInitializeDomainStoreFn,
-					initializers:            make(map[string]func(store any) any),
+					initializers:            make(map[string]func(_ int, rlm realm, store any) any),
 				}
 				vm.initializers["gno.land/r/gnoswap/position/v1"] = nil
 				return vm, "gno.land/r/gnoswap/position/v1"
@@ -245,14 +245,14 @@ func newMockStore(version string) *mockStore {
 }
 
 // Mock initializer function that returns a store wrapper
-func mockInitializer(version string) func(store any) any {
-	return func(store any) any {
+func mockInitializer(version string) func(_ int, rlm realm, store any) any {
+	return func(_ int, rlm realm, store any) any {
 		return newMockStore(version)
 	}
 }
 
 // initializeDomainStoreFn wrapper function
-func mockInitializeDomainStoreFn(kvStore store.KVStore) any {
+func mockInitializeDomainStoreFn(_ int, rlm realm, kvStore store.KVStore) any {
 	return kvStore
 }
 
@@ -394,7 +394,7 @@ func TestChangeImplementation_Success(cur realm, t *testing.T) {
 				domainPath:              tt.domainPath,
 				domainKVStore:           kvStore,
 				initializeDomainStoreFn: mockInitializeDomainStoreFn,
-				initializers:            make(map[string]func(store any) any),
+				initializers:            make(map[string]func(_ int, rlm realm, store any) any),
 				currentPackagePath:      "",
 				currentImplementation:   nil,
 			}
@@ -428,7 +428,7 @@ func TestGetInitializers(cur realm, t *testing.T) {
 			domainPath:              "gno.land/r/gnoswap/protocol_fee",
 			domainKVStore:           kvStore,
 			initializeDomainStoreFn: mockInitializeDomainStoreFn,
-			initializers:            make(map[string]func(store any) any),
+			initializers:            make(map[string]func(_ int, rlm realm, store any) any),
 		}
 
 		vm.initializers["gno.land/r/gnoswap/protocol_fee/v1"] = mockInitializer("v1")
@@ -449,7 +449,7 @@ func TestGetInitializers(cur realm, t *testing.T) {
 			domainPath:              "gno.land/r/gnoswap/pool",
 			domainKVStore:           kvStore,
 			initializeDomainStoreFn: mockInitializeDomainStoreFn,
-			initializers:            make(map[string]func(store any) any),
+			initializers:            make(map[string]func(_ int, rlm realm, store any) any),
 		}
 
 		versions := []string{"v1", "v2", "v3"}
@@ -475,7 +475,7 @@ func TestGetInitializers(cur realm, t *testing.T) {
 			domainPath:              "gno.land/r/gnoswap/position",
 			domainKVStore:           kvStore,
 			initializeDomainStoreFn: mockInitializeDomainStoreFn,
-			initializers:            make(map[string]func(store any) any),
+			initializers:            make(map[string]func(_ int, rlm realm, store any) any),
 		}
 
 		initializers := vm.GetInitializers()
@@ -508,7 +508,7 @@ func TestMakeInitializerSafe_InvalidType(cur realm, t *testing.T) {
 		},
 		{
 			name: "valid function does not panic",
-			input: func(store any) any {
+			input: func(_ int, rlm realm, store any) any {
 				return store
 			},
 			wantPanic: false,
@@ -628,7 +628,7 @@ func TestIsContainDomainPath(cur realm, t *testing.T) {
 				domainPath:              tt.domainPath,
 				domainKVStore:           kvStore,
 				initializeDomainStoreFn: mockInitializeDomainStoreFn,
-				initializers:            make(map[string]func(store any) any),
+				initializers:            make(map[string]func(_ int, rlm realm, store any) any),
 			}
 
 			result := vm.isContainDomainPath(tt.testPath)
@@ -691,7 +691,7 @@ func TestChangeImplementation_StateConsistency(cur realm, t *testing.T) {
 				domainPath:              tt.domainPath,
 				domainKVStore:           kvStore,
 				initializeDomainStoreFn: mockInitializeDomainStoreFn,
-				initializers:            make(map[string]func(store any) any),
+				initializers:            make(map[string]func(_ int, rlm realm, store any) any),
 				currentPackagePath:      "",
 				currentImplementation:   nil,
 			}

--- a/contract/r/gnoswap/gov/governance/_helper_test.gno
+++ b/contract/r/gnoswap/gov/governance/_helper_test.gno
@@ -21,7 +21,7 @@ func resetTestState(t *testing.T) {
 	versionManager = version_manager.NewVersionManager(
 		"gno.land/r/gnoswap/gov/governance",
 		kvStore,
-		func(_ store.KVStore) any {
+		func(_ int, rlm realm, _ store.KVStore) any {
 			return NewGovernanceStore(kvStore)
 		},
 	)

--- a/contract/r/gnoswap/gov/governance/state.gno
+++ b/contract/r/gnoswap/gov/governance/state.gno
@@ -27,7 +27,7 @@ func init() {
 	implementation = nil
 }
 
-func initializeDomainStore(kvStore store.KVStore) any {
+func initializeDomainStore(_ int, rlm realm, kvStore store.KVStore) any {
 	return NewGovernanceStore(kvStore)
 }
 

--- a/contract/r/gnoswap/gov/governance/upgrade.gno
+++ b/contract/r/gnoswap/gov/governance/upgrade.gno
@@ -7,7 +7,7 @@ import (
 )
 
 func RegisterInitializer(cur realm, initializer func(governanceStore IGovernanceStore, stakerAccessor GovStakerAccessor) IGovernance) {
-	initializerFunc := func(domainStore any) any {
+	initializerFunc := func(_ int, rlm realm, domainStore any) any {
 		currentGovernanceStore, ok := domainStore.(IGovernanceStore)
 		if !ok {
 			panic("domainStore is not an IGovernanceStore")

--- a/contract/r/gnoswap/gov/staker/_helper_test.gno
+++ b/contract/r/gnoswap/gov/staker/_helper_test.gno
@@ -21,7 +21,7 @@ func resetTestState(t *testing.T) {
 	versionManager = version_manager.NewVersionManager(
 		"gno.land/r/gnoswap/gov/staker",
 		kvStore,
-		func(_ store.KVStore) any {
+		func(_ int, rlm realm, _ store.KVStore) any {
 			return NewGovStakerStore(kvStore)
 		},
 	)

--- a/contract/r/gnoswap/gov/staker/state.gno
+++ b/contract/r/gnoswap/gov/staker/state.gno
@@ -29,7 +29,7 @@ func init() {
 	implementation = nil
 }
 
-func initializeDomainStore(kvStore store.KVStore) any {
+func initializeDomainStore(_ int, rlm realm, kvStore store.KVStore) any {
 	return NewGovStakerStore(kvStore)
 }
 

--- a/contract/r/gnoswap/gov/staker/state_test.gno
+++ b/contract/r/gnoswap/gov/staker/state_test.gno
@@ -8,13 +8,13 @@ import (
 )
 
 // TestState_initializeDomainStore tests the private initializeDomainStore function
-func TestState_initializeDomainStore(t *testing.T) {
+func TestState_initializeDomainStore(cur realm, t *testing.T) {
 	t.Run("initialize domain store", func(t *testing.T) {
 		// given
 		testKvStore := store.NewKVStore(currentAddress)
 
 		// when
-		result := initializeDomainStore(testKvStore)
+		result := initializeDomainStore(0, cur, testKvStore)
 
 		// then
 		uassert.NotNil(t, result)

--- a/contract/r/gnoswap/gov/staker/upgrade.gno
+++ b/contract/r/gnoswap/gov/staker/upgrade.gno
@@ -9,7 +9,7 @@ import (
 // RegisterInitializer registers an implementation
 // This function is called by each implementation version during init
 func RegisterInitializer(cur realm, initializer func(govStakerStore IGovStakerStore) IGovStaker) {
-	initializerFunc := func(domainStore any) any {
+	initializerFunc := func(_ int, rlm realm, domainStore any) any {
 		currentGovStakerStore, ok := domainStore.(IGovStakerStore)
 		if !ok {
 			panic("domainStore is not an IGovStakerStore")

--- a/contract/r/gnoswap/launchpad/_helper_test.gno
+++ b/contract/r/gnoswap/launchpad/_helper_test.gno
@@ -21,7 +21,7 @@ func resetTestState(t *testing.T) {
 	versionManager = version_manager.NewVersionManager(
 		"gno.land/r/gnoswap/launchpad",
 		kvStore,
-		func(_ store.KVStore) any {
+		func(_ int, rlm realm, _ store.KVStore) any {
 			return NewLaunchpadStore(kvStore)
 		},
 	)

--- a/contract/r/gnoswap/launchpad/state.gno
+++ b/contract/r/gnoswap/launchpad/state.gno
@@ -34,7 +34,7 @@ func init() {
 	implementation = nil
 }
 
-func initializeDomainStore(kvStore store.KVStore) any {
+func initializeDomainStore(_ int, rlm realm, kvStore store.KVStore) any {
 	return NewLaunchpadStore(kvStore)
 }
 

--- a/contract/r/gnoswap/launchpad/upgrade.gno
+++ b/contract/r/gnoswap/launchpad/upgrade.gno
@@ -16,7 +16,7 @@ import (
 // Security: Only contracts within the domain path can register initializers.
 // Each package path can only register once to prevent duplicate registrations.
 func RegisterInitializer(cur realm, initializer func(launchpadStore ILaunchpadStore) ILaunchpad) {
-	initializerFunc := func(domainStore any) any {
+	initializerFunc := func(_ int, rlm realm, domainStore any) any {
 		currentLaunchpadStore, ok := domainStore.(ILaunchpadStore)
 		if !ok {
 			panic("domainStore is not an ILaunchpadStore")

--- a/contract/r/gnoswap/pool/_helper_test.gno
+++ b/contract/r/gnoswap/pool/_helper_test.gno
@@ -21,7 +21,7 @@ func resetTestState(t *testing.T) {
 	versionManager = version_manager.NewVersionManager(
 		"gno.land/r/gnoswap/pool",
 		kvStore,
-		func(_ store.KVStore) any {
+		func(_ int, rlm realm, _ store.KVStore) any {
 			return NewPoolStore(kvStore)
 		},
 	)

--- a/contract/r/gnoswap/pool/state.gno
+++ b/contract/r/gnoswap/pool/state.gno
@@ -46,7 +46,7 @@ func init() {
 	implementation = nil
 }
 
-func initializeDomainStore(kvStore store.KVStore) any {
+func initializeDomainStore(_ int, rlm realm, kvStore store.KVStore) any {
 	return NewPoolStore(kvStore)
 }
 

--- a/contract/r/gnoswap/pool/upgrade.gno
+++ b/contract/r/gnoswap/pool/upgrade.gno
@@ -18,7 +18,7 @@ import (
 // Security: Only contracts within the domain path can register initializers.
 // Each package path can only register once to prevent duplicate registrations.
 func RegisterInitializer(cur realm, initializer func(poolStore IPoolStore) IPool) {
-	initializerFunc := func(domainStore any) any {
+	initializerFunc := func(_ int, rlm realm, domainStore any) any {
 		currentPoolStore, ok := domainStore.(IPoolStore)
 		if !ok {
 			panic("domainStore is not an IPoolStore")

--- a/contract/r/gnoswap/position/_helper_test.gno
+++ b/contract/r/gnoswap/position/_helper_test.gno
@@ -21,7 +21,7 @@ func resetTestState(t *testing.T) {
 	versionManager = version_manager.NewVersionManager(
 		"gno.land/r/gnoswap/position",
 		kvStore,
-		func(_ store.KVStore) any {
+		func(_ int, rlm realm, _ store.KVStore) any {
 			return NewPositionStore(kvStore)
 		},
 	)

--- a/contract/r/gnoswap/position/state.gno
+++ b/contract/r/gnoswap/position/state.gno
@@ -34,7 +34,7 @@ func init() {
 	implementation = nil
 }
 
-func initializeDomainStore(kvStore store.KVStore) any {
+func initializeDomainStore(_ int, rlm realm, kvStore store.KVStore) any {
 	return NewPositionStore(kvStore)
 }
 

--- a/contract/r/gnoswap/position/upgrade.gno
+++ b/contract/r/gnoswap/position/upgrade.gno
@@ -18,7 +18,7 @@ import (
 // Security: Only contracts within the domain path can register initializers.
 // Each package path can only register once to prevent duplicate registrations.
 func RegisterInitializer(cur realm, initializer func(positionStore IPositionStore) IPosition) {
-	initializerFunc := func(domainStore any) any {
+	initializerFunc := func(_ int, rlm realm, domainStore any) any {
 		currentPositionStore, ok := domainStore.(IPositionStore)
 		if !ok {
 			panic("domainStore is not an IPositionStore")

--- a/contract/r/gnoswap/protocol_fee/_helper_test.gno
+++ b/contract/r/gnoswap/protocol_fee/_helper_test.gno
@@ -21,7 +21,7 @@ func resetTestState(t *testing.T) {
 	versionManager = version_manager.NewVersionManager(
 		"gno.land/r/gnoswap/protocol_fee",
 		kvStore,
-		func(_ store.KVStore) any {
+		func(_ int, rlm realm, _ store.KVStore) any {
 			return NewProtocolFeeStore(kvStore)
 		},
 	)

--- a/contract/r/gnoswap/protocol_fee/state.gno
+++ b/contract/r/gnoswap/protocol_fee/state.gno
@@ -34,7 +34,7 @@ func init() {
 	implementation = nil
 }
 
-func initializeDomainStore(kvStore store.KVStore) any {
+func initializeDomainStore(_ int, rlm realm, kvStore store.KVStore) any {
 	return NewProtocolFeeStore(kvStore)
 }
 

--- a/contract/r/gnoswap/protocol_fee/upgrade.gno
+++ b/contract/r/gnoswap/protocol_fee/upgrade.gno
@@ -18,7 +18,7 @@ import (
 // Security: Only contracts within the domain path can register initializers.
 // Each package path can only register once to prevent duplicate registrations.
 func RegisterInitializer(cur realm, initializer func(protocolFeeStore IProtocolFeeStore) IProtocolFee) {
-	initializerFunc := func(domainStore any) any {
+	initializerFunc := func(_ int, rlm realm, domainStore any) any {
 		currentProtocolFeeStore, ok := domainStore.(IProtocolFeeStore)
 		if !ok {
 			panic("domainStore is not an IProtocolFeeStore")

--- a/contract/r/gnoswap/router/_helper_test.gno
+++ b/contract/r/gnoswap/router/_helper_test.gno
@@ -21,7 +21,7 @@ func resetTestState(t *testing.T) {
 	versionManager = version_manager.NewVersionManager(
 		"gno.land/r/gnoswap/router",
 		kvStore,
-		func(_ store.KVStore) any {
+		func(_ int, rlm realm, _ store.KVStore) any {
 			return NewRouterStore(kvStore)
 		},
 	)

--- a/contract/r/gnoswap/router/state.gno
+++ b/contract/r/gnoswap/router/state.gno
@@ -32,7 +32,7 @@ func init() {
 	implementation = nil
 }
 
-func initializeDomainStore(kvStore store.KVStore) any {
+func initializeDomainStore(_ int, rlm realm, kvStore store.KVStore) any {
 	return NewRouterStore(kvStore)
 }
 

--- a/contract/r/gnoswap/router/upgrade.gno
+++ b/contract/r/gnoswap/router/upgrade.gno
@@ -16,7 +16,7 @@ import (
 // Security: Only contracts within the domain path can register initializers.
 // Each package path can only register once to prevent duplicate registrations.
 func RegisterInitializer(cur realm, initializer func(routerStore IRouterStore) IRouter) {
-	initializerFunc := func(domainStore any) any {
+	initializerFunc := func(_ int, rlm realm, domainStore any) any {
 		currentRouterStore, ok := domainStore.(IRouterStore)
 		if !ok {
 			panic("domainStore is not an IRouterStore")

--- a/contract/r/gnoswap/staker/_helper_test.gno
+++ b/contract/r/gnoswap/staker/_helper_test.gno
@@ -21,7 +21,7 @@ func resetTestState(t *testing.T) {
 	versionManager = version_manager.NewVersionManager(
 		"gno.land/r/gnoswap/staker",
 		kvStore,
-		func(_ store.KVStore) any {
+		func(_ int, rlm realm, _ store.KVStore) any {
 			return NewStakerStore(kvStore)
 		},
 	)

--- a/contract/r/gnoswap/staker/state.gno
+++ b/contract/r/gnoswap/staker/state.gno
@@ -46,7 +46,7 @@ func initRegisterWritableContract() {
 	}
 }
 
-func initializeDomainStore(kvStore store.KVStore) any {
+func initializeDomainStore(_ int, rlm realm, kvStore store.KVStore) any {
 	return NewStakerStore(kvStore)
 }
 

--- a/contract/r/gnoswap/staker/upgrade.gno
+++ b/contract/r/gnoswap/staker/upgrade.gno
@@ -16,7 +16,7 @@ import (
 // Security: Only contracts within the domain path can register initializers.
 // Each package path can only register once to prevent duplicate registrations.
 func RegisterInitializer(cur realm, initializer func(stakerStore IStakerStore, poolAccessor PoolAccessor, emissionAccessor EmissionAccessor, nftAccessor NFTAccessor) IStaker) {
-	initializerFunc := func(domainStore any) any {
+	initializerFunc := func(_ int, rlm realm, domainStore any) any {
 		currentStakerStore, ok := domainStore.(IStakerStore)
 		if !ok {
 			panic("domainStore is not an IStakerStore")


### PR DESCRIPTION
## Summary

Propagate the v2 interrealm spec into the inner-closure layer of `version_manager`. The realm-threading marker `(_ int, rlm realm, ...)` is now consistently applied to the `initializer` and `initializeDomainStoreFn` signatures, matching the already-migrated `RegisterInitializer` / `ChangeImplementation` outer surface.

## Why

`RegisterInitializer(_ int, rlm realm, ...)` and `ChangeImplementation(_ int, rlm realm, ...)` were already migrated to the v2 spec, but their inner callbacks still used the v1 signatures `func(store any) any` and `func(kvStore store.KVStore) any`. This inconsistency hid realm context from the storage-initialization layer and left a half-migrated boundary inside the package.

This PR threads the live realm token end-to-end:

- `version_manager.initializers` now stores `map[string]func(_ int, rlm realm, store any) any`
- `initializeDomainStoreFn` now takes `(_ int, rlm realm, kvStore store.KVStore) any`
- All inner closures inside `RegisterInitializer` and `ChangeImplementation` call sites now visibly thread `0, rlm`

The domain-level `RegisterInitializer` public surface is left untouched to keep `v1/init.gno` callers (and scenario test implementations) unaffected. Only the proxy → version_manager bridge closure is updated.

## Changes

### `contract/p/gnoswap/version_manager`
- `types.gno`: `VersionManager` interface — `RegisterInitializer` and `GetInitializers` signatures updated to the v2 marker pattern.
- `version_manager.gno`: `versionManager` struct fields (`initializers`, `initializeDomainStoreFn`), `NewVersionManager` parameter, and `makeInitializerSafe` updated. Internal calls now pass `0, rlm`.
- `version_manager_test.gno`: `mockInitializer`, `mockInitializeDomainStoreFn`, map literals, and the `TestMakeInitializerSafe_InvalidType` valid-input case updated to the new signature.
- `doc.gno`: usage examples updated.

### 8 domain proxy realms (`contract/r/gnoswap/{protocol_fee,pool,position,staker,router,launchpad,gov/governance,gov/staker}`)
- `state.gno`: `initializeDomainStore` parameter list now `(_ int, rlm realm, kvStore store.KVStore)`.
- `upgrade.gno`: inner `initializerFunc` closure is now `func(_ int, rlm realm, domainStore any) any`. Public `RegisterInitializer` signatures (the domain-specific one consumed by `v1/init.gno`) are unchanged.
- `_helper_test.gno`: inline `NewVersionManager` closure updated.

### `contract/r/gnoswap/gov/staker/state_test.gno`
- `TestState_initializeDomainStore` updated to accept `cur realm` and pass `0, cur` to the now-realm-aware `initializeDomainStore`.

## Compatibility

- `v1/init.gno` files across all 8 domains are unaffected — they still call the domain-specific `RegisterInitializer(cur realm, initializer func(...) I...)`.
- Scenario test implementations under `contract/r/scenario/upgrade/implements/**` are unaffected for the same reason.
- No on-chain storage layout changes.