### PR TITLE
fix(staker/v1): update outside accumulation

### DIFF
--- a/contract/r/gnoswap/staker/pool.gno
+++ b/contract/r/gnoswap/staker/pool.gno
@@ -701,7 +701,7 @@ func (t *Tick) SetOutsideAccumulation(outsideAccumulation *UintTree) {
 	t.outsideAccumulation = outsideAccumulation
 }
 
-// SetOutsideAccumulation sets the outside accumulation tree
+// SetOutsideAccumulationAt sets the outside accumulation at the timestamp.
 func (t *Tick) SetOutsideAccumulationAt(timestamp int64, acc *u256.Uint) {
 	t.outsideAccumulation.Set(timestamp, u256.Zero().Set(acc))
 }

--- a/contract/r/gnoswap/staker/pool.gno
+++ b/contract/r/gnoswap/staker/pool.gno
@@ -701,6 +701,11 @@ func (t *Tick) SetOutsideAccumulation(outsideAccumulation *UintTree) {
 	t.outsideAccumulation = outsideAccumulation
 }
 
+// SetOutsideAccumulation sets the outside accumulation tree
+func (t *Tick) SetOutsideAccumulationAt(timestamp int64, acc *u256.Uint) {
+	t.outsideAccumulation.Set(timestamp, u256.Zero().Set(acc))
+}
+
 // Clone returns a deep copy of the tick.
 func (t *Tick) Clone() *Tick {
 	if t == nil {

--- a/contract/r/gnoswap/staker/v1/reward_calculation_tick.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_tick.gno
@@ -56,7 +56,7 @@ func (self *TickResolver) modifyDepositUpper(currentTime int64, liquidity *i256.
 func (self *TickResolver) updateCurrentOutsideAccumulation(timestamp int64, acc *u256.Uint) {
 	currentOutsideAccumulation := self.CurrentOutsideAccumulation(timestamp)
 	newOutsideAccumulation := u256.Zero().Sub(acc, currentOutsideAccumulation)
-	self.OutsideAccumulation().Set(timestamp, newOutsideAccumulation)
+	self.SetOutsideAccumulationAt(timestamp, newOutsideAccumulation)
 }
 
 func NewTickResolver(tick *sr.Tick) *TickResolver {


### PR DESCRIPTION
## Summary
- Add a tick-level SetOutsideAccumulationAt helper that stores a copied uint256 value.
- Route updateCurrentOutsideAccumulation through the tick helper instead of mutating the outside accumulation tree directly.

## Tests
- make test PKG=gno.land/r/gnoswap/scenario/halt RUN=./gno.land/r/gnoswap/scenario/halt/emergency_mode_collect_paths_allowed_filetest.gno

## Note
- A broader make test PKG=gno.land/r/gnoswap/staker/v1 run was started before this PR flow and was terminated with signal 15 before completion.