### PR TITLE
feat(staker): emit initial pool tier event

### DIFF
--- a/contract/r/gnoswap/staker/v1/emits.gno
+++ b/contract/r/gnoswap/staker/v1/emits.gno
@@ -1,0 +1,36 @@
+package staker
+
+import (
+	"chain"
+	"chain/runtime"
+
+	"gno.land/p/gnoswap/utils"
+)
+
+func emitSetPoolTier(
+	prevAddr string,
+	prevRealm string,
+	poolPath string,
+	tier uint64,
+	rewardPerSecond int64,
+	tierRewards map[uint64]int64,
+	counts [AllTierCount]uint64,
+	currentTime int64,
+) {
+	chain.Emit(
+		"SetPoolTier",
+		"prevAddr", prevAddr,
+		"prevRealm", prevRealm,
+		"poolPath", poolPath,
+		"tier", utils.FormatUint(tier),
+		"rewardPerSecond", utils.FormatInt(rewardPerSecond),
+		"tier1RewardPerSecond", utils.FormatInt(tierRewards[Tier1]),
+		"tier2RewardPerSecond", utils.FormatInt(tierRewards[Tier2]),
+		"tier3RewardPerSecond", utils.FormatInt(tierRewards[Tier3]),
+		"tier1Count", utils.FormatUint(counts[Tier1]),
+		"tier2Count", utils.FormatUint(counts[Tier2]),
+		"tier3Count", utils.FormatUint(counts[Tier3]),
+		"currentTime", utils.FormatInt(currentTime),
+		"currentHeight", utils.FormatInt(runtime.ChainHeight()),
+	)
+}

--- a/contract/r/gnoswap/staker/v1/init.gno
+++ b/contract/r/gnoswap/staker/v1/init.gno
@@ -16,6 +16,8 @@ const (
 	// unstakingFee is the fee charged when unstaking positions.
 	// This parameter can be modified through governance.
 	defaultUnstakingFee = uint64(100) // 1%
+
+	defaultInitialPoolTierPath = "gno.land/r/gnoland/wugnot.wugnot:gno.land/r/gnoswap/gns.GNS:3000"
 )
 
 func init(cur realm) {
@@ -130,7 +132,8 @@ func initStoreData(_ int, rlm realm, stakerStore sr.IStakerStore, emissionAccess
 		}
 	}
 
-	initializedPoolTier, initializedPools := initializePoolTier(stakerStore)
+	shouldEmitInitialPoolTier := !stakerStore.HasPoolTierMembershipsStoreKey()
+	initializedPoolTier, initializedPools, initialPoolTierTime, initialTierRewards := initializePoolTier(stakerStore)
 
 	if !stakerStore.HasPoolsStoreKey() {
 		err := stakerStore.SetPools(0, rlm, initializedPools.tree)
@@ -203,26 +206,40 @@ func initStoreData(_ int, rlm realm, stakerStore sr.IStakerStore, emissionAccess
 		}
 	}
 
+	if shouldEmitInitialPoolTier {
+		previousRealm := rlm.Previous()
+		emitSetPoolTier(
+			previousRealm.Address().String(),
+			previousRealm.PkgPath(),
+			defaultInitialPoolTierPath,
+			uint64(Tier1),
+			initializedPoolTier.currentEmission,
+			initialTierRewards,
+			initializedPoolTier.counts,
+			initialPoolTierTime,
+		)
+	}
+
 	return nil
 }
 
-func initializePoolTier(stakerStore sr.IStakerStore) (*PoolTier, *Pools) {
-	basicPoolPath := "gno.land/r/gnoland/wugnot.wugnot:gno.land/r/gnoswap/gns.GNS:3000"
-
+func initializePoolTier(stakerStore sr.IStakerStore) (*PoolTier, *Pools, int64, map[uint64]int64) {
 	pools := NewPools()
-	pl := NewPools().GetPoolOrNil(basicPoolPath)
+	currentTime := time.Now().Unix()
+
+	pl := NewPools().GetPoolOrNil(defaultInitialPoolTierPath)
 	if pl == nil {
-		pl = sr.NewPool(basicPoolPath, time.Now().Unix())
-		pools.set(basicPoolPath, pl)
+		pl = sr.NewPool(defaultInitialPoolTierPath, currentTime)
+		pools.set(defaultInitialPoolTierPath, pl)
 	}
 
 	poolTier := NewPoolTier(
 		pools,
-		time.Now().Unix(),
-		basicPoolPath,
+		currentTime,
+		defaultInitialPoolTierPath,
 		emission.GetStakerEmissionAmountPerSecond,
 		emission.GetStakerEmissionAmountPerSecondInRange,
 	)
 
-	return poolTier, pools
+	return poolTier, pools, currentTime, poolTier.computeTierRewards(poolTier.currentEmission)
 }

--- a/contract/r/gnoswap/staker/v1/init.gno
+++ b/contract/r/gnoswap/staker/v1/init.gno
@@ -132,8 +132,19 @@ func initStoreData(_ int, rlm realm, stakerStore sr.IStakerStore, emissionAccess
 		}
 	}
 
-	shouldEmitInitialPoolTier := !stakerStore.HasPoolTierMembershipsStoreKey()
 	initializedPoolTier, initializedPools, initialPoolTierTime, initialTierRewards := initializePoolTier(stakerStore)
+
+	previousRealm := rlm.Previous()
+	emitSetPoolTier(
+		previousRealm.Address().String(),
+		previousRealm.PkgPath(),
+		defaultInitialPoolTierPath,
+		uint64(Tier1),
+		initializedPoolTier.currentEmission,
+		initialTierRewards,
+		initializedPoolTier.counts,
+		initialPoolTierTime,
+	)
 
 	if !stakerStore.HasPoolsStoreKey() {
 		err := stakerStore.SetPools(0, rlm, initializedPools.tree)
@@ -204,20 +215,6 @@ func initStoreData(_ int, rlm realm, stakerStore sr.IStakerStore, emissionAccess
 		if err != nil {
 			return err
 		}
-	}
-
-	if shouldEmitInitialPoolTier {
-		previousRealm := rlm.Previous()
-		emitSetPoolTier(
-			previousRealm.Address().String(),
-			previousRealm.PkgPath(),
-			defaultInitialPoolTierPath,
-			uint64(Tier1),
-			initializedPoolTier.currentEmission,
-			initialTierRewards,
-			initializedPoolTier.counts,
-			initialPoolTierTime,
-		)
 	}
 
 	return nil

--- a/contract/r/gnoswap/staker/v1/manage_pool_tier_and_warmup.gno
+++ b/contract/r/gnoswap/staker/v1/manage_pool_tier_and_warmup.gno
@@ -43,21 +43,15 @@ func (s *stakerV1) SetPoolTier(_ int, rlm realm, poolPath string, tier uint64) {
 	rewardPerSecond, tierRewards := s.setPoolTier(0, rlm, poolPath, tier, currentTime)
 
 	previousRealm := rlm.Previous()
-	chain.Emit(
-		"SetPoolTier",
-		"prevAddr", previousRealm.Address().String(),
-		"prevRealm", previousRealm.PkgPath(),
-		"poolPath", poolPath,
-		"tier", utils.FormatUint(tier),
-		"rewardPerSecond", utils.FormatInt(rewardPerSecond),
-		"tier1RewardPerSecond", utils.FormatInt(tierRewards[Tier1]),
-		"tier2RewardPerSecond", utils.FormatInt(tierRewards[Tier2]),
-		"tier3RewardPerSecond", utils.FormatInt(tierRewards[Tier3]),
-		"tier1Count", utils.FormatUint(poolTier.counts[Tier1]),
-		"tier2Count", utils.FormatUint(poolTier.counts[Tier2]),
-		"tier3Count", utils.FormatUint(poolTier.counts[Tier3]),
-		"currentTime", utils.FormatInt(currentTime),
-		"currentHeight", utils.FormatInt(runtime.ChainHeight()),
+	emitSetPoolTier(
+		previousRealm.Address().String(),
+		previousRealm.PkgPath(),
+		poolPath,
+		tier,
+		rewardPerSecond,
+		tierRewards,
+		poolTier.counts,
+		currentTime,
 	)
 }
 

--- a/contract/r/scenario/upgrade/implements/v2_valid/staker/emits.gno
+++ b/contract/r/scenario/upgrade/implements/v2_valid/staker/emits.gno
@@ -1,0 +1,1 @@
+../../../../../gnoswap/staker/v1/emits.gno


### PR DESCRIPTION
## Summary
- Emits the canonical SetPoolTier event when the staker initializes the default tier-1 pool.
- Reuses a shared event helper so the initialization path and SetPoolTier path publish the same payload shape.

## Context
- The default WUGNOT/GNS tier-1 pool is initialized directly in staker state, so indexers did not receive a matching pool-tier event for that baseline state.

## Changes
- Added emitSetPoolTier to centralize SetPoolTier payload construction.
- Routed the existing SetPoolTier admin path through the helper.
- Emits the initial default pool tier event only when pool-tier membership storage is being initialized.

## Behavior Changes
- Initial staker setup now emits one SetPoolTier event for gno.land/r/gnoland/wugnot.wugnot:gno.land/r/gnoswap/gns.GNS:3000.
- The event includes tier reward-per-second snapshots, tier counts, current time, and current height.

## Verification
- make test PKG=gno.land/r/gnoswap/staker/v1 RUN=TestNewPoolTier WORKDIR=tmp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured `SetPoolTier` events containing pool identity, tier settings, reward rates, membership counts, and timing information.
  * Initial pool-tier setup now records its configuration when existing memberships require an initialization event.

* **Improvements**
  * Pool-tier updates and initial setup now use consistent event data, improving visibility into tier configuration changes and reward settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->