### PR TITLE
fix(staker): avoid int64 overflow in RewardState.applyWarmup

### DIFF
--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
@@ -387,7 +387,7 @@ func (self *RewardState) applyWarmup() {
 		warmupReward := self.rewards[i]
 
 		// calculate warmup reward applying warmup ratio
-		self.rewards[i] = gnsmath.SafeMulInt64(warmupReward, int64(warmup.WarmupRatio)) / 100
+		self.rewards[i] = gnsmath.SafeMulDivInt64(warmupReward, int64(warmup.WarmupRatio), 100)
 
 		// warmup penalty is the difference between the warmup reward and the warmup reward applying warmup ratio
 		self.penalties[i] = gnsmath.SafeSubInt64(warmupReward, self.rewards[i])

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool_test.gno
@@ -1,6 +1,7 @@
 package staker
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -683,6 +684,27 @@ func TestRewardStateApplyWarmup(cur realm, t *testing.T) {
 			warmupRatios:      []uint64{30},
 			expectedRewards:   []int64{300},
 			expectedPenalties: []int64{700},
+		},
+		{
+			name:              "apply 100% warmup without intermediate overflow",
+			rewards:           []int64{math.MaxInt64},
+			warmupRatios:      []uint64{100},
+			expectedRewards:   []int64{math.MaxInt64},
+			expectedPenalties: []int64{0},
+		},
+		{
+			name:              "apply 50% warmup without intermediate overflow",
+			rewards:           []int64{math.MaxInt64},
+			warmupRatios:      []uint64{50},
+			expectedRewards:   []int64{math.MaxInt64 / 2},
+			expectedPenalties: []int64{math.MaxInt64 - math.MaxInt64/2},
+		},
+		{
+			name:              "apply 100% warmup above int64 multiplication threshold",
+			rewards:           []int64{math.MaxInt64/100 + 1},
+			warmupRatios:      []uint64{100},
+			expectedRewards:   []int64{math.MaxInt64/100 + 1},
+			expectedPenalties: []int64{0},
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Prevent `RewardState.applyWarmup` from panicking on large rewards when only the intermediate `int64` multiplication overflows.
- Add regression coverage for large warmup rewards at 100% and 50% ratios.

## Context
- `applyWarmup` previously evaluated `SafeMulInt64(warmupReward, WarmupRatio) / 100`, so `CollectReward` and `UnStakeToken` could abort before the final scaled reward was computed.
- The intended final value can still fit in `int64`, especially at `WarmupRatio = 100`, where the result should equal `warmupReward`.

## Changes
- Use `gnsmath.SafeMulDivInt64(warmupReward, int64(warmup.WarmupRatio), 100)` so multiplication is performed in wider signed arithmetic and the final quotient is checked.
- Extend `TestRewardStateApplyWarmup` with `math.MaxInt64` and `MaxInt64/100 + 1` cases that reproduced the panic before the fix.

## Verification
- `make test PKG=gno.land/r/gnoswap/staker/v1 RUN=TestRewardStateApplyWarmup`
- `make test PKG=gno.land/p/gnoswap/gnsmath RUN=TestSafeMulDivInt64`
- `make test PKG=gno.land/r/gnoswap/staker/v1`

## Notes
- No ABI, event, schema, config, or Helm changes.
- No companion backend or indexer changes are required for this contract arithmetic fix.