### PR TITLE
fix(gov/governance): gate proposals by xgns balance

### DIFF
--- a/contract/r/gnoswap/gov/governance/README.md
+++ b/contract/r/gnoswap/gov/governance/README.md
@@ -16,7 +16,7 @@ The `governance.Config` type defines the core governance parameters. All values 
 | `VotingPeriod` | Duration for collecting votes | 7 days |
 | `VotingWeightSmoothingDuration` | Period for averaging voting weight (prevents flash loans) | 1 day |
 | `Quorum` | Percentage of active xGNS required for proposal passage | 50% |
-| `ProposalCreationThreshold` | Minimum GNS balance required to create a proposal | 1,000 GNS |
+| `ProposalCreationThreshold` | Minimum xGNS amount required to create a proposal | 1,000 xGNS |
 | `ExecutionDelay` | Waiting period after voting ends before execution | 1 day |
 | `ExecutionWindow` | Time window during which an approved proposal can be executed | 30 days |
 
@@ -43,7 +43,7 @@ GNS → Stake → xGNS (voting power) → Delegate → Vote
 
 ### Creation
 
-- Requires 1,000 GNS balance
+- Requires 1,000 xGNS balance
 - One active proposal per address
 - Valid type and parameters required
 

--- a/contract/r/gnoswap/gov/governance/config.gno
+++ b/contract/r/gnoswap/gov/governance/config.gno
@@ -12,9 +12,9 @@ type Config struct {
 	// VotingWeightSmoothingDuration is the period over which voting weight is averaged
 	// for proposal creation and cancellation threshold calculations (in seconds)
 	VotingWeightSmoothingDuration int64
-	// Quorum is the percentage of total GNS supply required for proposal approval
+	// Quorum is the percentage of active xGNS supply required for proposal approval
 	Quorum int64
-	// ProposalCreationThreshold is the minimum average voting weight required to create a proposal
+	// ProposalCreationThreshold is the minimum xGNS amount required to create a proposal
 	ProposalCreationThreshold int64
 	// ExecutionDelay is the waiting period after voting ends before a proposal can be executed (in seconds)
 	ExecutionDelay int64

--- a/contract/r/gnoswap/gov/governance/v1/README.md
+++ b/contract/r/gnoswap/gov/governance/v1/README.md
@@ -16,7 +16,7 @@ The `governance.Config` type defines the core governance parameters. All values 
 | `VotingPeriod` | Duration for collecting votes | 7 days |
 | `VotingWeightSmoothingDuration` | Period for averaging voting weight (prevents flash loans) | 1 day |
 | `Quorum` | Percentage of active xGNS required for proposal passage | 50% |
-| `ProposalCreationThreshold` | Minimum GNS balance required to create a proposal | 1,000 GNS |
+| `ProposalCreationThreshold` | Minimum xGNS amount required to create a proposal | 1,000 xGNS |
 | `ExecutionDelay` | Waiting period after voting ends before execution | 1 day |
 | `ExecutionWindow` | Time window during which an approved proposal can be executed | 30 days |
 
@@ -43,7 +43,7 @@ GNS → Stake → xGNS (voting power) → Delegate → Vote
 
 ### Creation
 
-- Requires 1,000 GNS balance
+- Requires 1,000 xGNS balance
 - One active proposal per address
 - Valid type and parameters required
 

--- a/contract/r/gnoswap/gov/governance/v1/governance_propose.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_propose.gno
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	bptree "gno.land/p/nt/bptree/v0"
-	"gno.land/r/gnoswap/gns"
+	"gno.land/r/gnoswap/gov/xgns"
 	"gno.land/r/gnoswap/halt"
 
 	"gno.land/r/gnoswap/gov/governance"
@@ -23,7 +23,7 @@ import (
 //   - description: Full proposal content with rationale and context
 //
 // Requirements:
-//   - Caller must hold minimum 1,000 GNS tokens
+//   - Caller must hold at least ProposalCreationThreshold amount in xGNS
 //   - No other active proposal from same address
 //   - Title and description must be non-empty
 //
@@ -44,7 +44,7 @@ func (gv *governanceV1) ProposeText(
 
 	createdAt := time.Now().Unix()
 	createdHeight := runtime.ChainHeight()
-	gnsBalance := gns.BalanceOf(callerAddress)
+	xgnsBalance := xgns.BalanceOf(callerAddress)
 
 	config, ok := gv.getCurrentConfig()
 	if !ok {
@@ -80,7 +80,7 @@ func (gv *governanceV1) ProposeText(
 		governance.NewProposalMetadata(title, description),
 		NewProposalTextData(),
 		callerAddress,
-		gnsBalance,
+		xgnsBalance,
 		createdAt,
 		createdHeight,
 	)
@@ -125,7 +125,7 @@ func (gv *governanceV1) ProposeText(
 //   - amount: Amount to transfer (in smallest unit)
 //
 // Requirements:
-//   - Caller must hold minimum 1,000 GNS tokens
+//   - Caller must hold at least ProposalCreationThreshold amount in xGNS
 //   - Sufficient balance in community pool
 //   - Valid recipient address
 //   - Supported token type
@@ -151,7 +151,7 @@ func (gv *governanceV1) ProposeCommunityPoolSpend(
 	createdHeight := runtime.ChainHeight()
 
 	callerAddress := runtime.PreviousRealm().Address()
-	gnsBalance := gns.BalanceOf(callerAddress)
+	xgnsBalance := xgns.BalanceOf(callerAddress)
 
 	config, ok := gv.getCurrentConfig()
 	if !ok {
@@ -187,7 +187,7 @@ func (gv *governanceV1) ProposeCommunityPoolSpend(
 		governance.NewProposalMetadata(title, description),
 		NewProposalCommunityPoolSpendData(tokenPath, to, amount, COMMUNITY_POOL_PATH),
 		callerAddress,
-		gnsBalance,
+		xgnsBalance,
 		createdAt,
 		createdHeight,
 	)
@@ -240,6 +240,7 @@ func (gv *governanceV1) ProposeCommunityPoolSpend(
 //	gno.land/r/gnoswap/gov/governance*EXE*SetExecutionDelay*EXE*86400
 //
 // Requirements:
+//   - Caller must hold at least ProposalCreationThreshold amount in xGNS
 //   - Encoded execution messages must match numToExecute
 //   - Target handlers must exist in the parameter registry
 //   - Parameters must match registered function signatures
@@ -257,7 +258,7 @@ func (gv *governanceV1) ProposeParameterChange(
 
 	createdAt := time.Now().Unix()
 	createdHeight := runtime.ChainHeight()
-	gnsBalance := gns.BalanceOf(callerAddress)
+	xgnsBalance := xgns.BalanceOf(callerAddress)
 
 	config, ok := gv.getCurrentConfig()
 	if !ok {
@@ -293,7 +294,7 @@ func (gv *governanceV1) ProposeParameterChange(
 		governance.NewProposalMetadata(title, description),
 		NewProposalExecutionData(numToExecute, executions),
 		callerAddress,
-		gnsBalance,
+		xgnsBalance,
 		createdAt,
 		createdHeight,
 	)
@@ -335,7 +336,7 @@ func (gv *governanceV1) createProposal(
 	proposalMetadata *governance.ProposalMetadata,
 	proposalData *governance.ProposalData,
 	proposerAddress address,
-	proposerGnsBalance int64,
+	proposerXGnsBalance int64,
 	createdAt int64,
 	createdHeight int64,
 ) (*governance.Proposal, error) {
@@ -353,8 +354,8 @@ func (gv *governanceV1) createProposal(
 		return nil, err
 	}
 
-	// Check if proposer has enough GNS balance to create proposal
-	if proposerGnsBalance < config.ProposalCreationThreshold {
+	// Check if proposer has enough xGNS balance to create proposal
+	if proposerXGnsBalance < config.ProposalCreationThreshold {
 		return nil, errNotEnoughBalance
 	}
 

--- a/contract/r/gnoswap/gov/governance/v1/governance_propose_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_propose_test.gno
@@ -9,6 +9,7 @@ import (
 	uassert "gno.land/p/nt/uassert/v0"
 
 	"gno.land/r/gnoswap/gns"
+	"gno.land/r/gnoswap/gov/xgns"
 	_ "gno.land/r/gnoswap/halt"
 
 	"gno.land/r/gnoswap/gov/governance"
@@ -22,7 +23,7 @@ func TestGovernancePropose_ProposeText(t *testing.T) {
 		description         string
 		callerAddress       address
 		setupConfig         *governance.Config
-		setupGnsBalance     int64
+		setupXGnsBalance     int64
 		setupActiveProposal bool
 		setupUserVotes      map[string]*governance.VotingInfo
 		maxVotingWeight     int64
@@ -45,7 +46,7 @@ func TestGovernancePropose_ProposeText(t *testing.T) {
 				ExecutionDelay:                86400,
 				ExecutionWindow:               2592000,
 			},
-			setupGnsBalance:     10_000_000_000,
+			setupXGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
 				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
@@ -55,7 +56,7 @@ func TestGovernancePropose_ProposeText(t *testing.T) {
 			expectedProposalId: 1,
 		},
 		{
-			name:          "fail - insufficient GNS balance",
+			name:          "fail - insufficient xGNS balance",
 			title:         "Test Text Proposal",
 			description:   "This is a test text proposal for governance",
 			callerAddress: testutils.TestAddress("poor_proposer"),
@@ -68,7 +69,7 @@ func TestGovernancePropose_ProposeText(t *testing.T) {
 				ExecutionDelay:                86400,
 				ExecutionWindow:               2592000,
 			},
-			setupGnsBalance:     500_000_000, // Less than threshold
+			setupXGnsBalance:     500_000_000, // Less than threshold
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
 				testutils.TestAddress("poor_proposer").String(): governance.NewVotingInfo(5_000_000_000),
@@ -91,7 +92,7 @@ func TestGovernancePropose_ProposeText(t *testing.T) {
 				ExecutionDelay:                86400,
 				ExecutionWindow:               2592000,
 			},
-			setupGnsBalance:     10_000_000_000,
+			setupXGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
 				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
@@ -114,7 +115,7 @@ func TestGovernancePropose_ProposeText(t *testing.T) {
 				ExecutionDelay:                86400,
 				ExecutionWindow:               2592000,
 			},
-			setupGnsBalance:     10_000_000_000,
+			setupXGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
 				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
@@ -137,7 +138,7 @@ func TestGovernancePropose_ProposeText(t *testing.T) {
 				ExecutionDelay:                86400,
 				ExecutionWindow:               2592000,
 			},
-			setupGnsBalance:     10_000_000_000,
+			setupXGnsBalance:     10_000_000_000,
 			setupActiveProposal: true,
 			setupUserVotes: map[string]*governance.VotingInfo{
 				testutils.TestAddress("active_proposer").String(): governance.NewVotingInfo(5_000_000_000),
@@ -160,7 +161,7 @@ func TestGovernancePropose_ProposeText(t *testing.T) {
 				ExecutionDelay:                86400,
 				ExecutionWindow:               2592000,
 			},
-			setupGnsBalance:     10_000_000_000,
+			setupXGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes:      map[string]*governance.VotingInfo{}, // Empty voting info
 			maxVotingWeight:     0,
@@ -175,7 +176,7 @@ func TestGovernancePropose_ProposeText(t *testing.T) {
 			gov := newMockGovernance()
 
 			setupTestConfig(t, gov, tt.setupConfig)
-			setupTestGnsBalance(t, tt.callerAddress, tt.setupGnsBalance)
+			setupTestXGnsBalance(t, tt.callerAddress, tt.setupXGnsBalance)
 			setupTestUserVotesWithDelegation(t, gov, tt.setupUserVotes, tt.maxVotingWeight)
 
 			if tt.setupActiveProposal {
@@ -228,7 +229,7 @@ func TestGovernancePropose_ProposeCommunityPoolSpend(t *testing.T) {
 		amount              int64
 		callerAddress       address
 		setupConfig         *governance.Config
-		setupGnsBalance     int64
+		setupXGnsBalance     int64
 		setupActiveProposal bool
 		setupUserVotes      map[string]*governance.VotingInfo
 		maxVotingWeight     int64
@@ -254,7 +255,7 @@ func TestGovernancePropose_ProposeCommunityPoolSpend(t *testing.T) {
 				ExecutionDelay:                86400,
 				ExecutionWindow:               2592000,
 			},
-			setupGnsBalance:     10_000_000_000,
+			setupXGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
 				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
@@ -280,7 +281,7 @@ func TestGovernancePropose_ProposeCommunityPoolSpend(t *testing.T) {
 				ExecutionDelay:                86400,
 				ExecutionWindow:               2592000,
 			},
-			setupGnsBalance:     10_000_000_000,
+			setupXGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
 				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
@@ -306,7 +307,7 @@ func TestGovernancePropose_ProposeCommunityPoolSpend(t *testing.T) {
 				ExecutionDelay:                86400,
 				ExecutionWindow:               2592000,
 			},
-			setupGnsBalance:     10_000_000_000,
+			setupXGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
 				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
@@ -332,7 +333,7 @@ func TestGovernancePropose_ProposeCommunityPoolSpend(t *testing.T) {
 				ExecutionDelay:                86400,
 				ExecutionWindow:               2592000,
 			},
-			setupGnsBalance:     10_000_000_000,
+			setupXGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
 				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
@@ -358,7 +359,7 @@ func TestGovernancePropose_ProposeCommunityPoolSpend(t *testing.T) {
 				ExecutionDelay:                86400,
 				ExecutionWindow:               2592000,
 			},
-			setupGnsBalance:     10_000_000_000,
+			setupXGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
 				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
@@ -375,7 +376,7 @@ func TestGovernancePropose_ProposeCommunityPoolSpend(t *testing.T) {
 			gov := newMockGovernance()
 
 			setupTestConfig(t, gov, tt.setupConfig)
-			setupTestGnsBalance(t, tt.callerAddress, tt.setupGnsBalance)
+			setupTestXGnsBalance(t, tt.callerAddress, tt.setupXGnsBalance)
 			setupTestUserVotesWithDelegation(t, gov, tt.setupUserVotes, tt.maxVotingWeight)
 
 			if tt.setupActiveProposal {
@@ -423,7 +424,7 @@ func TestGovernancePropose_ProposeParameterChange(t *testing.T) {
 		executions          string
 		callerAddress       address
 		setupConfig         *governance.Config
-		setupGnsBalance     int64
+		setupXGnsBalance     int64
 		setupActiveProposal bool
 		setupUserVotes      map[string]*governance.VotingInfo
 		maxVotingWeight     int64
@@ -448,7 +449,7 @@ func TestGovernancePropose_ProposeParameterChange(t *testing.T) {
 				ExecutionDelay:                86400,
 				ExecutionWindow:               2592000,
 			},
-			setupGnsBalance:     10_000_000_000,
+			setupXGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
 				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
@@ -473,7 +474,7 @@ func TestGovernancePropose_ProposeParameterChange(t *testing.T) {
 				ExecutionDelay:                86400,
 				ExecutionWindow:               2592000,
 			},
-			setupGnsBalance:     10_000_000_000,
+			setupXGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
 				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
@@ -498,7 +499,7 @@ func TestGovernancePropose_ProposeParameterChange(t *testing.T) {
 				ExecutionDelay:                86400,
 				ExecutionWindow:               2592000,
 			},
-			setupGnsBalance:     10_000_000_000,
+			setupXGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
 				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
@@ -523,7 +524,7 @@ func TestGovernancePropose_ProposeParameterChange(t *testing.T) {
 				ExecutionDelay:                86400,
 				ExecutionWindow:               2592000,
 			},
-			setupGnsBalance:     10_000_000_000,
+			setupXGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
 				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
@@ -548,7 +549,7 @@ func TestGovernancePropose_ProposeParameterChange(t *testing.T) {
 				ExecutionDelay:                86400,
 				ExecutionWindow:               2592000,
 			},
-			setupGnsBalance:     10_000_000_000,
+			setupXGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
 				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
@@ -573,7 +574,7 @@ func TestGovernancePropose_ProposeParameterChange(t *testing.T) {
 				ExecutionDelay:                86400,
 				ExecutionWindow:               2592000,
 			},
-			setupGnsBalance:     10_000_000_000,
+			setupXGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
 				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
@@ -598,7 +599,7 @@ func TestGovernancePropose_ProposeParameterChange(t *testing.T) {
 				ExecutionDelay:                86400,
 				ExecutionWindow:               2592000,
 			},
-			setupGnsBalance:     10_000_000_000,
+			setupXGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
 				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
@@ -623,7 +624,7 @@ func TestGovernancePropose_ProposeParameterChange(t *testing.T) {
 				ExecutionDelay:                86400,
 				ExecutionWindow:               2592000,
 			},
-			setupGnsBalance:     10_000_000_000,
+			setupXGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
 				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
@@ -648,7 +649,7 @@ func TestGovernancePropose_ProposeParameterChange(t *testing.T) {
 				ExecutionDelay:                86400,
 				ExecutionWindow:               2592000,
 			},
-			setupGnsBalance:     10_000_000_000,
+			setupXGnsBalance:     10_000_000_000,
 			setupActiveProposal: false,
 			setupUserVotes: map[string]*governance.VotingInfo{
 				testutils.TestAddress("proposer").String(): governance.NewVotingInfo(5_000_000_000),
@@ -665,7 +666,7 @@ func TestGovernancePropose_ProposeParameterChange(t *testing.T) {
 			gov := newMockGovernance()
 
 			setupTestConfig(t, gov, tt.setupConfig)
-			setupTestGnsBalance(t, tt.callerAddress, tt.setupGnsBalance)
+			setupTestXGnsBalance(t, tt.callerAddress, tt.setupXGnsBalance)
 			setupTestUserVotesWithDelegation(t, gov, tt.setupUserVotes, tt.maxVotingWeight)
 
 			if tt.setupActiveProposal {
@@ -779,7 +780,7 @@ func TestGovernancePropose_ProposeTextInputValidation(t *testing.T) {
 			})
 
 			caller := testutils.TestAddress("proposer")
-			setupTestGnsBalance(t, caller, 10_000_000_000)
+			setupTestXGnsBalance(t, caller, 10_000_000_000)
 			setupTestUserVotesWithDelegation(t, gov, map[string]*governance.VotingInfo{
 				caller.String(): governance.NewVotingInfo(5_000_000_000),
 			}, 5_000_000_000)
@@ -997,7 +998,7 @@ func TestGovernancePropose_ProposalStateValidation(t *testing.T) {
 			})
 
 			caller := testutils.TestAddress("proposer")
-			setupTestGnsBalance(t, caller, 10_000_000_000)
+			setupTestXGnsBalance(t, caller, 10_000_000_000)
 			setupTestUserVotesWithDelegation(t, gov, map[string]*governance.VotingInfo{
 				caller.String(): governance.NewVotingInfo(5_000_000_000),
 			}, 5_000_000_000)
@@ -1112,7 +1113,7 @@ func TestGovernancePropose_CommunityPoolSpendValidation(t *testing.T) {
 			})
 
 			caller := testutils.TestAddress("proposer")
-			setupTestGnsBalance(t, caller, 10_000_000_000)
+			setupTestXGnsBalance(t, caller, 10_000_000_000)
 			setupTestUserVotesWithDelegation(t, gov, map[string]*governance.VotingInfo{
 				caller.String(): governance.NewVotingInfo(5_000_000_000),
 			}, 5_000_000_000)
@@ -1325,7 +1326,7 @@ func TestGovernancePropose_ParameterChangeValidation(t *testing.T) {
 			})
 
 			caller := testutils.TestAddress("proposer")
-			setupTestGnsBalance(t, caller, 10_000_000_000)
+			setupTestXGnsBalance(t, caller, 10_000_000_000)
 			setupTestUserVotesWithDelegation(t, gov, map[string]*governance.VotingInfo{
 				caller.String(): governance.NewVotingInfo(5_000_000_000),
 			}, 5_000_000_000)
@@ -1356,6 +1357,174 @@ func TestGovernancePropose_ParameterChangeValidation(t *testing.T) {
 	}
 }
 
+func TestGovernancePropose_ProposalCreationThresholdUsesXGnsBalance(t *testing.T) {
+	threshold := int64(1_000_000_000)
+	gnsPath := "gno.land/r/gnoswap/gns"
+	parameterExecution := "gno.land/r/gnoswap/pool*EXE*SetPoolCreationFee*EXE*0"
+
+	t.Run("text proposal fails with GNS only", func(t *testing.T) {
+		gov := newMockGovernance()
+		caller := testutils.TestAddress("gns_text")
+
+		setupTestConfig(t, gov, &governance.Config{
+			VotingStartDelay:              86400,
+			VotingPeriod:                  604800,
+			VotingWeightSmoothingDuration: 86400,
+			Quorum:                        50,
+			ProposalCreationThreshold:     threshold,
+			ExecutionDelay:                86400,
+			ExecutionWindow:               2592000,
+		})
+		setupTestGnsBalance(t, caller, threshold)
+		setupTestUserVotesWithDelegation(t, gov, map[string]*governance.VotingInfo{
+			caller.String(): governance.NewVotingInfo(5_000_000_000),
+		}, 5_000_000_000)
+
+		testing.SetRealm(testing.NewUserRealm(caller))
+		uassert.AbortsContains(t, "[GNOSWAP-GOVERNANCE-003] not enough balance", func() {
+			func(cur realm) {
+				testing.SetRealm(govRealm)
+				gov.ProposeText("Text Proposal", "Description")
+			}(cross)
+		})
+	})
+
+	t.Run("text proposal succeeds with xGNS only", func(t *testing.T) {
+		gov := newMockGovernance()
+		caller := testutils.TestAddress("xgns_text")
+
+		setupTestConfig(t, gov, &governance.Config{
+			VotingStartDelay:              86400,
+			VotingPeriod:                  604800,
+			VotingWeightSmoothingDuration: 86400,
+			Quorum:                        50,
+			ProposalCreationThreshold:     threshold,
+			ExecutionDelay:                86400,
+			ExecutionWindow:               2592000,
+		})
+		setupTestXGnsBalance(t, caller, threshold)
+		setupTestUserVotesWithDelegation(t, gov, map[string]*governance.VotingInfo{
+			caller.String(): governance.NewVotingInfo(5_000_000_000),
+		}, 5_000_000_000)
+
+		testing.SetRealm(testing.NewUserRealm(caller))
+		var proposalId int64
+		func(cur realm) {
+			testing.SetRealm(govRealm)
+			proposalId = gov.ProposeText("Text Proposal", "Description")
+		}(cross)
+		uassert.Equal(t, int64(1), proposalId)
+	})
+
+	t.Run("community pool spend fails with GNS only", func(t *testing.T) {
+		gov := newMockGovernance()
+		caller := testutils.TestAddress("gns_cps")
+
+		setupTestConfig(t, gov, &governance.Config{
+			VotingStartDelay:              86400,
+			VotingPeriod:                  604800,
+			VotingWeightSmoothingDuration: 86400,
+			Quorum:                        50,
+			ProposalCreationThreshold:     threshold,
+			ExecutionDelay:                86400,
+			ExecutionWindow:               2592000,
+		})
+		setupTestGnsBalance(t, caller, threshold)
+		setupTestUserVotesWithDelegation(t, gov, map[string]*governance.VotingInfo{
+			caller.String(): governance.NewVotingInfo(5_000_000_000),
+		}, 5_000_000_000)
+
+		testing.SetRealm(testing.NewUserRealm(caller))
+		uassert.AbortsContains(t, "[GNOSWAP-GOVERNANCE-003] not enough balance", func() {
+			func(cur realm) {
+				testing.SetRealm(govRealm)
+				gov.ProposeCommunityPoolSpend("Community Pool Spend", "Description", testutils.TestAddress("recipient"), gnsPath, 1_000_000_000)
+			}(cross)
+		})
+	})
+
+	t.Run("community pool spend succeeds with xGNS only", func(t *testing.T) {
+		gov := newMockGovernance()
+		caller := testutils.TestAddress("xgns_cps")
+
+		setupTestConfig(t, gov, &governance.Config{
+			VotingStartDelay:              86400,
+			VotingPeriod:                  604800,
+			VotingWeightSmoothingDuration: 86400,
+			Quorum:                        50,
+			ProposalCreationThreshold:     threshold,
+			ExecutionDelay:                86400,
+			ExecutionWindow:               2592000,
+		})
+		setupTestXGnsBalance(t, caller, threshold)
+		setupTestUserVotesWithDelegation(t, gov, map[string]*governance.VotingInfo{
+			caller.String(): governance.NewVotingInfo(5_000_000_000),
+		}, 5_000_000_000)
+
+		testing.SetRealm(testing.NewUserRealm(caller))
+		var proposalId int64
+		func(cur realm) {
+			testing.SetRealm(govRealm)
+			proposalId = gov.ProposeCommunityPoolSpend("Community Pool Spend", "Description", testutils.TestAddress("recipient"), gnsPath, 1_000_000_000)
+		}(cross)
+		uassert.Equal(t, int64(1), proposalId)
+	})
+
+	t.Run("parameter change fails with GNS only", func(t *testing.T) {
+		gov := newMockGovernance()
+		caller := testutils.TestAddress("gns_param")
+
+		setupTestConfig(t, gov, &governance.Config{
+			VotingStartDelay:              86400,
+			VotingPeriod:                  604800,
+			VotingWeightSmoothingDuration: 86400,
+			Quorum:                        50,
+			ProposalCreationThreshold:     threshold,
+			ExecutionDelay:                86400,
+			ExecutionWindow:               2592000,
+		})
+		setupTestGnsBalance(t, caller, threshold)
+		setupTestUserVotesWithDelegation(t, gov, map[string]*governance.VotingInfo{
+			caller.String(): governance.NewVotingInfo(5_000_000_000),
+		}, 5_000_000_000)
+
+		testing.SetRealm(testing.NewUserRealm(caller))
+		uassert.AbortsContains(t, "[GNOSWAP-GOVERNANCE-003] not enough balance", func() {
+			func(cur realm) {
+				testing.SetRealm(govRealm)
+				gov.ProposeParameterChange("Parameter Change", "Description", 1, parameterExecution)
+			}(cross)
+		})
+	})
+
+	t.Run("parameter change succeeds with xGNS only", func(t *testing.T) {
+		gov := newMockGovernance()
+		caller := testutils.TestAddress("xgns_param")
+
+		setupTestConfig(t, gov, &governance.Config{
+			VotingStartDelay:              86400,
+			VotingPeriod:                  604800,
+			VotingWeightSmoothingDuration: 86400,
+			Quorum:                        50,
+			ProposalCreationThreshold:     threshold,
+			ExecutionDelay:                86400,
+			ExecutionWindow:               2592000,
+		})
+		setupTestXGnsBalance(t, caller, threshold)
+		setupTestUserVotesWithDelegation(t, gov, map[string]*governance.VotingInfo{
+			caller.String(): governance.NewVotingInfo(5_000_000_000),
+		}, 5_000_000_000)
+
+		testing.SetRealm(testing.NewUserRealm(caller))
+		var proposalId int64
+		func(cur realm) {
+			testing.SetRealm(govRealm)
+			proposalId = gov.ProposeParameterChange("Parameter Change", "Description", 1, parameterExecution)
+		}(cross)
+		uassert.Equal(t, int64(1), proposalId)
+	})
+}
+
 // Test proposal ID generation and active proposal limits
 func TestGovernancePropose_ProposalIDGeneration(t *testing.T) {
 	t.Run("sequential ID generation", func(t *testing.T) {
@@ -1376,9 +1545,9 @@ func TestGovernancePropose_ProposalIDGeneration(t *testing.T) {
 		caller2 := testutils.TestAddress("proposer2")
 		caller3 := testutils.TestAddress("proposer3")
 
-		setupTestGnsBalance(t, caller1, 10_000_000_000)
-		setupTestGnsBalance(t, caller2, 10_000_000_000)
-		setupTestGnsBalance(t, caller3, 10_000_000_000)
+		setupTestXGnsBalance(t, caller1, 10_000_000_000)
+		setupTestXGnsBalance(t, caller2, 10_000_000_000)
+		setupTestXGnsBalance(t, caller3, 10_000_000_000)
 		setupTestUserVotesWithDelegation(t, gov, map[string]*governance.VotingInfo{
 			caller1.String(): governance.NewVotingInfo(5_000_000_000),
 			caller2.String(): governance.NewVotingInfo(5_000_000_000),
@@ -1425,9 +1594,13 @@ func setupTestConfig(t *testing.T, gov *governanceV1, config *governance.Config)
 	gov.setConfig(nextVersion, *config)
 }
 
+func setupTestXGnsBalance(t *testing.T, address address, balance int64) {
+	testing.SetRealm(testing.NewUserRealm(govStakerAddr))
+
+	xgns.Mint(cross, address, balance)
+}
+
 func setupTestGnsBalance(t *testing.T, address address, balance int64) {
-	// Mock GNS balance setup
-	// In actual implementation, this would set up the GNS token balance
 	testing.SetRealm(adminRealm)
 
 	gns.Transfer(cross, address, balance)

--- a/contract/r/scenario/gov/governance/governance_vote_verify_with_smoothing_period_delegation_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_vote_verify_with_smoothing_period_delegation_filetest.gno
@@ -133,10 +133,6 @@ func initialDelegation() {
 	initialAmount := int64(3_000_000_000)
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
 
-	gns.Transfer(cross, user1Addr, initialAmount)
-	gns.Transfer(cross, user2Addr, initialAmount)
-	gns.Transfer(cross, user3Addr, initialAmount)
-
 	gns.Approve(cross, govStakerAddr, initialAmount)
 	gs.Delegate(cross, voter1Addr, initialAmount, "")
 
@@ -173,7 +169,20 @@ func checkCurrentXgnsBalance() {
 	ufmt.Printf("[INFO] Total xGNS supply: %d\n", totalXgns)
 }
 
+func prepareProposalCreator(proposerAddr address) {
+	amount := governance.GetLatestConfig().ProposalCreationThreshold
+
+	testing.SetRealm(testing.NewUserRealm(adminAddr))
+	gns.Transfer(cross, proposerAddr, amount)
+
+	testing.SetRealm(testing.NewUserRealm(proposerAddr))
+	gns.Approve(cross, govStakerAddr, amount)
+	gs.Delegate(cross, proposerAddr, amount, "")
+}
+
 func proposeText(proposerAddr address) int64 {
+	prepareProposalCreator(proposerAddr)
+
 	testing.SetRealm(testing.NewUserRealm(proposerAddr))
 	proposalId := governance.ProposeText(cross, "test_title", "test_description")
 	ufmt.Printf("[INFO] Created proposal ID: %d\n", proposalId)
@@ -286,7 +295,7 @@ func verifyVotingWeight(proposalId int64, hasVoter2VotingWeight bool) {
 // [SCENARIO] 13. Verify voting weights - ProposalID: 1
 // [EXPECTED] Voter1: vote weight=3000000000, xGNS=0, match=false
 // [EXPECTED] Voter2: vote weight=1000000000, xGNS=0, match=false
-// [EXPECTED] Quorum amount: 2000000000
+// [EXPECTED] Quorum amount: 2250000000
 // [EXPECTED] Yea weight: 3000000000 (voter1)
 // [EXPECTED] Nay weight: 1000000000 (voter2)
 //
@@ -298,7 +307,7 @@ func verifyVotingWeight(proposalId int64, hasVoter2VotingWeight bool) {
 // [SCENARIO] 15. Verify voting weights - ProposalID: 2
 // [EXPECTED] Voter1: vote weight=3000000000, xGNS=0, match=false
 // [EXPECTED] Voter2: vote weight=2000000000, xGNS=0, match=false
-// [EXPECTED] Quorum amount: 2500000000
+// [EXPECTED] Quorum amount: 3000000000
 // [EXPECTED] Yea weight: 3000000000 (voter1)
 // [EXPECTED] Nay weight: 2000000000 (voter2)
 //
@@ -310,6 +319,6 @@ func verifyVotingWeight(proposalId int64, hasVoter2VotingWeight bool) {
 // [SCENARIO] 17. Verify voting weights - ProposalID: 3
 // [EXPECTED] Voter1: vote weight=3000000000, xGNS=0, match=false
 // [EXPECTED] Voter2: vote weight=2000000000, xGNS=0, match=false
-// [EXPECTED] Quorum amount: 2500000000
+// [EXPECTED] Quorum amount: 3250000000
 // [EXPECTED] Yea weight: 3000000000 (voter1)
 // [EXPECTED] Nay weight: 2000000000 (voter2)

--- a/contract/r/scenario/halt/emergency_mode_governance_and_withdraw_filetest.gno
+++ b/contract/r/scenario/halt/emergency_mode_governance_and_withdraw_filetest.gno
@@ -60,6 +60,7 @@ import (
 	_ "gno.land/r/gnoswap/gov/governance/v1"
 	gs "gno.land/r/gnoswap/gov/staker"
 	_ "gno.land/r/gnoswap/gov/staker/v1"
+	"gno.land/r/gnoswap/gov/xgns"
 
 	"gno.land/r/onbloc/bar"
 	"gno.land/r/onbloc/foo"
@@ -82,6 +83,8 @@ var (
 
 	bobAddr  = testutils.TestAddress("bob")
 	bobRealm = testing.NewUserRealm(bobAddr)
+
+	proposalCreationDelegateeAddr = testutils.TestAddress("prop-delegatee")
 
 	barPath = "gno.land/r/onbloc/bar"
 	fooPath = "gno.land/r/onbloc/foo"
@@ -183,10 +186,25 @@ func initGovernancePoolAndTokens() {
 	testing.SetRealm(bobRealm)
 	gns.Approve(cross, govStakerAddr, INT64_MAX)
 	gs.Delegate(cross, bobAddr, delegatedAmount, "")
+	setupProposalCreationXGns()
 
 	ufmt.Printf("[INFO] Alice GNS balance: %d\n", gns.BalanceOf(aliceAddr))
 	ufmt.Printf("[INFO] Bob GNS balance: %d\n", gns.BalanceOf(bobAddr))
 	ufmt.Println("[INFO] Governance and tokens initialized")
+}
+
+func setupProposalCreationXGns() {
+	threshold := governance.GetLatestConfig().ProposalCreationThreshold
+	missingAmount := threshold - xgns.BalanceOf(aliceAddr)
+	if missingAmount <= 0 {
+		return
+	}
+
+	testing.SetRealm(adminRealm)
+	gns.Transfer(cross, aliceAddr, missingAmount)
+
+	testing.SetRealm(aliceRealm)
+	gs.Delegate(cross, proposalCreationDelegateeAddr, missingAmount, "")
 }
 
 func createPoolAndPosition() {

--- a/contract/r/scenario/halt/emission_halt_does_not_block_governance_filetest.gno
+++ b/contract/r/scenario/halt/emission_halt_does_not_block_governance_filetest.gno
@@ -23,6 +23,7 @@ import (
 	_ "gno.land/r/gnoswap/gov/governance/v1"
 	gs "gno.land/r/gnoswap/gov/staker"
 	_ "gno.land/r/gnoswap/gov/staker/v1"
+	"gno.land/r/gnoswap/gov/xgns"
 
 	_ "gno.land/r/onbloc/bar"
 	_ "gno.land/r/onbloc/foo"
@@ -42,6 +43,8 @@ var (
 
 	bobAddr  = testutils.TestAddress("bob")
 	bobRealm = testing.NewUserRealm(bobAddr)
+
+	proposalCreationDelegateeAddr = testutils.TestAddress("prop-delegatee")
 
 	currentBlockTime = int64(2)
 	proposalId       int64
@@ -103,10 +106,25 @@ func initGovernanceAndTokens() {
 	testing.SetRealm(bobRealm)
 	gns.Approve(cross, govStakerAddr, INT64_MAX)
 	gs.Delegate(cross, bobAddr, delegatedAmount, "")
+	setupProposalCreationXGns()
 
 	ufmt.Printf("[INFO] Alice GNS balance: %d\n", gns.BalanceOf(aliceAddr))
 	ufmt.Printf("[INFO] Bob GNS balance: %d\n", gns.BalanceOf(bobAddr))
 	ufmt.Println("[INFO] Governance and tokens initialized")
+}
+
+func setupProposalCreationXGns() {
+	threshold := governance.GetLatestConfig().ProposalCreationThreshold
+	missingAmount := threshold - xgns.BalanceOf(aliceAddr)
+	if missingAmount <= 0 {
+		return
+	}
+
+	testing.SetRealm(adminRealm)
+	gns.Transfer(cross, aliceAddr, missingAmount)
+
+	testing.SetRealm(aliceRealm)
+	gs.Delegate(cross, proposalCreationDelegateeAddr, missingAmount, "")
 }
 
 func createAndVoteProposalWithEmissionEnabled() {

--- a/tests/integration/testdata/gov/governance/create_text_proposal.txtar
+++ b/tests/integration/testdata/gov/governance/create_text_proposal.txtar
@@ -88,7 +88,7 @@ gnokey maketx call -pkgpath gno.land/r/gnoswap/gns -func Transfer -args $user1_u
 gnokey maketx call -pkgpath gno.land/r/gnoswap/gns -func Transfer -args $user1_user_addr -args 1 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" test1
 
 ### Now create the proposal and it should work because:
-### 1. proposalCreationThreshold is 0 (no GNS balance requirement)
+### 1. proposalCreationThreshold is 0 (no xGNS balance requirement)
 ### 2. votingWeightSmoothingDuration is 0 (delegations count immediately)  
 ### 3. test1 has delegated GNS and received xGNS voting power
 gnokey maketx call -pkgpath gno.land/r/gnoswap/gov/governance -func ProposeText -args "Test Proposal" -args "This is a test proposal" -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" test1


### PR DESCRIPTION
## Summary
- Change governance proposal creation threshold checks from GNS balance to xGNS balance.
- Update proposal creation tests to cover GNS-only failure and xGNS-only success for text, community pool spend, and parameter change proposals.
- Update governance docs/comments and halt scenarios for the xGNS threshold behavior.

## Tests
- `make test PKG=gno.land/r/gnoswap/gov/governance/v1`
- `make test PKG=gno.land/r/gnoswap/scenario/halt`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated governance proposal creation requirements to specify xGNS balance instead of GNS balance.
  * Clarified that proposal creation threshold (1,000 tokens) now applies to xGNS holdings.
  * Updated quorum calculation to reference active xGNS supply.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->