### PR TITLE
fix(pool): suppress DrySwap PoolTickCross events

### DIFF
--- a/contract/r/gnoswap/pool/v1/swap.gno
+++ b/contract/r/gnoswap/pool/v1/swap.gno
@@ -239,12 +239,18 @@ func (i *poolV1) Swap(
 	}
 
 	var onTickCross tickCrossHookFn
+	var hook func(cur realm, poolPath string, tickId int32, zeroForOne bool, timestamp int64)
 	if i.store.HasTickCrossHook() {
-		hook := i.store.GetTickCrossHook()
+		hook = i.store.GetTickCrossHook()
+	}
+	onTickCross = func(pool *pl.Pool, tickId int32, zeroForOne bool, timestamp int64) {
+		chain.Emit(
+			"PoolTickCross",
+			"poolPath", pool.PoolPath(),
+			"tick", NewTickEventInfo(tickId, *mustGetTick(pool, tickId)).ToString(),
+		)
 		if hook != nil {
-			onTickCross = func(poolPath string, tickId int32, zeroForOne bool, timestamp int64) {
-				hook(cross(rlm), poolPath, tickId, zeroForOne, timestamp)
-			}
+			hook(cross(rlm), pool.PoolPath(), tickId, zeroForOne, timestamp)
 		}
 	}
 
@@ -381,9 +387,9 @@ func (i *poolV1) DrySwap(
 	return result.Amount0.ToString(), result.Amount1.ToString(), true
 }
 
-// tickCrossHookFn is invoked from inside the swap loop whenever an
-// initialized tick is crossed. DrySwap passes nil to skip side effects.
-type tickCrossHookFn func(poolPath string, tickId int32, zeroForOne bool, timestamp int64)
+// tickCrossHookFn is invoked after an initialized tick is crossed. Swap uses it
+// for externally visible side effects; DrySwap passes nil.
+type tickCrossHookFn func(pool *pl.Pool, tickId int32, zeroForOne bool, timestamp int64)
 
 // computeSwap performs the core swap computation without modifying pool state.
 // The computation continues until either:
@@ -771,7 +777,7 @@ func (i *poolV1) tickTransition(step StepComputations, zeroForOne bool, state Sw
 		newState.liquidity = gnsmath.LiquidityMathAddDelta(state.liquidity, liquidityNet)
 
 		if onTickCross != nil {
-			onTickCross(pool.PoolPath(), step.tickNext, zeroForOne, cache.blockTimestamp)
+			onTickCross(pool, step.tickNext, zeroForOne, cache.blockTimestamp)
 		}
 	}
 

--- a/contract/r/gnoswap/pool/v1/swap.gno
+++ b/contract/r/gnoswap/pool/v1/swap.gno
@@ -238,12 +238,11 @@ func (i *poolV1) Swap(
 		Cache:             cache,
 	}
 
-	var onTickCross tickCrossHookFn
 	var hook func(cur realm, poolPath string, tickId int32, zeroForOne bool, timestamp int64)
 	if i.store.HasTickCrossHook() {
 		hook = i.store.GetTickCrossHook()
 	}
-	onTickCross = func(pool *pl.Pool, tickId int32, zeroForOne bool, timestamp int64) {
+	onTickCross := func(pool *pl.Pool, tickId int32, zeroForOne bool, timestamp int64) {
 		chain.Emit(
 			"PoolTickCross",
 			"poolPath", pool.PoolPath(),

--- a/contract/r/gnoswap/pool/v1/tick.gno
+++ b/contract/r/gnoswap/pool/v1/tick.gno
@@ -1,8 +1,6 @@
 package pool
 
 import (
-	"chain"
-
 	"gno.land/p/gnoswap/consts"
 	"gno.land/p/gnoswap/gnsmath"
 	ufmt "gno.land/p/nt/ufmt/v0"
@@ -266,12 +264,6 @@ func tickCross(
 	thisTick.SetSecondsOutside(uint32(blockTimestamp) - thisTick.SecondsOutside())
 
 	setTick(p, tick, thisTick)
-
-	chain.Emit(
-		"PoolTickCross",
-		"poolPath", p.PoolPath(),
-		"tick", NewTickEventInfo(tick, thisTick).ToString(),
-	)
 
 	return i256.MustFromDecimal(thisTick.LiquidityNet())
 }

--- a/tests/integration/testdata/staker/dryswap_does_not_dispatch_tick_cross_hook.txtar
+++ b/tests/integration/testdata/staker/dryswap_does_not_dispatch_tick_cross_hook.txtar
@@ -1,0 +1,120 @@
+loadpkg gno.land/p/nt/bptree/v0
+loadpkg gno.land/p/nt/ufmt/v0
+loadpkg gno.land/p/onbloc/json
+loadpkg gno.land/p/nt/ownable/v0
+loadpkg gno.land/p/demo/tokens/grc20
+loadpkg gno.land/p/demo/tokens/grc721
+loadpkg gno.land/r/demo/defi/foo20
+
+loadpkg gno.land/r/sys/users
+loadpkg gno.land/r/gnoland/wugnot
+loadpkg gno.land/r/demo/defi/grc20reg
+
+loadpkg gno.land/r/gnoswap/test_token/test_usdc
+loadpkg gno.land/r/onbloc/foo
+loadpkg gno.land/r/onbloc/bar
+loadpkg gno.land/r/onbloc/baz
+loadpkg gno.land/r/onbloc/qux
+loadpkg gno.land/r/onbloc/obl
+
+loadpkg gno.land/r/gnoswap/access
+loadpkg gno.land/p/gnoswap/uint256
+loadpkg gno.land/p/gnoswap/int256
+loadpkg gno.land/p/gnoswap/gnsmath
+loadpkg gno.land/p/gnoswap/store
+loadpkg gno.land/p/gnoswap/version_manager
+
+loadpkg gno.land/r/gnoswap/rbac
+loadpkg gno.land/r/gnoswap/halt
+loadpkg gno.land/r/gnoswap/common
+loadpkg gno.land/r/gnoswap/referral
+
+loadpkg gno.land/r/gnoswap/gns
+loadpkg gno.land/r/gnoswap/gnft
+loadpkg gno.land/r/gnoswap/gov/xgns
+loadpkg gno.land/r/gnoswap/emission
+loadpkg gno.land/r/gnoswap/protocol_fee
+
+loadpkg gno.land/r/gnoswap/pool
+loadpkg gno.land/r/gnoswap/position
+loadpkg gno.land/r/gnoswap/router
+loadpkg gno.land/r/gnoswap/staker
+
+loadpkg gno.land/r/gnoswap/protocol_fee/v1
+loadpkg gno.land/r/gnoswap/pool/v1
+loadpkg gno.land/r/gnoswap/position/v1
+loadpkg gno.land/r/gnoswap/router/v1
+loadpkg gno.land/r/gnoswap/staker/v1
+
+adduser test_admin
+patchpkg "g1lmvrrrr4er2us84h2732sru76c9zl2nvknha8c" $test_admin_user_addr
+
+adduser user1
+patchpkg "g16a7etgm9z2r653ucl36rj0l2yqcxgrz2jyegzx" $user1_user_addr
+
+## start a new node
+gnoland start
+
+# Transfer test tokens.
+gnokey maketx call -pkgpath gno.land/r/onbloc/bar -func Transfer -args $test_admin_user_addr -args 1000000000 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" test1
+gnokey maketx call -pkgpath gno.land/r/onbloc/bar -func Transfer -args $user1_user_addr -args 100000000 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" test1
+gnokey maketx call -pkgpath gno.land/r/onbloc/foo -func Transfer -args $test_admin_user_addr -args 1000000000 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" test1
+gnokey maketx call -pkgpath gno.land/r/onbloc/foo -func Transfer -args $user1_user_addr -args 100000000 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" test1
+
+# Approve pool and staker access.
+gnokey maketx call -pkgpath gno.land/r/onbloc/bar -func Approve -args g1dexaf6aqkkyr9yfy9d5up69lsn7ra80af34g5v -args 9223372036854775806 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" test1
+gnokey maketx call -pkgpath gno.land/r/onbloc/foo -func Approve -args g1dexaf6aqkkyr9yfy9d5up69lsn7ra80af34g5v -args 9223372036854775806 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" test1
+gnokey maketx call -pkgpath gno.land/r/onbloc/bar -func Approve -args g1q6d4ns7zkr492rgl0pcgf5ajaf2dlz0nnptky3 -args 9223372036854775806 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" test1
+gnokey maketx call -pkgpath gno.land/r/onbloc/foo -func Approve -args g1q6d4ns7zkr492rgl0pcgf5ajaf2dlz0nnptky3 -args 9223372036854775806 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" test1
+
+# Create a BAR:FOO pool at tick 0 and stake a position with initialized ticks at -60 and 60.
+gnokey maketx call -pkgpath gno.land/r/gnoswap/gns -func Approve -args g1dexaf6aqkkyr9yfy9d5up69lsn7ra80af34g5v -args 9223372036854775806 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" test1
+gnokey maketx call -pkgpath gno.land/r/gnoswap/pool -func CreatePool -args "gno.land/r/onbloc/bar" -args "gno.land/r/onbloc/foo" -args 3000 -args 79228162514264337593543950337 -gas-fee 10000000ugnot -gas-wanted 1000000000 -broadcast -chainid=tendermint_test test1
+
+gnokey maketx call -pkgpath gno.land/r/gnoswap/position -func Mint -args "gno.land/r/onbloc/bar" -args "gno.land/r/onbloc/foo" -args 3000 -args -60 -args 60 -args "5000000" -args "5000000" -args "1" -args "1" -args 9999999999 -args $test1_user_addr -args "" -gas-fee 10000000ugnot -gas-wanted 1000000000 -broadcast -chainid=tendermint_test test1
+# stdout 1
+# stdout "1669251248"
+
+gnokey maketx call -pkgpath gno.land/r/gnoswap/staker -func SetPoolTier -args "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:3000" -args 1 -gas-fee 10000000ugnot -gas-wanted 1000000000 -broadcast -chainid=tendermint_test test1
+
+gnokey maketx call -pkgpath gno.land/r/gnoswap/gnft -func Approve -args g1q6d4ns7zkr492rgl0pcgf5ajaf2dlz0nnptky3 -args 1 -gas-fee 10000000ugnot -gas-wanted 1000000000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gnoswap/staker -func StakeToken -args 1 -args "" -gas-fee 10000000ugnot -gas-wanted 1000000000 -broadcast -chainid=tendermint_test test1
+# stdout "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:3000"
+
+gnokey query vm/qeval --data "gno.land/r/gnoswap/staker.GetPoolStakedLiquidity(\"gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:3000\")"
+# stdout 1669251248
+
+# DrySwap may cross pool ticks during simulation, but it must not dispatch the staker tick-cross hook.
+gnokey maketx run test1 $WORK/run/dryswap_cross_tick.gno -gas-fee 10000000ugnot -gas-wanted 1000000000 -broadcast -chainid=tendermint_test
+# stdout true
+! stdout 'PoolTickCross'
+! stdout 'StakerTickCross'
+! stdout 'BatchStakerTickCross'
+
+gnokey query vm/qeval --data "gno.land/r/gnoswap/staker.GetPoolStakedLiquidity(\"gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:3000\")"
+# stdout 1669251248
+
+# A real swap across the same tick should still dispatch and batch the staker hook.
+gnokey maketx call -pkgpath gno.land/r/onbloc/bar -func Approve -args g1vc883gshu5z7ytk5cdynhc8c2dh67pdp4cszkp -args 9223372036854775806 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" test1
+gnokey maketx call -pkgpath gno.land/r/gnoswap/router -func ExactInSwapRoute -args gno.land/r/onbloc/bar -args gno.land/r/onbloc/foo -args 10000000 -args "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:3000" -args "100" -args "0" -args 9999999999 -args "" -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" test1
+# stdout 'BatchStakerTickCross'
+
+-- run/dryswap_cross_tick.gno --
+package main
+
+import pool "gno.land/r/gnoswap/pool"
+
+func main() {
+	amount0, amount1, ok := pool.DrySwap(
+		"gno.land/r/onbloc/bar",
+		"gno.land/r/onbloc/foo",
+		3000,
+		true,
+		"10000000",
+		"4306525355",
+	)
+
+	println(amount0)
+	println(amount1)
+	println(ok)
+}

--- a/tests/integration/testdata/staker/dryswap_does_not_dispatch_tick_cross_hook.txtar
+++ b/tests/integration/testdata/staker/dryswap_does_not_dispatch_tick_cross_hook.txtar
@@ -69,19 +69,19 @@ gnokey maketx call -pkgpath gno.land/r/onbloc/foo -func Approve -args g1q6d4ns7z
 
 # Create a BAR:FOO pool at tick 0 and stake a position with initialized ticks at -60 and 60.
 gnokey maketx call -pkgpath gno.land/r/gnoswap/gns -func Approve -args g1dexaf6aqkkyr9yfy9d5up69lsn7ra80af34g5v -args 9223372036854775806 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" test1
-gnokey maketx call -pkgpath gno.land/r/gnoswap/pool -func CreatePool -args "gno.land/r/onbloc/bar" -args "gno.land/r/onbloc/foo" -args 3000 -args 79228162514264337593543950337 -gas-fee 10000000ugnot -gas-wanted 1000000000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gnoswap/pool -func CreatePool -args "gno.land/r/onbloc/bar.BAR" -args "gno.land/r/onbloc/foo.FOO" -args 3000 -args 79228162514264337593543950337 -gas-fee 10000000ugnot -gas-wanted 1000000000 -broadcast -chainid=tendermint_test test1
 
-gnokey maketx call -pkgpath gno.land/r/gnoswap/position -func Mint -args "gno.land/r/onbloc/bar" -args "gno.land/r/onbloc/foo" -args 3000 -args -60 -args 60 -args "5000000" -args "5000000" -args "1" -args "1" -args 9999999999 -args $test1_user_addr -args "" -gas-fee 10000000ugnot -gas-wanted 1000000000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gnoswap/position -func Mint -args "gno.land/r/onbloc/bar.BAR" -args "gno.land/r/onbloc/foo.FOO" -args 3000 -args -60 -args 60 -args "5000000" -args "5000000" -args "1" -args "1" -args 9999999999 -args $test1_user_addr -args "" -gas-fee 10000000ugnot -gas-wanted 1000000000 -broadcast -chainid=tendermint_test test1
 # stdout 1
 # stdout "1669251248"
 
-gnokey maketx call -pkgpath gno.land/r/gnoswap/staker -func SetPoolTier -args "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:3000" -args 1 -gas-fee 10000000ugnot -gas-wanted 1000000000 -broadcast -chainid=tendermint_test test1
+gnokey maketx call -pkgpath gno.land/r/gnoswap/staker -func SetPoolTier -args "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:3000" -args 1 -gas-fee 10000000ugnot -gas-wanted 1000000000 -broadcast -chainid=tendermint_test test1
 
 gnokey maketx call -pkgpath gno.land/r/gnoswap/gnft -func Approve -args g1q6d4ns7zkr492rgl0pcgf5ajaf2dlz0nnptky3 -args 1 -gas-fee 10000000ugnot -gas-wanted 1000000000 -broadcast -chainid=tendermint_test test1
 gnokey maketx call -pkgpath gno.land/r/gnoswap/staker -func StakeToken -args 1 -args "" -gas-fee 10000000ugnot -gas-wanted 1000000000 -broadcast -chainid=tendermint_test test1
-# stdout "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:3000"
+# stdout "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:3000"
 
-gnokey query vm/qeval --data "gno.land/r/gnoswap/staker.GetPoolStakedLiquidity(\"gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:3000\")"
+gnokey query vm/qeval --data "gno.land/r/gnoswap/staker.GetPoolStakedLiquidity(\"gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:3000\")"
 # stdout 1669251248
 
 # DrySwap may cross pool ticks during simulation, but it must not dispatch the staker tick-cross hook.
@@ -91,12 +91,12 @@ gnokey maketx run test1 $WORK/run/dryswap_cross_tick.gno -gas-fee 10000000ugnot 
 ! stdout 'StakerTickCross'
 ! stdout 'BatchStakerTickCross'
 
-gnokey query vm/qeval --data "gno.land/r/gnoswap/staker.GetPoolStakedLiquidity(\"gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:3000\")"
+gnokey query vm/qeval --data "gno.land/r/gnoswap/staker.GetPoolStakedLiquidity(\"gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:3000\")"
 # stdout 1669251248
 
 # A real swap across the same tick should still dispatch and batch the staker hook.
 gnokey maketx call -pkgpath gno.land/r/onbloc/bar -func Approve -args g1vc883gshu5z7ytk5cdynhc8c2dh67pdp4cszkp -args 9223372036854775806 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" test1
-gnokey maketx call -pkgpath gno.land/r/gnoswap/router -func ExactInSwapRoute -args gno.land/r/onbloc/bar -args gno.land/r/onbloc/foo -args 10000000 -args "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:3000" -args "100" -args "0" -args 9999999999 -args "" -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" test1
+gnokey maketx call -pkgpath gno.land/r/gnoswap/router -func ExactInSwapRoute -args gno.land/r/onbloc/bar.BAR -args gno.land/r/onbloc/foo.FOO -args 10000000 -args "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:3000" -args "100" -args "0" -args 9999999999 -args "" -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" test1
 # stdout 'BatchStakerTickCross'
 
 -- run/dryswap_cross_tick.gno --
@@ -106,8 +106,8 @@ import pool "gno.land/r/gnoswap/pool"
 
 func main() {
 	amount0, amount1, ok := pool.DrySwap(
-		"gno.land/r/onbloc/bar",
-		"gno.land/r/onbloc/foo",
+		"gno.land/r/onbloc/bar.BAR",
+		"gno.land/r/onbloc/foo.FOO",
 		3000,
 		true,
 		"10000000",


### PR DESCRIPTION
## Summary

- Prevent `DrySwap` simulations from emitting canonical `PoolTickCross` events when simulated price movement crosses initialized ticks.
- Preserve `PoolTickCross` emission and staker tick-cross hook dispatch for real `Swap` execution.
- Add integration coverage proving `DrySwap` emits no tick-cross events while a real swap across the same tick still dispatches the staker batch event.

## Context

`DrySwap` reuses the normal swap computation path against a cloned pool. Before this change, `tickCross` emitted `PoolTickCross` directly, so a simulation could leak swap-like canonical events even though no real pool settlement occurred.

The staker hook path was already gated by the optional tick-cross callback and was not the active issue. This change moves `PoolTickCross` emission behind the same real-`Swap` callback boundary, so simulated tick crossing no longer produces canonical tick-cross events.

## Changes

- Move `PoolTickCross` emission from `tickCross` into the `Swap`-only tick-cross callback.
- Keep `DrySwap` on the shared computation path with a nil tick-cross callback.
- Update the tick-cross callback signature so real swap event payloads are still built from the crossed pool tick state.
- Add a staker integration fixture that rejects `PoolTickCross`, `StakerTickCross`, and `BatchStakerTickCross` during `DrySwap`, then confirms real swap behavior still emits the expected staker batch event.

## Verification

- `git diff --check`
- `make test PKG=gno.land/r/gnoswap/pool/v1`
- `make integration-test-run TEST=staker_dryswap_does_not_dispatch_tick_cross_hook`