### PR TITLE
fix(gov/staker): add SetWithdraw method to avoid readonly taint in delegation collection

### DIFF
--- a/contract/r/gnoswap/gov/staker/delegation.gno
+++ b/contract/r/gnoswap/gov/staker/delegation.gno
@@ -73,6 +73,10 @@ func (d *Delegation) AddWithdraw(withdraw DelegationWithdraw) {
 	d.withdraws = append(d.withdraws, withdraw)
 }
 
+func (d *Delegation) SetWithdraw(index int, withdraw DelegationWithdraw) {
+	d.withdraws[index] = withdraw
+}
+
 func (d *Delegation) SetWithdraws(withdraws []DelegationWithdraw) {
 	d.withdraws = withdraws
 }

--- a/contract/r/gnoswap/gov/staker/v1/delegation.gno
+++ b/contract/r/gnoswap/gov/staker/v1/delegation.gno
@@ -103,7 +103,7 @@ func (r *DelegationResolver) processCollection(currentTime int64) (int64, error)
 
 	for i := range withdraws {
 		if !withdraws[i].IsCollected() {
-			withdraws[currentIndex] = withdraws[i]
+			r.delegation.SetWithdraw(currentIndex, withdraws[i])
 			currentIndex++
 		}
 	}


### PR DESCRIPTION
## Summary

Under interrealm v2, a slice obtained from an external realm object becomes
**readonly-tainted** when its elements are mutated directly. In
`DelegationResolver.processCollection`, the in-place compaction of withdraws
used a direct index assignment on a slice returned by `r.delegation.Withdraws()`,
which is owned by the external `Delegation` realm object. This direct mutation
is readonly-tainted and does not reliably persist.

This PR routes the element mutation through a new `Delegation.SetWithdraw`
method so the write happens inside the owning realm's context, consistent with
the existing `AddWithdraw` / `SetWithdraws` accessors.

## Changes

- `contract/r/gnoswap/gov/staker/delegation.gno`
  - Add `SetWithdraw(index int, withdraw DelegationWithdraw)` accessor on `Delegation`.
- `contract/r/gnoswap/gov/staker/v1/delegation.gno`
  - Replace direct slice index assignment (`withdraws[currentIndex] = withdraws[i]`)
    in `processCollection` with `r.delegation.SetWithdraw(currentIndex, withdraws[i])`.

## Why

External realm field/index access is readonly-tainted in interrealm v2.
Mutating delegation state must go through methods on the owning object rather
than mutating a borrowed slice directly.
