### PR TITLE
fix(realms): align package names with directory/path names

### DIFF
--- a/contract/r/gnoswap/gov/governance/v1/_helper_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/_helper_test.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"testing"

--- a/contract/r/gnoswap/gov/governance/v1/_mock_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/_mock_test.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"gno.land/p/gnoswap/utils"

--- a/contract/r/gnoswap/gov/governance/v1/assert.gno
+++ b/contract/r/gnoswap/gov/governance/v1/assert.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"errors"

--- a/contract/r/gnoswap/gov/governance/v1/assert_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/assert_test.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"testing"

--- a/contract/r/gnoswap/gov/governance/v1/config.gno
+++ b/contract/r/gnoswap/gov/governance/v1/config.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"chain"

--- a/contract/r/gnoswap/gov/governance/v1/config_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/config_test.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"testing"

--- a/contract/r/gnoswap/gov/governance/v1/consts.gno
+++ b/contract/r/gnoswap/gov/governance/v1/consts.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 const (
 	// Governance can execute multiple messages in a single proposal

--- a/contract/r/gnoswap/gov/governance/v1/doc.gno
+++ b/contract/r/gnoswap/gov/governance/v1/doc.gno
@@ -1,1 +1,1 @@
-package v1
+package governance

--- a/contract/r/gnoswap/gov/governance/v1/errors.gno
+++ b/contract/r/gnoswap/gov/governance/v1/errors.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	ufmt "gno.land/p/nt/ufmt/v0"

--- a/contract/r/gnoswap/gov/governance/v1/getter.gno
+++ b/contract/r/gnoswap/gov/governance/v1/getter.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"errors"

--- a/contract/r/gnoswap/gov/governance/v1/getter_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/getter_test.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"chain/runtime"

--- a/contract/r/gnoswap/gov/governance/v1/governance_execute.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_execute.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"chain"

--- a/contract/r/gnoswap/gov/governance/v1/governance_execute_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_execute_test.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"testing"

--- a/contract/r/gnoswap/gov/governance/v1/governance_propose.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_propose.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"chain"

--- a/contract/r/gnoswap/gov/governance/v1/governance_propose_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_propose_test.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"strings"

--- a/contract/r/gnoswap/gov/governance/v1/governance_snapshot_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_snapshot_test.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"testing"

--- a/contract/r/gnoswap/gov/governance/v1/governance_vote.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_vote.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"chain"

--- a/contract/r/gnoswap/gov/governance/v1/governance_vote_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_vote_test.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"errors"

--- a/contract/r/gnoswap/gov/governance/v1/init.gno
+++ b/contract/r/gnoswap/gov/governance/v1/init.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"strconv"

--- a/contract/r/gnoswap/gov/governance/v1/init_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/init_test.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"testing"

--- a/contract/r/gnoswap/gov/governance/v1/instance.gno
+++ b/contract/r/gnoswap/gov/governance/v1/instance.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	bptree "gno.land/p/nt/bptree/v0"

--- a/contract/r/gnoswap/gov/governance/v1/instance_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/instance_test.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"testing"

--- a/contract/r/gnoswap/gov/governance/v1/parameter_registry.gno
+++ b/contract/r/gnoswap/gov/governance/v1/parameter_registry.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"strings"

--- a/contract/r/gnoswap/gov/governance/v1/parameter_registry_handler_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/parameter_registry_handler_test.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"errors"

--- a/contract/r/gnoswap/gov/governance/v1/parameter_registry_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/parameter_registry_test.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"errors"

--- a/contract/r/gnoswap/gov/governance/v1/proposal.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"errors"

--- a/contract/r/gnoswap/gov/governance/v1/proposal_action_status.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal_action_status.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"errors"

--- a/contract/r/gnoswap/gov/governance/v1/proposal_action_status_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal_action_status_test.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"testing"

--- a/contract/r/gnoswap/gov/governance/v1/proposal_data.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal_data.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"strings"

--- a/contract/r/gnoswap/gov/governance/v1/proposal_data_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal_data_test.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"testing"

--- a/contract/r/gnoswap/gov/governance/v1/proposal_schedule_status.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal_schedule_status.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	gnsmath "gno.land/p/gnoswap/gnsmath"

--- a/contract/r/gnoswap/gov/governance/v1/proposal_schedule_status_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal_schedule_status_test.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"testing"

--- a/contract/r/gnoswap/gov/governance/v1/proposal_status.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal_status.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	gnsmath "gno.land/p/gnoswap/gnsmath"

--- a/contract/r/gnoswap/gov/governance/v1/proposal_status_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal_status_test.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"testing"

--- a/contract/r/gnoswap/gov/governance/v1/proposal_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal_test.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"testing"

--- a/contract/r/gnoswap/gov/governance/v1/proposal_vote_status.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal_vote_status.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	gnsmath "gno.land/p/gnoswap/gnsmath"

--- a/contract/r/gnoswap/gov/governance/v1/proposal_vote_status_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/proposal_vote_status_test.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"testing"

--- a/contract/r/gnoswap/gov/governance/v1/utils.gno
+++ b/contract/r/gnoswap/gov/governance/v1/utils.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"strconv"

--- a/contract/r/gnoswap/gov/governance/v1/utils_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/utils_test.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"testing"

--- a/contract/r/gnoswap/gov/governance/v1/voting_info.gno
+++ b/contract/r/gnoswap/gov/governance/v1/voting_info.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"errors"

--- a/contract/r/gnoswap/gov/governance/v1/voting_info_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/voting_info_test.gno
@@ -1,4 +1,4 @@
-package v1
+package governance
 
 import (
 	"testing"

--- a/contract/r/gnoswap/gov/staker/v1/_helper_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/_helper_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"testing"

--- a/contract/r/gnoswap/gov/staker/v1/_mock_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/_mock_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"errors"

--- a/contract/r/gnoswap/gov/staker/v1/assert.gno
+++ b/contract/r/gnoswap/gov/staker/v1/assert.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"errors"

--- a/contract/r/gnoswap/gov/staker/v1/assert_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/assert_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"testing"

--- a/contract/r/gnoswap/gov/staker/v1/consts.gno
+++ b/contract/r/gnoswap/gov/staker/v1/consts.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 const (
 	minimumAmount = 1_000_000 // 1 GNS

--- a/contract/r/gnoswap/gov/staker/v1/counter_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/counter_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"testing"

--- a/contract/r/gnoswap/gov/staker/v1/delegation.gno
+++ b/contract/r/gnoswap/gov/staker/v1/delegation.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"errors"

--- a/contract/r/gnoswap/gov/staker/v1/delegation_manager.gno
+++ b/contract/r/gnoswap/gov/staker/v1/delegation_manager.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"gno.land/r/gnoswap/gov/staker"

--- a/contract/r/gnoswap/gov/staker/v1/delegation_manager_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/delegation_manager_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"testing"

--- a/contract/r/gnoswap/gov/staker/v1/delegation_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/delegation_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"math"

--- a/contract/r/gnoswap/gov/staker/v1/delegation_withdraw.gno
+++ b/contract/r/gnoswap/gov/staker/v1/delegation_withdraw.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"errors"

--- a/contract/r/gnoswap/gov/staker/v1/delegation_withdraw_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/delegation_withdraw_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"math"

--- a/contract/r/gnoswap/gov/staker/v1/doc.gno
+++ b/contract/r/gnoswap/gov/staker/v1/doc.gno
@@ -1,4 +1,4 @@
 // package v1 manages GNS token staking and delegation functionality.
 // It handles delegation of voting power, distribution of protocol rewards,
 // and implements a lockup period (default: 7-days) for unstaking operations (xGNS burned on collect).
-package v1
+package staker

--- a/contract/r/gnoswap/gov/staker/v1/emission_reward_manager.gno
+++ b/contract/r/gnoswap/gov/staker/v1/emission_reward_manager.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"errors"

--- a/contract/r/gnoswap/gov/staker/v1/emission_reward_manager_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/emission_reward_manager_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"math"

--- a/contract/r/gnoswap/gov/staker/v1/emission_reward_state.gno
+++ b/contract/r/gnoswap/gov/staker/v1/emission_reward_state.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"gno.land/p/gnoswap/consts"

--- a/contract/r/gnoswap/gov/staker/v1/emission_reward_state_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/emission_reward_state_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"testing"

--- a/contract/r/gnoswap/gov/staker/v1/errors.gno
+++ b/contract/r/gnoswap/gov/staker/v1/errors.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	ufmt "gno.land/p/nt/ufmt/v0"

--- a/contract/r/gnoswap/gov/staker/v1/getter.gno
+++ b/contract/r/gnoswap/gov/staker/v1/getter.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"strconv"

--- a/contract/r/gnoswap/gov/staker/v1/getter_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/getter_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"testing"

--- a/contract/r/gnoswap/gov/staker/v1/init.gno
+++ b/contract/r/gnoswap/gov/staker/v1/init.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"gno.land/r/gnoswap/gov/staker"

--- a/contract/r/gnoswap/gov/staker/v1/init_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/init_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"testing"

--- a/contract/r/gnoswap/gov/staker/v1/instance.gno
+++ b/contract/r/gnoswap/gov/staker/v1/instance.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"gno.land/r/gnoswap/gov/staker"

--- a/contract/r/gnoswap/gov/staker/v1/launchpad_project_deposits.gno
+++ b/contract/r/gnoswap/gov/staker/v1/launchpad_project_deposits.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	gnsmath "gno.land/p/gnoswap/gnsmath"

--- a/contract/r/gnoswap/gov/staker/v1/launchpad_project_deposits_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/launchpad_project_deposits_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"math"

--- a/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_manager.gno
+++ b/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_manager.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"errors"

--- a/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_manager_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_manager_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"math"

--- a/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_state.gno
+++ b/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_state.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"errors"

--- a/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_state_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_state_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"math"

--- a/contract/r/gnoswap/gov/staker/v1/staker_delegate.gno
+++ b/contract/r/gnoswap/gov/staker/v1/staker_delegate.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"chain"

--- a/contract/r/gnoswap/gov/staker/v1/staker_delegate_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/staker_delegate_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"chain/runtime"

--- a/contract/r/gnoswap/gov/staker/v1/staker_delegation_snapshot.gno
+++ b/contract/r/gnoswap/gov/staker/v1/staker_delegation_snapshot.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"chain"

--- a/contract/r/gnoswap/gov/staker/v1/staker_delegation_snapshot_cleanup_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/staker_delegation_snapshot_cleanup_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"testing"

--- a/contract/r/gnoswap/gov/staker/v1/staker_delegation_snapshot_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/staker_delegation_snapshot_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"math"

--- a/contract/r/gnoswap/gov/staker/v1/staker_reward.gno
+++ b/contract/r/gnoswap/gov/staker/v1/staker_reward.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"chain"

--- a/contract/r/gnoswap/gov/staker/v1/staker_reward_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/staker_reward_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"testing"

--- a/contract/r/gnoswap/gov/staker/v1/state.gno
+++ b/contract/r/gnoswap/gov/staker/v1/state.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"math"

--- a/contract/r/gnoswap/gov/staker/v1/state_delegation_history_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/state_delegation_history_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"testing"

--- a/contract/r/gnoswap/gov/staker/v1/state_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/state_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"testing"

--- a/contract/r/gnoswap/gov/staker/v1/util.gno
+++ b/contract/r/gnoswap/gov/staker/v1/util.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"strconv"

--- a/contract/r/gnoswap/gov/staker/v1/util_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/util_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"testing"

--- a/contract/r/gnoswap/launchpad/v1/_helper_test.gno
+++ b/contract/r/gnoswap/launchpad/v1/_helper_test.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	"chain"

--- a/contract/r/gnoswap/launchpad/v1/assert.gno
+++ b/contract/r/gnoswap/launchpad/v1/assert.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	ufmt "gno.land/p/nt/ufmt/v0"

--- a/contract/r/gnoswap/launchpad/v1/assert_test.gno
+++ b/contract/r/gnoswap/launchpad/v1/assert_test.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	"testing"

--- a/contract/r/gnoswap/launchpad/v1/consts.gno
+++ b/contract/r/gnoswap/launchpad/v1/consts.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 const (
 	projectTier30  = int64(30)

--- a/contract/r/gnoswap/launchpad/v1/deposit.gno
+++ b/contract/r/gnoswap/launchpad/v1/deposit.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import "gno.land/r/gnoswap/launchpad"
 

--- a/contract/r/gnoswap/launchpad/v1/deposit_test.gno
+++ b/contract/r/gnoswap/launchpad/v1/deposit_test.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	"math"

--- a/contract/r/gnoswap/launchpad/v1/errors.gno
+++ b/contract/r/gnoswap/launchpad/v1/errors.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	ufmt "gno.land/p/nt/ufmt/v0"

--- a/contract/r/gnoswap/launchpad/v1/getter.gno
+++ b/contract/r/gnoswap/launchpad/v1/getter.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	"errors"

--- a/contract/r/gnoswap/launchpad/v1/getter_test.gno
+++ b/contract/r/gnoswap/launchpad/v1/getter_test.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	"chain"

--- a/contract/r/gnoswap/launchpad/v1/init.gno
+++ b/contract/r/gnoswap/launchpad/v1/init.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	"gno.land/r/gnoswap/launchpad"

--- a/contract/r/gnoswap/launchpad/v1/instance.gno
+++ b/contract/r/gnoswap/launchpad/v1/instance.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	"gno.land/r/gnoswap/launchpad"

--- a/contract/r/gnoswap/launchpad/v1/launchpad_deposit.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_deposit.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	"chain"

--- a/contract/r/gnoswap/launchpad/v1/launchpad_deposit_test.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_deposit_test.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	"chain"

--- a/contract/r/gnoswap/launchpad/v1/launchpad_project.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_project.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	"chain"

--- a/contract/r/gnoswap/launchpad/v1/launchpad_project_test.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_project_test.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	"chain/runtime"

--- a/contract/r/gnoswap/launchpad/v1/launchpad_protocol_fee.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_protocol_fee.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	"errors"

--- a/contract/r/gnoswap/launchpad/v1/launchpad_protocol_fee_test.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_protocol_fee_test.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	"chain"

--- a/contract/r/gnoswap/launchpad/v1/launchpad_reward.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_reward.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	"chain"

--- a/contract/r/gnoswap/launchpad/v1/launchpad_reward_test.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_reward_test.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	"chain"

--- a/contract/r/gnoswap/launchpad/v1/launchpad_withdraw.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_withdraw.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	"chain"

--- a/contract/r/gnoswap/launchpad/v1/launchpad_withdraw_test.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_withdraw_test.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	"chain"

--- a/contract/r/gnoswap/launchpad/v1/project.gno
+++ b/contract/r/gnoswap/launchpad/v1/project.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	"errors"

--- a/contract/r/gnoswap/launchpad/v1/project_test.gno
+++ b/contract/r/gnoswap/launchpad/v1/project_test.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	"testing"

--- a/contract/r/gnoswap/launchpad/v1/project_tier.gno
+++ b/contract/r/gnoswap/launchpad/v1/project_tier.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	"errors"

--- a/contract/r/gnoswap/launchpad/v1/project_tier_test.gno
+++ b/contract/r/gnoswap/launchpad/v1/project_tier_test.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	"testing"

--- a/contract/r/gnoswap/launchpad/v1/reward_manager.gno
+++ b/contract/r/gnoswap/launchpad/v1/reward_manager.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	ufmt "gno.land/p/nt/ufmt/v0"

--- a/contract/r/gnoswap/launchpad/v1/reward_manager_test.gno
+++ b/contract/r/gnoswap/launchpad/v1/reward_manager_test.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	"math"

--- a/contract/r/gnoswap/launchpad/v1/reward_state.gno
+++ b/contract/r/gnoswap/launchpad/v1/reward_state.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	"errors"

--- a/contract/r/gnoswap/launchpad/v1/reward_state_test.gno
+++ b/contract/r/gnoswap/launchpad/v1/reward_state_test.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	"testing"

--- a/contract/r/gnoswap/launchpad/v1/state.gno
+++ b/contract/r/gnoswap/launchpad/v1/state.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	ufmt "gno.land/p/nt/ufmt/v0"

--- a/contract/r/gnoswap/launchpad/v1/tier_allocation_test.gno
+++ b/contract/r/gnoswap/launchpad/v1/tier_allocation_test.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	"testing"

--- a/contract/r/gnoswap/launchpad/v1/tier_duration_test.gno
+++ b/contract/r/gnoswap/launchpad/v1/tier_duration_test.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	"testing"

--- a/contract/r/gnoswap/launchpad/v1/utils.gno
+++ b/contract/r/gnoswap/launchpad/v1/utils.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	"math"

--- a/contract/r/gnoswap/launchpad/v1/utils_test.gno
+++ b/contract/r/gnoswap/launchpad/v1/utils_test.gno
@@ -1,4 +1,4 @@
-package v1
+package launchpad
 
 import (
 	"testing"

--- a/contract/r/gnoswap/pool/v1/_helper_test.gno
+++ b/contract/r/gnoswap/pool/v1/_helper_test.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"chain"

--- a/contract/r/gnoswap/pool/v1/_mock_test.gno
+++ b/contract/r/gnoswap/pool/v1/_mock_test.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"gno.land/r/gnoswap/mock"

--- a/contract/r/gnoswap/pool/v1/assert.gno
+++ b/contract/r/gnoswap/pool/v1/assert.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	ufmt "gno.land/p/nt/ufmt/v0"

--- a/contract/r/gnoswap/pool/v1/assert_test.gno
+++ b/contract/r/gnoswap/pool/v1/assert_test.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"chain/runtime"

--- a/contract/r/gnoswap/pool/v1/doc.gno
+++ b/contract/r/gnoswap/pool/v1/doc.gno
@@ -8,4 +8,4 @@
 // - Single-tick and cross-tick swaps
 // - Protocol fee collection
 // - Tick bitmap optimization for gas efficiency
-package v1
+package pool

--- a/contract/r/gnoswap/pool/v1/dsl_test.gno
+++ b/contract/r/gnoswap/pool/v1/dsl_test.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"chain/runtime"

--- a/contract/r/gnoswap/pool/v1/errors.gno
+++ b/contract/r/gnoswap/pool/v1/errors.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	ufmt "gno.land/p/nt/ufmt/v0"

--- a/contract/r/gnoswap/pool/v1/event_info.gno
+++ b/contract/r/gnoswap/pool/v1/event_info.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"gno.land/p/gnoswap/utils"

--- a/contract/r/gnoswap/pool/v1/event_info_test.gno
+++ b/contract/r/gnoswap/pool/v1/event_info_test.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"strings"

--- a/contract/r/gnoswap/pool/v1/factory_param.gno
+++ b/contract/r/gnoswap/pool/v1/factory_param.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"strings"

--- a/contract/r/gnoswap/pool/v1/factory_param_test.gno
+++ b/contract/r/gnoswap/pool/v1/factory_param_test.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"strings"

--- a/contract/r/gnoswap/pool/v1/getter.gno
+++ b/contract/r/gnoswap/pool/v1/getter.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	u256 "gno.land/p/gnoswap/uint256"

--- a/contract/r/gnoswap/pool/v1/getter_test.gno
+++ b/contract/r/gnoswap/pool/v1/getter_test.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"testing"

--- a/contract/r/gnoswap/pool/v1/init.gno
+++ b/contract/r/gnoswap/pool/v1/init.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"errors"

--- a/contract/r/gnoswap/pool/v1/init_test.gno
+++ b/contract/r/gnoswap/pool/v1/init_test.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"testing"

--- a/contract/r/gnoswap/pool/v1/instance.gno
+++ b/contract/r/gnoswap/pool/v1/instance.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"gno.land/r/gnoswap/pool"

--- a/contract/r/gnoswap/pool/v1/lock.gno
+++ b/contract/r/gnoswap/pool/v1/lock.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import "errors"
 

--- a/contract/r/gnoswap/pool/v1/manager.gno
+++ b/contract/r/gnoswap/pool/v1/manager.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"chain"

--- a/contract/r/gnoswap/pool/v1/manager_test.gno
+++ b/contract/r/gnoswap/pool/v1/manager_test.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"testing"

--- a/contract/r/gnoswap/pool/v1/oracle.gno
+++ b/contract/r/gnoswap/pool/v1/oracle.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"errors"

--- a/contract/r/gnoswap/pool/v1/oracle_integration_test.gno
+++ b/contract/r/gnoswap/pool/v1/oracle_integration_test.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"testing"

--- a/contract/r/gnoswap/pool/v1/oracle_spec_test.gno
+++ b/contract/r/gnoswap/pool/v1/oracle_spec_test.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"testing"

--- a/contract/r/gnoswap/pool/v1/oracle_test.gno
+++ b/contract/r/gnoswap/pool/v1/oracle_test.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"testing"

--- a/contract/r/gnoswap/pool/v1/pool.gno
+++ b/contract/r/gnoswap/pool/v1/pool.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"chain"

--- a/contract/r/gnoswap/pool/v1/pool_test.gno
+++ b/contract/r/gnoswap/pool/v1/pool_test.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"testing"

--- a/contract/r/gnoswap/pool/v1/position.gno
+++ b/contract/r/gnoswap/pool/v1/position.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"time"

--- a/contract/r/gnoswap/pool/v1/position_test.gno
+++ b/contract/r/gnoswap/pool/v1/position_test.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"testing"

--- a/contract/r/gnoswap/pool/v1/protocol_fee.gno
+++ b/contract/r/gnoswap/pool/v1/protocol_fee.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"chain"

--- a/contract/r/gnoswap/pool/v1/protocol_fee_test.gno
+++ b/contract/r/gnoswap/pool/v1/protocol_fee_test.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"strconv"

--- a/contract/r/gnoswap/pool/v1/swap.gno
+++ b/contract/r/gnoswap/pool/v1/swap.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"chain"

--- a/contract/r/gnoswap/pool/v1/swap_hooks_test.gno
+++ b/contract/r/gnoswap/pool/v1/swap_hooks_test.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"testing"

--- a/contract/r/gnoswap/pool/v1/swap_paid_test.gno
+++ b/contract/r/gnoswap/pool/v1/swap_paid_test.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"chain"

--- a/contract/r/gnoswap/pool/v1/swap_test.gno
+++ b/contract/r/gnoswap/pool/v1/swap_test.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"testing"

--- a/contract/r/gnoswap/pool/v1/tick.gno
+++ b/contract/r/gnoswap/pool/v1/tick.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"chain"

--- a/contract/r/gnoswap/pool/v1/tick_bitmap.gno
+++ b/contract/r/gnoswap/pool/v1/tick_bitmap.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"gno.land/p/gnoswap/gnsmath"

--- a/contract/r/gnoswap/pool/v1/tick_bitmap_test.gno
+++ b/contract/r/gnoswap/pool/v1/tick_bitmap_test.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"testing"

--- a/contract/r/gnoswap/pool/v1/tick_test.gno
+++ b/contract/r/gnoswap/pool/v1/tick_test.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"testing"

--- a/contract/r/gnoswap/pool/v1/transfer.gno
+++ b/contract/r/gnoswap/pool/v1/transfer.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	ufmt "gno.land/p/nt/ufmt/v0"

--- a/contract/r/gnoswap/pool/v1/transfer_test.gno
+++ b/contract/r/gnoswap/pool/v1/transfer_test.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"testing"

--- a/contract/r/gnoswap/pool/v1/twap_consistency_test.gno
+++ b/contract/r/gnoswap/pool/v1/twap_consistency_test.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"testing"

--- a/contract/r/gnoswap/pool/v1/type.gno
+++ b/contract/r/gnoswap/pool/v1/type.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"gno.land/p/gnoswap/gnsmath"

--- a/contract/r/gnoswap/pool/v1/utils.gno
+++ b/contract/r/gnoswap/pool/v1/utils.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	i256 "gno.land/p/gnoswap/int256"

--- a/contract/r/gnoswap/pool/v1/utils_test.gno
+++ b/contract/r/gnoswap/pool/v1/utils_test.gno
@@ -1,4 +1,4 @@
-package v1
+package pool
 
 import (
 	"testing"

--- a/contract/r/gnoswap/position/v1/_helper_test.gno
+++ b/contract/r/gnoswap/position/v1/_helper_test.gno
@@ -1,4 +1,4 @@
-package v1
+package position
 
 import (
 	"chain"

--- a/contract/r/gnoswap/position/v1/_mock_test.gno
+++ b/contract/r/gnoswap/position/v1/_mock_test.gno
@@ -1,4 +1,4 @@
-package v1
+package position
 
 import (
 	"strconv"

--- a/contract/r/gnoswap/position/v1/assert.gno
+++ b/contract/r/gnoswap/position/v1/assert.gno
@@ -1,4 +1,4 @@
-package v1
+package position
 
 import (
 	"errors"

--- a/contract/r/gnoswap/position/v1/assert_test.gno
+++ b/contract/r/gnoswap/position/v1/assert_test.gno
@@ -1,4 +1,4 @@
-package v1
+package position
 
 import (
 	"testing"

--- a/contract/r/gnoswap/position/v1/burn.gno
+++ b/contract/r/gnoswap/position/v1/burn.gno
@@ -1,4 +1,4 @@
-package v1
+package position
 
 import (
 	"errors"

--- a/contract/r/gnoswap/position/v1/burn_test.gno
+++ b/contract/r/gnoswap/position/v1/burn_test.gno
@@ -1,4 +1,4 @@
-package v1
+package position
 
 import (
 	"testing"

--- a/contract/r/gnoswap/position/v1/doc.gno
+++ b/contract/r/gnoswap/position/v1/doc.gno
@@ -3,4 +3,4 @@
 // Each position is represented as a non-transferable GRC721 NFT with concentrated
 // liquidity within a specific tick range. The package handles position lifecycle
 // including minting, liquidity adjustments, fee collection, and repositioning.
-package v1
+package position

--- a/contract/r/gnoswap/position/v1/errors.gno
+++ b/contract/r/gnoswap/position/v1/errors.gno
@@ -1,4 +1,4 @@
-package v1
+package position
 
 import (
 	ufmt "gno.land/p/nt/ufmt/v0"

--- a/contract/r/gnoswap/position/v1/getter.gno
+++ b/contract/r/gnoswap/position/v1/getter.gno
@@ -1,4 +1,4 @@
-package v1
+package position
 
 import (
 	"strconv"

--- a/contract/r/gnoswap/position/v1/getter_test.gno
+++ b/contract/r/gnoswap/position/v1/getter_test.gno
@@ -1,4 +1,4 @@
-package v1
+package position
 
 import (
 	"testing"

--- a/contract/r/gnoswap/position/v1/init.gno
+++ b/contract/r/gnoswap/position/v1/init.gno
@@ -1,4 +1,4 @@
-package v1
+package position
 
 import (
 	"errors"

--- a/contract/r/gnoswap/position/v1/instance.gno
+++ b/contract/r/gnoswap/position/v1/instance.gno
@@ -1,4 +1,4 @@
-package v1
+package position
 
 import (
 	"errors"

--- a/contract/r/gnoswap/position/v1/liquidity_management.gno
+++ b/contract/r/gnoswap/position/v1/liquidity_management.gno
@@ -1,4 +1,4 @@
-package v1
+package position
 
 import (
 	"gno.land/p/gnoswap/gnsmath"

--- a/contract/r/gnoswap/position/v1/liquidity_management_test.gno
+++ b/contract/r/gnoswap/position/v1/liquidity_management_test.gno
@@ -1,4 +1,4 @@
-package v1
+package position
 
 import (
 	"testing"

--- a/contract/r/gnoswap/position/v1/manager.gno
+++ b/contract/r/gnoswap/position/v1/manager.gno
@@ -1,4 +1,4 @@
-package v1
+package position
 
 import (
 	"gno.land/r/gnoswap/position"

--- a/contract/r/gnoswap/position/v1/mint.gno
+++ b/contract/r/gnoswap/position/v1/mint.gno
@@ -1,4 +1,4 @@
-package v1
+package position
 
 import (
 	"errors"

--- a/contract/r/gnoswap/position/v1/mint_test.gno
+++ b/contract/r/gnoswap/position/v1/mint_test.gno
@@ -1,4 +1,4 @@
-package v1
+package position
 
 import (
 	"strconv"

--- a/contract/r/gnoswap/position/v1/position.gno
+++ b/contract/r/gnoswap/position/v1/position.gno
@@ -1,4 +1,4 @@
-package v1
+package position
 
 import (
 	"chain"

--- a/contract/r/gnoswap/position/v1/position_test.gno
+++ b/contract/r/gnoswap/position/v1/position_test.gno
@@ -1,4 +1,4 @@
-package v1
+package position
 
 import (
 	"errors"

--- a/contract/r/gnoswap/position/v1/reposition.gno
+++ b/contract/r/gnoswap/position/v1/reposition.gno
@@ -1,4 +1,4 @@
-package v1
+package position
 
 import (
 	"chain"

--- a/contract/r/gnoswap/position/v1/type.gno
+++ b/contract/r/gnoswap/position/v1/type.gno
@@ -1,4 +1,4 @@
-package v1
+package position
 
 import (
 	u256 "gno.land/p/gnoswap/uint256"

--- a/contract/r/gnoswap/position/v1/utils.gno
+++ b/contract/r/gnoswap/position/v1/utils.gno
@@ -1,4 +1,4 @@
-package v1
+package position
 
 import (
 	"strconv"

--- a/contract/r/gnoswap/position/v1/utils_test.gno
+++ b/contract/r/gnoswap/position/v1/utils_test.gno
@@ -1,4 +1,4 @@
-package v1
+package position
 
 import (
 	"testing"

--- a/contract/r/gnoswap/protocol_fee/v1/_helper_test.gno
+++ b/contract/r/gnoswap/protocol_fee/v1/_helper_test.gno
@@ -1,4 +1,4 @@
-package v1
+package protocol_fee
 
 import (
 	prabc "gno.land/p/gnoswap/rbac"

--- a/contract/r/gnoswap/protocol_fee/v1/_mock_test.gno
+++ b/contract/r/gnoswap/protocol_fee/v1/_mock_test.gno
@@ -1,4 +1,4 @@
-package v1
+package protocol_fee
 
 import (
 	bptree "gno.land/p/nt/bptree/v0"

--- a/contract/r/gnoswap/protocol_fee/v1/assert.gno
+++ b/contract/r/gnoswap/protocol_fee/v1/assert.gno
@@ -1,4 +1,4 @@
-package v1
+package protocol_fee
 
 import (
 	prbac "gno.land/p/gnoswap/rbac"

--- a/contract/r/gnoswap/protocol_fee/v1/assert_test.gno
+++ b/contract/r/gnoswap/protocol_fee/v1/assert_test.gno
@@ -1,4 +1,4 @@
-package v1
+package protocol_fee
 
 import (
 	"testing"

--- a/contract/r/gnoswap/protocol_fee/v1/doc.gno
+++ b/contract/r/gnoswap/protocol_fee/v1/doc.gno
@@ -3,4 +3,4 @@
 // This contract accumulates fees generated from trading activity and
 // distributes them to devOps and governance stakers according to
 // configurable percentages set through governance.
-package v1
+package protocol_fee

--- a/contract/r/gnoswap/protocol_fee/v1/errors.gno
+++ b/contract/r/gnoswap/protocol_fee/v1/errors.gno
@@ -1,4 +1,4 @@
-package v1
+package protocol_fee
 
 import (
 	ufmt "gno.land/p/nt/ufmt/v0"

--- a/contract/r/gnoswap/protocol_fee/v1/getter.gno
+++ b/contract/r/gnoswap/protocol_fee/v1/getter.gno
@@ -1,4 +1,4 @@
-package v1
+package protocol_fee
 
 // GetDevOpsPct returns the percentage allocated to devOps.
 func (pf *protocolFeeV1) GetDevOpsPct() int64 {

--- a/contract/r/gnoswap/protocol_fee/v1/getter_test.gno
+++ b/contract/r/gnoswap/protocol_fee/v1/getter_test.gno
@@ -1,4 +1,4 @@
-package v1
+package protocol_fee
 
 import (
 	"testing"

--- a/contract/r/gnoswap/protocol_fee/v1/init.gno
+++ b/contract/r/gnoswap/protocol_fee/v1/init.gno
@@ -1,4 +1,4 @@
-package v1
+package protocol_fee
 
 import (
 	"gno.land/r/gnoswap/protocol_fee"

--- a/contract/r/gnoswap/protocol_fee/v1/instance.gno
+++ b/contract/r/gnoswap/protocol_fee/v1/instance.gno
@@ -1,4 +1,4 @@
-package v1
+package protocol_fee
 
 import (
 	"gno.land/r/gnoswap/protocol_fee"

--- a/contract/r/gnoswap/protocol_fee/v1/instance_test.gno
+++ b/contract/r/gnoswap/protocol_fee/v1/instance_test.gno
@@ -1,4 +1,4 @@
-package v1
+package protocol_fee
 
 import (
 	"testing"

--- a/contract/r/gnoswap/protocol_fee/v1/protocol_fee.gno
+++ b/contract/r/gnoswap/protocol_fee/v1/protocol_fee.gno
@@ -1,4 +1,4 @@
-package v1
+package protocol_fee
 
 import (
 	"chain"

--- a/contract/r/gnoswap/protocol_fee/v1/protocol_fee_state.gno
+++ b/contract/r/gnoswap/protocol_fee/v1/protocol_fee_state.gno
@@ -1,4 +1,4 @@
-package v1
+package protocol_fee
 
 import (
 	bptree "gno.land/p/nt/bptree/v0"

--- a/contract/r/gnoswap/protocol_fee/v1/protocol_fee_state_test.gno
+++ b/contract/r/gnoswap/protocol_fee/v1/protocol_fee_state_test.gno
@@ -1,4 +1,4 @@
-package v1
+package protocol_fee
 
 import (
 	"testing"

--- a/contract/r/gnoswap/protocol_fee/v1/protocol_fee_test.gno
+++ b/contract/r/gnoswap/protocol_fee/v1/protocol_fee_test.gno
@@ -1,4 +1,4 @@
-package v1
+package protocol_fee
 
 import (
 	"chain/runtime"

--- a/contract/r/gnoswap/protocol_fee/v1/utils.gno
+++ b/contract/r/gnoswap/protocol_fee/v1/utils.gno
@@ -1,1 +1,1 @@
-package v1
+package protocol_fee

--- a/contract/r/gnoswap/router/v1/_helper_test.gno
+++ b/contract/r/gnoswap/router/v1/_helper_test.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	"chain"

--- a/contract/r/gnoswap/router/v1/_mock_test.gno
+++ b/contract/r/gnoswap/router/v1/_mock_test.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	"strconv"

--- a/contract/r/gnoswap/router/v1/assert.gno
+++ b/contract/r/gnoswap/router/v1/assert.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	"strings"

--- a/contract/r/gnoswap/router/v1/assert_test.gno
+++ b/contract/r/gnoswap/router/v1/assert_test.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	"testing"

--- a/contract/r/gnoswap/router/v1/base.gno
+++ b/contract/r/gnoswap/router/v1/base.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	"errors"

--- a/contract/r/gnoswap/router/v1/base_test.gno
+++ b/contract/r/gnoswap/router/v1/base_test.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	"errors"

--- a/contract/r/gnoswap/router/v1/consts.gno
+++ b/contract/r/gnoswap/router/v1/consts.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 var routerImplAddr address
 

--- a/contract/r/gnoswap/router/v1/doc.gno
+++ b/contract/r/gnoswap/router/v1/doc.gno
@@ -6,4 +6,4 @@
 //
 // All swap functions include deadline checks and minimum output validation
 // to protect users from unfavorable price movements.
-package v1
+package router

--- a/contract/r/gnoswap/router/v1/dsl_test.gno
+++ b/contract/r/gnoswap/router/v1/dsl_test.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	"testing"

--- a/contract/r/gnoswap/router/v1/errors.gno
+++ b/contract/r/gnoswap/router/v1/errors.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	ufmt "gno.land/p/nt/ufmt/v0"

--- a/contract/r/gnoswap/router/v1/exact_in.gno
+++ b/contract/r/gnoswap/router/v1/exact_in.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	"chain"

--- a/contract/r/gnoswap/router/v1/exact_in_test.gno
+++ b/contract/r/gnoswap/router/v1/exact_in_test.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	"chain"

--- a/contract/r/gnoswap/router/v1/exact_out.gno
+++ b/contract/r/gnoswap/router/v1/exact_out.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	"chain"

--- a/contract/r/gnoswap/router/v1/exact_out_test.gno
+++ b/contract/r/gnoswap/router/v1/exact_out_test.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	"strings"

--- a/contract/r/gnoswap/router/v1/init.gno
+++ b/contract/r/gnoswap/router/v1/init.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	"gno.land/r/gnoswap/router"

--- a/contract/r/gnoswap/router/v1/instance.gno
+++ b/contract/r/gnoswap/router/v1/instance.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	"gno.land/r/gnoswap/router"

--- a/contract/r/gnoswap/router/v1/protocol_fee_swap.gno
+++ b/contract/r/gnoswap/router/v1/protocol_fee_swap.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	"chain"

--- a/contract/r/gnoswap/router/v1/protocol_fee_swap_test.gno
+++ b/contract/r/gnoswap/router/v1/protocol_fee_swap_test.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	"math"

--- a/contract/r/gnoswap/router/v1/router.gno
+++ b/contract/r/gnoswap/router/v1/router.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	"errors"

--- a/contract/r/gnoswap/router/v1/router_dry.gno
+++ b/contract/r/gnoswap/router/v1/router_dry.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	"chain/runtime/unsafe"

--- a/contract/r/gnoswap/router/v1/router_dry_test.gno
+++ b/contract/r/gnoswap/router/v1/router_dry_test.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	"strings"

--- a/contract/r/gnoswap/router/v1/router_test.gno
+++ b/contract/r/gnoswap/router/v1/router_test.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	"chain"

--- a/contract/r/gnoswap/router/v1/swap_callback.gno
+++ b/contract/r/gnoswap/router/v1/swap_callback.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	"errors"

--- a/contract/r/gnoswap/router/v1/swap_callback_test.gno
+++ b/contract/r/gnoswap/router/v1/swap_callback_test.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	"chain"

--- a/contract/r/gnoswap/router/v1/swap_inner.gno
+++ b/contract/r/gnoswap/router/v1/swap_inner.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	"gno.land/p/gnoswap/gnsmath"

--- a/contract/r/gnoswap/router/v1/swap_inner_test.gno
+++ b/contract/r/gnoswap/router/v1/swap_inner_test.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	"strconv"

--- a/contract/r/gnoswap/router/v1/swap_multi.gno
+++ b/contract/r/gnoswap/router/v1/swap_multi.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	prbac "gno.land/p/gnoswap/rbac"

--- a/contract/r/gnoswap/router/v1/swap_multi_test.gno
+++ b/contract/r/gnoswap/router/v1/swap_multi_test.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	"strconv"

--- a/contract/r/gnoswap/router/v1/swap_single.gno
+++ b/contract/r/gnoswap/router/v1/swap_single.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	"errors"

--- a/contract/r/gnoswap/router/v1/swap_single_test.gno
+++ b/contract/r/gnoswap/router/v1/swap_single_test.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	"strconv"

--- a/contract/r/gnoswap/router/v1/swap_test.gno
+++ b/contract/r/gnoswap/router/v1/swap_test.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	"testing"

--- a/contract/r/gnoswap/router/v1/type.gno
+++ b/contract/r/gnoswap/router/v1/type.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	u256 "gno.land/p/gnoswap/uint256"

--- a/contract/r/gnoswap/router/v1/type_test.gno
+++ b/contract/r/gnoswap/router/v1/type_test.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	"testing"

--- a/contract/r/gnoswap/router/v1/utils.gno
+++ b/contract/r/gnoswap/router/v1/utils.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	"errors"

--- a/contract/r/gnoswap/router/v1/utils_test.gno
+++ b/contract/r/gnoswap/router/v1/utils_test.gno
@@ -1,4 +1,4 @@
-package v1
+package router
 
 import (
 	"strconv"

--- a/contract/r/gnoswap/staker/v1/_helper_test.gno
+++ b/contract/r/gnoswap/staker/v1/_helper_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"chain"

--- a/contract/r/gnoswap/staker/v1/_mock_test.gno
+++ b/contract/r/gnoswap/staker/v1/_mock_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"testing"

--- a/contract/r/gnoswap/staker/v1/assert.gno
+++ b/contract/r/gnoswap/staker/v1/assert.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"strconv"

--- a/contract/r/gnoswap/staker/v1/assert_test.gno
+++ b/contract/r/gnoswap/staker/v1/assert_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"testing"

--- a/contract/r/gnoswap/staker/v1/calculate_pool_position_reward.gno
+++ b/contract/r/gnoswap/staker/v1/calculate_pool_position_reward.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"gno.land/p/gnoswap/gnsmath"

--- a/contract/r/gnoswap/staker/v1/calculate_pool_position_reward_test.gno
+++ b/contract/r/gnoswap/staker/v1/calculate_pool_position_reward_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"chain/runtime"

--- a/contract/r/gnoswap/staker/v1/consts.gno
+++ b/contract/r/gnoswap/staker/v1/consts.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 const (
 	GNS_PATH    string = "gno.land/r/gnoswap/gns"

--- a/contract/r/gnoswap/staker/v1/doc.gno
+++ b/contract/r/gnoswap/staker/v1/doc.gno
@@ -6,4 +6,4 @@
 //
 // Rewards are calculated per-tick and accumulate over time, with automatic
 // compounding and fee collection integration.
-package v1
+package staker

--- a/contract/r/gnoswap/staker/v1/errors.gno
+++ b/contract/r/gnoswap/staker/v1/errors.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	ufmt "gno.land/p/nt/ufmt/v0"

--- a/contract/r/gnoswap/staker/v1/event_info.gno
+++ b/contract/r/gnoswap/staker/v1/event_info.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	i256 "gno.land/p/gnoswap/int256"

--- a/contract/r/gnoswap/staker/v1/event_info_test.gno
+++ b/contract/r/gnoswap/staker/v1/event_info_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"strings"

--- a/contract/r/gnoswap/staker/v1/external_deposit_fee.gno
+++ b/contract/r/gnoswap/staker/v1/external_deposit_fee.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"chain"

--- a/contract/r/gnoswap/staker/v1/external_deposit_fee_test.gno
+++ b/contract/r/gnoswap/staker/v1/external_deposit_fee_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"testing"

--- a/contract/r/gnoswap/staker/v1/external_incentive.gno
+++ b/contract/r/gnoswap/staker/v1/external_incentive.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"errors"

--- a/contract/r/gnoswap/staker/v1/external_incentive_test.gno
+++ b/contract/r/gnoswap/staker/v1/external_incentive_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"chain/runtime"

--- a/contract/r/gnoswap/staker/v1/external_token_list.gno
+++ b/contract/r/gnoswap/staker/v1/external_token_list.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"chain"

--- a/contract/r/gnoswap/staker/v1/external_token_list_test.gno
+++ b/contract/r/gnoswap/staker/v1/external_token_list_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"testing"

--- a/contract/r/gnoswap/staker/v1/getter.gno
+++ b/contract/r/gnoswap/staker/v1/getter.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"chain/runtime"

--- a/contract/r/gnoswap/staker/v1/getter_test.gno
+++ b/contract/r/gnoswap/staker/v1/getter_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"testing"

--- a/contract/r/gnoswap/staker/v1/init.gno
+++ b/contract/r/gnoswap/staker/v1/init.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"errors"

--- a/contract/r/gnoswap/staker/v1/init_test.gno
+++ b/contract/r/gnoswap/staker/v1/init_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"testing"

--- a/contract/r/gnoswap/staker/v1/instance.gno
+++ b/contract/r/gnoswap/staker/v1/instance.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import sr "gno.land/r/gnoswap/staker"
 

--- a/contract/r/gnoswap/staker/v1/manage_pool_tier_and_warmup.gno
+++ b/contract/r/gnoswap/staker/v1/manage_pool_tier_and_warmup.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"chain"

--- a/contract/r/gnoswap/staker/v1/manage_pool_tier_and_warmup_test.gno
+++ b/contract/r/gnoswap/staker/v1/manage_pool_tier_and_warmup_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"math"

--- a/contract/r/gnoswap/staker/v1/pool_incentive_validation_test.gno
+++ b/contract/r/gnoswap/staker/v1/pool_incentive_validation_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"testing"

--- a/contract/r/gnoswap/staker/v1/protocol_fee_unstaking.gno
+++ b/contract/r/gnoswap/staker/v1/protocol_fee_unstaking.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"chain"

--- a/contract/r/gnoswap/staker/v1/protocol_fee_unstaking_test.gno
+++ b/contract/r/gnoswap/staker/v1/protocol_fee_unstaking_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"testing"

--- a/contract/r/gnoswap/staker/v1/reward_calculation_canonical_env_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_canonical_env_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 // "Canonical" implementation of reward calculation.
 // Used for testing and reference.

--- a/contract/r/gnoswap/staker/v1/reward_calculation_canonical_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_canonical_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 // Evaluate against the canonical implementation
 

--- a/contract/r/gnoswap/staker/v1/reward_calculation_incentives.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_incentives.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"gno.land/p/gnoswap/gnsmath"

--- a/contract/r/gnoswap/staker/v1/reward_calculation_incentives_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_incentives_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"chain/runtime"

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"errors"

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"testing"

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"errors"

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"testing"

--- a/contract/r/gnoswap/staker/v1/reward_calculation_tick.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_tick.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"chain"

--- a/contract/r/gnoswap/staker/v1/reward_calculation_tick_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_tick_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"testing"

--- a/contract/r/gnoswap/staker/v1/reward_calculation_types.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_types.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"strconv"

--- a/contract/r/gnoswap/staker/v1/reward_calculation_types_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_types_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"testing"

--- a/contract/r/gnoswap/staker/v1/reward_calculation_warmup.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_warmup.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"errors"

--- a/contract/r/gnoswap/staker/v1/reward_calculation_warmup_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_warmup_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"math"

--- a/contract/r/gnoswap/staker/v1/staker.gno
+++ b/contract/r/gnoswap/staker/v1/staker.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"chain"

--- a/contract/r/gnoswap/staker/v1/staker_test.gno
+++ b/contract/r/gnoswap/staker/v1/staker_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"chain/runtime"

--- a/contract/r/gnoswap/staker/v1/type.gno
+++ b/contract/r/gnoswap/staker/v1/type.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"gno.land/p/gnoswap/gnsmath"

--- a/contract/r/gnoswap/staker/v1/utils.gno
+++ b/contract/r/gnoswap/staker/v1/utils.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"errors"

--- a/contract/r/gnoswap/staker/v1/utils_test.gno
+++ b/contract/r/gnoswap/staker/v1/utils_test.gno
@@ -1,4 +1,4 @@
-package v1
+package staker
 
 import (
 	"math"

--- a/contract/r/gnoswap/test_token/test_atom/atom.gno
+++ b/contract/r/gnoswap/test_token/test_atom/atom.gno
@@ -1,4 +1,4 @@
-package atom
+package test_atom
 
 import (
 	"strings"

--- a/contract/r/gnoswap/test_token/test_atone/atone.gno
+++ b/contract/r/gnoswap/test_token/test_atone/atone.gno
@@ -1,4 +1,4 @@
-package atone
+package test_atone
 
 import (
 	"strings"

--- a/contract/r/gnoswap/test_token/test_btc/btc.gno
+++ b/contract/r/gnoswap/test_token/test_btc/btc.gno
@@ -1,4 +1,4 @@
-package btc
+package test_btc
 
 import (
 	"strings"

--- a/contract/r/gnoswap/test_token/test_dai/dai.gno
+++ b/contract/r/gnoswap/test_token/test_dai/dai.gno
@@ -1,4 +1,4 @@
-package dai
+package test_dai
 
 import (
 	"strings"

--- a/contract/r/gnoswap/test_token/test_eth/eth.gno
+++ b/contract/r/gnoswap/test_token/test_eth/eth.gno
@@ -1,4 +1,4 @@
-package eth
+package test_eth
 
 import (
 	"strings"

--- a/contract/r/gnoswap/test_token/test_photon/photon.gno
+++ b/contract/r/gnoswap/test_token/test_photon/photon.gno
@@ -1,4 +1,4 @@
-package photon
+package test_photon
 
 import (
 	"strings"

--- a/contract/r/gnoswap/test_token/test_sol/sol.gno
+++ b/contract/r/gnoswap/test_token/test_sol/sol.gno
@@ -1,4 +1,4 @@
-package sol
+package test_sol
 
 import (
 	"strings"

--- a/contract/r/gnoswap/test_token/test_trx/trx.gno
+++ b/contract/r/gnoswap/test_token/test_trx/trx.gno
@@ -1,4 +1,4 @@
-package trx
+package test_trx
 
 import (
 	"strings"

--- a/contract/r/gnoswap/test_token/test_usdc/usdc.gno
+++ b/contract/r/gnoswap/test_token/test_usdc/usdc.gno
@@ -1,4 +1,4 @@
-package usdc
+package test_usdc
 
 import (
 	"strings"

--- a/contract/r/gnoswap/test_token/test_usdt/usdt.gno
+++ b/contract/r/gnoswap/test_token/test_usdt/usdt.gno
@@ -1,4 +1,4 @@
-package usdt
+package test_usdt
 
 import (
 	"strings"

--- a/contract/r/scenario/upgrade/implements/mock/gov/staker/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/mock/gov/staker/test_impl.gno
@@ -3,7 +3,7 @@ package mock
 
 import (
 	"gno.land/r/gnoswap/gov/staker"
-	"gno.land/r/gnoswap/gov/staker/v1"
+	v1 "gno.land/r/gnoswap/gov/staker/v1"
 )
 
 func NewV3ValidGovStaker(store staker.IGovStakerStore) staker.IGovStaker {

--- a/contract/r/scenario/upgrade/implements/mock/position/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/mock/position/test_impl.gno
@@ -9,7 +9,7 @@ import (
 
 	"gno.land/r/gnoswap/gnft"
 	"gno.land/r/gnoswap/position"
-	"gno.land/r/gnoswap/position/v1"
+	v1 "gno.land/r/gnoswap/position/v1"
 )
 
 // NFTAccessor implementation for test

--- a/contract/r/scenario/upgrade/implements/security/attempt_store_writer/attempt_store_writer.gno
+++ b/contract/r/scenario/upgrade/implements/security/attempt_store_writer/attempt_store_writer.gno
@@ -1,4 +1,4 @@
-package v_permprobe
+package attempt_store_writer
 
 import (
 	pool "gno.land/r/gnoswap/pool"

--- a/contract/r/scenario/upgrade/implements/security/register_duplicated_version/duplicated_package.gno
+++ b/contract/r/scenario/upgrade/implements/security/register_duplicated_version/duplicated_package.gno
@@ -1,4 +1,4 @@
-package v_dup_probe
+package register_duplicated_version
 
 import (
 	pool "gno.land/r/gnoswap/pool"

--- a/contract/r/scenario/upgrade/implements/security/try_register_pool_initializer/initializer.gno
+++ b/contract/r/scenario/upgrade/implements/security/try_register_pool_initializer/initializer.gno
@@ -1,4 +1,4 @@
-package pool_initializer
+package try_register_pool_initializer
 
 import (
 	pool "gno.land/r/gnoswap/pool"

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/assert.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/assert.gno
@@ -1,4 +1,4 @@
-package v3
+package v3_valid
 
 import (
 	ufmt "gno.land/p/nt/ufmt/v0"

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/consts.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/consts.gno
@@ -1,4 +1,4 @@
-package v3
+package v3_valid
 
 import (
 	u256 "gno.land/p/gnoswap/uint256"

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/deposit.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/deposit.gno
@@ -1,4 +1,4 @@
-package v3
+package v3_valid
 
 import "gno.land/r/gnoswap/launchpad"
 

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/errors.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/errors.gno
@@ -1,4 +1,4 @@
-package v3
+package v3_valid
 
 import (
 	"errors"

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/getter.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/getter.gno
@@ -1,4 +1,4 @@
-package v3
+package v3_valid
 
 import (
 	"errors"

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/init.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/init.gno
@@ -1,4 +1,4 @@
-package v3
+package v3_valid
 
 import (
 	bptree "gno.land/p/nt/bptree/v0"

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/instance.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/instance.gno
@@ -1,4 +1,4 @@
-package v3
+package v3_valid
 
 import (
 	"gno.land/r/gnoswap/launchpad"

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_deposit.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_deposit.gno
@@ -1,4 +1,4 @@
-package v3
+package v3_valid
 
 import (
 	"chain"

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_project.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_project.gno
@@ -1,4 +1,4 @@
-package v3
+package v3_valid
 
 import (
 	"chain"

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_protocol_fee.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_protocol_fee.gno
@@ -1,4 +1,4 @@
-package v3
+package v3_valid
 
 import (
 	"gno.land/r/gnoswap/halt"

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_reward.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_reward.gno
@@ -1,4 +1,4 @@
-package v3
+package v3_valid
 
 import (
 	"chain"

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_withdraw.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_withdraw.gno
@@ -1,4 +1,4 @@
-package v3
+package v3_valid
 
 import (
 	"chain"

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/project.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/project.gno
@@ -1,4 +1,4 @@
-package v3
+package v3_valid
 
 import (
 	"errors"

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/project_tier.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/project_tier.gno
@@ -1,4 +1,4 @@
-package v3
+package v3_valid
 
 import (
 	"gno.land/r/gnoswap/launchpad"

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/reward_manager.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/reward_manager.gno
@@ -1,4 +1,4 @@
-package v3
+package v3_valid
 
 import (
 	ufmt "gno.land/p/nt/ufmt/v0"

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/reward_state.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/reward_state.gno
@@ -1,4 +1,4 @@
-package v3
+package v3_valid
 
 import (
 	"gno.land/r/gnoswap/launchpad"

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/state.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/state.gno
@@ -1,4 +1,4 @@
-package v3
+package v3_valid
 
 import (
 	ufmt "gno.land/p/nt/ufmt/v0"

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/utils.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/utils.gno
@@ -1,4 +1,4 @@
-package v3
+package v3_valid
 
 import (
 	"math"


### PR DESCRIPTION
## Summary
- Renamed several package declarations so they match the last element of their import path, as required by the latest gno rule that validates package name against path on deploy.

## Context
- gno now enforces that a package's declared name must equal the last path element of its import path (or the element before a version suffix like `v1`/`v2`), and rejects `addpkg` otherwise. See gnolang/gno#5048.
- `refactor/interrealm-v2` merged into `main` and was deleted, so this PR is now rebased directly onto `main`.
- Several groups of packages in this repo didn't follow the naming convention and fail to deploy under the latest gno.

## Changes
- `contract/r/gnoswap/test_token/test_*`: 10 test-token realms declared package names without the `test_` prefix (e.g. `package usdc` under `test_usdc/`). Renamed to match their directory (e.g. `package test_usdc`).
- 8 versioned implementation realms declared `package v1` instead of the name expected for a version-suffixed path. Renamed to match their parent directory: `position/v1`, `launchpad/v1`, `protocol_fee/v1`, `staker/v1`, `pool/v1`, `router/v1`, `gov/governance/v1`, `gov/staker/v1` (281 files, package-clause-only changes).
- Added an explicit `v1` import alias in the two consumers that import both a renamed `v1` package and its same-named proxy package together (`contract/r/scenario/upgrade/implements/mock/position/test_impl.gno`, `.../mock/gov/staker/test_impl.gno`), to avoid an identifier collision.
- 4 additional scenario/upgrade test realms had the same mismatch, found while investigating related integration test failures:
  - `contract/r/scenario/upgrade/implements/v3_valid/launchpad`: `package v3` → `package v3_valid`
  - `contract/r/scenario/upgrade/implements/security/register_duplicated_version`: `package v_dup_probe` → `package register_duplicated_version`
  - `contract/r/scenario/upgrade/implements/security/attempt_store_writer`: `package v_permprobe` → `package attempt_store_writer`
  - `contract/r/scenario/upgrade/implements/security/try_register_pool_initializer`: `package pool_initializer` → `package try_register_pool_initializer`
- All other external references to these packages were either blank imports (`_ "..."`) or path string constants, so they're unaffected by the rename.

## Verification
- `gno test ./gno.land/r/gnoswap/...` against a local build of `gnoswap-labs/gno` (master) for all renamed packages: pass.
- Integration tests `upgradable_initializer_security`, `upgradable_launchpad_upgrade`, `upgradable_store_permission_enforcement` pass locally with these fixes applied.
- Confirmed via `git diff` against `main` that this branch's commits don't touch any of the files affected by the separate, pre-existing `bptree.BPTree.Get()` API-change fallout that's being fixed in #1340 (`fix/latest-gno-api-compat`).

## Notes
- CI on this PR may still show failures unrelated to this diff: `main` doesn't yet include #1340's `bptree.BPTree.Get()` adaptation, so packages depending on that API change (staker, pool, position, protocol_fee, launchpad, referral, gov/staker) won't build until #1340 merges. This PR's own changes don't touch those files.

## References
- gnolang/gno#5048 — upstream change enforcing package name matches path
