### PR TITLE
refactor(r/emission): migrate to interrealm v2

### DIFF
--- a/contract/r/gnoswap/emission/README.md
+++ b/contract/r/gnoswap/emission/README.md
@@ -88,18 +88,19 @@ halvingCount = floor(timeSinceStart / halvingPeriod)
 ## Usage
 
 ```go
-// Set emission start (one-time by admin)
-SetDistributionStartTime(1704067200) // Jan 1, 2024
+// Set emission start (one-time by admin/governance)
+SetDistributionStartTime(cross(cur), 1704067200) // Jan 1, 2024
 
-// Trigger emission (called automatically)
-amount, ok := MintAndDistributeGns()
+// Trigger emission (called automatically by protocol flows)
+amount, ok := MintAndDistributeGns(cross(cur))
 
 // Update distribution ratios
 ChangeDistributionPct(
-    1, 7000,  // 70% to liquidity stakers
-    2, 2000,  // 20% to devops
-    3, 1000,  // 10% to community pool
-    4, 0      // 0% to governance stakers
+    cross(cur),
+    7000, // 70% to liquidity stakers
+    2000, // 20% to devops
+    1000, // 10% to community pool
+    0,    // 0% to governance stakers
 )
 
 // Query distribution info

--- a/contract/r/gnoswap/emission/_helper_test.gno
+++ b/contract/r/gnoswap/emission/_helper_test.gno
@@ -16,6 +16,7 @@ var (
 	devOpsAddr, _        = access.GetAddress(prbac.ROLE_DEVOPS.String())
 	communityPoolAddr, _ = access.GetAddress(prbac.ROLE_COMMUNITY_POOL.String())
 
+	emissionRealm  = testing.NewUserRealm(emissionAddr)
 	adminRealm     = testing.NewUserRealm(adminAddr)
 	stakerRealm    = testing.NewUserRealm(stakerAddr)
 	govRealm       = testing.NewUserRealm(govAddr)

--- a/contract/r/gnoswap/emission/distribution.gno
+++ b/contract/r/gnoswap/emission/distribution.gno
@@ -2,7 +2,6 @@ package emission
 
 import (
 	"chain"
-	"chain/runtime"
 	"time"
 
 	ufmt "gno.land/p/nt/ufmt/v0"
@@ -93,7 +92,7 @@ func ChangeDistributionPct(
 ) {
 	halt.AssertIsNotHaltedEmission()
 
-	caller := runtime.PreviousRealm().Address()
+	caller := cur.Previous().Address()
 	access.AssertIsAdminOrGovernance(caller)
 
 	assertValidDistributionPct(liquidityStakerPct, devOpsPct, communityPoolPct, govStakerPct)
@@ -101,7 +100,7 @@ func ChangeDistributionPct(
 	// Distribute accumulated emissions with current ratios before changing ratios.
 	// This prevents retroactive application of new ratios to emissions that occurred
 	// under previous ratio configurations.
-	MintAndDistributeGns(cross)
+	MintAndDistributeGns(cur)
 
 	if onDistributionPctChangeCallback != nil {
 		currentTimestamp := time.Now().Unix()
@@ -111,7 +110,7 @@ func ChangeDistributionPct(
 
 	changeDistributionPcts(liquidityStakerPct, devOpsPct, communityPoolPct, govStakerPct)
 
-	previousRealm := runtime.PreviousRealm()
+	previousRealm := cur.Previous()
 	chain.Emit(
 		"ChangeDistributionPct",
 		"prevAddr", previousRealm.Address().String(),
@@ -209,9 +208,9 @@ func applyDistribution(targets map[int]int64) (map[address]int64, error) {
 	return amountByAddress, nil
 }
 
-func transferToTarget(targets map[address]int64) error {
+func transferToTarget(_ int, rlm realm, targets map[address]int64) error {
 	for address, amount := range targets {
-		gns.Transfer(cross, address, amount)
+		gns.Transfer(cross(rlm), address, amount)
 	}
 
 	return nil
@@ -309,7 +308,7 @@ func GetStakerEmissionAmountPerSecondInRange(start, end int64) ([]int64, []int64
 //
 // Only callable by staker contract.
 func ClearDistributedToStaker(cur realm) {
-	caller := runtime.PreviousRealm().Address()
+	caller := cur.Previous().Address()
 	access.AssertIsStaker(caller)
 
 	distributedToStaker = 0
@@ -319,7 +318,7 @@ func ClearDistributedToStaker(cur realm) {
 //
 // Only callable by governance staker contract.
 func ClearDistributedToGovStaker(cur realm) {
-	caller := runtime.PreviousRealm().Address()
+	caller := cur.Previous().Address()
 	access.AssertIsGovStaker(caller)
 	distributedToGovStaker = 0
 }

--- a/contract/r/gnoswap/emission/distribution_test.gno
+++ b/contract/r/gnoswap/emission/distribution_test.gno
@@ -11,16 +11,17 @@ import (
 
 	"gno.land/r/gnoswap/access"
 	"gno.land/r/gnoswap/gns"
+	"gno.land/r/gnoswap/rbac"
 )
 
-func TestChangeDistributionPct(t *testing.T) {
+func TestChangeDistributionPct(cur realm, t *testing.T) {
 	resetObject(t)
 
 	tests := []struct {
 		name               string
 		shouldPanic        bool
 		panicMsg           string
-		setup              func()
+		setup              func(cur realm)
 		callerRealm        runtime.Realm
 		liquidityStakerPct int64
 		devOpsPct          int64
@@ -65,9 +66,9 @@ func TestChangeDistributionPct(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.setup != nil {
-				tt.setup()
+				tt.setup(cur)
 			}
 
 			if tt.callerRealm != (runtime.Realm{}) {
@@ -75,9 +76,9 @@ func TestChangeDistributionPct(t *testing.T) {
 			}
 
 			if tt.shouldPanic {
-				uassert.AbortsWithMessage(t, tt.panicMsg, func() {
+				uassert.AbortsWithMessage(t, cur, tt.panicMsg, func() {
 					ChangeDistributionPct(
-						cross,
+						cross(cur),
 						tt.liquidityStakerPct,
 						tt.devOpsPct,
 						tt.communityPoolPct,
@@ -85,9 +86,9 @@ func TestChangeDistributionPct(t *testing.T) {
 					)
 				})
 			} else {
-				uassert.NotPanics(t, func() {
+				uassert.NotPanics(t, cur, func() {
 					ChangeDistributionPct(
-						cross,
+						cross(cur),
 						tt.liquidityStakerPct,
 						tt.devOpsPct,
 						tt.communityPoolPct,
@@ -100,7 +101,7 @@ func TestChangeDistributionPct(t *testing.T) {
 	}
 }
 
-func TestChangeDistributionPcts(t *testing.T) {
+func TestChangeDistributionPcts(cur realm, t *testing.T) {
 	resetObject(t)
 
 	changeDistributionPcts(1000, 2000, 3000, 4000)
@@ -110,7 +111,7 @@ func TestChangeDistributionPcts(t *testing.T) {
 	uassert.Equal(t, int64(4000), GetDistributionBpsPct(GOV_STAKER))
 }
 
-func TestCalculateAmount(t *testing.T) {
+func TestCalculateAmount(cur realm, t *testing.T) {
 	tests := []struct {
 		name     string
 		pct      int64
@@ -123,15 +124,14 @@ func TestCalculateAmount(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			uassert.Equal(t, tt.expected, calculateAmount(int64(1000), tt.pct))
 		})
 	}
 }
 
-func TestTransferToTarget(t *testing.T) {
+func TestTransferToTarget(cur realm, t *testing.T) {
 	resetObject(t)
-	emissionAddr, _ := access.GetAddress(prbac.ROLE_EMISSION.String())
 
 	tests := []struct {
 		name         string
@@ -139,7 +139,7 @@ func TestTransferToTarget(t *testing.T) {
 		shouldError  bool
 		abortMessage string
 		errorMsg     string
-		setup        func()
+		setup        func(cur realm)
 		target       int
 		amount       int64
 		verify       func()
@@ -163,10 +163,10 @@ func TestTransferToTarget(t *testing.T) {
 		{
 			name:   "transfer to LIQUIDITY_STAKER",
 			target: LIQUIDITY_STAKER,
-			setup: func() {
+			setup: func(cur realm) {
 				resetObject(t)
 				testing.SetRealm(adminRealm)
-				gns.Transfer(cross, emissionAddr, 100000) // give enough balance for emission
+				gns.Transfer(cross(cur), emissionAddr, 100000) // give enough balance for emission
 			},
 			amount: 100,
 			verify: func() {
@@ -204,18 +204,20 @@ func TestTransferToTarget(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.setup != nil {
-				tt.setup()
+				tt.setup(cur)
 			}
 
 			targets := map[int]int64{tt.target: tt.amount}
 			if tt.shouldAbort {
-				uassert.AbortsWithMessage(t, tt.abortMessage, func() {
-					amountByAddress, err := applyDistribution(targets)
-					uassert.NoError(t, err)
-					transferToTarget(amountByAddress)
-				})
+				uassert.AbortsWithMessage(
+					t, cur, tt.abortMessage, func() {
+						amountByAddress, err := applyDistribution(targets)
+						uassert.NoError(t, err)
+						testing.SetRealm(emissionRealm)
+						transferToTarget(0, cur, amountByAddress)
+					})
 
 				return
 			}
@@ -225,7 +227,8 @@ func TestTransferToTarget(t *testing.T) {
 				uassert.Equal(t, tt.errorMsg, err.Error())
 			} else {
 				uassert.NoError(t, err)
-				err = transferToTarget(amountByAddress)
+				testing.SetRealm(emissionRealm)
+				err = transferToTarget(0, cur, amountByAddress)
 				uassert.NoError(t, err)
 				tt.verify()
 			}
@@ -233,7 +236,7 @@ func TestTransferToTarget(t *testing.T) {
 	}
 }
 
-func TestClearDistributedToStaker(t *testing.T) {
+func TestClearDistributedToStaker(cur realm, t *testing.T) {
 	distributedToStaker = 100
 
 	tests := []struct {
@@ -256,17 +259,18 @@ func TestClearDistributedToStaker(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.callerRealm != (runtime.Realm{}) {
 				testing.SetRealm(tt.callerRealm)
 			}
 
 			if tt.shouldPanic {
-				uassert.AbortsWithMessage(t, tt.panicMsg, func() {
-					ClearDistributedToStaker(cross)
-				})
+				uassert.AbortsWithMessage(
+					t, cur, tt.panicMsg, func() {
+						ClearDistributedToStaker(cross(cur))
+					})
 			} else {
-				ClearDistributedToStaker(cross)
+				ClearDistributedToStaker(cross(cur))
 				if distributedToStaker != 0 {
 					t.Errorf("distributedToStaker is not 0, got %d", distributedToStaker)
 				}
@@ -275,7 +279,7 @@ func TestClearDistributedToStaker(t *testing.T) {
 	}
 }
 
-func TestClearClearDistributedToGovStaker(t *testing.T) {
+func TestClearClearDistributedToGovStaker(cur realm, t *testing.T) {
 	distributedToGovStaker = 100
 
 	tests := []struct {
@@ -298,17 +302,18 @@ func TestClearClearDistributedToGovStaker(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.callerRealm != (runtime.Realm{}) {
 				testing.SetRealm(tt.callerRealm)
 			}
 
 			if tt.shouldPanic {
-				uassert.AbortsWithMessage(t, tt.panicMsg, func() {
-					ClearDistributedToGovStaker(cross)
-				})
+				uassert.AbortsWithMessage(
+					t, cur, tt.panicMsg, func() {
+						ClearDistributedToGovStaker(cross(cur))
+					})
 			} else {
-				ClearDistributedToGovStaker(cross)
+				ClearDistributedToGovStaker(cross(cur))
 				if distributedToGovStaker != 0 {
 					t.Errorf("distributedToGovStaker is not 0, got %d", distributedToGovStaker)
 				}
@@ -317,7 +322,7 @@ func TestClearClearDistributedToGovStaker(t *testing.T) {
 	}
 }
 
-func setupTestEnv(t *testing.T) {
+func setupTestEnv(cur realm, t *testing.T) {
 	distributionBpsPct = make(map[int]int64)
 
 	distributionBpsPct[LIQUIDITY_STAKER] = 7500
@@ -331,23 +336,21 @@ func setupTestEnv(t *testing.T) {
 	distributedToGovStaker = 0
 
 	testing.SetRealm(adminRealm)
-	emissionAddr, _ := access.GetAddress(prbac.ROLE_EMISSION.String())
-	gns.Transfer(cross, emissionAddr, 1000000)
+	gns.Transfer(cross(cur), emissionAddr, 1000000)
 }
 
-func TestCalculateAmount_Panic(t *testing.T) {
+func TestCalculateAmount_Panic(cur realm, t *testing.T) {
 	resetObject(t)
 
 	testing.SetRealm(adminRealm)
-	gns.Transfer(cross, emissionAddr, 10000000) // 10M GNS tokens
-
-	testing.SetRealm(govRealm)
+	gns.Transfer(cross(cur), emissionAddr, 10000000) // 10M GNS tokens
 
 	// attempts to set 40000 basis points = 400%
-	t.Run("Attack via ChangeDistributionPct - Should fail with current validation", func(t *testing.T) {
-		uassert.AbortsWithMessage(t, "[GNOSWAP-EMISSION-002] invalid emission percentage || sum of percentages must be 10000, got 40000", func() {
+	t.Run("Attack via ChangeDistributionPct - Should fail with current validation", func(cur realm, t *testing.T) {
+		testing.SetRealm(govRealm)
+		uassert.AbortsWithMessage(t, cur, "[GNOSWAP-EMISSION-002] invalid emission percentage || sum of percentages must be 10000, got 40000", func() {
 			ChangeDistributionPct(
-				cross,
+				cross(cur),
 				10000, // 100% to liquidityStaker
 				10000, // 100% to devOps
 				10000, // 100% to communityPool
@@ -356,7 +359,7 @@ func TestCalculateAmount_Panic(t *testing.T) {
 		})
 	})
 
-	t.Run("Direct calculateAmount", func(t *testing.T) {
+	t.Run("Direct calculateAmount", func(cur realm, t *testing.T) {
 		tests := []struct {
 			name        string
 			amount      int64
@@ -394,7 +397,7 @@ func TestCalculateAmount_Panic(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
+			t.Run(tt.name, func(cur realm, t *testing.T) {
 				if tt.shouldPanic {
 					defer func() {
 						if r := recover(); r != nil {
@@ -410,7 +413,7 @@ func TestCalculateAmount_Panic(t *testing.T) {
 		}
 	})
 
-	t.Run("Overflow protection boundary test", func(t *testing.T) {
+	t.Run("Overflow protection boundary test", func(cur realm, t *testing.T) {
 		maxSafeAmount := int64(9223372036854775807 / 10000)
 
 		// under the limit
@@ -418,26 +421,28 @@ func TestCalculateAmount_Panic(t *testing.T) {
 		uassert.Equal(t, maxSafeAmount, result)
 
 		// over the limit
-		uassert.PanicsWithMessage(t, "amount too large, would cause overflow", func() {
-			calculateAmount(maxSafeAmount+1, 10000)
-		})
+		uassert.PanicsWithMessage(
+			t, cur, "amount too large, would cause overflow", func() {
+				calculateAmount(maxSafeAmount+1, 10000)
+			})
 
 		// over the limit
 		unsafeAmount := maxSafeAmount / 10 // 10x smaller than max
 		hugebptPct := int64(100001)        // Just over 1000%
 
-		uassert.PanicsWithMessage(t, "invalid amount or bptPct", func() {
-			calculateAmount(unsafeAmount, hugebptPct)
-		})
+		uassert.PanicsWithMessage(
+			t, cur, "invalid amount or bptPct", func() {
+				calculateAmount(unsafeAmount, hugebptPct)
+			})
 	})
 }
 
-func TestDistribution_SetOnDistributionPctChangeCallback(t *testing.T) {
+func TestDistribution_SetOnDistributionPctChangeCallback(cur realm, t *testing.T) {
 	currentEmissionAmount := int64(0)
 
 	tests := []struct {
 		name                   string
-		setup                  func()
+		setup                  func(cur realm)
 		caller                 address
 		callback               func(int64)
 		emissionAmount         int64
@@ -488,10 +493,10 @@ func TestDistribution_SetOnDistributionPctChangeCallback(t *testing.T) {
 		{
 			name:   "success - existing callback is called with 0 when replaced",
 			caller: stakerAddr,
-			setup: func() {
+			setup: func(cur realm) {
 				// Set initial callback
 				testing.SetRealm(stakerRealm)
-				SetOnDistributionPctChangeCallback(cross, func(amount int64) {
+				SetOnDistributionPctChangeCallback(cross(cur), func(amount int64) {
 					currentEmissionAmount = amount
 				})
 			},
@@ -505,28 +510,30 @@ func TestDistribution_SetOnDistributionPctChangeCallback(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			currentEmissionAmount = 0
 
 			// Given
 			resetObject(t)
 			if tt.setup != nil {
-				tt.setup()
+				tt.setup(cur)
 			}
 			testing.SetRealm(testing.NewUserRealm(tt.caller))
 
 			// When - Then
 			if tt.wantErr {
-				uassert.AbortsWithMessage(t, tt.errMsg, func() {
-					SetOnDistributionPctChangeCallback(cross, tt.callback)
-				})
+				uassert.AbortsWithMessage(
+					t, cur, tt.errMsg, func() {
+						SetOnDistributionPctChangeCallback(cross(cur), tt.callback)
+					})
 				return
 			}
 
 			// When
-			uassert.NotPanics(t, func() {
-				SetOnDistributionPctChangeCallback(cross, tt.callback)
-			})
+			uassert.NotPanics(
+				t, cur, func() {
+					SetOnDistributionPctChangeCallback(cross(cur), tt.callback)
+				})
 
 			// Then - callback is called with 100
 			if onDistributionPctChangeCallback != nil {
@@ -541,10 +548,10 @@ func TestDistribution_SetOnDistributionPctChangeCallback(t *testing.T) {
 	}
 }
 
-func TestDistribution_GetDistributionBpsPct_EdgeCases(t *testing.T) {
+func TestDistribution_GetDistributionBpsPct_EdgeCases(cur realm, t *testing.T) {
 	tests := []struct {
 		name    string
-		setup   func()
+		setup   func(cur realm)
 		target  int
 		want    int64
 		wantErr bool
@@ -572,27 +579,27 @@ func TestDistribution_GetDistributionBpsPct_EdgeCases(t *testing.T) {
 		},
 		{
 			name: "success - get modified percentage",
-			setup: func() {
+			setup: func(cur realm) {
 				testing.SetRealm(adminRealm)
-				ChangeDistributionPct(cross, 5000, 3000, 1000, 1000)
+				ChangeDistributionPct(cross(cur), 5000, 3000, 1000, 1000)
 			},
 			target: LIQUIDITY_STAKER,
 			want:   5000,
 		},
 		{
 			name: "success - get 100% allocation",
-			setup: func() {
+			setup: func(cur realm) {
 				testing.SetRealm(adminRealm)
-				ChangeDistributionPct(cross, 10000, 0, 0, 0)
+				ChangeDistributionPct(cross(cur), 10000, 0, 0, 0)
 			},
 			target: LIQUIDITY_STAKER,
 			want:   10000,
 		},
 		{
 			name: "success - get 0% allocation",
-			setup: func() {
+			setup: func(cur realm) {
 				testing.SetRealm(adminRealm)
-				ChangeDistributionPct(cross, 10000, 0, 0, 0)
+				ChangeDistributionPct(cross(cur), 10000, 0, 0, 0)
 			},
 			target: DEVOPS,
 			want:   0,
@@ -636,18 +643,19 @@ func TestDistribution_GetDistributionBpsPct_EdgeCases(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Given
 			resetObject(t)
 			if tt.setup != nil {
-				tt.setup()
+				tt.setup(cur)
 			}
 
 			// When - Then
 			if tt.wantErr {
-				uassert.PanicsWithMessage(t, tt.errMsg, func() {
-					GetDistributionBpsPct(tt.target)
-				})
+				uassert.PanicsWithMessage(
+					t, cur, tt.errMsg, func() {
+						GetDistributionBpsPct(tt.target)
+					})
 				return
 			}
 
@@ -660,50 +668,52 @@ func TestDistribution_GetDistributionBpsPct_EdgeCases(t *testing.T) {
 	}
 }
 
-func TestDistribution_GetterFunctions_EdgeCases(t *testing.T) {
-	t.Run("GetDistributedToStaker", func(t *testing.T) {
+func TestDistribution_GetterFunctions_EdgeCases(cur realm, t *testing.T) {
+	t.Run("GetDistributedToStaker", func(cur realm, t *testing.T) {
 		tests := []struct {
 			name  string
-			setup func()
+			setup func(cur realm)
 			want  int64
 		}{
 			{
 				name:  "success - initial value is 0",
-				setup: func() { resetObject(t) },
+				setup: func(cur realm) { resetObject(t) },
 				want:  0,
 			},
 			{
 				name: "success - after distribution",
-				setup: func() {
+				setup: func(cur realm) {
 					resetObject(t)
-					setupTestEnv(t)
+					setupTestEnv(cur, t)
 					distributable, _ := calculateDistributableAmounts(10000)
 					amountByAddress, err := applyDistribution(distributable)
 					uassert.NoError(t, err)
-					uassert.NoError(t, transferToTarget(amountByAddress))
+					testing.SetRealm(emissionRealm)
+					uassert.NoError(t, transferToTarget(0, cur, amountByAddress))
 				},
 				want: 7500,
 			},
 			{
 				name: "success - after clearing",
-				setup: func() {
+				setup: func(cur realm) {
 					resetObject(t)
-					setupTestEnv(t)
+					setupTestEnv(cur, t)
 					distributable, _ := calculateDistributableAmounts(10000)
 					amountByAddress, err := applyDistribution(distributable)
 					uassert.NoError(t, err)
-					uassert.NoError(t, transferToTarget(amountByAddress))
+					testing.SetRealm(emissionRealm)
+					uassert.NoError(t, transferToTarget(0, cur, amountByAddress))
 					testing.SetRealm(stakerRealm)
-					ClearDistributedToStaker(cross)
+					ClearDistributedToStaker(cross(cur))
 				},
 				want: 0,
 			},
 		}
 
 		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
+			t.Run(tt.name, func(cur realm, t *testing.T) {
 				// Given
-				tt.setup()
+				tt.setup(cur)
 
 				// When
 				got := GetDistributedToStaker()
@@ -714,35 +724,36 @@ func TestDistribution_GetterFunctions_EdgeCases(t *testing.T) {
 		}
 	})
 
-	t.Run("GetDistributedToDevOps", func(t *testing.T) {
+	t.Run("GetDistributedToDevOps", func(cur realm, t *testing.T) {
 		tests := []struct {
 			name  string
-			setup func()
+			setup func(cur realm)
 			want  int64
 		}{
 			{
 				name:  "success - initial value is 0",
-				setup: func() { resetObject(t) },
+				setup: func(cur realm) { resetObject(t) },
 				want:  0,
 			},
 			{
 				name: "success - after distribution",
-				setup: func() {
+				setup: func(cur realm) {
 					resetObject(t)
-					setupTestEnv(t)
+					setupTestEnv(cur, t)
 					distributable, _ := calculateDistributableAmounts(10000)
 					amountByAddress, err := applyDistribution(distributable)
 					uassert.NoError(t, err)
-					uassert.NoError(t, transferToTarget(amountByAddress))
+					testing.SetRealm(emissionRealm)
+					uassert.NoError(t, transferToTarget(0, cur, amountByAddress))
 				},
 				want: 2000,
 			},
 		}
 
 		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
+			t.Run(tt.name, func(cur realm, t *testing.T) {
 				// Given
-				tt.setup()
+				tt.setup(cur)
 
 				// When
 				got := GetDistributedToDevOps()
@@ -753,35 +764,36 @@ func TestDistribution_GetterFunctions_EdgeCases(t *testing.T) {
 		}
 	})
 
-	t.Run("GetDistributedToCommunityPool", func(t *testing.T) {
+	t.Run("GetDistributedToCommunityPool", func(cur realm, t *testing.T) {
 		tests := []struct {
 			name  string
-			setup func()
+			setup func(cur realm)
 			want  int64
 		}{
 			{
 				name:  "success - initial value is 0",
-				setup: func() { resetObject(t) },
+				setup: func(cur realm) { resetObject(t) },
 				want:  0,
 			},
 			{
 				name: "success - after distribution",
-				setup: func() {
+				setup: func(cur realm) {
 					resetObject(t)
-					setupTestEnv(t)
+					setupTestEnv(cur, t)
 					distributable, _ := calculateDistributableAmounts(10000)
 					amountByAddress, err := applyDistribution(distributable)
 					uassert.NoError(t, err)
-					uassert.NoError(t, transferToTarget(amountByAddress))
+					testing.SetRealm(emissionRealm)
+					uassert.NoError(t, transferToTarget(0, cur, amountByAddress))
 				},
 				want: 500,
 			},
 		}
 
 		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
+			t.Run(tt.name, func(cur realm, t *testing.T) {
 				// Given
-				tt.setup()
+				tt.setup(cur)
 
 				// When
 				got := GetDistributedToCommunityPool()
@@ -792,39 +804,40 @@ func TestDistribution_GetterFunctions_EdgeCases(t *testing.T) {
 		}
 	})
 
-	t.Run("GetDistributedToGovStaker", func(t *testing.T) {
+	t.Run("GetDistributedToGovStaker", func(cur realm, t *testing.T) {
 		tests := []struct {
 			name  string
-			setup func()
+			setup func(cur realm)
 			want  int64
 		}{
 			{
 				name:  "success - initial value is 0",
-				setup: func() { resetObject(t) },
+				setup: func(cur realm) { resetObject(t) },
 				want:  0,
 			},
 			{
 				name: "success - after clearing",
-				setup: func() {
+				setup: func(cur realm) {
 					resetObject(t)
-					setupTestEnv(t)
+					setupTestEnv(cur, t)
 					testing.SetRealm(adminRealm)
-					ChangeDistributionPct(cross, 5000, 2000, 1000, 2000)
+					ChangeDistributionPct(cross(cur), 5000, 2000, 1000, 2000)
 					distributable, _ := calculateDistributableAmounts(10000)
 					amountByAddress, err := applyDistribution(distributable)
 					uassert.NoError(t, err)
-					uassert.NoError(t, transferToTarget(amountByAddress))
+					testing.SetRealm(emissionRealm)
+					uassert.NoError(t, transferToTarget(0, cur, amountByAddress))
 					testing.SetRealm(govStakerRealm)
-					ClearDistributedToGovStaker(cross)
+					ClearDistributedToGovStaker(cross(cur))
 				},
 				want: 0,
 			},
 		}
 
 		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
+			t.Run(tt.name, func(cur realm, t *testing.T) {
 				// Given
-				tt.setup()
+				tt.setup(cur)
 
 				// When
 				got := GetDistributedToGovStaker()
@@ -835,15 +848,16 @@ func TestDistribution_GetterFunctions_EdgeCases(t *testing.T) {
 		}
 	})
 
-	t.Run("GetAccuDistributedTo functions", func(t *testing.T) {
+	t.Run("GetAccuDistributedTo functions", func(cur realm, t *testing.T) {
 		resetObject(t)
-		setupTestEnv(t)
+		setupTestEnv(cur, t)
 
 		// First distribution
 		distributable, _ := calculateDistributableAmounts(10000)
 		amountByAddress, err := applyDistribution(distributable)
 		uassert.NoError(t, err)
-		uassert.NoError(t, transferToTarget(amountByAddress))
+		testing.SetRealm(emissionRealm)
+		uassert.NoError(t, transferToTarget(0, cur, amountByAddress))
 
 		// Verify accumulated amounts
 		uassert.Equal(t, int64(7500), GetAccuDistributedToStaker())
@@ -853,15 +867,16 @@ func TestDistribution_GetterFunctions_EdgeCases(t *testing.T) {
 
 		// Clear current amounts
 		testing.SetRealm(stakerRealm)
-		ClearDistributedToStaker(cross)
+		ClearDistributedToStaker(cross(cur))
 
 		// Second distribution
 		testing.SetRealm(adminRealm)
-		gns.Transfer(cross, emissionAddr, 1000000)
+		gns.Transfer(cross(cur), emissionAddr, 1000000)
 		distributable2, _ := calculateDistributableAmounts(10000)
 		amountByAddress, err = applyDistribution(distributable2)
 		uassert.NoError(t, err)
-		uassert.NoError(t, transferToTarget(amountByAddress))
+		testing.SetRealm(emissionRealm)
+		uassert.NoError(t, transferToTarget(0, cur, amountByAddress))
 
 		// Verify accumulated amounts increased
 		uassert.Equal(t, int64(15000), GetAccuDistributedToStaker())
@@ -872,8 +887,8 @@ func TestDistribution_GetterFunctions_EdgeCases(t *testing.T) {
 }
 
 // TestMapBasedDistribution_EdgeCases tests edge cases specific to map-based distribution
-func TestMapBasedDistribution_EdgeCases(t *testing.T) {
-	t.Run("distribution scenarios", func(t *testing.T) {
+func TestMapBasedDistribution_EdgeCases(cur realm, t *testing.T) {
+	t.Run("distribution scenarios", func(cur realm, t *testing.T) {
 		tests := []struct {
 			name                      string
 			description               string
@@ -1007,9 +1022,9 @@ func TestMapBasedDistribution_EdgeCases(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
+			t.Run(tt.name, func(cur realm, t *testing.T) {
 				resetObject(t)
-				setupTestEnv(t)
+				setupTestEnv(cur, t)
 
 				if tt.useEmptyMap {
 					distributionBpsPct = make(map[int]int64)
@@ -1027,7 +1042,8 @@ func TestMapBasedDistribution_EdgeCases(t *testing.T) {
 				totalSent := tt.amountToDistribute - leftAmt
 				amountByAddress, err := applyDistribution(distributable)
 				uassert.NoError(t, err)
-				err = transferToTarget(amountByAddress)
+				testing.SetRealm(emissionRealm)
+				err = transferToTarget(0, cur, amountByAddress)
 				uassert.NoError(t, err)
 				uassert.Equal(t, tt.expectedTotalSent, totalSent)
 				uassert.Equal(t, tt.expectedDistributedStaker, distributedToStaker)
@@ -1038,7 +1054,7 @@ func TestMapBasedDistribution_EdgeCases(t *testing.T) {
 		}
 	})
 
-	t.Run("map state management", func(t *testing.T) {
+	t.Run("map state management", func(cur realm, t *testing.T) {
 		tests := []struct {
 			name        string
 			description string
@@ -1055,9 +1071,10 @@ func TestMapBasedDistribution_EdgeCases(t *testing.T) {
 					return saved
 				},
 				testFunc: func(t *testing.T) {
-					uassert.PanicsWithMessage(t, "distributionBpsPct is nil", func() {
-						GetDistributionBpsPct(LIQUIDITY_STAKER)
-					})
+					uassert.PanicsWithMessage(
+						t, cur, "distributionBpsPct is nil", func() {
+							GetDistributionBpsPct(LIQUIDITY_STAKER)
+						})
 				},
 				cleanupFunc: func(saved map[int]int64) {
 					distributionBpsPct = saved
@@ -1090,9 +1107,10 @@ func TestMapBasedDistribution_EdgeCases(t *testing.T) {
 					return saved
 				},
 				testFunc: func(t *testing.T) {
-					uassert.PanicsWithMessage(t, "[GNOSWAP-EMISSION-001] invalid emission target || invalid target(2)", func() {
-						GetDistributionBpsPct(DEVOPS)
-					})
+					uassert.PanicsWithMessage(
+						t, cur, "[GNOSWAP-EMISSION-001] invalid emission target || invalid target(2)", func() {
+							GetDistributionBpsPct(DEVOPS)
+						})
 				},
 				cleanupFunc: func(saved map[int]int64) {
 					distributionBpsPct = saved
@@ -1101,7 +1119,7 @@ func TestMapBasedDistribution_EdgeCases(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
+			t.Run(tt.name, func(cur realm, t *testing.T) {
 				saved := tt.setupFunc()
 				defer tt.cleanupFunc(saved)
 				tt.testFunc(t)
@@ -1109,7 +1127,7 @@ func TestMapBasedDistribution_EdgeCases(t *testing.T) {
 		}
 	})
 
-	t.Run("map operations", func(t *testing.T) {
+	t.Run("map operations", func(cur realm, t *testing.T) {
 		tests := []struct {
 			name        string
 			description string
@@ -1152,7 +1170,7 @@ func TestMapBasedDistribution_EdgeCases(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
+			t.Run(tt.name, func(cur realm, t *testing.T) {
 				resetObject(t)
 
 				for _, op := range tt.operations {
@@ -1173,7 +1191,7 @@ func TestMapBasedDistribution_EdgeCases(t *testing.T) {
 		}
 	})
 
-	t.Run("map iteration order independence", func(t *testing.T) {
+	t.Run("map iteration order independence", func(cur realm, t *testing.T) {
 		tests := []struct {
 			name                      string
 			description               string
@@ -1199,16 +1217,17 @@ func TestMapBasedDistribution_EdgeCases(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
+			t.Run(tt.name, func(cur realm, t *testing.T) {
 				for i := 0; i < tt.iterations; i++ {
 					resetObject(t)
-					setupTestEnv(t)
+					setupTestEnv(cur, t)
 
 					distributable, leftAmt := calculateDistributableAmounts(tt.amountToDistribute)
 					totalSent := tt.amountToDistribute - leftAmt
 					amountByAddress, err := applyDistribution(distributable)
 					uassert.NoError(t, err)
-					err = transferToTarget(amountByAddress)
+					testing.SetRealm(emissionRealm)
+					err = transferToTarget(0, cur, amountByAddress)
 					uassert.NoError(t, err)
 					uassert.Equal(t, tt.expectedTotalSent, totalSent)
 					uassert.Equal(t, tt.expectedDistributedStaker, distributedToStaker)
@@ -1220,7 +1239,7 @@ func TestMapBasedDistribution_EdgeCases(t *testing.T) {
 		}
 	})
 
-	t.Run("read-write access pattern", func(t *testing.T) {
+	t.Run("read-write access pattern", func(cur realm, t *testing.T) {
 		tests := []struct {
 			name         string
 			description  string
@@ -1240,7 +1259,7 @@ func TestMapBasedDistribution_EdgeCases(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
+			t.Run(tt.name, func(cur realm, t *testing.T) {
 				resetObject(t)
 
 				// Multiple reads
@@ -1260,20 +1279,13 @@ func TestMapBasedDistribution_EdgeCases(t *testing.T) {
 		}
 	})
 
-	t.Run("duplicate target addresses are accumulated before transfer", func(t *testing.T) {
+	t.Run("duplicate target addresses are accumulated before transfer", func(cur realm, t *testing.T) {
 		resetObject(t)
-		emissionAddr, _ := access.GetAddress(prbac.ROLE_EMISSION.String())
 		originalDevOpsAddr, _ := access.GetAddress(prbac.ROLE_DEVOPS.String())
 
 		testing.SetRealm(adminRealm)
-		gns.Transfer(cross, emissionAddr, 100000)
-		testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/rbac"))
-		access.SetRoleAddress(cross, prbac.ROLE_DEVOPS.String(), stakerAddr)
-		testing.SetRealm(adminRealm)
-		defer func() {
-			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/rbac"))
-			access.SetRoleAddress(cross, prbac.ROLE_DEVOPS.String(), originalDevOpsAddr)
-		}()
+		gns.Transfer(cross(cur), emissionAddr, 100000)
+		rbac.UpdateRoleAddress(cross(cur), prbac.ROLE_DEVOPS.String(), stakerAddr)
 
 		targets := map[int]int64{
 			LIQUIDITY_STAKER: 700,
@@ -1283,10 +1295,13 @@ func TestMapBasedDistribution_EdgeCases(t *testing.T) {
 		stakerBalanceBefore := gns.BalanceOf(stakerAddr)
 
 		amountByAddress, err := applyDistribution(targets)
+		testing.SetRealm(adminRealm)
+		rbac.UpdateRoleAddress(cross(cur), prbac.ROLE_DEVOPS.String(), originalDevOpsAddr)
 		uassert.NoError(t, err)
 		uassert.Equal(t, 1, len(amountByAddress))
 		uassert.Equal(t, int64(1000), amountByAddress[stakerAddr])
-		uassert.NoError(t, transferToTarget(amountByAddress))
+		testing.SetRealm(emissionRealm)
+		uassert.NoError(t, transferToTarget(0, cur, amountByAddress))
 
 		uassert.Equal(t, stakerBalanceBefore+1000, gns.BalanceOf(stakerAddr))
 		uassert.Equal(t, int64(700), distributedToStaker)

--- a/contract/r/gnoswap/emission/emission.gno
+++ b/contract/r/gnoswap/emission/emission.gno
@@ -21,7 +21,7 @@ var (
 	lastExecutedTimestamp int64
 
 	// emissionAddr is the address of the emission realm
-	emissionAddr = runtime.CurrentRealm().Address()
+	emissionAddr address
 
 	// distributionStartTimestamp is the timestamp from which emission distribution starts
 	// Default is 0, meaning distribution is not started until explicitly set
@@ -31,6 +31,10 @@ var (
 	// This allows external contracts (like staker) to update their caches
 	onDistributionPctChangeCallback func(emissionAmountPerSecond int64)
 )
+
+func init(cur realm) {
+	emissionAddr = cur.Address()
+}
 
 // setLeftGNSAmount updates the undistributed GNS token amount
 func setLeftGNSAmount(amount int64) {
@@ -89,7 +93,7 @@ func MintAndDistributeGns(cur realm) (int64, bool) {
 	}
 
 	// Mint new tokens and add any leftover amounts from previous distribution
-	mintedEmissionRewardAmount := gns.MintGns(cross, emissionAddr)
+	mintedEmissionRewardAmount := gns.MintGns(cross(cur), emissionAddr)
 
 	// Validate minted amount
 	if mintedEmissionRewardAmount < 0 {
@@ -121,11 +125,11 @@ func MintAndDistributeGns(cur realm) (int64, bool) {
 		panic(err)
 	}
 
-	if err := transferToTarget(amountByAddress); err != nil {
+	if err := transferToTarget(0, cur, amountByAddress); err != nil {
 		panic(err)
 	}
 
-	previousRealm := runtime.PreviousRealm()
+	previousRealm := cur.Previous()
 	chain.Emit(
 		"MintAndDistributeGns",
 		"prevAddr", previousRealm.Address().String(),
@@ -166,7 +170,7 @@ func MintAndDistributeGns(cur realm) (int64, bool) {
 func SetDistributionStartTime(cur realm, startTimestamp int64) {
 	halt.AssertIsNotHaltedEmission()
 
-	caller := runtime.PreviousRealm().Address()
+	caller := cur.Previous().Address()
 	access.AssertIsAdminOrGovernance(caller)
 
 	if startTimestamp <= 0 {
@@ -193,7 +197,7 @@ func SetDistributionStartTime(cur realm, startTimestamp int64) {
 
 	if gns.MintedEmissionAmount() == 0 {
 		currentHeight := runtime.ChainHeight()
-		gns.InitEmissionState(cross, currentHeight, startTimestamp)
+		gns.InitEmissionState(cross(cur), currentHeight, startTimestamp)
 	}
 
 	distributionStartTimestamp = startTimestamp
@@ -213,7 +217,7 @@ func SetDistributionStartTime(cur realm, startTimestamp int64) {
 //
 // Only callable by the staker contract.
 func SetOnDistributionPctChangeCallback(cur realm, callback func(int64)) {
-	caller := runtime.PreviousRealm().Address()
+	caller := cur.Previous().Address()
 	access.AssertIsStaker(caller)
 
 	onDistributionPctChangeCallback = callback

--- a/contract/r/gnoswap/emission/emission_test.gno
+++ b/contract/r/gnoswap/emission/emission_test.gno
@@ -15,12 +15,12 @@ import (
 
 var alice = testutils.TestAddress("alice")
 
-func TestSetDistributionStartTime(t *testing.T) {
+func TestSetDistributionStartTime(cur realm, t *testing.T) {
 	now := time.Now().Unix()
 
 	tests := []struct {
 		name        string
-		setup       func()
+		setup       func(cur realm)
 		timestamp   int64
 		caller      address
 		shouldPanic bool
@@ -52,19 +52,19 @@ func TestSetDistributionStartTime(t *testing.T) {
 		},
 		{
 			name: "update existing distribution start time",
-			setup: func() {
-				testing.SetOriginCaller(adminAddr)
-				SetDistributionStartTime(cross, 5000+now)
+			setup: func(cur realm) {
+				testing.SetRealm(adminRealm)
+				SetDistributionStartTime(cross(cur), 5000+now)
 			},
 			timestamp: 10000 + now,
 			caller:    govAddr,
 		},
 		{
 			name: "cannot change start time after distribution has started",
-			setup: func() {
+			setup: func(cur realm) {
 				// Set initial distribution start time to 100
-				testing.SetOriginCaller(adminAddr)
-				SetDistributionStartTime(cross, 100+now)
+				testing.SetRealm(adminRealm)
+				SetDistributionStartTime(cross(cur), 100+now)
 				testing.SkipHeights(21) // skip to 21 to simulate time advancing to 105 (past start time)
 			},
 			timestamp:   200 + now,
@@ -75,20 +75,21 @@ func TestSetDistributionStartTime(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			testing.SetHeight(123)
 			if tt.setup != nil {
-				tt.setup()
+				tt.setup(cur)
 			}
 
 			testing.SetRealm(testing.NewUserRealm(tt.caller))
 
 			if tt.shouldPanic {
-				uassert.AbortsWithMessage(t, tt.panicMsg, func() {
-					SetDistributionStartTime(cross, tt.timestamp)
-				})
+				uassert.AbortsWithMessage(
+					t, cur, tt.panicMsg, func() {
+						SetDistributionStartTime(cross(cur), tt.timestamp)
+					})
 			} else {
-				SetDistributionStartTime(cross, tt.timestamp)
+				SetDistributionStartTime(cross(cur), tt.timestamp)
 				uassert.Equal(t, tt.timestamp, GetDistributionStartTimestamp())
 			}
 		})
@@ -97,7 +98,7 @@ func TestSetDistributionStartTime(t *testing.T) {
 	}
 }
 
-func TestMintAndDistributeGnsWithDistributionStartTime(t *testing.T) {
+func TestMintAndDistributeGnsWithDistributionStartTime(cur realm, t *testing.T) {
 	tests := []struct {
 		name         string
 		startTime    int64
@@ -143,20 +144,20 @@ func TestMintAndDistributeGnsWithDistributionStartTime(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			resetObject(t)
 
 			now := time.Now().Unix()
 
-			testing.SetOriginCaller(adminAddr)
-			SetDistributionStartTime(cross, 100+now)
+			testing.SetRealm(adminRealm)
+			SetDistributionStartTime(cross(cur), 100+now)
 
 			testing.SkipHeights(tt.skipHeight)
 			defer func() {
 				testing.SkipHeights(-tt.skipHeight)
 			}()
 
-			distributed, _ := MintAndDistributeGns(cross)
+			distributed, _ := MintAndDistributeGns(cross(cur))
 			if tt.verify != nil {
 				tt.verify(distributed)
 			}
@@ -166,107 +167,107 @@ func TestMintAndDistributeGnsWithDistributionStartTime(t *testing.T) {
 	}
 }
 
-func TestEmission_MintAndDistributeGns_EdgeCases(t *testing.T) {
+func TestEmission_MintAndDistributeGns_EdgeCases(cur realm, t *testing.T) {
 	tests := []struct {
 		name    string
-		setup   func()
+		setup   func(cur realm)
 		wantErr bool
 		errMsg  string
-		verify  func(t *testing.T)
+		verify  func(cur realm, t *testing.T)
 	}{
 		{
 			name: "success - distributes with leftover from previous round",
-			setup: func() {
+			setup: func(cur realm) {
 				resetObject(t)
 				now := time.Now().Unix()
-				testing.SetOriginCaller(adminAddr)
-				SetDistributionStartTime(cross, now+100)
+				testing.SetRealm(adminRealm)
+				SetDistributionStartTime(cross(cur), now+100)
 				testing.SkipHeights(200)
 				// First distribution to get some GNS minted
-				MintAndDistributeGns(cross)
+				MintAndDistributeGns(cross(cur))
 				// Skip more time to allow another mint
 				testing.SkipHeights(100)
 				// Now set leftover amount for next distribution
 				setLeftGNSAmount(100)
 			},
-			verify: func(t *testing.T) {
-				distributed, _ := MintAndDistributeGns(cross)
+			verify: func(cur realm, t *testing.T) {
+				distributed, _ := MintAndDistributeGns(cross(cur))
 				uassert.True(t, distributed >= 0)
 			},
 		},
 		{
 			name: "success - no distribution when start timestamp is 0",
-			setup: func() {
+			setup: func(cur realm) {
 				resetObject(t)
 				distributionStartTimestamp = 0
 			},
-			verify: func(t *testing.T) {
-				distributed, _ := MintAndDistributeGns(cross)
+			verify: func(cur realm, t *testing.T) {
+				distributed, _ := MintAndDistributeGns(cross(cur))
 				uassert.Equal(t, int64(0), distributed)
 			},
 		},
 		{
 			name: "success - no distribution when current time < start timestamp",
-			setup: func() {
+			setup: func(cur realm) {
 				resetObject(t)
 				now := time.Now().Unix()
-				testing.SetOriginCaller(adminAddr)
-				SetDistributionStartTime(cross, now+1000000)
+				testing.SetRealm(adminRealm)
+				SetDistributionStartTime(cross(cur), now+1000000)
 			},
-			verify: func(t *testing.T) {
-				distributed, ok := MintAndDistributeGns(cross)
+			verify: func(cur realm, t *testing.T) {
+				distributed, ok := MintAndDistributeGns(cross(cur))
 				uassert.Equal(t, int64(0), distributed)
 				uassert.True(t, ok)
 			},
 		},
 		{
 			name: "success - skip when already minted at this timestamp",
-			setup: func() {
+			setup: func(cur realm) {
 				resetObject(t)
 				now := time.Now().Unix()
-				testing.SetOriginCaller(adminAddr)
-				SetDistributionStartTime(cross, now+100)
+				testing.SetRealm(adminRealm)
+				SetDistributionStartTime(cross(cur), now+100)
 				testing.SkipHeights(200)
 				// First distribution
-				MintAndDistributeGns(cross)
+				MintAndDistributeGns(cross(cur))
 			},
-			verify: func(t *testing.T) {
+			verify: func(cur realm, t *testing.T) {
 				// Second distribution at same timestamp should return 0
-				distributed, ok := MintAndDistributeGns(cross)
+				distributed, ok := MintAndDistributeGns(cross(cur))
 				uassert.True(t, ok)
 				uassert.Equal(t, int64(0), distributed)
 			},
 		},
 		{
 			name: "success - prevent re-entrancy when lastExecutedTimestamp >= currentTimestamp",
-			setup: func() {
+			setup: func(cur realm) {
 				resetObject(t)
 				now := time.Now().Unix()
-				testing.SetOriginCaller(adminAddr)
-				SetDistributionStartTime(cross, now+100)
+				testing.SetRealm(adminRealm)
+				SetDistributionStartTime(cross(cur), now+100)
 				testing.SkipHeights(200)
 				setLastExecutedTimestamp(now + 1000)
 			},
-			verify: func(t *testing.T) {
-				distributed, _ := MintAndDistributeGns(cross)
+			verify: func(cur realm, t *testing.T) {
+				distributed, _ := MintAndDistributeGns(cross(cur))
 				uassert.Equal(t, int64(0), distributed)
 			},
 		},
 		{
 			name: "success - tracks leftGNSAmount when remainder exists",
-			setup: func() {
+			setup: func(cur realm) {
 				resetObject(t)
 				now := time.Now().Unix()
-				testing.SetOriginCaller(adminAddr)
-				SetDistributionStartTime(cross, now+100)
+				testing.SetRealm(adminRealm)
+				SetDistributionStartTime(cross(cur), now+100)
 				testing.SkipHeights(200)
 				// Set distribution percentages that will create remainder
 				changeDistributionPcts(3333, 3333, 3333, 1)
 			},
-			verify: func(t *testing.T) {
+			verify: func(cur realm, t *testing.T) {
 				testing.SkipHeights(1)
 				initialLeft := GetLeftGNSAmount()
-				MintAndDistributeGns(cross)
+				MintAndDistributeGns(cross(cur))
 				// Should have some leftover due to rounding
 				finalLeft := GetLeftGNSAmount()
 				uassert.True(t, finalLeft >= initialLeft)
@@ -274,53 +275,54 @@ func TestEmission_MintAndDistributeGns_EdgeCases(t *testing.T) {
 		},
 		{
 			name: "success - no distribution when halted (halt check in emission layer)",
-			setup: func() {
+			setup: func(cur realm) {
 				resetObject(t)
 				now := time.Now().Unix()
-				testing.SetOriginCaller(adminAddr)
-				SetDistributionStartTime(cross, now+100)
+				testing.SetRealm(adminRealm)
+				SetDistributionStartTime(cross(cur), now+100)
 				testing.SkipHeights(200)
 				// Set halt to emergency level
-				halt.SetHaltLevel(cross, halt.HaltLevelEmergency)
+				halt.SetHaltLevel(cross(cur), halt.HaltLevelEmergency)
 			},
-			verify: func(t *testing.T) {
-				distributed, ok := MintAndDistributeGns(cross)
+			verify: func(cur realm, t *testing.T) {
+				distributed, ok := MintAndDistributeGns(cross(cur))
 				uassert.Equal(t, int64(0), distributed)
 				uassert.False(t, ok)
 				// Reset halt for other tests
-				testing.SetOriginCaller(adminAddr)
-				halt.SetHaltLevel(cross, halt.HaltLevelNone)
+				testing.SetRealm(adminRealm)
+				halt.SetHaltLevel(cross(cur), halt.HaltLevelNone)
 			},
 		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Given
 			if tt.setup != nil {
-				tt.setup()
+				tt.setup(cur)
 			}
 
 			// When - Then
 			if tt.wantErr {
-				uassert.PanicsWithMessage(t, tt.errMsg, func() {
-					MintAndDistributeGns(cross)
-				})
+				uassert.PanicsWithMessage(
+					t, cur, tt.errMsg, func() {
+						MintAndDistributeGns(cross(cur))
+					})
 				return
 			}
 
 			// When
 			if tt.verify != nil {
-				tt.verify(t)
+				tt.verify(cur, t)
 			}
 		})
 	}
 }
 
-func TestEmission_SetDistributionStartTime_EdgeCases(t *testing.T) {
+func TestEmission_SetDistributionStartTime_EdgeCases(cur realm, t *testing.T) {
 	tests := []struct {
 		name      string
-		setup     func()
+		setup     func(cur realm)
 		timestamp int64
 		caller    address
 		wantErr   bool
@@ -368,11 +370,11 @@ func TestEmission_SetDistributionStartTime_EdgeCases(t *testing.T) {
 		},
 		{
 			name: "panic - set to past time when distribution already started (future time error takes precedence)",
-			setup: func() {
+			setup: func(cur realm) {
 				resetObject(t)
 				now := time.Now().Unix()
-				testing.SetOriginCaller(adminAddr)
-				SetDistributionStartTime(cross, now+100)
+				testing.SetRealm(adminRealm)
+				SetDistributionStartTime(cross(cur), now+100)
 				testing.SkipHeights(200) // distribution started
 			},
 			timestamp: time.Now().Unix() - 100, // past time
@@ -382,11 +384,11 @@ func TestEmission_SetDistributionStartTime_EdgeCases(t *testing.T) {
 		},
 		{
 			name: "panic - set to current time when distribution already started (future time error takes precedence)",
-			setup: func() {
+			setup: func(cur realm) {
 				resetObject(t)
 				now := time.Now().Unix()
-				testing.SetOriginCaller(adminAddr)
-				SetDistributionStartTime(cross, now+100)
+				testing.SetRealm(adminRealm)
+				SetDistributionStartTime(cross(cur), now+100)
 				testing.SkipHeights(200) // distribution started
 			},
 			timestamp: time.Now().Unix(), // current time
@@ -397,24 +399,25 @@ func TestEmission_SetDistributionStartTime_EdgeCases(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Given
 			resetObject(t)
 			if tt.setup != nil {
-				tt.setup()
+				tt.setup(cur)
 			}
 			testing.SetRealm(testing.NewUserRealm(tt.caller))
 
 			// When - Then
 			if tt.wantErr {
-				uassert.AbortsWithMessage(t, tt.errMsg, func() {
-					SetDistributionStartTime(cross, tt.timestamp)
-				})
+				uassert.AbortsWithMessage(
+					t, cur, tt.errMsg, func() {
+						SetDistributionStartTime(cross(cur), tt.timestamp)
+					})
 				return
 			}
 
 			// When
-			SetDistributionStartTime(cross, tt.timestamp)
+			SetDistributionStartTime(cross(cur), tt.timestamp)
 
 			// Then
 			uassert.Equal(t, tt.timestamp, GetDistributionStartTimestamp())
@@ -422,20 +425,20 @@ func TestEmission_SetDistributionStartTime_EdgeCases(t *testing.T) {
 	}
 }
 
-func TestEmission_GetLeftGNSAmount(t *testing.T) {
+func TestEmission_GetLeftGNSAmount(cur realm, t *testing.T) {
 	tests := []struct {
 		name  string
-		setup func()
+		setup func(cur realm)
 		want  int64
 	}{
 		{
 			name:  "success - initial value is 0",
-			setup: func() { resetObject(t) },
+			setup: func(cur realm) { resetObject(t) },
 			want:  0,
 		},
 		{
 			name: "success - returns set value",
-			setup: func() {
+			setup: func(cur realm) {
 				resetObject(t)
 				setLeftGNSAmount(12345)
 			},
@@ -443,7 +446,7 @@ func TestEmission_GetLeftGNSAmount(t *testing.T) {
 		},
 		{
 			name: "success - returns max int64",
-			setup: func() {
+			setup: func(cur realm) {
 				resetObject(t)
 				setLeftGNSAmount(9223372036854775807)
 			},
@@ -452,9 +455,9 @@ func TestEmission_GetLeftGNSAmount(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Given
-			tt.setup()
+			tt.setup(cur)
 
 			// When
 			got := GetLeftGNSAmount()
@@ -465,20 +468,20 @@ func TestEmission_GetLeftGNSAmount(t *testing.T) {
 	}
 }
 
-func TestEmission_GetLastExecutedTimestamp(t *testing.T) {
+func TestEmission_GetLastExecutedTimestamp(cur realm, t *testing.T) {
 	tests := []struct {
 		name  string
-		setup func()
+		setup func(cur realm)
 		want  int64
 	}{
 		{
 			name:  "success - initial value is 0",
-			setup: func() { resetObject(t) },
+			setup: func(cur realm) { resetObject(t) },
 			want:  0,
 		},
 		{
 			name: "success - returns set value",
-			setup: func() {
+			setup: func(cur realm) {
 				resetObject(t)
 				setLastExecutedTimestamp(1234567890)
 			},
@@ -486,7 +489,7 @@ func TestEmission_GetLastExecutedTimestamp(t *testing.T) {
 		},
 		{
 			name: "success - returns max int64",
-			setup: func() {
+			setup: func(cur realm) {
 				resetObject(t)
 				setLastExecutedTimestamp(9223372036854775807)
 			},
@@ -495,9 +498,9 @@ func TestEmission_GetLastExecutedTimestamp(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Given
-			tt.setup()
+			tt.setup(cur)
 
 			// When
 			got := GetLastExecutedTimestamp()
@@ -508,33 +511,33 @@ func TestEmission_GetLastExecutedTimestamp(t *testing.T) {
 	}
 }
 
-func TestEmission_GetDistributionStartTimestamp(t *testing.T) {
+func TestEmission_GetDistributionStartTimestamp(cur realm, t *testing.T) {
 	tests := []struct {
 		name  string
-		setup func()
+		setup func(cur realm)
 		want  int64
 	}{
 		{
 			name:  "success - initial value is 0",
-			setup: func() { resetObject(t) },
+			setup: func(cur realm) { resetObject(t) },
 			want:  0,
 		},
 		{
 			name: "success - returns set value",
-			setup: func() {
+			setup: func(cur realm) {
 				resetObject(t)
 				now := time.Now().Unix()
-				testing.SetOriginCaller(adminAddr)
-				SetDistributionStartTime(cross, now+1000)
+				testing.SetRealm(adminRealm)
+				SetDistributionStartTime(cross(cur), now+1000)
 			},
 			want: time.Now().Unix() + 1000,
 		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Given
-			tt.setup()
+			tt.setup(cur)
 
 			// When
 			got := GetDistributionStartTimestamp()
@@ -550,25 +553,25 @@ func TestEmission_GetDistributionStartTimestamp(t *testing.T) {
 	}
 }
 
-func TestSetDistributionStartTime_InitEmissionStateWithBlockHeight(t *testing.T) {
+func TestSetDistributionStartTime_InitEmissionStateWithBlockHeight(cur realm, t *testing.T) {
 	// This test verifies that InitEmissionState is called with actual block height,
 	// not timestamp value, fixing the semantic inconsistency issue.
 	tests := []struct {
 		name        string
 		blockHeight int64
-		setup       func() int64
+		setup       func(cur realm) int64
 		wantCheck   func(t *testing.T, startTimestamp, createdHeight, expectedHeight int64)
 	}{
 		{
 			name:        "emission start height should be block height not timestamp",
 			blockHeight: 150,
-			setup: func() int64 {
+			setup: func(cur realm) int64 {
 				now := time.Now().Unix()
 				futureTimestamp := now + 10000
 
 				// Call SetDistributionStartTime which internally calls InitEmissionState
-				testing.SetOriginCaller(adminAddr)
-				SetDistributionStartTime(cross, futureTimestamp)
+				testing.SetRealm(adminRealm)
+				SetDistributionStartTime(cross(cur), futureTimestamp)
 
 				return futureTimestamp
 			},
@@ -588,12 +591,12 @@ func TestSetDistributionStartTime_InitEmissionStateWithBlockHeight(t *testing.T)
 		{
 			name:        "emission start height tracks blockchain height correctly",
 			blockHeight: 500,
-			setup: func() int64 {
+			setup: func(cur realm) int64 {
 				now := time.Now().Unix()
 				futureTimestamp := now + 20000
 
-				testing.SetOriginCaller(adminAddr)
-				SetDistributionStartTime(cross, futureTimestamp)
+				testing.SetRealm(adminRealm)
+				SetDistributionStartTime(cross(cur), futureTimestamp)
 
 				return futureTimestamp
 			},
@@ -608,7 +611,7 @@ func TestSetDistributionStartTime_InitEmissionStateWithBlockHeight(t *testing.T)
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Reset state before each test
 			resetObject(t)
 
@@ -617,14 +620,11 @@ func TestSetDistributionStartTime_InitEmissionStateWithBlockHeight(t *testing.T)
 
 			// Manually reset GNS emission state with the correct height
 			// This ensures the emission state is initialized with the test's block height
-			testing.SetOriginCaller(adminAddr)
-			func(cur realm) {
-				testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/emission"))
-				gns.InitEmissionState(cross, tt.blockHeight, time.Now().Unix())
-			}(cross)
+			testing.SetRealm(emissionRealm)
+			gns.InitEmissionState(cross(cur), tt.blockHeight, time.Now().Unix())
 
 			// Setup and get the start timestamp used
-			startTimestamp := tt.setup()
+			startTimestamp := tt.setup(cur)
 
 			// Get the emission start height from GNS
 			createdHeight := gns.GetEmissionCreatedHeight()
@@ -635,7 +635,7 @@ func TestSetDistributionStartTime_InitEmissionStateWithBlockHeight(t *testing.T)
 	}
 }
 
-func TestSetLeftGNSAmount_EdgeCases(t *testing.T) {
+func TestSetLeftGNSAmount_EdgeCases(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		amount      int64
@@ -669,15 +669,16 @@ func TestSetLeftGNSAmount_EdgeCases(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Given
 			resetObject(t)
 
 			// When - Then
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.panicMsg, func() {
-					setLeftGNSAmount(tt.amount)
-				})
+				uassert.PanicsWithMessage(
+					t, cur, tt.panicMsg, func() {
+						setLeftGNSAmount(tt.amount)
+					})
 				return
 			}
 
@@ -690,7 +691,7 @@ func TestSetLeftGNSAmount_EdgeCases(t *testing.T) {
 	}
 }
 
-func TestSetLastExecutedTimestamp_EdgeCases(t *testing.T) {
+func TestSetLastExecutedTimestamp_EdgeCases(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		timestamp   int64
@@ -724,15 +725,16 @@ func TestSetLastExecutedTimestamp_EdgeCases(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Given
 			resetObject(t)
 
 			// When - Then
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.panicMsg, func() {
-					setLastExecutedTimestamp(tt.timestamp)
-				})
+				uassert.PanicsWithMessage(
+					t, cur, tt.panicMsg, func() {
+						setLastExecutedTimestamp(tt.timestamp)
+					})
 				return
 			}
 
@@ -745,7 +747,7 @@ func TestSetLastExecutedTimestamp_EdgeCases(t *testing.T) {
 	}
 }
 
-func TestTargetToStr(t *testing.T) {
+func TestTargetToStr(cur realm, t *testing.T) {
 	tests := []struct {
 		name     string
 		target   int
@@ -794,7 +796,7 @@ func TestTargetToStr(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// When
 			result := targetToStr(tt.target)
 
@@ -804,7 +806,7 @@ func TestTargetToStr(t *testing.T) {
 	}
 }
 
-func TestAssertValidDistributionPct_NegativeAndExceed(t *testing.T) {
+func TestAssertValidDistributionPct_NegativeAndExceed(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		pcts        [4]int64
@@ -878,19 +880,21 @@ func TestAssertValidDistributionPct_NegativeAndExceed(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// When - Then
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.panicMsg, func() {
-					assertValidDistributionPct(tt.pcts[0], tt.pcts[1], tt.pcts[2], tt.pcts[3])
-				})
+				uassert.PanicsWithMessage(
+					t, cur, tt.panicMsg, func() {
+						assertValidDistributionPct(tt.pcts[0], tt.pcts[1], tt.pcts[2], tt.pcts[3])
+					})
 				return
 			}
 
 			// When
-			uassert.NotPanics(t, func() {
-				assertValidDistributionPct(tt.pcts[0], tt.pcts[1], tt.pcts[2], tt.pcts[3])
-			})
+			uassert.NotPanics(
+				t, cur, func() {
+					assertValidDistributionPct(tt.pcts[0], tt.pcts[1], tt.pcts[2], tt.pcts[3])
+				})
 		})
 	}
 }

--- a/contract/r/gnoswap/emission/getter_test.gno
+++ b/contract/r/gnoswap/emission/getter_test.gno
@@ -6,7 +6,7 @@ import (
 	uassert "gno.land/p/nt/uassert/v0"
 )
 
-func TestGetDistributableAmount(t *testing.T) {
+func TestGetDistributableAmount(cur realm, t *testing.T) {
 	resetObject(t)
 
 	distributionStartTimestamp = 1000
@@ -20,7 +20,7 @@ func TestGetDistributableAmount(t *testing.T) {
 	uassert.Equal(t, int64(0), distributed[GOV_STAKER])
 }
 
-func TestGetDistributableAmount_WithRemainder(t *testing.T) {
+func TestGetDistributableAmount_WithRemainder(cur realm, t *testing.T) {
 	resetObject(t)
 
 	distributionStartTimestamp = 1000
@@ -34,7 +34,7 @@ func TestGetDistributableAmount_WithRemainder(t *testing.T) {
 	uassert.Equal(t, int64(0), distributed[GOV_STAKER])
 }
 
-func TestGetDistributableAmount_OutsideWindow(t *testing.T) {
+func TestGetDistributableAmount_OutsideWindow(cur realm, t *testing.T) {
 	resetObject(t)
 
 	distributionStartTimestamp = 1000
@@ -49,7 +49,7 @@ func TestGetDistributableAmount_OutsideWindow(t *testing.T) {
 	uassert.Equal(t, 0, len(distributedAfter))
 }
 
-func TestGetDistributableAmountIsolation(t *testing.T) {
+func TestGetDistributableAmountIsolation(cur realm, t *testing.T) {
 	resetObject(t)
 
 	distributionStartTimestamp = 1000
@@ -63,14 +63,14 @@ func TestGetDistributableAmountIsolation(t *testing.T) {
 	uassert.Equal(t, false, exists)
 }
 
-func TestGetLeftGNSAmount(t *testing.T) {
+func TestGetLeftGNSAmount(cur realm, t *testing.T) {
 	resetObject(t)
 
 	leftGNSAmount = 12345
 	uassert.Equal(t, int64(12345), GetLeftGNSAmount())
 }
 
-func TestGetDistributionStartTimestamp(t *testing.T) {
+func TestGetDistributionStartTimestamp(cur realm, t *testing.T) {
 	resetObject(t)
 
 	uassert.Equal(t, int64(0), GetDistributionStartTimestamp())
@@ -79,7 +79,7 @@ func TestGetDistributionStartTimestamp(t *testing.T) {
 	uassert.Equal(t, int64(1000), GetDistributionStartTimestamp())
 }
 
-func TestGetLastExecutedTimestamp(t *testing.T) {
+func TestGetLastExecutedTimestamp(cur realm, t *testing.T) {
 	resetObject(t)
 
 	uassert.Equal(t, int64(0), GetLastExecutedTimestamp())
@@ -88,7 +88,7 @@ func TestGetLastExecutedTimestamp(t *testing.T) {
 	uassert.Equal(t, int64(2000), GetLastExecutedTimestamp())
 }
 
-func TestGetAllDistributionBpsPct(t *testing.T) {
+func TestGetAllDistributionBpsPct(cur realm, t *testing.T) {
 	resetObject(t)
 
 	all := GetAllDistributionBpsPct()
@@ -105,7 +105,7 @@ func TestGetAllDistributionBpsPct(t *testing.T) {
 	uassert.Equal(t, 0, len(empty))
 }
 
-func TestGetTotalAccuDistributed(t *testing.T) {
+func TestGetTotalAccuDistributed(cur realm, t *testing.T) {
 	resetObject(t)
 
 	accuDistributedToStaker = 10
@@ -116,7 +116,7 @@ func TestGetTotalAccuDistributed(t *testing.T) {
 	uassert.Equal(t, int64(100), GetTotalAccuDistributed())
 }
 
-func TestGetTotalDistributed(t *testing.T) {
+func TestGetTotalDistributed(cur realm, t *testing.T) {
 	resetObject(t)
 
 	distributedToStaker = 1
@@ -127,7 +127,7 @@ func TestGetTotalDistributed(t *testing.T) {
 	uassert.Equal(t, int64(10), GetTotalDistributed())
 }
 
-func TestGetDistributionEndTimestamp(t *testing.T) {
+func TestGetDistributionEndTimestamp(cur realm, t *testing.T) {
 	resetObject(t)
 
 	uassert.Equal(t, int64(0), GetDistributionEndTimestamp())

--- a/contract/r/gnoswap/emission/leftamount_test.gno
+++ b/contract/r/gnoswap/emission/leftamount_test.gno
@@ -8,11 +8,11 @@ import (
 	"gno.land/r/gnoswap/gns"
 )
 
-func TestLeftAmountFix(t *testing.T) {
+func TestLeftAmountFix(cur realm, t *testing.T) {
 	resetObject(t)
 
 	testing.SetRealm(adminRealm)
-	gns.Transfer(cross, emissionAddr, 10000000) // 10M GNS tokens
+	gns.Transfer(cross(cur), emissionAddr, 10000000) // 10M GNS tokens
 
 	tests := []struct {
 		name               string
@@ -106,7 +106,7 @@ func TestLeftAmountFix(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			// Setup
 			if tt.setupFunc != nil {
 				tt.setupFunc()
@@ -122,7 +122,8 @@ func TestLeftAmountFix(t *testing.T) {
 			totalSent := tt.distributionAmount - leftAmt
 			amountByAddress, err := applyDistribution(distributable)
 			uassert.NoError(t, err)
-			err = transferToTarget(amountByAddress)
+			testing.SetRealm(emissionRealm)
+			err = transferToTarget(0, cur, amountByAddress)
 
 			if tt.shouldError {
 				uassert.Equal(t, tt.errorMessage, err.Error())

--- a/contract/r/gnoswap/emission/security_test.gno
+++ b/contract/r/gnoswap/emission/security_test.gno
@@ -6,12 +6,10 @@ import (
 
 	uassert "gno.land/p/nt/uassert/v0"
 
-	prbac "gno.land/p/gnoswap/rbac"
-	"gno.land/r/gnoswap/access"
 	"gno.land/r/gnoswap/gns"
 )
 
-func TestCalculateAmount_SecurityValidation(t *testing.T) {
+func TestCalculateAmount_SecurityValidation(cur realm, t *testing.T) {
 	tests := []struct {
 		name                 string
 		amount               int64
@@ -72,7 +70,7 @@ func TestCalculateAmount_SecurityValidation(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			defer func() {
 				if r := recover(); r != nil {
 					if tc.expectedHasPanic {
@@ -94,7 +92,7 @@ func TestCalculateAmount_SecurityValidation(t *testing.T) {
 	}
 }
 
-func TestSetLeftGNSAmount_SecurityValidation(t *testing.T) {
+func TestSetLeftGNSAmount_SecurityValidation(cur realm, t *testing.T) {
 	tests := []struct {
 		name                 string
 		amount               int64
@@ -120,7 +118,7 @@ func TestSetLeftGNSAmount_SecurityValidation(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			defer func() {
 				if r := recover(); r != nil {
 					if tc.expectedHasPanic {
@@ -144,7 +142,7 @@ func TestSetLeftGNSAmount_SecurityValidation(t *testing.T) {
 	}
 }
 
-func TestSetLastExecutedHeight_SecurityValidation(t *testing.T) {
+func TestSetLastExecutedHeight_SecurityValidation(cur realm, t *testing.T) {
 	tests := []struct {
 		name                 string
 		timestamp            int64
@@ -170,7 +168,7 @@ func TestSetLastExecutedHeight_SecurityValidation(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			defer func() {
 				if r := recover(); r != nil {
 					if tc.expectedHasPanic {
@@ -194,7 +192,7 @@ func TestSetLastExecutedHeight_SecurityValidation(t *testing.T) {
 	}
 }
 
-func TestAssertValidDistributionPct_SecurityValidation(t *testing.T) {
+func TestAssertValidDistributionPct_SecurityValidation(cur realm, t *testing.T) {
 	tests := []struct {
 		name                 string
 		pct01                int64
@@ -251,7 +249,7 @@ func TestAssertValidDistributionPct_SecurityValidation(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			defer func() {
 				if r := recover(); r != nil {
 					if tc.expectedHasPanic {
@@ -275,7 +273,7 @@ func TestAssertValidDistributionPct_SecurityValidation(t *testing.T) {
 }
 
 // Test the calculateAmount function in isolation
-func TestCalculateAmount_IsolatedSecurity(t *testing.T) {
+func TestCalculateAmount_IsolatedSecurity(cur realm, t *testing.T) {
 	tests := []struct {
 		name                 string
 		amount               int64
@@ -319,7 +317,7 @@ func TestCalculateAmount_IsolatedSecurity(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			defer func() {
 				if r := recover(); r != nil {
 					if tc.expectedHasPanic {
@@ -343,7 +341,7 @@ func TestCalculateAmount_IsolatedSecurity(t *testing.T) {
 	}
 }
 
-func TestAssertValidDistributionPct_IsolatedSecurity(t *testing.T) {
+func TestAssertValidDistributionPct_IsolatedSecurity(cur realm, t *testing.T) {
 	tests := []struct {
 		name                 string
 		pct01                int64
@@ -372,7 +370,7 @@ func TestAssertValidDistributionPct_IsolatedSecurity(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(cur realm, t *testing.T) {
 			defer func() {
 				if r := recover(); r != nil {
 					if tc.expectedHasPanic {
@@ -404,7 +402,7 @@ func TestAssertValidDistributionPct_IsolatedSecurity(t *testing.T) {
 }
 
 // TestAssertValidDistributionTarget tests validation of single distribution targets
-func TestAssertValidDistributionTarget(t *testing.T) {
+func TestAssertValidDistributionTarget(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		target      int
@@ -464,15 +462,17 @@ func TestAssertValidDistributionTarget(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.panicMsg, func() {
-					assertValidDistributionTarget(tt.target)
-				})
+				uassert.PanicsWithMessage(
+					t, cur, tt.panicMsg, func() {
+						assertValidDistributionTarget(tt.target)
+					})
 			} else {
-				uassert.NotPanics(t, func() {
-					assertValidDistributionTarget(tt.target)
-				})
+				uassert.NotPanics(
+					t, cur, func() {
+						assertValidDistributionTarget(tt.target)
+					})
 			}
 		})
 	}
@@ -480,7 +480,7 @@ func TestAssertValidDistributionTarget(t *testing.T) {
 
 // TestTransferToTarget_CEIPattern tests the Checks-Effects-Interactions pattern
 // This verifies that state is updated BEFORE external calls (gns.Transfer)
-func TestTransferToTarget_CEIPattern(t *testing.T) {
+func TestTransferToTarget_CEIPattern(cur realm, t *testing.T) {
 	tests := []struct {
 		name                         string
 		description                  string
@@ -596,7 +596,7 @@ func TestTransferToTarget_CEIPattern(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			resetObject(t)
 
 			// Setup initial state based on target
@@ -617,9 +617,8 @@ func TestTransferToTarget_CEIPattern(t *testing.T) {
 
 			// Setup balance for emission
 			if tt.setupBalance {
-				emissionAddr, _ := access.GetAddress(prbac.ROLE_EMISSION.String())
 				testing.SetRealm(adminRealm)
-				gns.Transfer(cross, emissionAddr, tt.balanceToSetup)
+				gns.Transfer(cross(cur), emissionAddr, tt.balanceToSetup)
 			}
 
 			// Execute transfer
@@ -628,7 +627,7 @@ func TestTransferToTarget_CEIPattern(t *testing.T) {
 			var err error
 
 			transferToTargetFunc := func(cur realm) error {
-				testing.SetRealm(testing.NewUserRealm(emissionAddr))
+				testing.SetRealm(emissionRealm)
 				targets := map[int]int64{tt.target: tt.amount}
 				amountByAddress, err := applyDistribution(targets)
 				if err != nil {
@@ -637,7 +636,7 @@ func TestTransferToTarget_CEIPattern(t *testing.T) {
 
 				beforeBalance := gns.BalanceOf(emissionAddr)
 
-				err = transferToTarget(amountByAddress)
+				err = transferToTarget(0, cur, amountByAddress)
 				if err != nil {
 					return err
 				}
@@ -648,13 +647,13 @@ func TestTransferToTarget_CEIPattern(t *testing.T) {
 			}
 
 			if !tt.setupBalance {
-				uassert.AbortsContains(t, "overflow", func() {
-					transferToTargetFunc(cross)
+				uassert.AbortsContains(t, cur, "overflow", func() {
+					_ = transferToTargetFunc(cross(cur))
 				})
 
 				return
 			} else {
-				err = transferToTargetFunc(cross)
+				err = transferToTargetFunc(cross(cur))
 			}
 
 			uassert.NoError(t, err)
@@ -681,7 +680,7 @@ func TestTransferToTarget_CEIPattern(t *testing.T) {
 }
 
 // TestAccumulatedDistribution_SafeMath tests safe math for accumulated distribution values
-func TestAccumulatedDistribution_SafeMath(t *testing.T) {
+func TestAccumulatedDistribution_SafeMath(cur realm, t *testing.T) {
 	tests := []struct {
 		name                    string
 		description             string
@@ -760,7 +759,7 @@ func TestAccumulatedDistribution_SafeMath(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			resetObject(t)
 
 			// Setup initial state
@@ -780,14 +779,14 @@ func TestAccumulatedDistribution_SafeMath(t *testing.T) {
 			}
 
 			// Setup balance for emission
-			emissionAddr, _ := access.GetAddress(prbac.ROLE_EMISSION.String())
 			testing.SetRealm(adminRealm)
-			gns.Transfer(cross, emissionAddr, 1000000000)
+			gns.Transfer(cross(cur), emissionAddr, 1000000000)
 
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.panicMessage, func() {
-					_, _ = applyDistribution(map[int]int64{tt.target: tt.amountToAdd})
-				})
+				uassert.PanicsWithMessage(
+					t, cur, tt.panicMessage, func() {
+						_, _ = applyDistribution(map[int]int64{tt.target: tt.amountToAdd})
+					})
 			} else {
 				_, err := applyDistribution(map[int]int64{tt.target: tt.amountToAdd})
 				uassert.NoError(t, err)
@@ -813,7 +812,7 @@ func TestAccumulatedDistribution_SafeMath(t *testing.T) {
 }
 
 // TestFormatInt tests formatInt function with edge cases
-func TestFormatInt(t *testing.T) {
+func TestFormatInt(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		value       any
@@ -878,7 +877,7 @@ func TestFormatInt(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.shouldPanic {
 				defer func() {
 					if r := recover(); r == nil {
@@ -895,7 +894,7 @@ func TestFormatInt(t *testing.T) {
 }
 
 // TestSafeAddInt64 tests the safeAddInt64 function for overflow and underflow protection
-func TestSafeAddInt64(t *testing.T) {
+func TestSafeAddInt64(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		a           int64
@@ -1015,23 +1014,25 @@ func TestSafeAddInt64(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.panicMsg, func() {
-					safeAddInt64(tt.a, tt.b)
-				})
+				uassert.PanicsWithMessage(
+					t, cur, tt.panicMsg, func() {
+						safeAddInt64(tt.a, tt.b)
+					})
 			} else {
-				uassert.NotPanics(t, func() {
-					result := safeAddInt64(tt.a, tt.b)
-					uassert.Equal(t, tt.expected, result)
-				})
+				uassert.NotPanics(
+					t, cur, func() {
+						result := safeAddInt64(tt.a, tt.b)
+						uassert.Equal(t, tt.expected, result)
+					})
 			}
 		})
 	}
 }
 
 // TestSafeSubInt64 tests the safeSubInt64 function for overflow and underflow protection
-func TestSafeSubInt64(t *testing.T) {
+func TestSafeSubInt64(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		a           int64
@@ -1157,16 +1158,18 @@ func TestSafeSubInt64(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.panicMsg, func() {
-					safeSubInt64(tt.a, tt.b)
-				})
+				uassert.PanicsWithMessage(
+					t, cur, tt.panicMsg, func() {
+						safeSubInt64(tt.a, tt.b)
+					})
 			} else {
-				uassert.NotPanics(t, func() {
-					result := safeSubInt64(tt.a, tt.b)
-					uassert.Equal(t, tt.expected, result)
-				})
+				uassert.NotPanics(
+					t, cur, func() {
+						result := safeSubInt64(tt.a, tt.b)
+						uassert.Equal(t, tt.expected, result)
+					})
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Migrates the emission realm and tests to Interrealm v2 call semantics.
- Updates emission distribution flows to pass `cur` through cross-realm calls.
- Removes test helpers that hid realm setup and updates tests to set caller realms explicitly.

## Changes
- Initializes the emission realm address from `init(cur realm)`.
- Updates `MintAndDistributeGns`, `SetDistributionStartTime`, callbacks, and `transferToTarget` call sites to use Interrealm v2 patterns.
- Restores the CEI overflow test through `transferToTargetFunc(cross(cur))` and asserts the crossing abort with `AbortsContains`.

## Validation
- `gno fmt contract/r/gnoswap/emission`
- `make test PKG=gno.land/r/gnoswap/emission`
- `GIT_MASTER=1 git diff --check`