### PR TITLE
refactor(test): migrate pure package tests to interrealm v2

### DIFF
--- a/contract/p/gnoswap/gnsmath/bit_math_test.gno
+++ b/contract/p/gnoswap/gnsmath/bit_math_test.gno
@@ -7,7 +7,7 @@ import (
 	uassert "gno.land/p/nt/uassert/v0"
 )
 
-func TestBitMath_BitMathMostSignificantBit(t *testing.T) {
+func TestBitMath_BitMathMostSignificantBit(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		input       string
@@ -164,7 +164,7 @@ func TestBitMath_BitMathMostSignificantBit(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.shouldPanic {
-				uassert.PanicsWithMessage(t, errMSBZeroInput.Error(), func() {
+				uassert.PanicsWithMessage(t, cur, errMSBZeroInput.Error(), func() {
 					BitMathMostSignificantBit(u256.MustFromDecimal(tc.input))
 				})
 				return
@@ -186,7 +186,7 @@ func TestBitMath_BitMathMostSignificantBit_PowersOfTwo(t *testing.T) {
 	}
 }
 
-func TestBitMath_BitMathLeastSignificantBit(t *testing.T) {
+func TestBitMath_BitMathLeastSignificantBit(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		input       string
@@ -342,7 +342,7 @@ func TestBitMath_BitMathLeastSignificantBit(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.shouldPanic {
-				uassert.PanicsWithMessage(t, errLSBZeroInput.Error(), func() {
+				uassert.PanicsWithMessage(t, cur, errLSBZeroInput.Error(), func() {
 					BitMathLeastSignificantBit(u256.MustFromDecimal(tc.input))
 				})
 				return

--- a/contract/p/gnoswap/gnsmath/sqrt_price_math_test.gno
+++ b/contract/p/gnoswap/gnsmath/sqrt_price_math_test.gno
@@ -107,7 +107,7 @@ func TestSqrtPriceMath_getNextPriceAmount0Add_BranchCoverage(t *testing.T) {
 }
 
 // TestGetNextPriceAmount0Remove tests the internal helper for removing token0
-func TestSqrtPriceMath_getNextPriceAmount0Remove(t *testing.T) {
+func TestSqrtPriceMath_getNextPriceAmount0Remove(cur realm, t *testing.T) {
 	tiny := u256.One()
 	medium := u256.MustFromDecimal("100000000000000000")
 	huge := u256.MustFromDecimal("1000000000000000000000000000000")
@@ -214,7 +214,7 @@ func TestSqrtPriceMath_getNextPriceAmount0Remove(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			before := tt.current.Clone()
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.panicMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.panicMsg, func() {
 					_ = getNextPriceAmount0Remove(tt.current, tt.liquidity, tt.amountToRemove)
 				})
 				return
@@ -226,7 +226,7 @@ func TestSqrtPriceMath_getNextPriceAmount0Remove(t *testing.T) {
 }
 
 // TestGetNextSqrtPriceFromAmount0RoundingUp tests price calculation when adding/removing token0
-func TestSqrtPriceMath_getNextSqrtPriceFromAmount0RoundingUp(t *testing.T) {
+func TestSqrtPriceMath_getNextSqrtPriceFromAmount0RoundingUp(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		sqrtPX96    *u256.Uint
@@ -319,7 +319,7 @@ func TestSqrtPriceMath_getNextSqrtPriceFromAmount0RoundingUp(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.panicMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.panicMsg, func() {
 					getNextSqrtPriceFromAmount0RoundingUp(tt.sqrtPX96, tt.liquidity, tt.amount, tt.add)
 				})
 				return
@@ -332,7 +332,7 @@ func TestSqrtPriceMath_getNextSqrtPriceFromAmount0RoundingUp(t *testing.T) {
 }
 
 // TestGetNextPriceAmount1Add tests the internal helper for adding token1
-func TestSqrtPriceMath_getNextPriceAmount1Add(t *testing.T) {
+func TestSqrtPriceMath_getNextPriceAmount1Add(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		sqrtPX96    *u256.Uint
@@ -412,7 +412,7 @@ func TestSqrtPriceMath_getNextPriceAmount1Add(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.panicMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.panicMsg, func() {
 					getNextPriceAmount1Add(tt.sqrtPX96, tt.liquidity, tt.amount)
 				})
 				return
@@ -461,7 +461,7 @@ func TestSqrtPriceMath_getNextPriceAmount1Add_MAX160Boundary(t *testing.T) {
 }
 
 // TestGetNextPriceAmount1Remove tests the internal helper for removing token1
-func TestSqrtPriceMath_getNextPriceAmount1Remove(t *testing.T) {
+func TestSqrtPriceMath_getNextPriceAmount1Remove(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		sqrtPX96    *u256.Uint
@@ -618,7 +618,7 @@ func TestSqrtPriceMath_getNextPriceAmount1Remove(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.panicMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.panicMsg, func() {
 					getNextPriceAmount1Remove(tt.sqrtPX96, tt.liquidity, tt.amount)
 				})
 				return
@@ -661,7 +661,7 @@ func TestSqrtPriceMath_getNextPriceAmount1Remove_MAX160Boundary(t *testing.T) {
 }
 
 // TestGetNextSqrtPriceFromAmount1RoundingDown tests price calculation when adding/removing token1
-func TestSqrtPriceMath_getNextSqrtPriceFromAmount1RoundingDown(t *testing.T) {
+func TestSqrtPriceMath_getNextSqrtPriceFromAmount1RoundingDown(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		sqrtPX96    *u256.Uint
@@ -701,7 +701,7 @@ func TestSqrtPriceMath_getNextSqrtPriceFromAmount1RoundingDown(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.panicMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.panicMsg, func() {
 					getNextSqrtPriceFromAmount1RoundingDown(tt.sqrtPX96, tt.liquidity, tt.amount, tt.add)
 				})
 				return
@@ -714,7 +714,7 @@ func TestSqrtPriceMath_getNextSqrtPriceFromAmount1RoundingDown(t *testing.T) {
 }
 
 // TestGetNextSqrtPriceFromInput tests input swap calculations
-func TestSqrtPriceMath_getNextSqrtPriceFromInput(t *testing.T) {
+func TestSqrtPriceMath_getNextSqrtPriceFromInput(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		sqrtPX96    *u256.Uint
@@ -772,7 +772,7 @@ func TestSqrtPriceMath_getNextSqrtPriceFromInput(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.panicMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.panicMsg, func() {
 					getNextSqrtPriceFromInput(tt.sqrtPX96, tt.liquidity, tt.amountIn, tt.zeroForOne)
 				})
 				return
@@ -785,7 +785,7 @@ func TestSqrtPriceMath_getNextSqrtPriceFromInput(t *testing.T) {
 }
 
 // TestGetNextSqrtPriceFromOutput tests output swap calculations
-func TestSqrtPriceMath_getNextSqrtPriceFromOutput(t *testing.T) {
+func TestSqrtPriceMath_getNextSqrtPriceFromOutput(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		sqrtPX96    *u256.Uint
@@ -852,7 +852,7 @@ func TestSqrtPriceMath_getNextSqrtPriceFromOutput(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.panicMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.panicMsg, func() {
 					getNextSqrtPriceFromOutput(tt.sqrtPX96, tt.liquidity, tt.amountOut, tt.zeroForOne)
 				})
 				return
@@ -865,7 +865,7 @@ func TestSqrtPriceMath_getNextSqrtPriceFromOutput(t *testing.T) {
 }
 
 // TestGetAmount0DeltaHelper tests amount0 calculation helper
-func TestSqrtPriceMath_getAmount0DeltaHelper(t *testing.T) {
+func TestSqrtPriceMath_getAmount0DeltaHelper(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
 		sqrtRatioAX96 *u256.Uint
@@ -959,7 +959,7 @@ func TestSqrtPriceMath_getAmount0DeltaHelper(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.panicMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.panicMsg, func() {
 					getAmount0DeltaHelper(tt.sqrtRatioAX96, tt.sqrtRatioBX96, tt.liquidity, tt.roundUp)
 				})
 				return
@@ -1060,7 +1060,7 @@ func TestSqrtPriceMath_getAmount1DeltaHelper(t *testing.T) {
 }
 
 // TestGetAmount0Delta tests string representation with signed liquidity
-func TestSqrtPriceMath_GetAmount0Delta(t *testing.T) {
+func TestSqrtPriceMath_GetAmount0Delta(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
 		sqrtRatioAX96 *u256.Uint
@@ -1131,7 +1131,7 @@ func TestSqrtPriceMath_GetAmount0Delta(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.panicMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.panicMsg, func() {
 					GetAmount0Delta(tt.sqrtRatioAX96, tt.sqrtRatioBX96, tt.liquidity)
 				})
 				return
@@ -1144,7 +1144,7 @@ func TestSqrtPriceMath_GetAmount0Delta(t *testing.T) {
 }
 
 // TestGetAmount1Delta tests string representation with signed liquidity
-func TestSqrtPriceMath_GetAmount1Delta(t *testing.T) {
+func TestSqrtPriceMath_GetAmount1Delta(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
 		sqrtRatioAX96 *u256.Uint
@@ -1229,7 +1229,7 @@ func TestSqrtPriceMath_GetAmount1Delta(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, tt.panicMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.panicMsg, func() {
 					GetAmount1Delta(tt.sqrtRatioAX96, tt.sqrtRatioBX96, tt.liquidity)
 				})
 				return

--- a/contract/p/gnoswap/gnsmath/swap_math_test.gno
+++ b/contract/p/gnoswap/gnsmath/swap_math_test.gno
@@ -10,7 +10,7 @@ import (
 	u256 "gno.land/p/gnoswap/uint256"
 )
 
-func TestSwapMath_SwapMathComputeSwapStep(t *testing.T) {
+func TestSwapMath_SwapMathComputeSwapStep(cur realm, t *testing.T) {
 	tests := []struct {
 		name                           string
 		currentX96, targetX96          *u256.Uint
@@ -282,7 +282,7 @@ func TestSwapMath_SwapMathComputeSwapStep(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if test.shouldPanic {
-				uassert.PanicsWithMessage(t, test.panicMsg, func() {
+				uassert.PanicsWithMessage(t, cur, test.panicMsg, func() {
 					SwapMathComputeSwapStep(
 						test.currentX96, test.targetX96, test.liquidity, test.amountRemaining, test.feePips,
 					)

--- a/contract/p/gnoswap/int256/conversion_test.gno
+++ b/contract/p/gnoswap/int256/conversion_test.gno
@@ -92,7 +92,7 @@ func TestMustFromDecimal(t *testing.T) {
 	}
 }
 
-func TestFromUint256(t *testing.T) {
+func TestFromUint256(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		input       *uint256.Uint
@@ -122,7 +122,7 @@ func TestFromUint256(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.shouldPanic {
-				uassert.PanicsContains(t, "int256: overflow", func() {
+				uassert.PanicsContains(t, cur, "int256: overflow", func() {
 					FromUint256(tt.input)
 				})
 				return

--- a/contract/p/gnoswap/int256/int256_test.gno
+++ b/contract/p/gnoswap/int256/int256_test.gno
@@ -28,7 +28,7 @@ func TestSign(t *testing.T) {
 	}
 }
 
-func TestAbs(t *testing.T) {
+func TestAbs(cur realm, t *testing.T) {
 	tests := []struct {
 		x, want             string
 		expectedHasOverflow bool
@@ -51,7 +51,7 @@ func TestAbs(t *testing.T) {
 		}
 
 		if tc.expectedHasOverflow {
-			uassert.PanicsContains(t, "int256: overflow", func() {
+			uassert.PanicsContains(t, cur, "int256: overflow", func() {
 				x.Abs()
 			})
 			continue
@@ -65,7 +65,7 @@ func TestAbs(t *testing.T) {
 	}
 }
 
-func TestAbsWithPanicCases(t *testing.T) {
+func TestAbsWithPanicCases(cur realm, t *testing.T) {
 	tests := []struct {
 		x, want   string
 		wantErr   bool
@@ -106,7 +106,7 @@ func TestAbsWithPanicCases(t *testing.T) {
 		}
 
 		if tc.wantPanic {
-			uassert.PanicsContains(t, "int256: overflow", func() {
+			uassert.PanicsContains(t, cur, "int256: overflow", func() {
 				x.Abs()
 			})
 			ufmt.Printf("Abs(%s) correctly panicked with overflow\n", tc.x)
@@ -1125,21 +1125,21 @@ func TestRsh(t *testing.T) {
 	}
 }
 
-func TestLsh_NoPanic(t *testing.T) {
+func TestLsh_NoPanic(cur realm, t *testing.T) {
 	x := MustFromDecimal("-12345678901234567890")
 
 	for n := uint(0); n < 300; n++ {
-		uassert.NotPanics(t, func() {
+		uassert.NotPanics(t, cur, func() {
 			_ = new(Int).Lsh(x, n)
 		})
 	}
 }
 
-func TestRsh_NoPanic(t *testing.T) {
+func TestRsh_NoPanic(cur realm, t *testing.T) {
 	x := MustFromDecimal("-12345678901234567890")
 
 	for n := uint(0); n < 300; n++ {
-		uassert.NotPanics(t, func() {
+		uassert.NotPanics(t, cur, func() {
 			_ = new(Int).Rsh(x, n)
 		})
 	}
@@ -1814,7 +1814,7 @@ func TestSetUint64(t *testing.T) {
 	}
 }
 
-func TestUint64(t *testing.T) {
+func TestUint64(cur realm, t *testing.T) {
 	tests := []struct {
 		x      string
 		want   uint64
@@ -1842,7 +1842,7 @@ func TestUint64(t *testing.T) {
 		z := MustFromDecimal(tc.x)
 
 		if tc.panics {
-			uassert.PanicsContains(t, "uint64 overflow", func() {
+			uassert.PanicsContains(t, cur, "uint64 overflow", func() {
 				z.Uint64()
 			})
 			continue
@@ -1855,7 +1855,7 @@ func TestUint64(t *testing.T) {
 	}
 }
 
-func TestInt64(t *testing.T) {
+func TestInt64(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
 		x             string
@@ -1910,7 +1910,7 @@ func TestInt64(t *testing.T) {
 			z := MustFromDecimal(tc.x)
 
 			if tc.panics {
-				uassert.PanicsContains(t, "int64 overflow", func() {
+				uassert.PanicsContains(t, cur, "int64 overflow", func() {
 					z.Int64()
 				})
 				return
@@ -1961,7 +1961,7 @@ func TestNeg(t *testing.T) {
 	}
 }
 
-func TestNegOverflow(t *testing.T) {
+func TestNegOverflow(cur realm, t *testing.T) {
 	tests := []struct {
 		x           string
 		want        string
@@ -1982,7 +1982,7 @@ func TestNegOverflow(t *testing.T) {
 		z := MustFromDecimal(tc.x)
 
 		if tc.shouldPanic {
-			uassert.PanicsContains(t, "int256: overflow", func() {
+			uassert.PanicsContains(t, cur, "int256: overflow", func() {
 				z.NegOverflow(z)
 			})
 			continue

--- a/contract/p/gnoswap/uint256/uint256_test.gno
+++ b/contract/p/gnoswap/uint256/uint256_test.gno
@@ -6,7 +6,7 @@ import (
 	uassert "gno.land/p/nt/uassert/v0"
 )
 
-func TestFromDecimal(t *testing.T) {
+func TestFromDecimal(cur realm, t *testing.T) {
 	t.Run("valid_inputs", func(t *testing.T) {
 		tests := []struct {
 			name     string
@@ -43,7 +43,7 @@ func TestFromDecimal(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				uassert.PanicsWithMessage(t, tt.panicMsg, func() {
+				uassert.PanicsWithMessage(t, cur, tt.panicMsg, func() {
 					MustFromDecimal(tt.input)
 				})
 			})
@@ -310,7 +310,7 @@ func TestOperationConsistency(t *testing.T) {
 	})
 }
 
-func TestInt64Conversion(t *testing.T) {
+func TestInt64Conversion(cur realm, t *testing.T) {
 	t.Run("Int64", func(t *testing.T) {
 		tests := []struct {
 			name string
@@ -345,7 +345,7 @@ func TestInt64Conversion(t *testing.T) {
 		})
 
 		t.Run("negative panics", func(t *testing.T) {
-			uassert.PanicsContains(t, "val is negative", func() {
+			uassert.PanicsContains(t, cur, "val is negative", func() {
 				NewUintFromInt64(-1)
 			})
 		})

--- a/contract/r/gnoswap/gns/_helper_test.gno
+++ b/contract/r/gnoswap/gns/_helper_test.gno
@@ -27,7 +27,7 @@ func resetGnsTokenObject(cur realm, t *testing.T) {
 	t.Helper()
 
 	token, privateLedger = grc20.NewToken(0, cur, "Gnoswap", "GNS", 6)
-	UserTeller = token.CallerTeller()
+	userTeller = token.CallerTeller()
 
 	privateLedger.Mint(adminAddr, INITIAL_MINT_AMOUNT)
 }

--- a/contract/r/gnoswap/rbac/rbac_test.gno
+++ b/contract/r/gnoswap/rbac/rbac_test.gno
@@ -12,7 +12,7 @@ import (
 func TestRbac_RegisterRole(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
-		setup         func()
+		setup         func(cur realm)
 		roleName      string
 		roleAddress   address
 		callerRealm   address // Test with different callers (ADMIN or GOVERNANCE)
@@ -21,7 +21,7 @@ func TestRbac_RegisterRole(cur realm, t *testing.T) {
 	}{
 		{
 			name: "Register role with valid address succeeds (ADMIN)",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 			},
@@ -32,7 +32,7 @@ func TestRbac_RegisterRole(cur realm, t *testing.T) {
 		},
 		{
 			name: "Register role with valid address succeeds (GOVERNANCE)",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 			},
@@ -43,7 +43,7 @@ func TestRbac_RegisterRole(cur realm, t *testing.T) {
 		},
 		{
 			name: "Register role with different valid address succeeds (ADMIN)",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 			},
@@ -54,7 +54,7 @@ func TestRbac_RegisterRole(cur realm, t *testing.T) {
 		},
 		{
 			name: "Register role with empty address fails (ADMIN)",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 			},
@@ -66,7 +66,7 @@ func TestRbac_RegisterRole(cur realm, t *testing.T) {
 		},
 		{
 			name: "Register role with empty address fails (GOVERNANCE)",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 			},
@@ -78,7 +78,7 @@ func TestRbac_RegisterRole(cur realm, t *testing.T) {
 		},
 		{
 			name: "Register duplicate role with different address fails (ADMIN)",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 				// Pre-register a role
@@ -93,7 +93,7 @@ func TestRbac_RegisterRole(cur realm, t *testing.T) {
 		},
 		{
 			name: "Register system role with new address fails (GOVERNANCE)",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 			},
@@ -105,7 +105,7 @@ func TestRbac_RegisterRole(cur realm, t *testing.T) {
 		},
 		{
 			name: "Register role with unauthorized caller fails",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 			},
@@ -117,7 +117,7 @@ func TestRbac_RegisterRole(cur realm, t *testing.T) {
 		},
 		{
 			name: "Register role with devops caller fails (not admin or governance)",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 			},
@@ -129,7 +129,7 @@ func TestRbac_RegisterRole(cur realm, t *testing.T) {
 		},
 		{
 			name: "Register role with empty role name fails",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 			},
@@ -141,7 +141,7 @@ func TestRbac_RegisterRole(cur realm, t *testing.T) {
 		},
 		{
 			name: "Register role with whitespace-only name fails",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 			},
@@ -153,7 +153,7 @@ func TestRbac_RegisterRole(cur realm, t *testing.T) {
 		},
 		{
 			name: "Register role with tab and space name fails",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 			},
@@ -165,7 +165,7 @@ func TestRbac_RegisterRole(cur realm, t *testing.T) {
 		},
 		{
 			name: "Register role with invalid address format fails",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 			},
@@ -177,7 +177,7 @@ func TestRbac_RegisterRole(cur realm, t *testing.T) {
 		},
 		{
 			name: "Register role with malformed address fails",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 			},
@@ -191,7 +191,7 @@ func TestRbac_RegisterRole(cur realm, t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
-			tt.setup()
+			tt.setup(cur)
 
 			// Set realm to the specified caller for authorization testing
 			testing.SetRealm(testing.NewUserRealm(tt.callerRealm))
@@ -215,14 +215,14 @@ func TestRbac_RegisterRole(cur realm, t *testing.T) {
 func TestRbac_RemoveRole(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
-		setup       func()
+		setup       func(cur realm)
 		roleName    string
 		shouldError bool
 		errorMsg    string
 	}{
 		{
 			name: "Remove custom role should succeed",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 				manager.RegisterRole("removable_role", testutils.TestAddress("removable_address"))
@@ -232,7 +232,7 @@ func TestRbac_RemoveRole(cur realm, t *testing.T) {
 		},
 		{
 			name: "Remove system role should error",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 			},
@@ -242,7 +242,7 @@ func TestRbac_RemoveRole(cur realm, t *testing.T) {
 		},
 		{
 			name: "Remove non-existent role should error",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 			},
@@ -252,7 +252,7 @@ func TestRbac_RemoveRole(cur realm, t *testing.T) {
 		},
 		{
 			name: "Remove role with empty string should error",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 			},
@@ -262,7 +262,7 @@ func TestRbac_RemoveRole(cur realm, t *testing.T) {
 		},
 		{
 			name: "Remove role multiple times should error on second attempt",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 				manager.RegisterRole("remove_twice_role", testutils.TestAddress("remove_twice_address"))
@@ -276,7 +276,7 @@ func TestRbac_RemoveRole(cur realm, t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
-			tt.setup()
+			tt.setup(cur)
 			testing.SetRealm(testing.NewUserRealm(ADMIN))
 			err := manager.RemoveRole(tt.roleName)
 
@@ -435,7 +435,7 @@ func TestUpdateAccessRoleAddresses(cur realm, t *testing.T) {
 func TestAddressChangeComplete(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
-		setup         func()
+		setup         func(cur realm)
 		roleName      string
 		oldAddress    address
 		newAddress    address
@@ -444,7 +444,7 @@ func TestAddressChangeComplete(cur realm, t *testing.T) {
 	}{
 		{
 			name: "Change admin role address",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 			},
@@ -465,7 +465,7 @@ func TestAddressChangeComplete(cur realm, t *testing.T) {
 		},
 		{
 			name: "Change custom role address",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 				manager.RegisterRole("custom_role", testutils.TestAddress("custom_address"))
@@ -488,7 +488,7 @@ func TestAddressChangeComplete(cur realm, t *testing.T) {
 		},
 		{
 			name: "Change multiple role addresses sequentially",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 			},
@@ -531,7 +531,7 @@ func TestAddressChangeComplete(cur realm, t *testing.T) {
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/rbac"))
 
 			// Setup
-			tt.setup()
+			tt.setup(cur)
 
 			// Verify initial address
 			initialAddr, err := manager.GetRoleAddress(tt.roleName)
@@ -720,7 +720,7 @@ func TestRBACToAccessSync(cur realm, t *testing.T) {
 func TestRbac_UpdateRoleAddress_WithAuthorization(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
-		setup         func()
+		setup         func(cur realm)
 		roleName      string
 		newAddr       address
 		callerRealm   address
@@ -729,7 +729,7 @@ func TestRbac_UpdateRoleAddress_WithAuthorization(cur realm, t *testing.T) {
 	}{
 		{
 			name: "Update role with admin caller succeeds",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 				testing.SetRealm(testing.NewUserRealm(ADMIN))
@@ -742,7 +742,7 @@ func TestRbac_UpdateRoleAddress_WithAuthorization(cur realm, t *testing.T) {
 		},
 		{
 			name: "Update role with governance caller succeeds",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 				testing.SetRealm(testing.NewUserRealm(ADMIN))
@@ -755,7 +755,7 @@ func TestRbac_UpdateRoleAddress_WithAuthorization(cur realm, t *testing.T) {
 		},
 		{
 			name: "Update role with unauthorized caller fails",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 				testing.SetRealm(testing.NewUserRealm(ADMIN))
@@ -769,7 +769,7 @@ func TestRbac_UpdateRoleAddress_WithAuthorization(cur realm, t *testing.T) {
 		},
 		{
 			name: "Update role with devops caller fails",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 				testing.SetRealm(testing.NewUserRealm(ADMIN))
@@ -783,7 +783,7 @@ func TestRbac_UpdateRoleAddress_WithAuthorization(cur realm, t *testing.T) {
 		},
 		{
 			name: "Update role with empty role name fails",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 			},
@@ -795,7 +795,7 @@ func TestRbac_UpdateRoleAddress_WithAuthorization(cur realm, t *testing.T) {
 		},
 		{
 			name: "Update role with empty address fails",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 				testing.SetRealm(testing.NewUserRealm(ADMIN))
@@ -809,7 +809,7 @@ func TestRbac_UpdateRoleAddress_WithAuthorization(cur realm, t *testing.T) {
 		},
 		{
 			name: "Update role with invalid address format fails",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 				testing.SetRealm(testing.NewUserRealm(ADMIN))
@@ -823,7 +823,7 @@ func TestRbac_UpdateRoleAddress_WithAuthorization(cur realm, t *testing.T) {
 		},
 		{
 			name: "Update role with malformed address fails",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 				testing.SetRealm(testing.NewUserRealm(ADMIN))
@@ -837,7 +837,7 @@ func TestRbac_UpdateRoleAddress_WithAuthorization(cur realm, t *testing.T) {
 		},
 		{
 			name: "Update non-existent role fails",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 			},
@@ -849,7 +849,7 @@ func TestRbac_UpdateRoleAddress_WithAuthorization(cur realm, t *testing.T) {
 		},
 		{
 			name: "Update role with same address succeeds (idempotent)",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 				testing.SetRealm(testing.NewUserRealm(ADMIN))
@@ -862,7 +862,7 @@ func TestRbac_UpdateRoleAddress_WithAuthorization(cur realm, t *testing.T) {
 		},
 		{
 			name: "Update admin role via UpdateRoleAddress fails",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 			},
@@ -874,7 +874,7 @@ func TestRbac_UpdateRoleAddress_WithAuthorization(cur realm, t *testing.T) {
 		},
 		{
 			name: "Update whitespace padded admin role via UpdateRoleAddress fails",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 			},
@@ -888,7 +888,7 @@ func TestRbac_UpdateRoleAddress_WithAuthorization(cur realm, t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
-			tt.setup()
+			tt.setup(cur)
 
 			// Set realm to the specified caller for authorization testing
 			testing.SetRealm(testing.NewUserRealm(tt.callerRealm))
@@ -912,7 +912,7 @@ func TestRbac_UpdateRoleAddress_WithAuthorization(cur realm, t *testing.T) {
 func TestRbac_RemoveRole_WithAuthorization(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
-		setup         func()
+		setup         func(cur realm)
 		roleName      string
 		callerRealm   address
 		shouldPanic   bool
@@ -920,7 +920,7 @@ func TestRbac_RemoveRole_WithAuthorization(cur realm, t *testing.T) {
 	}{
 		{
 			name: "Remove role with admin caller succeeds",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 				testing.SetRealm(testing.NewUserRealm(ADMIN))
@@ -932,7 +932,7 @@ func TestRbac_RemoveRole_WithAuthorization(cur realm, t *testing.T) {
 		},
 		{
 			name: "Remove role with governance caller succeeds",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 				testing.SetRealm(testing.NewUserRealm(ADMIN))
@@ -944,7 +944,7 @@ func TestRbac_RemoveRole_WithAuthorization(cur realm, t *testing.T) {
 		},
 		{
 			name: "Remove role with unauthorized caller fails",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 				testing.SetRealm(testing.NewUserRealm(ADMIN))
@@ -957,7 +957,7 @@ func TestRbac_RemoveRole_WithAuthorization(cur realm, t *testing.T) {
 		},
 		{
 			name: "Remove role with devops caller fails",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 				testing.SetRealm(testing.NewUserRealm(ADMIN))
@@ -970,7 +970,7 @@ func TestRbac_RemoveRole_WithAuthorization(cur realm, t *testing.T) {
 		},
 		{
 			name: "Remove role with empty role name fails",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 			},
@@ -981,7 +981,7 @@ func TestRbac_RemoveRole_WithAuthorization(cur realm, t *testing.T) {
 		},
 		{
 			name: "Remove admin role fails",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 			},
@@ -992,7 +992,7 @@ func TestRbac_RemoveRole_WithAuthorization(cur realm, t *testing.T) {
 		},
 		{
 			name: "Remove whitespace padded admin role fails",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 			},
@@ -1003,7 +1003,7 @@ func TestRbac_RemoveRole_WithAuthorization(cur realm, t *testing.T) {
 		},
 		{
 			name: "Remove non-existent role fails",
-			setup: func() {
+			setup: func(cur realm) {
 				manager = prbac.NewRBACWithAddress(ADMIN)
 				initRbac(cur)
 			},
@@ -1016,7 +1016,7 @@ func TestRbac_RemoveRole_WithAuthorization(cur realm, t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
-			tt.setup()
+			tt.setup(cur)
 
 			// Set realm to the specified caller for authorization testing
 			testing.SetRealm(testing.NewUserRealm(tt.callerRealm))


### PR DESCRIPTION
## Summary
- Migrate pure package tests under `p/gnoswap` to Interrealm v2 `cur realm` uassert helpers.
- Update `r/gnoswap/gns` test helper naming for the Interrealm v2 test setup.
- Migrate `r/gnoswap/rbac` setup closures to accept the current realm.

## Tests
- `make test PKG=gno.land/p/gnoswap/gnsmath`
- `make test PKG=gno.land/p/gnoswap/int256`
- `make test PKG=gno.land/p/gnoswap/uint256`
- `make test PKG=gno.land/r/gnoswap/gns`
- `make test PKG=gno.land/r/gnoswap/rbac`