### PR TITLE
fix(pool): reject upgrade while pool reentrancy lock is held

### DIFF
--- a/contract/r/gnoswap/pool/errors.gno
+++ b/contract/r/gnoswap/pool/errors.gno
@@ -1,0 +1,7 @@
+package pool
+
+const ErrSpoofedRealm = "rlm does not match the current crossing frame"
+
+// errUpgradeWhileLocked is returned when UpgradeImpl is invoked while the
+// pool's reentrancy lock (StoreKeyUnlocked) is held.
+const errUpgradeWhileLocked = "cannot upgrade pool implementation while pool is locked"

--- a/contract/r/gnoswap/pool/state.gno
+++ b/contract/r/gnoswap/pool/state.gno
@@ -10,8 +10,6 @@ import (
 	_ "gno.land/r/gnoswap/rbac"
 )
 
-const ErrSpoofedRealm = "rlm does not match the current crossing frame"
-
 var (
 	domainPath string
 

--- a/contract/r/gnoswap/pool/upgrade.gno
+++ b/contract/r/gnoswap/pool/upgrade.gno
@@ -48,10 +48,7 @@ func RegisterInitializer(cur realm, initializer func(_ int, rlm realm, poolStore
 //
 // Security: Only admin or governance can perform upgrades.
 // The new implementation must have been previously registered via RegisterInitializer.
-// The pool's reentrancy lock must not be held: a swap can reach here through
-// swapCallback -> governance.Execute before it finishes, and running the new
-// version's initializer against swap accounting that is still mid-update can
-// corrupt pool state or leave the pool unusable.
+// The pool must not be locked (see assertPoolUnlocked).
 func UpgradeImpl(cur realm, packagePath string) {
 	// Ensure only admin or governance can perform upgrades
 	caller := cur.Previous().Address()

--- a/contract/r/gnoswap/pool/upgrade.gno
+++ b/contract/r/gnoswap/pool/upgrade.gno
@@ -2,6 +2,7 @@ package pool
 
 import (
 	"errors"
+
 	"gno.land/r/gnoswap/access"
 )
 
@@ -47,10 +48,16 @@ func RegisterInitializer(cur realm, initializer func(_ int, rlm realm, poolStore
 //
 // Security: Only admin or governance can perform upgrades.
 // The new implementation must have been previously registered via RegisterInitializer.
+// The pool's reentrancy lock must not be held: a swap can reach here through
+// swapCallback -> governance.Execute before it finishes, and running the new
+// version's initializer against swap accounting that is still mid-update can
+// corrupt pool state or leave the pool unusable.
 func UpgradeImpl(cur realm, packagePath string) {
 	// Ensure only admin or governance can perform upgrades
 	caller := cur.Previous().Address()
 	access.AssertIsAdminOrGovernance(caller)
+
+	assertPoolUnlocked()
 
 	err := versionManager.ChangeImplementation(0, cur, packagePath)
 	if err != nil {
@@ -60,6 +67,22 @@ func UpgradeImpl(cur realm, packagePath string) {
 	err = updateImplementation()
 	if err != nil {
 		panic(err)
+	}
+}
+
+// errUpgradeWhileLocked is returned when UpgradeImpl is invoked while the
+// pool's reentrancy lock (StoreKeyUnlocked) is held.
+const errUpgradeWhileLocked = "cannot upgrade pool implementation while pool is locked"
+
+// assertPoolUnlocked panics if the pool's reentrancy lock is currently held.
+// It mirrors poolV1.assertPoolUnlocked (r/gnoswap/pool/v1/lock.gno): read-only,
+// so it is safe to call before the admin/governance authorization check too.
+// HasUnlocked() is false until a swap has ever run, so pools with no swap
+// history are unaffected.
+func assertPoolUnlocked() {
+	s := NewPoolStore(kvStore)
+	if s.HasUnlocked() && !s.GetUnlocked() {
+		panic(errors.New(errUpgradeWhileLocked))
 	}
 }
 

--- a/contract/r/gnoswap/pool/upgrade.gno
+++ b/contract/r/gnoswap/pool/upgrade.gno
@@ -70,10 +70,6 @@ func UpgradeImpl(cur realm, packagePath string) {
 	}
 }
 
-// errUpgradeWhileLocked is returned when UpgradeImpl is invoked while the
-// pool's reentrancy lock (StoreKeyUnlocked) is held.
-const errUpgradeWhileLocked = "cannot upgrade pool implementation while pool is locked"
-
 // assertPoolUnlocked panics if the pool's reentrancy lock is currently held.
 // It mirrors poolV1.assertPoolUnlocked (r/gnoswap/pool/v1/lock.gno): read-only,
 // so it is safe to call before the admin/governance authorization check too.

--- a/contract/r/gnoswap/pool/upgrade_test.gno
+++ b/contract/r/gnoswap/pool/upgrade_test.gno
@@ -131,6 +131,26 @@ func TestUpgradeImpl(cur realm, t *testing.T) {
 			expectedHasAbort:     true,
 			expectedAbortMessage: "version_manager: initializer not found for package path:gno.land/r/gnoswap/pool/nonexistent",
 		},
+		{
+			name: "upgrade impl is failed while pool is locked",
+			setup: func(cur realm, t *testing.T) {
+				testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/pool/v1"))
+				RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+
+				testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/pool/new_version"))
+				RegisterInitializer(cross(cur), makeMockInitializer("new_version"))
+
+				// Simulate a swap holding the reentrancy lock, e.g. a swapCallback
+				// reentering through governance.Execute before the swap unlocks.
+				testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/pool"))
+				NewPoolStore(kvStore).SetUnlocked(0, cur, false)
+			},
+			packagePath:          "gno.land/r/gnoswap/pool/new_version",
+			callerRealm:          testing.NewUserRealm(adminAddr),
+			expectedVersion:      "v1",
+			expectedHasAbort:     true,
+			expectedAbortMessage: errUpgradeWhileLocked,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- `pool.UpgradeImpl` now rejects the upgrade if the pool's reentrancy lock (`StoreKeyUnlocked`) is currently held.

## Context
- A swap holds the pool's reentrancy lock from `lockPool` until the deferred `unlockPool` runs, but that lock was only enforced on the pool's own entrypoints (Mint/Burn/Swap/etc.), not on `UpgradeImpl`.
- `Swap` invokes a caller-supplied `swapCallback` synchronously before it returns and before the lock is released. If that callback calls `governance.Execute` on an executable upgrade proposal, it can reach `pool.UpgradeImpl` -> `versionManager.ChangeImplementation` while the swap is still mid-flight — running the new version's initializer against a KV store whose swap accounting (fees, oracle, liquidity) isn't fully settled yet.
- `UpgradeImpl` is the only call site that reaches `versionManager.ChangeImplementation` for the pool domain, so gating it there covers the full path.

## Changes
- Add `assertPoolUnlocked()` in `contract/r/gnoswap/pool/upgrade.gno`, called at the top of `UpgradeImpl`, panicking if `StoreKeyUnlocked == false`. Mirrors the existing `poolV1.assertPoolUnlocked` reentrancy check (`r/gnoswap/pool/v1/lock.gno`), applied at the proxy layer since that's where the reentrant governance call actually lands.
- Move error constants (`ErrSpoofedRealm`, new `errUpgradeWhileLocked`) into a dedicated `errors.gno`, matching the `position` package's convention.
- Add a test case to `TestUpgradeImpl` simulating a swap holding the lock and asserting the upgrade aborts.

## Verification
- `make test PKG=gno.land/r/gnoswap/pool` (full suite and `-run TestUpgradeImpl`) — all pass.

## Notes
- Out of scope: `RegisterInitializer` isn't guarded the same way, since it's only reachable from a version package's own deploy-time `init()`, not from a governance-triggered reentrant call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented pool implementation upgrades while the pool is locked, preserving the active implementation and avoiding unsafe state changes.
  * Improved error handling by standardizing the realm-mismatch error and the specific “upgrade while locked” error.
* **Tests**
  * Added a new test case to confirm upgrades are rejected when locked and the pool version remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->