### PR TITLE
feat(gov): add split reward claim ABI stubs

### DIFF
--- a/contract/r/gnoswap/gov/staker/_mock_test.gno
+++ b/contract/r/gnoswap/gov/staker/_mock_test.gno
@@ -79,8 +79,24 @@ func (m *MockGovStaker) CollectReward(_ int, rlm realm) {
 	m.Response.Get("CollectReward")
 }
 
+func (m *MockGovStaker) CollectEmissionReward(_ int, rlm realm) {
+	m.Response.Get("CollectEmissionReward")
+}
+
+func (m *MockGovStaker) CollectProtocolFeeReward(_ int, rlm realm, tokenPath string) {
+	m.Response.Get("CollectProtocolFeeReward")
+}
+
 func (m *MockGovStaker) CollectRewardFromLaunchPad(_ int, rlm realm, to address) {
 	m.Response.Get("CollectRewardFromLaunchPad")
+}
+
+func (m *MockGovStaker) CollectEmissionRewardFromLaunchPad(_ int, rlm realm, to address) {
+	m.Response.Get("CollectEmissionRewardFromLaunchPad")
+}
+
+func (m *MockGovStaker) CollectProtocolFeeRewardFromLaunchPad(_ int, rlm realm, to address, tokenPath string) {
+	m.Response.Get("CollectProtocolFeeRewardFromLaunchPad")
 }
 
 func (m *MockGovStaker) SetAmountByProjectWallet(_ int, rlm realm, addr address, amount int64, add bool) {

--- a/contract/r/gnoswap/gov/staker/protocol_fee_reward_manager.gno
+++ b/contract/r/gnoswap/gov/staker/protocol_fee_reward_manager.gno
@@ -98,6 +98,20 @@ func (p *ProtocolFeeRewardManager) SetProtocolFeeAmounts(protocolFeeAmounts map[
 	p.protocolFeeAmounts = protocolFeeAmounts
 }
 
+func (p *ProtocolFeeRewardManager) SetAccumulatedProtocolFeeX128PerStakeForToken(token string, value *u256.Uint) {
+	if p.accumulatedProtocolFeeX128PerStake == nil {
+		p.accumulatedProtocolFeeX128PerStake = make(map[string]*u256.Uint)
+	}
+	p.accumulatedProtocolFeeX128PerStake[token] = value
+}
+
+func (p *ProtocolFeeRewardManager) SetProtocolFeeAmountForToken(token string, amount int64) {
+	if p.protocolFeeAmounts == nil {
+		p.protocolFeeAmounts = make(map[string]int64)
+	}
+	p.protocolFeeAmounts[token] = amount
+}
+
 func (p *ProtocolFeeRewardManager) SetAccumulatedTimestamp(accumulatedTimestamp int64) {
 	p.accumulatedTimestamp = accumulatedTimestamp
 }

--- a/contract/r/gnoswap/gov/staker/proxy.gno
+++ b/contract/r/gnoswap/gov/staker/proxy.gno
@@ -55,12 +55,39 @@ func CollectReward(cur realm) {
 	getImplementation().CollectReward(0, cur)
 }
 
+// CollectEmissionReward claims accumulated GNS emission rewards.
+func CollectEmissionReward(cur realm) {
+	getImplementation().CollectEmissionReward(0, cur)
+}
+
+// CollectProtocolFeeReward claims accumulated protocol fee rewards for the provided token path.
+func CollectProtocolFeeReward(cur realm, tokenPath string) {
+	getImplementation().CollectProtocolFeeReward(0, cur, tokenPath)
+}
+
 // CollectRewardFromLaunchPad claims rewards from launchpad projects.
 //
 // Parameters:
 //   - to: address to collect rewards for
 func CollectRewardFromLaunchPad(cur realm, to address) {
 	getImplementation().CollectRewardFromLaunchPad(0, cur, to)
+}
+
+// CollectEmissionRewardFromLaunchPad claims accumulated launchpad emission rewards.
+//
+// Parameters:
+//   - to: address to collect rewards for
+func CollectEmissionRewardFromLaunchPad(cur realm, to address) {
+	getImplementation().CollectEmissionRewardFromLaunchPad(0, cur, to)
+}
+
+// CollectProtocolFeeRewardFromLaunchPad claims accumulated launchpad protocol fee rewards for the provided token path.
+//
+// Parameters:
+//   - to: address to collect rewards for
+//   - tokenPath: token path to collect
+func CollectProtocolFeeRewardFromLaunchPad(cur realm, to address, tokenPath string) {
+	getImplementation().CollectProtocolFeeRewardFromLaunchPad(0, cur, to, tokenPath)
 }
 
 // SetAmountByProjectWallet sets reward amount for a project wallet.

--- a/contract/r/gnoswap/gov/staker/types.gno
+++ b/contract/r/gnoswap/gov/staker/types.gno
@@ -32,7 +32,11 @@ type IGovStakerDelegation interface {
 type IGovStakerReward interface {
 	// Reward collection
 	CollectReward(_ int, rlm realm)
+	CollectEmissionReward(_ int, rlm realm)
+	CollectProtocolFeeReward(_ int, rlm realm, tokenPath string)
 	CollectRewardFromLaunchPad(_ int, rlm realm, to address)
+	CollectEmissionRewardFromLaunchPad(_ int, rlm realm, to address)
+	CollectProtocolFeeRewardFromLaunchPad(_ int, rlm realm, to address, tokenPath string)
 	SetAmountByProjectWallet(_ int, rlm realm, addr address, amount int64, add bool)
 }
 

--- a/contract/r/gnoswap/gov/staker/upgrade_test.gno
+++ b/contract/r/gnoswap/gov/staker/upgrade_test.gno
@@ -243,6 +243,68 @@ func TestCollectReward(cur realm, t *testing.T) {
 	}
 }
 
+// TestCollectEmissionReward tests the CollectEmissionReward proxy function
+func TestCollectEmissionReward(cur realm, t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{
+			name: "collect emission reward is success",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
+			resetTestState(t)
+			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/gov/staker/v1"))
+			RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+
+			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/gov/staker"))
+
+			// Action
+			CollectEmissionReward(cross(cur))
+
+			// Assert
+			mockGovStaker := implementation.(*MockGovStaker)
+			if mockGovStaker.Response.CallCount("CollectEmissionReward") != 1 {
+				t.Error("CollectEmissionReward was not called on the implementation")
+			}
+		})
+	}
+}
+
+// TestCollectProtocolFeeReward tests the CollectProtocolFeeReward proxy function
+func TestCollectProtocolFeeReward(cur realm, t *testing.T) {
+	tests := []struct {
+		name      string
+		tokenPath string
+	}{
+		{
+			name:      "collect protocol fee reward is success",
+			tokenPath: "gno.land/r/gnoswap/gns",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
+			resetTestState(t)
+			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/gov/staker/v1"))
+			RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+
+			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/gov/staker"))
+
+			// Action
+			CollectProtocolFeeReward(cross(cur), tt.tokenPath)
+
+			// Assert
+			mockGovStaker := implementation.(*MockGovStaker)
+			if mockGovStaker.Response.CallCount("CollectProtocolFeeReward") != 1 {
+				t.Error("CollectProtocolFeeReward was not called on the implementation")
+			}
+		})
+	}
+}
+
 // TestCollectRewardFromLaunchPad tests the CollectRewardFromLaunchPad proxy function
 func TestCollectRewardFromLaunchPad(cur realm, t *testing.T) {
 	tests := []struct {
@@ -270,6 +332,64 @@ func TestCollectRewardFromLaunchPad(cur realm, t *testing.T) {
 			mockGovStaker := implementation.(*MockGovStaker)
 			if mockGovStaker.Response.CallCount("CollectRewardFromLaunchPad") != 1 {
 				t.Error("CollectRewardFromLaunchPad was not called on the implementation")
+			}
+		})
+	}
+}
+
+func TestCollectEmissionRewardFromLaunchPad(cur realm, t *testing.T) {
+	tests := []struct {
+		name string
+		to   address
+	}{
+		{
+			name: "collect emission reward from launchpad is success",
+			to:   adminAddr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
+			resetTestState(t)
+			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/gov/staker/v1"))
+			RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+
+			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/gov/staker"))
+			CollectEmissionRewardFromLaunchPad(cross(cur), tt.to)
+
+			mockGovStaker := implementation.(*MockGovStaker)
+			if mockGovStaker.Response.CallCount("CollectEmissionRewardFromLaunchPad") != 1 {
+				t.Error("CollectEmissionRewardFromLaunchPad was not called on the implementation")
+			}
+		})
+	}
+}
+
+func TestCollectProtocolFeeRewardFromLaunchPad(cur realm, t *testing.T) {
+	tests := []struct {
+		name      string
+		to        address
+		tokenPath string
+	}{
+		{
+			name:      "collect protocol fee reward from launchpad is success",
+			to:        adminAddr,
+			tokenPath: "gno.land/r/gnoswap/gns",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
+			resetTestState(t)
+			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/gov/staker/v1"))
+			RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+
+			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/gov/staker"))
+			CollectProtocolFeeRewardFromLaunchPad(cross(cur), tt.to, tt.tokenPath)
+
+			mockGovStaker := implementation.(*MockGovStaker)
+			if mockGovStaker.Response.CallCount("CollectProtocolFeeRewardFromLaunchPad") != 1 {
+				t.Error("CollectProtocolFeeRewardFromLaunchPad was not called on the implementation")
 			}
 		})
 	}

--- a/contract/r/gnoswap/gov/staker/v1/assert.gno
+++ b/contract/r/gnoswap/gov/staker/v1/assert.gno
@@ -77,3 +77,7 @@ func assertNoSameDelegatee(delegatee, newDelegatee address) {
 		panic(errors.New(errSameDelegatee))
 	}
 }
+
+func assertNotImplementYet() {
+	panic("NotImplementYet")
+}

--- a/contract/r/gnoswap/gov/staker/v1/staker_reward.gno
+++ b/contract/r/gnoswap/gov/staker/v1/staker_reward.gno
@@ -93,6 +93,16 @@ func (gs *govStakerV1) CollectReward(_ int, rlm realm) {
 	}
 }
 
+// CollectEmissionReward collects accumulated GNS emission rewards only.
+func (gs *govStakerV1) CollectEmissionReward(_ int, rlm realm) {
+	assertNotImplementYet()
+}
+
+// CollectProtocolFeeReward collects accumulated protocol fee rewards for the provided token path.
+func (gs *govStakerV1) CollectProtocolFeeReward(_ int, rlm realm, tokenPath string) {
+	assertNotImplementYet()
+}
+
 // CollectRewardFromLaunchPad collects rewards for launchpad project wallets.
 //
 // Parameters:
@@ -160,6 +170,16 @@ func (gs *govStakerV1) CollectRewardFromLaunchPad(_ int, rlm realm, to address) 
 			)
 		}
 	}
+}
+
+// CollectEmissionRewardFromLaunchPad collects emission rewards only for launchpad project wallets.
+func (gs *govStakerV1) CollectEmissionRewardFromLaunchPad(_ int, rlm realm, to address) {
+	assertNotImplementYet()
+}
+
+// CollectProtocolFeeRewardFromLaunchPad collects one token path of protocol fee rewards for launchpad project wallets.
+func (gs *govStakerV1) CollectProtocolFeeRewardFromLaunchPad(_ int, rlm realm, to address, tokenPath string) {
+	assertNotImplementYet()
 }
 
 // SetAmountByProjectWallet sets the amount of reward for the project wallet.

--- a/contract/r/gnoswap/launchpad/_mock_test.gno
+++ b/contract/r/gnoswap/launchpad/_mock_test.gno
@@ -76,6 +76,14 @@ func (m *MockLaunchpad) CollectProtocolFee(_ int, rlm realm) {
 	m.Response.Get("CollectProtocolFee")
 }
 
+func (m *MockLaunchpad) CollectEmissionReward(_ int, rlm realm) {
+	m.Response.Get("CollectEmissionReward")
+}
+
+func (m *MockLaunchpad) CollectProtocolFeeReward(_ int, rlm realm, tokenPath string) {
+	m.Response.Get("CollectProtocolFeeReward")
+}
+
 func (m *MockLaunchpad) DepositGns(_ int, rlm realm, targetProjectTierID string, depositAmount int64, referrer string) string {
 	res, ok := m.Response.Get("DepositGns")
 	if !ok {

--- a/contract/r/gnoswap/launchpad/proxy.gno
+++ b/contract/r/gnoswap/launchpad/proxy.gno
@@ -35,6 +35,16 @@ func CollectProtocolFee(cur realm) {
 	getImplementation().CollectProtocolFee(0, cur)
 }
 
+// CollectEmissionReward collects accumulated launchpad emission rewards.
+func CollectEmissionReward(cur realm) {
+	getImplementation().CollectEmissionReward(0, cur)
+}
+
+// CollectProtocolFeeReward collects accumulated launchpad protocol fee rewards for the provided token path.
+func CollectProtocolFeeReward(cur realm, tokenPath string) {
+	getImplementation().CollectProtocolFeeReward(0, cur, tokenPath)
+}
+
 // TransferLeftFromProjectByAdmin transfers the remaining rewards of a project to a specified recipient.
 func TransferLeftFromProjectByAdmin(cur realm, projectID string, recipient address) int64 {
 	return getImplementation().TransferLeftFromProjectByAdmin(0, cur, projectID, recipient)

--- a/contract/r/gnoswap/launchpad/types.gno
+++ b/contract/r/gnoswap/launchpad/types.gno
@@ -28,6 +28,8 @@ type ILaunchpadProject interface {
 	) string
 	TransferLeftFromProjectByAdmin(_ int, rlm realm, projectID string, recipient address) int64
 	CollectProtocolFee(_ int, rlm realm)
+	CollectEmissionReward(_ int, rlm realm)
+	CollectProtocolFeeReward(_ int, rlm realm, tokenPath string)
 }
 
 type ILaunchpadDeposit interface {

--- a/contract/r/gnoswap/launchpad/upgrade_test.gno
+++ b/contract/r/gnoswap/launchpad/upgrade_test.gno
@@ -58,7 +58,7 @@ func TestRegisterInitializer(cur realm, t *testing.T) {
 			})
 		} else {
 			testing.SetRealm(tt.callerRealm)
-				RegisterInitializer(cross(cur), tt.initializer)
+			RegisterInitializer(cross(cur), tt.initializer)
 		}
 	}
 }
@@ -132,7 +132,7 @@ func TestUpgradeImpl(cur realm, t *testing.T) {
 				})
 			} else {
 				testing.SetRealm(tt.callerRealm)
-					UpgradeImpl(cross(cur), tt.packagePath)
+				UpgradeImpl(cross(cur), tt.packagePath)
 			}
 		})
 	}
@@ -173,7 +173,7 @@ func TestCreateProject(cur realm, t *testing.T) {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
 			resetTestState(cur, t)
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad/v1"))
-				RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+			RegisterInitializer(cross(cur), makeMockInitializer("v1"))
 			testing.SetRealm(testing.NewUserRealm(adminAddr))
 			UpgradeImpl(cross(cur), "gno.land/r/gnoswap/launchpad/v1")
 
@@ -203,7 +203,7 @@ func TestTransferLeftFromProjectByAdmin(cur realm, t *testing.T) {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
 			resetTestState(cur, t)
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad/v1"))
-				RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+			RegisterInitializer(cross(cur), makeMockInitializer("v1"))
 			testing.SetRealm(testing.NewUserRealm(adminAddr))
 			UpgradeImpl(cross(cur), "gno.land/r/gnoswap/launchpad/v1")
 
@@ -229,12 +229,74 @@ func TestCollectProtocolFee(cur realm, t *testing.T) {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
 			resetTestState(cur, t)
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad/v1"))
-				RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+			RegisterInitializer(cross(cur), makeMockInitializer("v1"))
 			testing.SetRealm(testing.NewUserRealm(adminAddr))
 			UpgradeImpl(cross(cur), "gno.land/r/gnoswap/launchpad/v1")
 
 			testing.SetRealm(tt.callerRealm)
 			CollectProtocolFee(cross(cur))
+		})
+	}
+}
+
+func TestCollectEmissionReward(cur realm, t *testing.T) {
+	tests := []struct {
+		name        string
+		callerRealm runtime.Realm
+	}{
+		{
+			name:        "collect emission reward is not implemented",
+			callerRealm: testing.NewCodeRealm("gno.land/r/gnoswap/launchpad"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
+			resetTestState(cur, t)
+			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad/v1"))
+			RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+			testing.SetRealm(testing.NewUserRealm(adminAddr))
+			UpgradeImpl(cross(cur), "gno.land/r/gnoswap/launchpad/v1")
+
+			testing.SetRealm(tt.callerRealm)
+			CollectEmissionReward(cross(cur))
+
+			mockLaunchpad := implementation.(*MockLaunchpad)
+			if mockLaunchpad.Response.CallCount("CollectEmissionReward") != 1 {
+				t.Error("CollectEmissionReward was not called on the implementation")
+			}
+		})
+	}
+}
+
+func TestCollectProtocolFeeReward(cur realm, t *testing.T) {
+	tests := []struct {
+		name        string
+		callerRealm runtime.Realm
+		tokenPath   string
+	}{
+		{
+			name:        "collect protocol fee reward is not implemented",
+			callerRealm: testing.NewCodeRealm("gno.land/r/gnoswap/launchpad"),
+			tokenPath:   "gno.land/r/gnoswap/gns",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
+			resetTestState(cur, t)
+			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad/v1"))
+			RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+			testing.SetRealm(testing.NewUserRealm(adminAddr))
+			UpgradeImpl(cross(cur), "gno.land/r/gnoswap/launchpad/v1")
+
+			testing.SetRealm(tt.callerRealm)
+			CollectProtocolFeeReward(cross(cur), tt.tokenPath)
+
+			mockLaunchpad := implementation.(*MockLaunchpad)
+			if mockLaunchpad.Response.CallCount("CollectProtocolFeeReward") != 1 {
+				t.Error("CollectProtocolFeeReward was not called on the implementation")
+			}
 		})
 	}
 }
@@ -260,7 +322,7 @@ func TestDepositGns(cur realm, t *testing.T) {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
 			resetTestState(cur, t)
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad/v1"))
-				RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+			RegisterInitializer(cross(cur), makeMockInitializer("v1"))
 			testing.SetRealm(testing.NewUserRealm(adminAddr))
 			UpgradeImpl(cross(cur), "gno.land/r/gnoswap/launchpad/v1")
 
@@ -288,7 +350,7 @@ func TestCollectDepositGns(cur realm, t *testing.T) {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
 			resetTestState(cur, t)
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad/v1"))
-				RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+			RegisterInitializer(cross(cur), makeMockInitializer("v1"))
 			testing.SetRealm(testing.NewUserRealm(adminAddr))
 			UpgradeImpl(cross(cur), "gno.land/r/gnoswap/launchpad/v1")
 
@@ -315,7 +377,7 @@ func TestCollectRewardByDepositId(cur realm, t *testing.T) {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
 			resetTestState(cur, t)
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad/v1"))
-				RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+			RegisterInitializer(cross(cur), makeMockInitializer("v1"))
 			testing.SetRealm(testing.NewUserRealm(adminAddr))
 			UpgradeImpl(cross(cur), "gno.land/r/gnoswap/launchpad/v1")
 
@@ -343,7 +405,7 @@ func TestGetProjectCount(cur realm, t *testing.T) {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
 			resetTestState(cur, t)
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad/v1"))
-				RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+			RegisterInitializer(cross(cur), makeMockInitializer("v1"))
 
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad"))
 
@@ -372,7 +434,7 @@ func TestGetDepositCount(cur realm, t *testing.T) {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
 			resetTestState(cur, t)
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad/v1"))
-				RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+			RegisterInitializer(cross(cur), makeMockInitializer("v1"))
 
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad"))
 
@@ -403,7 +465,7 @@ func TestGetProject(cur realm, t *testing.T) {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
 			resetTestState(cur, t)
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad/v1"))
-				RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+			RegisterInitializer(cross(cur), makeMockInitializer("v1"))
 
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad"))
 
@@ -434,7 +496,7 @@ func TestGetDeposit(cur realm, t *testing.T) {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
 			resetTestState(cur, t)
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad/v1"))
-				RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+			RegisterInitializer(cross(cur), makeMockInitializer("v1"))
 
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad"))
 
@@ -467,7 +529,7 @@ func TestGetProjectTier(cur realm, t *testing.T) {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
 			resetTestState(cur, t)
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad/v1"))
-				RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+			RegisterInitializer(cross(cur), makeMockInitializer("v1"))
 
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad"))
 
@@ -498,7 +560,7 @@ func TestGetProjectActiveStatus(cur realm, t *testing.T) {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
 			resetTestState(cur, t)
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad/v1"))
-				RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+			RegisterInitializer(cross(cur), makeMockInitializer("v1"))
 
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad"))
 
@@ -531,7 +593,7 @@ func TestGetProjectIDs(cur realm, t *testing.T) {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
 			resetTestState(cur, t)
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad/v1"))
-				RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+			RegisterInitializer(cross(cur), makeMockInitializer("v1"))
 
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad"))
 
@@ -568,7 +630,7 @@ func TestGetProjectTierDepositIDs(cur realm, t *testing.T) {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
 			resetTestState(cur, t)
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad/v1"))
-				RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+			RegisterInitializer(cross(cur), makeMockInitializer("v1"))
 
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad"))
 
@@ -597,7 +659,7 @@ func TestGetProjectTierRewardManagerCount(cur realm, t *testing.T) {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
 			resetTestState(cur, t)
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad/v1"))
-				RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+			RegisterInitializer(cross(cur), makeMockInitializer("v1"))
 
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad"))
 
@@ -626,7 +688,7 @@ func TestGetCurrentDepositId(cur realm, t *testing.T) {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
 			resetTestState(cur, t)
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad/v1"))
-				RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+			RegisterInitializer(cross(cur), makeMockInitializer("v1"))
 
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad"))
 
@@ -659,7 +721,7 @@ func TestGetProjectCondition(cur realm, t *testing.T) {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
 			resetTestState(cur, t)
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad/v1"))
-				RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+			RegisterInitializer(cross(cur), makeMockInitializer("v1"))
 
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad"))
 
@@ -690,7 +752,7 @@ func TestGetProjectTierRewardManager(cur realm, t *testing.T) {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
 			resetTestState(cur, t)
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad/v1"))
-				RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+			RegisterInitializer(cross(cur), makeMockInitializer("v1"))
 
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad"))
 
@@ -723,7 +785,7 @@ func TestGetRewardState(cur realm, t *testing.T) {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
 			resetTestState(cur, t)
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad/v1"))
-				RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+			RegisterInitializer(cross(cur), makeMockInitializer("v1"))
 
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad"))
 
@@ -756,7 +818,7 @@ func TestGetImplementationPackagePath(cur realm, t *testing.T) {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
 			resetTestState(cur, t)
 			testing.SetRealm(testing.NewCodeRealm(tt.packagePath))
-				RegisterInitializer(cross(cur), makeMockInitializer(tt.packagePath))
+			RegisterInitializer(cross(cur), makeMockInitializer(tt.packagePath))
 
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad"))
 

--- a/contract/r/gnoswap/launchpad/v1/assert.gno
+++ b/contract/r/gnoswap/launchpad/v1/assert.gno
@@ -60,3 +60,7 @@ func (lp *launchpadV1) assertHasProject(caller address) {
 		))
 	}
 }
+
+func assertNotImplementYet() {
+	panic("NotImplementYet")
+}

--- a/contract/r/gnoswap/launchpad/v1/launchpad_protocol_fee.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_protocol_fee.gno
@@ -2,6 +2,7 @@ package launchpad
 
 import (
 	"errors"
+
 	gov_staker "gno.land/r/gnoswap/gov/staker"
 	"gno.land/r/gnoswap/halt"
 )
@@ -21,4 +22,16 @@ func (lp *launchpadV1) CollectProtocolFee(_ int, rlm realm) {
 	lp.assertHasProject(caller)
 
 	gov_staker.CollectRewardFromLaunchPad(cross(rlm), caller)
+}
+
+// CollectEmissionReward collects emission rewards from gov/staker for project recipient wallets.
+// Only project recipients can call this function.
+func (lp *launchpadV1) CollectEmissionReward(_ int, rlm realm) {
+	assertNotImplementYet()
+}
+
+// CollectProtocolFeeReward collects one token path of protocol fee rewards from gov/staker for project recipient wallets.
+// Only project recipients can call this function.
+func (lp *launchpadV1) CollectProtocolFeeReward(_ int, rlm realm, tokenPath string) {
+	assertNotImplementYet()
 }

--- a/contract/r/gnoswap/protocol_fee/_mock_test.gno
+++ b/contract/r/gnoswap/protocol_fee/_mock_test.gno
@@ -43,6 +43,10 @@ func (m *MockProtocolFee) DistributeProtocolFee(_ int, rlm realm) {
 	m.Response.Get("DistributeProtocolFee")
 }
 
+func (m *MockProtocolFee) DistributeProtocolFeeByTokenPath(_ int, rlm realm, tokenPath string) {
+	m.Response.Get("DistributeProtocolFeeByTokenPath")
+}
+
 func (m *MockProtocolFee) SetDevOpsPct(_ int, rlm realm, pct int64) {
 	m.Response.Get("SetDevOpsPct")
 }

--- a/contract/r/gnoswap/protocol_fee/proxy.gno
+++ b/contract/r/gnoswap/protocol_fee/proxy.gno
@@ -5,6 +5,11 @@ func DistributeProtocolFee(cur realm) {
 	getImplementation().DistributeProtocolFee(0, cur)
 }
 
+// DistributeProtocolFeeByTokenPath distributes accumulated protocol fees for a single token path.
+func DistributeProtocolFeeByTokenPath(cur realm, tokenPath string) {
+	getImplementation().DistributeProtocolFeeByTokenPath(0, cur, tokenPath)
+}
+
 // SetDevOpsPct sets the percentage of protocol fees allocated to DevOps.
 //
 // Parameters:

--- a/contract/r/gnoswap/protocol_fee/types.gno
+++ b/contract/r/gnoswap/protocol_fee/types.gno
@@ -14,6 +14,7 @@ type IProtocolFeeManager interface {
 	// surfaces at every call site as a literal `0`, making the realm threading
 	// visible to readers.
 	DistributeProtocolFee(_ int, rlm realm)
+	DistributeProtocolFeeByTokenPath(_ int, rlm realm, tokenPath string)
 	SetDevOpsPct(_ int, rlm realm, pct int64)
 	SetGovStakerPct(_ int, rlm realm, pct int64)
 	AddToProtocolFee(_ int, rlm realm, tokenPath string, amount int64) error

--- a/contract/r/gnoswap/protocol_fee/v1/assert.gno
+++ b/contract/r/gnoswap/protocol_fee/v1/assert.gno
@@ -48,3 +48,7 @@ func assertIsValidPercent(pct int64) {
 		))
 	}
 }
+
+func assertNotImplementYet() {
+	panic("NotImplementYet")
+}

--- a/contract/r/gnoswap/protocol_fee/v1/protocol_fee.gno
+++ b/contract/r/gnoswap/protocol_fee/v1/protocol_fee.gno
@@ -84,6 +84,11 @@ func (pf *protocolFeeV1) DistributeProtocolFee(_ int, rlm realm) {
 	)
 }
 
+// DistributeProtocolFeeByTokenPath is retained for ABI compatibility while token-path distribution is deferred.
+func (pf *protocolFeeV1) DistributeProtocolFeeByTokenPath(_ int, rlm realm, tokenPath string) {
+	assertNotImplementYet()
+}
+
 // SetDevOpsPct sets the devOpsPct.
 //
 // Parameters:

--- a/contract/r/scenario/upgrade/gov_staker_upgrade_filetest.gno
+++ b/contract/r/scenario/upgrade/gov_staker_upgrade_filetest.gno
@@ -134,6 +134,22 @@ func verifyTestImplementation(cur realm) {
 	})
 	ufmt.Println("[EXPECTED] CollectRewardFromLaunchPad panics correctly")
 
+	// Test CollectEmissionRewardFromLaunchPad - should panic with test implementation message
+	ufmt.Println("[INFO] Testing CollectEmissionRewardFromLaunchPad function panics correctly")
+	testing.SetRealm(adminRealm)
+	uassert.AbortsWithMessage(t, cur, "test implementation: CollectEmissionRewardFromLaunchPad not supported", func() {
+		govStaker.CollectEmissionRewardFromLaunchPad(cross(cur), adminAddr)
+	})
+	ufmt.Println("[EXPECTED] CollectEmissionRewardFromLaunchPad panics correctly")
+
+	// Test CollectProtocolFeeRewardFromLaunchPad - should panic with test implementation message
+	ufmt.Println("[INFO] Testing CollectProtocolFeeRewardFromLaunchPad function panics correctly")
+	testing.SetRealm(adminRealm)
+	uassert.AbortsWithMessage(t, cur, "test implementation: CollectProtocolFeeRewardFromLaunchPad not supported", func() {
+		govStaker.CollectProtocolFeeRewardFromLaunchPad(cross(cur), adminAddr, "gno.land/r/gnoswap/gns")
+	})
+	ufmt.Println("[EXPECTED] CollectProtocolFeeRewardFromLaunchPad panics correctly")
+
 	// Test SetAmountByProjectWallet - should panic with test implementation message
 	ufmt.Println("[INFO] Testing SetAmountByProjectWallet function panics correctly")
 	testing.SetRealm(adminRealm)
@@ -182,6 +198,10 @@ func verifyTestImplementation(cur realm) {
 // [EXPECTED] CollectUndelegatedGns panics correctly
 // [INFO] Testing CollectRewardFromLaunchPad function panics correctly
 // [EXPECTED] CollectRewardFromLaunchPad panics correctly
+// [INFO] Testing CollectEmissionRewardFromLaunchPad function panics correctly
+// [EXPECTED] CollectEmissionRewardFromLaunchPad panics correctly
+// [INFO] Testing CollectProtocolFeeRewardFromLaunchPad function panics correctly
+// [EXPECTED] CollectProtocolFeeRewardFromLaunchPad panics correctly
 // [INFO] Testing SetAmountByProjectWallet function panics correctly
 // [EXPECTED] SetAmountByProjectWallet panics correctly
 // [INFO] Testing CleanStakerDelegationSnapshotByAdmin function panics correctly

--- a/contract/r/scenario/upgrade/implements/mock/gov/staker/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/mock/gov/staker/test_impl.gno
@@ -84,11 +84,48 @@ func (t *TestGovStaker) CollectReward(_ int, rlm realm) {
 	)
 }
 
+func (t *TestGovStaker) CollectEmissionReward(_ int, rlm realm) {
+	t.ExecuteFn(
+		"CollectEmissionReward",
+		func(args ...any) any { t.instance.CollectEmissionReward(0, rlm); return nil },
+	)
+}
+
+func (t *TestGovStaker) CollectProtocolFeeReward(_ int, rlm realm, tokenPath string) {
+	t.ExecuteFn(
+		"CollectProtocolFeeReward",
+		func(args ...any) any { t.instance.CollectProtocolFeeReward(0, rlm, args[0].(string)); return nil },
+		tokenPath,
+	)
+}
+
 func (t *TestGovStaker) CollectRewardFromLaunchPad(_ int, rlm realm, to address) {
 	t.ExecuteFn(
 		"CollectRewardFromLaunchPad",
 		func(args ...any) any { t.instance.CollectRewardFromLaunchPad(0, rlm, args[0].(address)); return nil },
 		to,
+	)
+}
+
+func (t *TestGovStaker) CollectEmissionRewardFromLaunchPad(_ int, rlm realm, to address) {
+	t.ExecuteFn(
+		"CollectEmissionRewardFromLaunchPad",
+		func(args ...any) any {
+			t.instance.CollectEmissionRewardFromLaunchPad(0, rlm, args[0].(address))
+			return nil
+		},
+		to,
+	)
+}
+
+func (t *TestGovStaker) CollectProtocolFeeRewardFromLaunchPad(_ int, rlm realm, to address, tokenPath string) {
+	t.ExecuteFn(
+		"CollectProtocolFeeRewardFromLaunchPad",
+		func(args ...any) any {
+			t.instance.CollectProtocolFeeRewardFromLaunchPad(0, rlm, args[0].(address), args[1].(string))
+			return nil
+		},
+		to, tokenPath,
 	)
 }
 
@@ -198,7 +235,10 @@ func (t *TestGovStaker) CleanStakerDelegationSnapshotByAdmin(_ int, rlm realm, t
 func (t *TestGovStaker) SetUnDelegationLockupPeriodByAdmin(_ int, rlm realm, period int64) {
 	t.ExecuteFn(
 		"SetUnDelegationLockupPeriodByAdmin",
-		func(args ...any) any { t.instance.SetUnDelegationLockupPeriodByAdmin(0, rlm, args[0].(int64)); return nil },
+		func(args ...any) any {
+			t.instance.SetUnDelegationLockupPeriodByAdmin(0, rlm, args[0].(int64))
+			return nil
+		},
 		period,
 	)
 }

--- a/contract/r/scenario/upgrade/implements/mock/protocol_fee/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/mock/protocol_fee/test_impl.gno
@@ -48,6 +48,17 @@ func (t *TestProtocolFee) DistributeProtocolFee(_ int, rlm realm) {
 	)
 }
 
+func (t *TestProtocolFee) DistributeProtocolFeeByTokenPath(_ int, rlm realm, tokenPath string) {
+	t.ExecuteFn(
+		"DistributeProtocolFeeByTokenPath",
+		func(args ...any) any {
+			t.instance.DistributeProtocolFeeByTokenPath(0, rlm, args[0].(string))
+			return nil
+		},
+		tokenPath,
+	)
+}
+
 func (t *TestProtocolFee) SetDevOpsPct(_ int, rlm realm, pct int64) {
 	t.ExecuteFn(
 		"SetDevOpsPct",

--- a/contract/r/scenario/upgrade/implements/v2_invalid/gov/staker/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v2_invalid/gov/staker/test_impl.gno
@@ -74,11 +74,39 @@ func (t *TestGovStaker) CollectReward(_ int, rlm realm) {
 	t.instance.CollectReward(0, rlm)
 }
 
+func (t *TestGovStaker) CollectEmissionReward(_ int, rlm realm) {
+	if !t.isActive("CollectEmissionReward") {
+		panic("test implementation: CollectEmissionReward not supported")
+	}
+	t.instance.CollectEmissionReward(0, rlm)
+}
+
+func (t *TestGovStaker) CollectProtocolFeeReward(_ int, rlm realm, tokenPath string) {
+	if !t.isActive("CollectProtocolFeeReward") {
+		panic("test implementation: CollectProtocolFeeReward not supported")
+	}
+	t.instance.CollectProtocolFeeReward(0, rlm, tokenPath)
+}
+
 func (t *TestGovStaker) CollectRewardFromLaunchPad(_ int, rlm realm, to address) {
 	if !t.isActive("CollectRewardFromLaunchPad") {
 		panic("test implementation: CollectRewardFromLaunchPad not supported")
 	}
 	t.instance.CollectRewardFromLaunchPad(0, rlm, to)
+}
+
+func (t *TestGovStaker) CollectEmissionRewardFromLaunchPad(_ int, rlm realm, to address) {
+	if !t.isActive("CollectEmissionRewardFromLaunchPad") {
+		panic("test implementation: CollectEmissionRewardFromLaunchPad not supported")
+	}
+	t.instance.CollectEmissionRewardFromLaunchPad(0, rlm, to)
+}
+
+func (t *TestGovStaker) CollectProtocolFeeRewardFromLaunchPad(_ int, rlm realm, to address, tokenPath string) {
+	if !t.isActive("CollectProtocolFeeRewardFromLaunchPad") {
+		panic("test implementation: CollectProtocolFeeRewardFromLaunchPad not supported")
+	}
+	t.instance.CollectProtocolFeeRewardFromLaunchPad(0, rlm, to, tokenPath)
 }
 
 func (t *TestGovStaker) SetAmountByProjectWallet(_ int, rlm realm, addr address, amount int64, add bool) {

--- a/contract/r/scenario/upgrade/implements/v2_invalid/protocol_fee/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v2_invalid/protocol_fee/test_impl.gno
@@ -44,6 +44,13 @@ func (t *TestProtocolFee) DistributeProtocolFee(_ int, rlm realm) {
 	t.instance.DistributeProtocolFee(0, rlm)
 }
 
+func (t *TestProtocolFee) DistributeProtocolFeeByTokenPath(_ int, rlm realm, tokenPath string) {
+	if !t.isActive("DistributeProtocolFeeByTokenPath") {
+		panic("test implementation: DistributeProtocolFeeByTokenPath not supported")
+	}
+	t.instance.DistributeProtocolFeeByTokenPath(0, rlm, tokenPath)
+}
+
 func (t *TestProtocolFee) SetDevOpsPct(_ int, rlm realm, pct int64) {
 	if !t.isActive("SetDevOpsPct") {
 		panic("test implementation: SetDevOpsPct not supported")

--- a/contract/r/scenario/upgrade/implements/v3_valid/gov/staker/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/gov/staker/test_impl.gno
@@ -46,8 +46,24 @@ func (t *TestGovStaker) CollectReward(_ int, rlm realm) {
 	t.instance.CollectReward(0, rlm)
 }
 
+func (t *TestGovStaker) CollectEmissionReward(_ int, rlm realm) {
+	t.instance.CollectEmissionReward(0, rlm)
+}
+
+func (t *TestGovStaker) CollectProtocolFeeReward(_ int, rlm realm, tokenPath string) {
+	t.instance.CollectProtocolFeeReward(0, rlm, tokenPath)
+}
+
 func (t *TestGovStaker) CollectRewardFromLaunchPad(_ int, rlm realm, to address) {
 	t.instance.CollectRewardFromLaunchPad(0, rlm, to)
+}
+
+func (t *TestGovStaker) CollectEmissionRewardFromLaunchPad(_ int, rlm realm, to address) {
+	t.instance.CollectEmissionRewardFromLaunchPad(0, rlm, to)
+}
+
+func (t *TestGovStaker) CollectProtocolFeeRewardFromLaunchPad(_ int, rlm realm, to address, tokenPath string) {
+	t.instance.CollectProtocolFeeRewardFromLaunchPad(0, rlm, to, tokenPath)
 }
 
 func (t *TestGovStaker) SetAmountByProjectWallet(_ int, rlm realm, addr address, amount int64, add bool) {

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_protocol_fee.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_protocol_fee.gno
@@ -1,8 +1,8 @@
 package v3_valid
 
 import (
-	"gno.land/r/gnoswap/halt"
 	gov_staker "gno.land/r/gnoswap/gov/staker"
+	"gno.land/r/gnoswap/halt"
 )
 
 // CollectProtocolFee collects protocol fee from gov/staker for project recipient wallets.
@@ -21,4 +21,40 @@ func (lp *launchpadV1) CollectProtocolFee(_ int, rlm realm) {
 	lp.assertHasProject(caller)
 
 	gov_staker.CollectRewardFromLaunchPad(cross(rlm), caller)
+}
+
+// CollectEmissionReward collects emission rewards from gov/staker for project recipient wallets.
+// Only project recipients can call this function.
+func (lp *launchpadV1) CollectEmissionReward(_ int, rlm realm) {
+	if !rlm.IsCurrent() {
+		panic(errSpoofedRealm)
+	}
+
+	halt.AssertIsNotHaltedLaunchpad()
+	halt.AssertIsNotHaltedWithdraw()
+
+	previousRealm := rlm.Previous()
+
+	caller := previousRealm.Address()
+	lp.assertHasProject(caller)
+
+	gov_staker.CollectEmissionRewardFromLaunchPad(cross(rlm), caller)
+}
+
+// CollectProtocolFeeReward collects one token path of protocol fee rewards from gov/staker for project recipient wallets.
+// Only project recipients can call this function.
+func (lp *launchpadV1) CollectProtocolFeeReward(_ int, rlm realm, tokenPath string) {
+	if !rlm.IsCurrent() {
+		panic(errSpoofedRealm)
+	}
+
+	halt.AssertIsNotHaltedLaunchpad()
+	halt.AssertIsNotHaltedWithdraw()
+
+	previousRealm := rlm.Previous()
+
+	caller := previousRealm.Address()
+	lp.assertHasProject(caller)
+
+	gov_staker.CollectProtocolFeeRewardFromLaunchPad(cross(rlm), caller, tokenPath)
 }

--- a/contract/r/scenario/upgrade/implements/v3_valid/protocol_fee/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/protocol_fee/test_impl.gno
@@ -28,6 +28,10 @@ func (t *TestProtocolFee) DistributeProtocolFee(_ int, rlm realm) {
 	t.instance.DistributeProtocolFee(0, rlm)
 }
 
+func (t *TestProtocolFee) DistributeProtocolFeeByTokenPath(_ int, rlm realm, tokenPath string) {
+	t.instance.DistributeProtocolFeeByTokenPath(0, rlm, tokenPath)
+}
+
 func (t *TestProtocolFee) SetDevOpsPct(_ int, rlm realm, pct int64) {
 	t.instance.SetDevOpsPct(0, rlm, pct)
 }


### PR DESCRIPTION
## Summary
- Add split-claim ABI surfaces for governance rewards.
- Keep the actual split-claim implementation out of scope for this PR; the new ABI methods fail with `NotImplementYet` for now.
- Keep the existing claim-all methods for backward compatibility.

## Added Surfaces
- `gov/staker`
  - `CollectEmissionReward()`
  - `CollectProtocolFeeReward(tokenPath)`
  - `CollectEmissionRewardFromLaunchPad(to)`
  - `CollectProtocolFeeRewardFromLaunchPad(to, tokenPath)`
- `launchpad`
  - `CollectEmissionReward()`
  - `CollectProtocolFeeReward(tokenPath)`
- `protocol_fee`
  - `DistributeProtocolFeeByTokenPath(tokenPath)`

## Implementation Notes
- The new v1 methods call a shared `assertNotImplementYet()` helper and panic with `NotImplementYet`.
- The helper is defined in each v1 package's `assert.gno`.
- The earlier experimental token-path claim implementation was removed; this PR keeps only the ABI/proxy/interface/mock/test surfaces.
- The branch history was squashed into one clean commit.

## Validation
- `gofumpt -w` on targeted changed `.gno` files
- `git diff --check`
- `git show --check HEAD`
- Attempted targeted test:
  - `make test PKG=gno.land/r/gnoswap/gov/staker/v1 RUN='TestStakerReward_SplitRewardABIsNotImplementYet'`

## Note
- The targeted test fails before reaching the changed code due to the existing Gno toolchain/source mismatch:
  - `gno.land/p/gnoswap/store/kv_store.gno:133:18-38: name CurrentRealm not declared (code=gnoPreprocessError)`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate emission and protocol-fee reward collection options, including launchpad-specific collection.
  * Added token-specific protocol-fee distribution and fee tracking capabilities.
  * Expanded launchpad and governance reward interfaces to support the new operations.
* **Bug Fixes**
  * Improved launchpad reward validation and routing for existing reward claims.
* **Tests**
  * Added coverage for proxy forwarding, launchpad access, token-specific distribution, and unimplemented entrypoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->