### PR TITLE
feat(launchpad): emit stake snapshots for deposits

### DIFF
--- a/contract/r/gnoswap/launchpad/_mock_test.gno
+++ b/contract/r/gnoswap/launchpad/_mock_test.gno
@@ -122,6 +122,14 @@ func (m *MockLaunchpad) GetDepositCount() int {
 	return res[0].(int)
 }
 
+func (m *MockLaunchpad) GetTotalGNSStakedAmount() int64 {
+	res, ok := m.Response.Get("GetTotalGNSStakedAmount")
+	if !ok {
+		return 0
+	}
+	return res[0].(int64)
+}
+
 func (m *MockLaunchpad) GetProjectTierRewardManagerCount() int {
 	res, ok := m.Response.Get("GetProjectTierRewardManagerCount")
 	if !ok {

--- a/contract/r/gnoswap/launchpad/getter.gno
+++ b/contract/r/gnoswap/launchpad/getter.gno
@@ -222,6 +222,11 @@ func GetDepositEndTime(depositId string) (int64, error) {
 	return getImplementation().GetDepositEndTime(depositId)
 }
 
+// GetTotalGNSStakedAmount returns the total amount of GNS currently staked across all launchpad deposits.
+func GetTotalGNSStakedAmount() int64 {
+	return getImplementation().GetTotalGNSStakedAmount()
+}
+
 // GetProjectTierRewardManagerCount returns the total number of reward managers.
 func GetProjectTierRewardManagerCount() int {
 	return getImplementation().GetProjectTierRewardManagerCount()

--- a/contract/r/gnoswap/launchpad/store.gno
+++ b/contract/r/gnoswap/launchpad/store.gno
@@ -31,6 +31,7 @@ const (
 	StoreKeyProjectTierRewardManagers StoreKey = "projectTierRewardManagers" // Project tier reward managers tree
 	StoreKeyDepositCounter            StoreKey = "depositCounter"            // Deposit counter
 	StoreKeyDeposits                  StoreKey = "deposits"                  // Deposits tree
+	StoreKeyTotalGNSStakedAmount      StoreKey = "totalGNSStakedAmount"      // Total active launchpad GNS stake
 )
 
 type launchpadStore struct {
@@ -157,6 +158,32 @@ func (s *launchpadStore) SetDeposits(_ int, rlm realm, deposits *bptree.BPTree) 
 	}
 
 	return s.kvStore.Set(0, rlm, StoreKeyDeposits.String(), deposits)
+}
+
+func (s *launchpadStore) HasTotalGNSStakedAmountKey() bool {
+	return s.kvStore.Has(StoreKeyTotalGNSStakedAmount.String())
+}
+
+func (s *launchpadStore) GetTotalGNSStakedAmount() int64 {
+	result, err := s.kvStore.Get(StoreKeyTotalGNSStakedAmount.String())
+	if err != nil {
+		panic(err)
+	}
+
+	amount, ok := result.(int64)
+	if !ok {
+		panic(ufmt.Sprintf("failed to cast result to int64: %T", result))
+	}
+
+	return amount
+}
+
+func (s *launchpadStore) SetTotalGNSStakedAmount(_ int, rlm realm, amount int64) error {
+	if !rlm.IsCurrent() {
+		return errors.New(ErrSpoofedRealm)
+	}
+
+	return s.kvStore.Set(0, rlm, StoreKeyTotalGNSStakedAmount.String(), amount)
 }
 
 // NewLaunchpadStore creates a new launchpad store instance with the provided KV store.

--- a/contract/r/gnoswap/launchpad/store_test.gno
+++ b/contract/r/gnoswap/launchpad/store_test.gno
@@ -351,6 +351,61 @@ func TestStoreSetAndGetDeposits(cur realm, t *testing.T) {
 	}
 }
 
+func TestStoreSetAndGetTotalGNSStakedAmount(cur realm, t *testing.T) {
+	tests := []struct {
+		name         string
+		setupFn      func(cur realm, ls ILaunchpadStore)
+		testFn       func(cur realm, t *testing.T, ls ILaunchpadStore)
+		shouldPanic  bool
+		panicMessage string
+	}{
+		{
+			name: "set and get total GNS staked amount successfully",
+			setupFn: func(cur realm, ls ILaunchpadStore) {
+				ls.SetTotalGNSStakedAmount(0, cur, 1000)
+			},
+			testFn: func(cur realm, t *testing.T, ls ILaunchpadStore) {
+				uassert.True(t, ls.HasTotalGNSStakedAmountKey(), "should have total GNS staked amount after setting")
+				uassert.Equal(t, int64(1000), ls.GetTotalGNSStakedAmount())
+			},
+		},
+		{
+			name: "should not have total GNS staked amount initially",
+			testFn: func(cur realm, t *testing.T, ls ILaunchpadStore) {
+				uassert.False(t, ls.HasTotalGNSStakedAmountKey(), "should not have total GNS staked amount initially")
+			},
+		},
+		{
+			name: "panic when getting uninitialized total GNS staked amount",
+			testFn: func(cur realm, t *testing.T, ls ILaunchpadStore) {
+				ls.GetTotalGNSStakedAmount()
+			},
+			shouldPanic:  true,
+			panicMessage: "should panic when getting uninitialized total GNS staked amount",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
+			resetTestState(cur, t)
+			ls := NewLaunchpadStore(kvStore)
+
+			if tt.setupFn != nil {
+				tt.setupFn(cur, ls)
+			}
+
+			if tt.shouldPanic {
+				defer func() {
+					r := recover()
+					uassert.NotEqual(t, nil, r, tt.panicMessage)
+				}()
+			}
+
+			tt.testFn(cur, t, ls)
+		})
+	}
+}
+
 func TestStoreMultipleSetAndGet(cur realm, t *testing.T) {
 	tests := []struct {
 		name     string
@@ -374,12 +429,15 @@ func TestStoreMultipleSetAndGet(cur realm, t *testing.T) {
 				deposits := bptree.NewBPTreeN(16)
 				deposits.Set("deposit1", "ddata1")
 				ls.SetDeposits(0, cur, deposits)
+
+				ls.SetTotalGNSStakedAmount(0, cur, 1000)
 			},
 			verifyFn: func(cur realm, t *testing.T, ls ILaunchpadStore) {
 				uassert.True(t, ls.HasProjectsKey())
 				uassert.True(t, ls.HasProjectTierRewardManagersKey())
 				uassert.True(t, ls.HasDepositCounterStoreKey())
 				uassert.True(t, ls.HasDepositsKey())
+				uassert.True(t, ls.HasTotalGNSStakedAmountKey())
 
 				retrievedProjects := ls.GetProjects()
 				val := retrievedProjects.Get("project1")
@@ -397,6 +455,8 @@ func TestStoreMultipleSetAndGet(cur realm, t *testing.T) {
 				val = retrievedDeposits.Get("deposit1")
 				uassert.NotNil(t, val, "deposit1 should not be nil")
 				uassert.Equal(t, "ddata1", val)
+
+				uassert.Equal(t, int64(1000), ls.GetTotalGNSStakedAmount())
 			},
 		},
 	}

--- a/contract/r/gnoswap/launchpad/types.gno
+++ b/contract/r/gnoswap/launchpad/types.gno
@@ -75,6 +75,7 @@ type ILaunchpadGetter interface {
 	GetDepositCreatedHeight(depositId string) (int64, error)
 	GetDepositCreatedAt(depositId string) (int64, error)
 	GetDepositEndTime(depositId string) (int64, error)
+	GetTotalGNSStakedAmount() int64
 
 	GetProjectTierRewardManagerCount() int
 	GetProjectTierRewardManager(projectTierId string) (*RewardManager, error)

--- a/contract/r/gnoswap/launchpad/types.gno
+++ b/contract/r/gnoswap/launchpad/types.gno
@@ -110,4 +110,8 @@ type ILaunchpadStore interface {
 	HasDepositsKey() bool
 	GetDeposits() *bptree.BPTree
 	SetDeposits(_ int, rlm realm, deposits *bptree.BPTree) error
+
+	HasTotalGNSStakedAmountKey() bool
+	GetTotalGNSStakedAmount() int64
+	SetTotalGNSStakedAmount(_ int, rlm realm, amount int64) error
 }

--- a/contract/r/gnoswap/launchpad/v1/_helper_test.gno
+++ b/contract/r/gnoswap/launchpad/v1/_helper_test.gno
@@ -319,6 +319,7 @@ func initTestStore() {
 		projectTierRewardManagers: launchpad.NewBPTreeN(16),
 		depositCounter:            launchpad.NewCounter(),
 		deposits:                  launchpad.NewBPTreeN(16),
+		totalGNSStakedAmount:      0,
 	}
 	impl := NewLaunchpadV1(testStore)
 	testImpl = impl.(*launchpadV1)
@@ -336,6 +337,7 @@ type testLaunchpadStore struct {
 	projectTierRewardManagers *bptree.BPTree
 	depositCounter            *launchpad.Counter
 	deposits                  *bptree.BPTree
+	totalGNSStakedAmount      int64
 }
 
 func (s *testLaunchpadStore) HasProjectsKey() bool {
@@ -400,6 +402,19 @@ func (s *testLaunchpadStore) GetDeposits() *bptree.BPTree {
 
 func (s *testLaunchpadStore) SetDeposits(_ int, rlm realm, deposits *bptree.BPTree) error {
 	s.deposits = deposits
+	return nil
+}
+
+func (s *testLaunchpadStore) HasTotalGNSStakedAmountKey() bool {
+	return true // Always available in mock
+}
+
+func (s *testLaunchpadStore) GetTotalGNSStakedAmount() int64 {
+	return s.totalGNSStakedAmount
+}
+
+func (s *testLaunchpadStore) SetTotalGNSStakedAmount(_ int, rlm realm, amount int64) error {
+	s.totalGNSStakedAmount = amount
 	return nil
 }
 

--- a/contract/r/gnoswap/launchpad/v1/getter.gno
+++ b/contract/r/gnoswap/launchpad/v1/getter.gno
@@ -32,7 +32,6 @@ func (lp *launchpadV1) GetProjectIDs(offset, count int) []string {
 	})
 
 	return projectIDs
-
 }
 
 // GetProject retrieves a project by its ID.
@@ -475,6 +474,11 @@ func (lp *launchpadV1) GetDepositEndTime(depositId string) (int64, error) {
 	}
 
 	return deposit.EndTime(), nil
+}
+
+// GetTotalGNSStakedAmount returns the total amount of GNS currently staked across all launchpad deposits.
+func (lp *launchpadV1) GetTotalGNSStakedAmount() int64 {
+	return lp.store.GetTotalGNSStakedAmount()
 }
 
 // GetProjectTierRewardManagerCount returns the total number of reward managers.

--- a/contract/r/gnoswap/launchpad/v1/init.gno
+++ b/contract/r/gnoswap/launchpad/v1/init.gno
@@ -1,8 +1,6 @@
 package launchpad
 
-import (
-	"gno.land/r/gnoswap/launchpad"
-)
+import "gno.land/r/gnoswap/launchpad"
 
 func init(cur realm) {
 	registerLaunchpadV1(cur)
@@ -43,6 +41,13 @@ func initStoreData(_ int, rlm realm, launchpadStore launchpad.ILaunchpadStore) e
 
 	if !launchpadStore.HasDepositsKey() {
 		err := launchpadStore.SetDeposits(0, rlm, launchpad.NewBPTreeN(16))
+		if err != nil {
+			return err
+		}
+	}
+
+	if !launchpadStore.HasTotalGNSStakedAmountKey() {
+		err := launchpadStore.SetTotalGNSStakedAmount(0, rlm, 0)
 		if err != nil {
 			return err
 		}

--- a/contract/r/gnoswap/launchpad/v1/launchpad_deposit.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_deposit.gno
@@ -76,6 +76,8 @@ func (lp *launchpadV1) DepositGns(_ int, rlm realm, targetProjectTierID string, 
 			"depositId", deposit.ID(),
 			"claimableTime", utils.FormatInt(rewardState.ClaimableTime()),
 			"tierAmountPerSecondX128", distributeAmountPerSecondX128,
+			"totalGNSStakedAmount", utils.FormatInt(afterTotalGNSStakedAmount),
+			"recipient", project.Recipient().String(),
 		)
 	}
 

--- a/contract/r/gnoswap/launchpad/v1/launchpad_deposit.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_deposit.gno
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"time"
 
+	gnsmath "gno.land/p/gnoswap/gnsmath"
 	"gno.land/p/gnoswap/utils"
 
 	"gno.land/r/gnoswap/common"
@@ -44,6 +45,8 @@ func (lp *launchpadV1) DepositGns(_ int, rlm realm, targetProjectTierID string, 
 		panic(err.Error())
 	}
 
+	beforeTotalGNSStakedAmount := lp.store.GetTotalGNSStakedAmount()
+
 	deposit, rewardState, isFirstDeposit, distributeAmountPerSecondX128, err := lp.depositGns(
 		0,
 		rlm,
@@ -53,6 +56,11 @@ func (lp *launchpadV1) DepositGns(_ int, rlm realm, targetProjectTierID string, 
 		caller,
 	)
 	if err != nil {
+		panic(err.Error())
+	}
+
+	afterTotalGNSStakedAmount := gnsmath.SafeAddInt64(beforeTotalGNSStakedAmount, depositAmount)
+	if err := lp.store.SetTotalGNSStakedAmount(0, rlm, afterTotalGNSStakedAmount); err != nil {
 		panic(err.Error())
 	}
 
@@ -80,6 +88,9 @@ func (lp *launchpadV1) DepositGns(_ int, rlm realm, targetProjectTierID string, 
 		"depositId", deposit.ID(),
 		"claimableTime", utils.FormatInt(rewardState.ClaimableTime()),
 		"referrer", actualReferrer,
+		"beforeTotalGNSStakedAmount", utils.FormatInt(beforeTotalGNSStakedAmount),
+		"afterTotalGNSStakedAmount", utils.FormatInt(afterTotalGNSStakedAmount),
+		"recipient", project.Recipient().String(),
 	)
 
 	launchpadAddress := rlm.Address()

--- a/contract/r/gnoswap/launchpad/v1/launchpad_deposit.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_deposit.gno
@@ -88,8 +88,7 @@ func (lp *launchpadV1) DepositGns(_ int, rlm realm, targetProjectTierID string, 
 		"depositId", deposit.ID(),
 		"claimableTime", utils.FormatInt(rewardState.ClaimableTime()),
 		"referrer", actualReferrer,
-		"beforeTotalGNSStakedAmount", utils.FormatInt(beforeTotalGNSStakedAmount),
-		"afterTotalGNSStakedAmount", utils.FormatInt(afterTotalGNSStakedAmount),
+		"totalGNSStakedAmount", utils.FormatInt(afterTotalGNSStakedAmount),
 		"recipient", project.Recipient().String(),
 	)
 

--- a/contract/r/gnoswap/launchpad/v1/launchpad_withdraw.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_withdraw.gno
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"time"
 
+	gnsmath "gno.land/p/gnoswap/gnsmath"
 	"gno.land/p/gnoswap/utils"
 	ufmt "gno.land/p/nt/ufmt/v0"
 
@@ -48,8 +49,15 @@ func (lp *launchpadV1) CollectDepositGns(_ int, rlm realm, depositID string) (in
 		panic(err)
 	}
 
+	beforeTotalGNSStakedAmount := lp.store.GetTotalGNSStakedAmount()
+
 	recipient, withdrawalAmount, err := lp.withdrawDeposit(0, rlm, deposit, runtime.ChainHeight(), currentTime)
 	if err != nil {
+		panic(err.Error())
+	}
+
+	afterTotalGNSStakedAmount := gnsmath.SafeSubInt64(beforeTotalGNSStakedAmount, withdrawalAmount)
+	if err := lp.store.SetTotalGNSStakedAmount(0, rlm, afterTotalGNSStakedAmount); err != nil {
 		panic(err.Error())
 	}
 
@@ -78,6 +86,9 @@ func (lp *launchpadV1) CollectDepositGns(_ int, rlm realm, depositID string) (in
 		"prevRealm", previousRealm.PkgPath(),
 		"depositId", depositID,
 		"amount", utils.FormatInt(withdrawalAmount),
+		"beforeTotalGNSStakedAmount", utils.FormatInt(beforeTotalGNSStakedAmount),
+		"afterTotalGNSStakedAmount", utils.FormatInt(afterTotalGNSStakedAmount),
+		"recipient", recipient.String(),
 	)
 
 	return withdrawalAmount, nil

--- a/contract/r/gnoswap/launchpad/v1/launchpad_withdraw.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_withdraw.gno
@@ -86,8 +86,7 @@ func (lp *launchpadV1) CollectDepositGns(_ int, rlm realm, depositID string) (in
 		"prevRealm", previousRealm.PkgPath(),
 		"depositId", depositID,
 		"amount", utils.FormatInt(withdrawalAmount),
-		"beforeTotalGNSStakedAmount", utils.FormatInt(beforeTotalGNSStakedAmount),
-		"afterTotalGNSStakedAmount", utils.FormatInt(afterTotalGNSStakedAmount),
+		"totalGNSStakedAmount", utils.FormatInt(afterTotalGNSStakedAmount),
 		"recipient", recipient.String(),
 	)
 

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/getter.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/getter.gno
@@ -265,6 +265,11 @@ func (lp *launchpadV1) GetDepositCount() int {
 	return deposits.Size()
 }
 
+// GetTotalGNSStakedAmount returns the total amount of GNS currently staked across all launchpad deposits.
+func (lp *launchpadV1) GetTotalGNSStakedAmount() int64 {
+	return lp.store.GetTotalGNSStakedAmount()
+}
+
 // GetCurrentDepositId returns the current deposit counter value.
 func (lp *launchpadV1) GetCurrentDepositId() int64 {
 	counter := lp.store.GetDepositCounter()


### PR DESCRIPTION
## Summary
- Adds an aggregate launchpad GNS stake store value so deposit and withdrawal events can emit before/after total stake snapshots.
- Emits the project `recipient` alongside stake totals on `DepositGns` and `CollectDepositGns` events.
- Initializes the new aggregate value at `0` for first deployment without a historical backfill path.

## Context
- This is stacked on #1344 to keep the launchpad stake snapshot work separate from the broader contract event-field updates.
- The emitted fields let downstream event routing build launchpad stake context without requiring a launchpad-owned follow-up message.

## Changes
- Added `totalGNSStakedAmount` to the launchpad store interface and implementation.
- Updates the aggregate on launchpad GNS deposit and withdrawal.
- Emits `beforeTotalGNSStakedAmount`, `afterTotalGNSStakedAmount`, and `recipient` in launchpad deposit/withdraw events.
- Added store coverage for the new aggregate value.

## Verification
- `gno fmt -w -q r/gnoswap/launchpad/store.gno r/gnoswap/launchpad/store_test.gno r/gnoswap/launchpad/types.gno r/gnoswap/launchpad/v1/init.gno r/gnoswap/launchpad/v1/_helper_test.gno r/gnoswap/launchpad/v1/launchpad_deposit.gno r/gnoswap/launchpad/v1/launchpad_withdraw.gno`
- `make test PKG=gno.land/r/gnoswap/launchpad/v1`
- `make test PKG=gno.land/r/gnoswap/launchpad`
- `git diff --check origin/chore/add-contract-events..HEAD`

## Notes
- The `gno fmt` command exits successfully but still prints existing local warnings about missing `/Users/junghoon/gno/examples` packages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a getter for the total amount of GNS currently staked across launchpad deposits.
  - Total staked GNS is now initialized, persisted, and updated automatically when users deposit or withdraw.
  - Deposit and withdrawal events now include the updated staking total and recipient details.

- **Tests**
  - Added coverage for storing, retrieving, initializing, and updating the total staked GNS amount.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->