### PR TITLE
feat(emission): emit reward-per-second on MintAndDistributeGns

### DIFF
--- a/contract/r/gnoswap/emission/emission.gno
+++ b/contract/r/gnoswap/emission/emission.gno
@@ -132,6 +132,9 @@ func MintAndDistributeGns(cur realm) (int64, bool) {
 		panic(err)
 	}
 
+	stakerRewardPerSecond := GetEmissionAmountPerSecondBy(currentTimestamp, GetDistributionBpsPct(LIQUIDITY_STAKER))
+	govStakerRewardPerSecond := GetEmissionAmountPerSecondBy(currentTimestamp, GetDistributionBpsPct(GOV_STAKER))
+
 	previousRealm := cur.Previous()
 	chain.Emit(
 		"MintAndDistributeGns",
@@ -145,6 +148,8 @@ func MintAndDistributeGns(cur realm) (int64, bool) {
 		"distributedAmount", utils.FormatInt(totalDistAmount),
 		"currentLeftAmount", utils.FormatInt(GetLeftGNSAmount()),
 		"gnsTotalSupply", utils.FormatInt(gns.TotalSupply()),
+		"stakerRewardPerSecond", utils.FormatInt(stakerRewardPerSecond),
+		"govStakerRewardPerSecond", utils.FormatInt(govStakerRewardPerSecond),
 	)
 
 	return totalDistAmount, true


### PR DESCRIPTION
## Summary
- `MintAndDistributeGns` now emits `stakerRewardPerSecond` and `govStakerRewardPerSecond` alongside the existing minted/distributed amounts.

## Context
`MintAndDistributeGns` previously emitted only `mintedAmount`, `distributedAmount`, and related totals. Any off-chain consumer that needed the staker/gov-staker reward-per-second in effect at that block had no way to read it directly off this event, and had to re-derive or separately query it instead.

`ChangeDistributionPct` already computes and emits these same two fields for its own event (`stakerRewardPerSecond`, `govStakerRewardPerSecond`), using `GetEmissionAmountPerSecondBy` + `GetDistributionBpsPct`. This change brings `MintAndDistributeGns` in line with that existing pattern.

## Changes
- `contract/r/gnoswap/emission/emission.gno`: compute `stakerRewardPerSecond` / `govStakerRewardPerSecond` via `GetEmissionAmountPerSecondBy(currentTimestamp, GetDistributionBpsPct(LIQUIDITY_STAKER/GOV_STAKER))` using the block's existing `currentTimestamp`, and add both fields to the `MintAndDistributeGns` event.

## Verification
- `make test WORKDIR=<cached gno checkout> PKG=gno.land/r/gnoswap/emission` — all existing tests pass
- `gofumpt -l` — no formatting issues

## Notes
- No behavior change to minting/distribution logic or existing event fields; this only adds two new fields to the emitted event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added staker and governance staker reward-per-second metrics to the GNS distribution event data.
  * Distribution updates now provide more detailed reward information for monitoring and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->