### PR TITLE
refactor(r/protocol_fee): allocate BPTrees under protocol_fee realm

### DIFF
--- a/contract/r/gnoswap/protocol_fee/store.gno
+++ b/contract/r/gnoswap/protocol_fee/store.gno
@@ -35,6 +35,14 @@ const defaultDevOpsPct = int64(0)
 
 var errSpoofedRealm = errors.New("rlm does not match the current crossing frame")
 
+// NewBPTreeN allocates a BP-tree under /r/gnoswap/protocol_fee's realm context
+// so tree.Set leaf-slot writes clear the readonly-taint gate regardless of
+// which realm (protocol_fee/v1, mock, tests) calls Set. Callers must allocate
+// protocol_fee trees through here rather than bptree.NewBPTreeN directly.
+func NewBPTreeN(fanout int) *bptree.BPTree {
+	return bptree.NewBPTreeN(fanout)
+}
+
 type protocolFeeStore struct {
 	kvStore store.KVStore
 }
@@ -79,7 +87,7 @@ func (s *protocolFeeStore) InitializeAccuToGovStaker(_ int, rlm realm) error {
 		return errSpoofedRealm
 	}
 
-	return s.kvStore.Set(0, rlm, StoreKeyAccuToGovStaker.String(), bptree.NewBPTreeN(16))
+	return s.kvStore.Set(0, rlm, StoreKeyAccuToGovStaker.String(), NewBPTreeN(16))
 }
 
 func (s *protocolFeeStore) GetAccuToGovStaker() *bptree.BPTree {
@@ -135,7 +143,7 @@ func (s *protocolFeeStore) InitializeAccuToDevOps(_ int, rlm realm) error {
 		return errSpoofedRealm
 	}
 
-	return s.kvStore.Set(0, rlm, StoreKeyAccuToDevOps.String(), bptree.NewBPTreeN(16))
+	return s.kvStore.Set(0, rlm, StoreKeyAccuToDevOps.String(), NewBPTreeN(16))
 }
 
 func (s *protocolFeeStore) GetAccuToDevOps() *bptree.BPTree {
@@ -191,7 +199,7 @@ func (s *protocolFeeStore) InitializeDistributedToGovStakerHistory(_ int, rlm re
 		return errSpoofedRealm
 	}
 
-	return s.kvStore.Set(0, rlm, StoreKeyDistributedToGovStakerHistory.String(), bptree.NewBPTreeN(16))
+	return s.kvStore.Set(0, rlm, StoreKeyDistributedToGovStakerHistory.String(), NewBPTreeN(16))
 }
 
 func (s *protocolFeeStore) GetDistributedToGovStakerHistory() *bptree.BPTree {
@@ -247,7 +255,7 @@ func (s *protocolFeeStore) InitializeDistributedToDevOpsHistory(_ int, rlm realm
 		return errSpoofedRealm
 	}
 
-	return s.kvStore.Set(0, rlm, StoreKeyDistributedToDevOpsHistory.String(), bptree.NewBPTreeN(16))
+	return s.kvStore.Set(0, rlm, StoreKeyDistributedToDevOpsHistory.String(), NewBPTreeN(16))
 }
 
 func (s *protocolFeeStore) GetDistributedToDevOpsHistory() *bptree.BPTree {

--- a/contract/r/gnoswap/protocol_fee/v1/_mock_test.gno
+++ b/contract/r/gnoswap/protocol_fee/v1/_mock_test.gno
@@ -40,7 +40,7 @@ func (s *mockProtocolFeeStore) HasAccuToGovStakerStoreKey() bool {
 }
 
 func (s *mockProtocolFeeStore) InitializeAccuToGovStaker(_ int, rlm realm) error {
-	s.accuToGovStaker = bptree.NewBPTreeN(16)
+	s.accuToGovStaker = protocol_fee.NewBPTreeN(16)
 	return nil
 }
 
@@ -74,7 +74,7 @@ func (s *mockProtocolFeeStore) HasAccuToDevOpsStoreKey() bool {
 }
 
 func (s *mockProtocolFeeStore) InitializeAccuToDevOps(_ int, rlm realm) error {
-	s.accuToDevOps = bptree.NewBPTreeN(16)
+	s.accuToDevOps = protocol_fee.NewBPTreeN(16)
 	return nil
 }
 
@@ -107,7 +107,7 @@ func (s *mockProtocolFeeStore) HasDistributedToGovStakerHistoryStoreKey() bool {
 }
 
 func (s *mockProtocolFeeStore) InitializeDistributedToGovStakerHistory(_ int, rlm realm) error {
-	s.distributedToGovStakerHistory = bptree.NewBPTreeN(16)
+	s.distributedToGovStakerHistory = protocol_fee.NewBPTreeN(16)
 	return nil
 }
 
@@ -139,7 +139,7 @@ func (s *mockProtocolFeeStore) HasDistributedToDevOpsHistoryStoreKey() bool {
 }
 
 func (s *mockProtocolFeeStore) InitializeDistributedToDevOpsHistory(_ int, rlm realm) error {
-	s.distributedToDevOpsHistory = bptree.NewBPTreeN(16)
+	s.distributedToDevOpsHistory = protocol_fee.NewBPTreeN(16)
 	return nil
 }
 
@@ -198,10 +198,10 @@ func (s *mockProtocolFeeStore) AddReservedToken(_ int, rlm realm, tokenPath stri
 func newMockProtocolFeeStore() protocol_fee.IProtocolFeeStore {
 	return &mockProtocolFeeStore{
 		devOpsPct:                     0,
-		accuToGovStaker:               bptree.NewBPTreeN(16),
-		accuToDevOps:                  bptree.NewBPTreeN(16),
-		distributedToGovStakerHistory: bptree.NewBPTreeN(16),
-		distributedToDevOpsHistory:    bptree.NewBPTreeN(16),
+		accuToGovStaker:               protocol_fee.NewBPTreeN(16),
+		accuToDevOps:                  protocol_fee.NewBPTreeN(16),
+		distributedToGovStakerHistory: protocol_fee.NewBPTreeN(16),
+		distributedToDevOpsHistory:    protocol_fee.NewBPTreeN(16),
 		reservedTokens:                []string{},
 	}
 }


### PR DESCRIPTION
Provide NewBPTreeN that allocates a BPTree under the protocol_fee realm context so tree.Set leaf-slot writes clear the readonly-taint gate regardless of calling realm. Replace direct uses of bptree.NewBPTreeN with protocol_fee.NewBPTreeN in store and mock tests.