### PR TITLE
refactor: router impl validation and harden staker token-specific minimum rewards

### DIFF
--- a/contract/r/gnoswap/router/v1/_helper_test.gno
+++ b/contract/r/gnoswap/router/v1/_helper_test.gno
@@ -87,7 +87,7 @@ var (
 	routerPath  = "gno.land/r/gnoswap/router"
 	routerRealm = testing.NewCodeRealm(routerPath)
 
-	// SwapCallback's assertIsRouterV1 compares the caller against the router
+	// SwapCallback's assertIsRouterImplementation compares the caller against the router
 	// v1 implementation address, so the callback caller must be the v1 realm.
 	routerV1Path = "gno.land/r/gnoswap/router/v1"
 

--- a/contract/r/gnoswap/router/v1/assert.gno
+++ b/contract/r/gnoswap/router/v1/assert.gno
@@ -88,11 +88,11 @@ func assertIsExistsPools(routePathArr string) {
 	}
 }
 
-func assertIsRouterV1(caller address) {
-	if caller != routerV1Addr {
+func assertIsRouterImplementation(caller address) {
+	if caller != routerImplAddr {
 		panic(makeErrorWithDetails(
 			errUnAuthorizedCaller,
-			ufmt.Sprintf("caller %s is not router v1(%s)", caller, routerV1Addr),
+			ufmt.Sprintf("caller %s is not router implementation(%s)", caller, routerImplAddr),
 		))
 	}
 }

--- a/contract/r/gnoswap/router/v1/consts.gno
+++ b/contract/r/gnoswap/router/v1/consts.gno
@@ -1,7 +1,7 @@
 package v1
 
-import (
-	"chain"
-)
+var routerImplAddr address
 
-var routerV1Addr = chain.PackageAddress("gno.land/r/gnoswap/router/v1")
+func init(cur realm) {
+	routerImplAddr = cur.Address()
+}

--- a/contract/r/gnoswap/router/v1/swap_callback.gno
+++ b/contract/r/gnoswap/router/v1/swap_callback.gno
@@ -47,7 +47,7 @@ func (r *routerV1) SwapCallback(
 	halt.AssertIsNotHaltedRouter()
 
 	caller := rlm.Previous().Address()
-	assertIsRouterV1(caller)
+	assertIsRouterImplementation(caller)
 
 	var tokenToPay string
 	var amountToPay int64

--- a/contract/r/gnoswap/router/v1/swap_callback_test.gno
+++ b/contract/r/gnoswap/router/v1/swap_callback_test.gno
@@ -151,8 +151,8 @@ func TestSwapCallback(cur realm, t *testing.T) {
 	}
 }
 
-// TestSwapCallback_AssertIsRouterV1 tests the assertIsRouterV1 function with various caller types
-func TestSwapCallback_AssertIsRouterV1(cur realm, t *testing.T) {
+// TestSwapCallback_assertIsRouterImplementation tests the assertIsRouterImplementation function with various caller types
+func TestSwapCallback_assertIsRouterImplementation(cur realm, t *testing.T) {
 	tests := []struct {
 		name             string
 		callerAddress    address
@@ -207,11 +207,11 @@ func TestSwapCallback_AssertIsRouterV1(cur realm, t *testing.T) {
 			// Execute and verify
 			if tt.shouldError {
 				uassert.PanicsContains(t, cur, tt.expectedErrorMsg, func() {
-					assertIsRouterV1(tt.callerAddress)
+					assertIsRouterImplementation(tt.callerAddress)
 				})
 			} else {
 				// Should not panic
-				assertIsRouterV1(tt.callerAddress)
+				assertIsRouterImplementation(tt.callerAddress)
 			}
 		})
 	}

--- a/contract/r/gnoswap/staker/store.gno
+++ b/contract/r/gnoswap/staker/store.gno
@@ -263,6 +263,44 @@ func (s *stakerStore) SetTokenSpecificMinimumRewards(_ int, rlm realm, rewards m
 	return s.kvStore.Set(0, rlm, StoreKeyTokenSpecificMinimumRewards.String(), rewards)
 }
 
+// SetTokenSpecificMinimumRewardItem sets a single token's minimum reward amount.
+func (s *stakerStore) SetTokenSpecificMinimumRewardItem(_ int, rlm realm, tokenPath string, amount int64) error {
+	if !rlm.IsCurrent() {
+		return ErrSpoofedRealm
+	}
+
+	rewards := s.GetTokenSpecificMinimumRewards()
+
+	owned := make(map[string]int64)
+	for k, v := range rewards {
+		owned[k] = v
+	}
+
+	owned[tokenPath] = amount
+
+	return s.kvStore.Set(0, rlm, StoreKeyTokenSpecificMinimumRewards.String(), owned)
+}
+
+// RemoveTokenSpecificMinimumRewardItem removes a single token's minimum reward entry.
+func (s *stakerStore) RemoveTokenSpecificMinimumRewardItem(_ int, rlm realm, tokenPath string) error {
+	if !rlm.IsCurrent() {
+		return ErrSpoofedRealm
+	}
+
+	rewards := s.GetTokenSpecificMinimumRewards()
+
+	owned := make(map[string]int64)
+	for k, v := range rewards {
+		if k == tokenPath {
+			continue
+		}
+
+		owned[k] = v
+	}
+
+	return s.kvStore.Set(0, rlm, StoreKeyTokenSpecificMinimumRewards.String(), owned)
+}
+
 // UnstakingFee
 func (s *stakerStore) HasUnstakingFeeStoreKey() bool {
 	return s.kvStore.Has(StoreKeyUnstakingFee.String())

--- a/contract/r/gnoswap/staker/types.gno
+++ b/contract/r/gnoswap/staker/types.gno
@@ -147,6 +147,8 @@ type IStakerStore interface {
 	HasTokenSpecificMinimumRewardsStoreKey() bool
 	GetTokenSpecificMinimumRewards() map[string]int64
 	SetTokenSpecificMinimumRewards(_ int, rlm realm, rewards map[string]int64) error
+	SetTokenSpecificMinimumRewardItem(_ int, rlm realm, tokenPath string, amount int64) error
+	RemoveTokenSpecificMinimumRewardItem(_ int, rlm realm, tokenPath string) error
 
 	// UnstakingFee
 	HasUnstakingFeeStoreKey() bool

--- a/contract/r/gnoswap/staker/v1/_mock_test.gno
+++ b/contract/r/gnoswap/staker/v1/_mock_test.gno
@@ -152,6 +152,19 @@ func (s *MockStakerStore) SetTokenSpecificMinimumRewards(_ int, rlm realm, rewar
 	return nil
 }
 
+func (s *MockStakerStore) SetTokenSpecificMinimumRewardItem(_ int, rlm realm, tokenPath string, amount int64) error {
+	if s.tokenSpecificMinimumRewards == nil {
+		s.tokenSpecificMinimumRewards = make(map[string]int64)
+	}
+	s.tokenSpecificMinimumRewards[tokenPath] = amount
+	return nil
+}
+
+func (s *MockStakerStore) RemoveTokenSpecificMinimumRewardItem(_ int, rlm realm, tokenPath string) error {
+	delete(s.tokenSpecificMinimumRewards, tokenPath)
+	return nil
+}
+
 // UnstakingFee
 func (s *MockStakerStore) HasUnstakingFeeStoreKey() bool {
 	return s.unstakingFee != 0
@@ -337,18 +350,18 @@ func newMockStakerStore() *MockStakerStore {
 	swapBatch := sr.NewSwapBatchProcessor("", nil, 0)
 	swapBatch.SetIsActive(false)
 	return &MockStakerStore{
-		depositGnsAmount:            1_000_000_000,
-		minimumRewardAmount:         1_000_000_000,
-		deposits:                    sr.NewBPTreeN(16),
-		externalIncentives:          sr.NewBPTreeN(16),
-		totalEmissionSent:           0,
-		allowedTokens:               []string{"ugnot", "gno.land/r/gnoswap/gns"},
-		incentiveCounter:            sr.NewCounter(),
-		tokenSpecificMinimumRewards: make(map[string]int64),
-		unstakingFee:                0,
-		pendingProtocolFees:         make(map[string]int64),
-		pools:                       sr.NewBPTreeN(16),
-		poolTierMemberships:         sr.NewBPTreeN(16),
+		depositGnsAmount:                 1_000_000_000,
+		minimumRewardAmount:              1_000_000_000,
+		deposits:                         sr.NewBPTreeN(16),
+		externalIncentives:               sr.NewBPTreeN(16),
+		totalEmissionSent:                0,
+		allowedTokens:                    []string{"ugnot", "gno.land/r/gnoswap/gns"},
+		incentiveCounter:                 sr.NewCounter(),
+		tokenSpecificMinimumRewards:      make(map[string]int64),
+		unstakingFee:                     0,
+		pendingProtocolFees:              make(map[string]int64),
+		pools:                            sr.NewBPTreeN(16),
+		poolTierMemberships:              sr.NewBPTreeN(16),
 		poolTierRatio:                    sr.NewTierRatio(0, 0, 0),
 		poolTierCounts:                   [sr.AllTierCount]uint64{},
 		poolTierLastRewardCacheTimestamp: 0,

--- a/contract/r/gnoswap/staker/v1/external_deposit_fee.gno
+++ b/contract/r/gnoswap/staker/v1/external_deposit_fee.gno
@@ -127,10 +127,14 @@ func (s *stakerV1) SetTokenMinimumRewardAmount(_ int, rlm realm, paramsStr strin
 	if amount64 == 0 {
 		// Only attempt removal if an entry actually existed
 		if found {
-			delete(s.store.GetTokenSpecificMinimumRewards(), tokenPath)
+			if err := s.store.RemoveTokenSpecificMinimumRewardItem(0, rlm, tokenPath); err != nil {
+				panic(err)
+			}
 		}
 	} else {
-		s.store.GetTokenSpecificMinimumRewards()[tokenPath] = amount64
+		if err := s.store.SetTokenSpecificMinimumRewardItem(0, rlm, tokenPath, amount64); err != nil {
+			panic(err)
+		}
 	}
 
 	chain.Emit(

--- a/docs/pool.md
+++ b/docs/pool.md
@@ -4,12 +4,12 @@ Core AMM. All pools live in a single singleton realm.
 
 ## Key Files
 
-| File | Purpose |
-|------|---------|
-| `swap.gno` | Swap execution, reentrancy lock, oracle |
-| `pool.gno` | Pool data structures, Slot0 |
-| `position.gno` | Per-pool position tracking |
-| `manager.gno` | Pool creation |
+| File           | Purpose                                      |
+| -------------- | -------------------------------------------- |
+| `swap.gno`     | Swap execution, reentrancy lock, oracle      |
+| `pool.gno`     | Pool data structures, Slot0                  |
+| `position.gno` | Per-pool position tracking                   |
+| `manager.gno`  | Pool creation                                |
 | `transfer.gno` | Token transfer helpers (`SafeGRC20Transfer`) |
 
 ## Rules
@@ -31,7 +31,7 @@ Find next tick → `ComputeSwapStep` → accumulate fees → cross tick (update 
 Pool sends output → SwapCallback on router → router sends input to pool
 ```
 
-Both checks required: `access.AssertIsPool(caller)` + `assertIsRouterV1()`.
+Both checks required: `access.AssertIsPool(caller)` + `assertIsRouterImplementation()`.
 
 ## Reentrancy
 
@@ -39,12 +39,12 @@ Both checks required: `access.AssertIsPool(caller)` + `assertIsRouterV1()`.
 
 ## AMM Primitives
 
-| Primitive | Format | Detail |
-|-----------|--------|--------|
-| sqrtPriceX96 | Q64.96 | √price × 2^96 |
-| feeGrowthGlobal | Q128.128 | Cumulative fee per unit liquidity |
-| Tick range | int | `[-887272, 887272]` |
-| Fee tiers | fixed | 0.01% / 0.05% / 0.3% / 1% — no new tiers post-deploy |
+| Primitive       | Format   | Detail                                               |
+| --------------- | -------- | ---------------------------------------------------- |
+| sqrtPriceX96    | Q64.96   | √price × 2^96                                        |
+| feeGrowthGlobal | Q128.128 | Cumulative fee per unit liquidity                    |
+| Tick range      | int      | `[-887272, 887272]`                                  |
+| Fee tiers       | fixed    | 0.01% / 0.05% / 0.3% / 1% — no new tiers post-deploy |
 
 ## Pitfalls
 

--- a/docs/router.md
+++ b/docs/router.md
@@ -4,19 +4,19 @@ Swap routing: single-hop, multi-hop (max 3 hops), exact-in, exact-out, split rou
 
 ## Key Files
 
-| File | Purpose |
-|------|---------|
-| `exact_in.gno` | Exact input swap logic |
-| `exact_out.gno` | Exact output swap logic |
-| `swap_single.gno` | Single-hop swap |
-| `swap_multi.gno` | Multi-hop swap (up to 3 hops) |
-| `swap_inner.gno` | Core swap execution |
-| `router.gno` | Router entry points |
-| `base.gno` | Base utilities |
+| File              | Purpose                       |
+| ----------------- | ----------------------------- |
+| `exact_in.gno`    | Exact input swap logic        |
+| `exact_out.gno`   | Exact output swap logic       |
+| `swap_single.gno` | Single-hop swap               |
+| `swap_multi.gno`  | Multi-hop swap (up to 3 hops) |
+| `swap_inner.gno`  | Core swap execution           |
+| `router.gno`      | Router entry points           |
+| `base.gno`        | Base utilities                |
 
 ## Rules
 
-- **SwapCallback** must verify both: `access.AssertIsPool(caller)` + `assertIsRouterV1()`. Missing either check allows forged callbacks.
+- **SwapCallback** must verify both: `access.AssertIsPool(caller)` + `assertIsRouterImplementation()`. Missing either check allows forged callbacks.
 - Exact-out slippage: output tolerance is ±`swapCount` (one per hop) to account for rounding.
 - Router fee charged on output tokens. Fee cap: 10%. Validate all fee-setting functions.
 - Route format: `TOKEN0:TOKEN1:FEE*POOL*TOKEN1:TOKEN2:FEE*POOL*...` — verify any route-parsing changes against this.


### PR DESCRIPTION
## Summary

This PR contains two related improvements to the router and staker modules:

1. **Router validation clarity** — Renames the router caller-validation helper to better
   reflect what it actually checks, and derives the implementation address at runtime instead
   of hardcoding the `v1` package path.
2. **Staker store taint fix** — Resolves a readonly-taint issue in `SetTokenMinimumRewardAmount`
   by introducing dedicated store methods for managing individual token minimum rewards, instead
   of mutating the map returned by the getter directly.

## Changes

### `refactor(router)` — rename router validation functions for clarity
- Renamed `assertIsRouterV1` → `assertIsRouterImplementation` to clarify that the check
  validates the caller against the current router *implementation* address, not a specific version.
- Replaced the hardcoded `chain.PackageAddress("gno.land/r/gnoswap/router/v1")` constant
  (`routerV1Addr`) with `routerImplAddr`, which is now resolved in `init(cur realm)` via
  `cur.Address()`.
- Updated the `SwapCallback` call site, related tests (`TestSwapCallback_assertIsRouterImplementation`),
  and error messages accordingly.
- Updated `docs/pool.md` and `docs/router.md` references and reformatted their tables.

### `fix(staker)` — resolve taint issue by managing token-specific minimum rewards
- Added two store methods that own and persist the rewards map through the KV store
  (with the mandatory `rlm.IsCurrent()` spoofed-realm guard):
  - `SetTokenSpecificMinimumRewardItem(_ int, rlm realm, tokenPath string, amount int64) error`
  - `RemoveTokenSpecificMinimumRewardItem(_ int, rlm realm, tokenPath string) error`
- Extended the `IStakerStore` interface and the test `MockStakerStore` with the new methods.
- Updated `SetTokenMinimumRewardAmount` to call the new store methods instead of directly mutating
  the map returned by `GetTokenSpecificMinimumRewards()` (which was readonly-tainted and never
  actually persisted the change).

## Why
- The previous name `assertIsRouterV1` implied a version-specific check, which is misleading and
  brittle; `assertIsRouterImplementation` with a runtime-derived address is clearer and survives
  implementation upgrades.
- Mutating the map returned by the store getter is a readonly-taint violation under the interrealm
  model and does not persist to the KV store. Routing all writes through dedicated `Set*`/`Remove*`
  methods ensures changes are correctly persisted and guarded against spoofed realm tokens.