### PR TITLE
fix(launchpad): prevent repeated admin refunds

### DIFF
--- a/contract/r/gnoswap/launchpad/v1/launchpad_project.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_project.gno
@@ -378,12 +378,6 @@ func (lp *launchpadV1) transferLeftFromProject(_ int, rlm realm, project *launch
 		}
 		project.SetTiers(updatedTiers)
 
-		projects := lp.store.GetProjects()
-		projects.Set(project.ID(), project)
-		if err := lp.store.SetProjects(0, rlm, projects); err != nil {
-			return 0, err
-		}
-
 		common.SafeGRC20Transfer(cross(rlm), project.TokenPath(), recipient, refundableAmount)
 	}
 

--- a/contract/r/gnoswap/launchpad/v1/launchpad_project.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_project.gno
@@ -320,13 +320,16 @@ func (lp *launchpadV1) transferLeftFromProject(_ int, rlm realm, project *launch
 	accumLeftReward := int64(0)
 	accumCollectedReward := int64(0)
 	accumCollectableReward := int64(0)
+	refundableAmountsByTier := make(map[int64]int64)
 
-	for _, tier := range project.Tiers() {
+	for duration, tier := range project.Tiers() {
 		// Calculate pending rewards for remaining depositors
 		currentDepositCount := getTierCurrentDepositCount(tier)
+		claimableReward := int64(0)
 
 		if currentDepositCount > 0 {
-			claimableReward, err := lp.applyTierRewardGrowthWithRewards(tier, currentTime)
+			var err error
+			claimableReward, err = lp.applyTierRewardGrowthWithRewards(tier, currentTime)
 			if err != nil {
 				return 0, err
 			}
@@ -335,6 +338,12 @@ func (lp *launchpadV1) transferLeftFromProject(_ int, rlm realm, project *launch
 		}
 
 		leftReward := getCalculatedLeftReward(tier)
+		refundableAmount := gnsmath.SafeSubInt64(leftReward, claimableReward)
+		if refundableAmount < 0 {
+			return 0, errors.New(ufmt.Sprintf("refundableAmount(%d) < 0", refundableAmount))
+		}
+
+		refundableAmountsByTier[duration] = refundableAmount
 		accumLeftReward = gnsmath.SafeAddInt64(accumLeftReward, leftReward)
 		accumCollectedReward = gnsmath.SafeAddInt64(accumCollectedReward, tier.TotalCollectedAmount())
 		accumTotalDistributeAmount = gnsmath.SafeAddInt64(accumTotalDistributeAmount, tier.TotalDistributeAmount())
@@ -358,6 +367,23 @@ func (lp *launchpadV1) transferLeftFromProject(_ int, rlm realm, project *launch
 	}
 
 	if refundableAmount > 0 {
+		updatedTiers := make(map[int64]*launchpad.ProjectTier)
+		for duration, tier := range project.Tiers() {
+			tierRefundableAmount := refundableAmountsByTier[duration]
+			if tierRefundableAmount > 0 {
+				tier.SetTotalCollectedAmount(gnsmath.SafeAddInt64(tier.TotalCollectedAmount(), tierRefundableAmount))
+			}
+
+			updatedTiers[duration] = tier
+		}
+		project.SetTiers(updatedTiers)
+
+		projects := lp.store.GetProjects()
+		projects.Set(project.ID(), project)
+		if err := lp.store.SetProjects(0, rlm, projects); err != nil {
+			return 0, err
+		}
+
 		common.SafeGRC20Transfer(cross(rlm), project.TokenPath(), recipient, refundableAmount)
 	}
 

--- a/contract/r/gnoswap/launchpad/v1/launchpad_project.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_project.gno
@@ -325,25 +325,25 @@ func (lp *launchpadV1) transferLeftFromProject(_ int, rlm realm, project *launch
 	for duration, tier := range project.Tiers() {
 		// Calculate pending rewards for remaining depositors
 		currentDepositCount := getTierCurrentDepositCount(tier)
-		claimableReward := int64(0)
+		tierCollectableReward := int64(0)
 
 		if currentDepositCount > 0 {
 			var err error
-			claimableReward, err = lp.applyTierRewardGrowthWithRewards(tier, currentTime)
+			tierCollectableReward, err = lp.applyTierRewardGrowthWithRewards(tier, currentTime)
 			if err != nil {
 				return 0, err
 			}
 
-			accumCollectableReward = gnsmath.SafeAddInt64(accumCollectableReward, claimableReward)
+			accumCollectableReward = gnsmath.SafeAddInt64(accumCollectableReward, tierCollectableReward)
 		}
 
 		leftReward := getCalculatedLeftReward(tier)
-		refundableAmount := gnsmath.SafeSubInt64(leftReward, claimableReward)
-		if refundableAmount < 0 {
-			return 0, errors.New(ufmt.Sprintf("refundableAmount(%d) < 0", refundableAmount))
+		tierRefundableAmount := gnsmath.SafeSubInt64(leftReward, tierCollectableReward)
+		if tierRefundableAmount < 0 {
+			return 0, errors.New(ufmt.Sprintf("tierRefundableAmount(%d) < 0", tierRefundableAmount))
 		}
 
-		refundableAmountsByTier[duration] = refundableAmount
+		refundableAmountsByTier[duration] = tierRefundableAmount
 		accumLeftReward = gnsmath.SafeAddInt64(accumLeftReward, leftReward)
 		accumCollectedReward = gnsmath.SafeAddInt64(accumCollectedReward, tier.TotalCollectedAmount())
 		accumTotalDistributeAmount = gnsmath.SafeAddInt64(accumTotalDistributeAmount, tier.TotalDistributeAmount())
@@ -358,15 +358,15 @@ func (lp *launchpadV1) transferLeftFromProject(_ int, rlm realm, project *launch
 		return 0, errors.New(ufmt.Sprintf("accumTotalDistributeAmount(%d) != accumCollectedReward(%d)+accumLeftReward(%d)", accumTotalDistributeAmount, accumCollectedReward, accumLeftReward))
 	}
 
-	// Calculate refundable amount: project remaining minus claimable rewards for remaining depositors
+	// Calculate refundable amount: project remaining minus collectable rewards for remaining depositors
 	projectLeftReward := accumLeftReward
-	refundableAmount := gnsmath.SafeSubInt64(projectLeftReward, accumCollectableReward)
+	projectRefundableAmount := gnsmath.SafeSubInt64(projectLeftReward, accumCollectableReward)
 
-	if refundableAmount < 0 {
-		return 0, errors.New(ufmt.Sprintf("refundableAmount(%d) < 0", refundableAmount))
+	if projectRefundableAmount < 0 {
+		return 0, errors.New(ufmt.Sprintf("projectRefundableAmount(%d) < 0", projectRefundableAmount))
 	}
 
-	if refundableAmount > 0 {
+	if projectRefundableAmount > 0 {
 		updatedTiers := make(map[int64]*launchpad.ProjectTier)
 		for duration, tier := range project.Tiers() {
 			tierRefundableAmount := refundableAmountsByTier[duration]
@@ -378,13 +378,13 @@ func (lp *launchpadV1) transferLeftFromProject(_ int, rlm realm, project *launch
 		}
 		project.SetTiers(updatedTiers)
 
-		common.SafeGRC20Transfer(cross(rlm), project.TokenPath(), recipient, refundableAmount)
+		common.SafeGRC20Transfer(cross(rlm), project.TokenPath(), recipient, projectRefundableAmount)
 	}
 
-	return refundableAmount, nil
+	return projectRefundableAmount, nil
 }
 
-// applyTierRewardGrowthWithRewards calculates the total claimable rewards
+// applyTierRewardGrowthWithRewards calculates the total collectable rewards
 // for all active deposits in a specific tier.
 func (lp *launchpadV1) applyTierRewardGrowthWithRewards(tier *launchpad.ProjectTier, currentTime int64) (int64, error) {
 	rewardManager, err := lp.getProjectTierRewardManager(tier.ID())
@@ -392,7 +392,7 @@ func (lp *launchpadV1) applyTierRewardGrowthWithRewards(tier *launchpad.ProjectT
 		return 0, err
 	}
 
-	// Update reward accumulation to current time before calculating claimable.
+	// Update reward accumulation to current time before calculating collectable rewards.
 	err = updateRewardPerDepositX128(rewardManager, getTierCurrentDepositAmount(tier), currentTime)
 	if err != nil {
 		return 0, err

--- a/contract/r/gnoswap/launchpad/v1/launchpad_project_test.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_project_test.gno
@@ -1381,51 +1381,39 @@ func TestLaunchpadProject_TransferLeftFromProjectRepeatedRefundDoesNotDrainOther
 	launchpadAddr, _ := access.GetAddress(prbac.ROLE_LAUNCHPAD.String())
 	adminRealm := testing.NewUserRealm(adminAddr)
 
-	projectAID := "gno.land/r/onbloc/obl.OBL:123"
-	projectBID := "gno.land/r/onbloc/obl.OBL:456"
-	projectARecipient := testutils.TestAddress("project-a")
-	projectBRecipient := testutils.TestAddress("project-b")
+	projectID := "gno.land/r/onbloc/obl.OBL:123"
+	recipient := testutils.TestAddress("project")
 	rewardAmount := int64(1_000_000)
 	currentTime := int64(2001)
 
-	projectA := newRefundableNoDepositorProject(projectAID, projectARecipient, rewardAmount)
-	projectB := newRefundableNoDepositorProject(projectBID, projectBRecipient, rewardAmount)
+	project := newRefundableNoDepositorProject(projectID, recipient, rewardAmount)
 
 	projects := lp.store.GetProjects()
-	projects.Set(projectAID, projectA)
-	projects.Set(projectBID, projectB)
+	projects.Set(projectID, project)
 	uassert.NoError(t, lp.store.SetProjects(0, cur, projects))
 
 	projectTierRewardManagers := lp.store.GetProjectTierRewardManagers()
-	projectTierRewardManagers.Set(projectAID+":180", newRewardManager(rewardAmount, 1000, 2000, 0))
-	projectTierRewardManagers.Set(projectBID+":180", newRewardManager(rewardAmount, 1000, 2000, 0))
+	projectTierRewardManagers.Set(projectID+":180", newRewardManager(rewardAmount, 1000, 2000, 0))
 	uassert.NoError(t, lp.store.SetProjectTierRewardManagers(0, cur, projectTierRewardManagers))
 
 	testing.SetRealm(adminRealm)
-	projectAInitialBalance := obl.BalanceOf(projectARecipient)
-	projectBInitialBalance := obl.BalanceOf(projectBRecipient)
-	obl.Transfer(cross(cur), launchpadAddr, rewardAmount*2)
+	initialBalance := obl.BalanceOf(recipient)
+	obl.Transfer(cross(cur), launchpadAddr, rewardAmount)
 
-	refundedAmount, err := lp.transferLeftFromProject(0, cur, projectA, projectARecipient, currentTime)
+	refundedAmount, err := lp.transferLeftFromProject(0, cur, project, recipient, currentTime)
 	uassert.NoError(t, err)
 	uassert.Equal(t, rewardAmount, refundedAmount)
-	uassert.Equal(t, projectAInitialBalance+rewardAmount, obl.BalanceOf(projectARecipient))
+	uassert.Equal(t, initialBalance+rewardAmount, obl.BalanceOf(recipient))
 
-	projectA, err = lp.getProject(projectAID)
+	project, err = lp.getProject(projectID)
 	uassert.NoError(t, err)
-	projectATier, err := getProjectTier(projectA, projectTier180)
+	projectTier, err := getProjectTier(project, projectTier180)
 	uassert.NoError(t, err)
-	uassert.Equal(t, rewardAmount, projectATier.TotalCollectedAmount())
-	_, err = lp.transferLeftFromProject(0, cur, projectA, projectARecipient, currentTime)
+	uassert.Equal(t, rewardAmount, projectTier.TotalCollectedAmount())
+
+	_, err = lp.transferLeftFromProject(0, cur, project, recipient, currentTime)
 	uassert.ErrorContains(t, err, "project has no remaining amount")
-	uassert.Equal(t, projectAInitialBalance+rewardAmount, obl.BalanceOf(projectARecipient))
-
-	projectB, err = lp.getProject(projectBID)
-	uassert.NoError(t, err)
-	refundedAmount, err = lp.transferLeftFromProject(0, cur, projectB, projectBRecipient, currentTime)
-	uassert.NoError(t, err)
-	uassert.Equal(t, rewardAmount, refundedAmount)
-	uassert.Equal(t, projectBInitialBalance+rewardAmount, obl.BalanceOf(projectBRecipient))
+	uassert.Equal(t, initialBalance+rewardAmount, obl.BalanceOf(recipient))
 }
 
 func newRefundableNoDepositorProject(projectID string, recipient address, rewardAmount int64) *launchpad.Project {

--- a/contract/r/gnoswap/launchpad/v1/launchpad_project_test.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_project_test.gno
@@ -1372,3 +1372,75 @@ func TestLaunchpadProject_TransferLeftFromProjectNoDepositors(cur realm, t *test
 		})
 	}
 }
+
+func TestLaunchpadProject_TransferLeftFromProjectRepeatedRefundDoesNotDrainOtherProject(cur realm, t *testing.T) {
+	initLaunchpadProjectTest(t)
+	lp := getTestImplementation()
+
+	adminAddr, _ := access.GetAddress(prbac.ROLE_ADMIN.String())
+	launchpadAddr, _ := access.GetAddress(prbac.ROLE_LAUNCHPAD.String())
+	adminRealm := testing.NewUserRealm(adminAddr)
+
+	projectAID := "gno.land/r/onbloc/obl.OBL:123"
+	projectBID := "gno.land/r/onbloc/obl.OBL:456"
+	projectARecipient := testutils.TestAddress("project-a")
+	projectBRecipient := testutils.TestAddress("project-b")
+	rewardAmount := int64(1_000_000)
+	currentTime := int64(2001)
+
+	projectA := newRefundableNoDepositorProject(projectAID, projectARecipient, rewardAmount)
+	projectB := newRefundableNoDepositorProject(projectBID, projectBRecipient, rewardAmount)
+
+	projects := lp.store.GetProjects()
+	projects.Set(projectAID, projectA)
+	projects.Set(projectBID, projectB)
+	uassert.NoError(t, lp.store.SetProjects(0, cur, projects))
+
+	projectTierRewardManagers := lp.store.GetProjectTierRewardManagers()
+	projectTierRewardManagers.Set(projectAID+":180", newRewardManager(rewardAmount, 1000, 2000, 0))
+	projectTierRewardManagers.Set(projectBID+":180", newRewardManager(rewardAmount, 1000, 2000, 0))
+	uassert.NoError(t, lp.store.SetProjectTierRewardManagers(0, cur, projectTierRewardManagers))
+
+	testing.SetRealm(adminRealm)
+	projectAInitialBalance := obl.BalanceOf(projectARecipient)
+	projectBInitialBalance := obl.BalanceOf(projectBRecipient)
+	obl.Transfer(cross(cur), launchpadAddr, rewardAmount*2)
+
+	refundedAmount, err := lp.transferLeftFromProject(0, cur, projectA, projectARecipient, currentTime)
+	uassert.NoError(t, err)
+	uassert.Equal(t, rewardAmount, refundedAmount)
+	uassert.Equal(t, projectAInitialBalance+rewardAmount, obl.BalanceOf(projectARecipient))
+
+	projectA, err = lp.getProject(projectAID)
+	uassert.NoError(t, err)
+	projectATier, err := getProjectTier(projectA, projectTier180)
+	uassert.NoError(t, err)
+	uassert.Equal(t, rewardAmount, projectATier.TotalCollectedAmount())
+	_, err = lp.transferLeftFromProject(0, cur, projectA, projectARecipient, currentTime)
+	uassert.ErrorContains(t, err, "project has no remaining amount")
+	uassert.Equal(t, projectAInitialBalance+rewardAmount, obl.BalanceOf(projectARecipient))
+
+	projectB, err = lp.getProject(projectBID)
+	uassert.NoError(t, err)
+	refundedAmount, err = lp.transferLeftFromProject(0, cur, projectB, projectBRecipient, currentTime)
+	uassert.NoError(t, err)
+	uassert.Equal(t, rewardAmount, refundedAmount)
+	uassert.Equal(t, projectBInitialBalance+rewardAmount, obl.BalanceOf(projectBRecipient))
+}
+
+func newRefundableNoDepositorProject(projectID string, recipient address, rewardAmount int64) *launchpad.Project {
+	tier := launchpad.NewProjectTier(projectID, projectTier180, rewardAmount, 1000, 2000)
+	tier.SetID(projectID + ":180")
+	tier.SetTotalDepositCount(0)
+	tier.SetTotalWithdrawCount(0)
+	tier.SetTotalCollectedAmount(0)
+
+	project := launchpad.NewProject(projectID, "gno.land/r/onbloc/obl.OBL", 0, recipient, 100, 1000)
+	project.SetID(projectID)
+
+	tiers := make(map[int64]*launchpad.ProjectTier)
+	tiers[projectTier180] = tier
+	project.SetTiers(tiers)
+
+	return project
+}

--- a/contract/r/scenario/launchpad/launchpad_repeated_admin_refund_filetest.gno
+++ b/contract/r/scenario/launchpad/launchpad_repeated_admin_refund_filetest.gno
@@ -1,0 +1,141 @@
+// launchpad repeated admin refund must not drain another project
+
+// PKGPATH: gno.land/r/gnoswap/v1/main
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	prbac "gno.land/p/gnoswap/rbac"
+	_ "gno.land/r/gnoswap/rbac"
+
+	_ "gno.land/r/gnoswap/protocol_fee/v1"
+
+	_ "gno.land/r/gnoswap/gov/staker"
+	_ "gno.land/r/gnoswap/gov/staker/v1"
+
+	testutils "gno.land/p/nt/testutils/v0"
+	uassert "gno.land/p/nt/uassert/v0"
+	ufmt "gno.land/p/nt/ufmt/v0"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/launchpad"
+	_ "gno.land/r/gnoswap/launchpad/v1"
+
+	"gno.land/r/onbloc/obl"
+)
+
+var (
+	t *testing.T
+
+	blockTimeSeconds int64 = 5
+	secondsInDay     int64 = 24 * 60 * 60
+	skipBlocks180Day int64 = 180 * secondsInDay / blockTimeSeconds
+
+	adminAddr, _ = access.GetAddress(prbac.ROLE_ADMIN.String())
+	adminRealm   = testing.NewUserRealm(adminAddr)
+
+	launchpadAddr, _ = access.GetAddress(prbac.ROLE_LAUNCHPAD.String())
+
+	projectAAddr = testutils.TestAddress("project-a")
+	projectBAddr = testutils.TestAddress("project-b")
+)
+
+func main(cur realm) {
+	println("[SCENARIO] Repeated admin refund is idempotent per project")
+	println("[INFO] Two ended launchpad projects share the same OBL balance in the launchpad realm")
+	println()
+
+	println("[SCENARIO] 1. Create project A with 1,000,000 OBL")
+	projectAID := createOBLProject(cur, "Project A", projectAAddr, 1_000_000)
+	println()
+
+	println("[SCENARIO] 2. Create project B with 1,000,000 OBL")
+	projectBID := createOBLProject(cur, "Project B", projectBAddr, 1_000_000)
+	println()
+
+	println("[SCENARIO] 3. Skip to end both projects")
+	testing.SkipHeights(skipBlocks180Day + 6)
+	ufmt.Printf("[INFO] Launchpad OBL balance before refunds: %d\n", obl.BalanceOf(launchpadAddr))
+	println()
+
+	println("[SCENARIO] 4. Refund project A once")
+	refundProject(cur, projectAID, projectAAddr)
+	ufmt.Printf("[INFO] Project A OBL after first refund: %d\n", obl.BalanceOf(projectAAddr))
+	ufmt.Printf("[INFO] Launchpad OBL after first refund: %d\n", obl.BalanceOf(launchpadAddr))
+	println()
+
+	println("[SCENARIO] 5. Repeat project A refund")
+	uassert.AbortsContains(t, cur, "project has no remaining amount", func() {
+		refundProject(cur, projectAID, projectAAddr)
+	})
+	println("[EXPECTED] Repeated project A refund is blocked")
+	ufmt.Printf("[INFO] Project A OBL after repeated refund attempt: %d\n", obl.BalanceOf(projectAAddr))
+	ufmt.Printf("[INFO] Launchpad OBL after repeated refund attempt: %d\n", obl.BalanceOf(launchpadAddr))
+	println()
+
+	println("[SCENARIO] 6. Refund project B")
+	refundProject(cur, projectBID, projectBAddr)
+	ufmt.Printf("[INFO] Project B OBL after refund: %d\n", obl.BalanceOf(projectBAddr))
+	ufmt.Printf("[INFO] Launchpad OBL after project B refund: %d\n", obl.BalanceOf(launchpadAddr))
+	println()
+}
+
+func createOBLProject(cur realm, name string, recipient address, rewardAmount int64) string {
+	rewardTokenPath := "gno.land/r/onbloc/obl.OBL"
+	startTime := int64(time.Now().Unix() + 604800)
+
+	testing.SetRealm(adminRealm)
+	obl.Approve(cross(cur), launchpadAddr, rewardAmount)
+	projectID := launchpad.CreateProject(
+		cross(cur),
+		name,
+		rewardTokenPath,
+		recipient,
+		rewardAmount,
+		"",
+		"",
+		0,
+		0,
+		100,
+		startTime,
+	)
+
+	testing.SkipHeights(604800 / blockTimeSeconds)
+	println("[INFO] Project created with ID:", projectID)
+	return projectID
+}
+
+func refundProject(cur realm, projectID string, recipient address) {
+	testing.SetRealm(adminRealm)
+	launchpad.TransferLeftFromProjectByAdmin(cross(cur), projectID, recipient)
+}
+
+// Output:
+// [SCENARIO] Repeated admin refund is idempotent per project
+// [INFO] Two ended launchpad projects share the same OBL balance in the launchpad realm
+//
+// [SCENARIO] 1. Create project A with 1,000,000 OBL
+// [INFO] Project created with ID: gno.land/r/onbloc/obl.OBL:123
+//
+// [SCENARIO] 2. Create project B with 1,000,000 OBL
+// [INFO] Project created with ID: gno.land/r/onbloc/obl.OBL:121083
+//
+// [SCENARIO] 3. Skip to end both projects
+// [INFO] Launchpad OBL balance before refunds: 2000000
+//
+// [SCENARIO] 4. Refund project A once
+// [INFO] Project A OBL after first refund: 1000000
+// [INFO] Launchpad OBL after first refund: 1000000
+//
+// [SCENARIO] 5. Repeat project A refund
+// [EXPECTED] Repeated project A refund is blocked
+// [INFO] Project A OBL after repeated refund attempt: 1000000
+// [INFO] Launchpad OBL after repeated refund attempt: 1000000
+//
+// [SCENARIO] 6. Refund project B
+// [INFO] Project B OBL after refund: 1000000
+// [INFO] Launchpad OBL after project B refund: 0
+//


### PR DESCRIPTION
## Summary
- Prevent repeated admin refunds from reusing reward-token balance that belongs to other launchpad projects.
- Mark refunded tier rewards through existing collected-amount accounting.
- Add regression coverage for repeated admin refunds and keep unit coverage focused on persisted project accounting.

## Context
- Admin refund accounting previously recalculated refundable rewards from static tier distribution state, so calling the same project refund again could drain shared launchpad reward-token balance.

## Changes
- Record each refunded tier amount in `ProjectTier.TotalCollectedAmount`.
- Rebuild the project tier map before persisting tier accounting to avoid readonly-tainted map mutation.
- Add scenario coverage for two ended projects sharing the same OBL balance.
- Keep the unit regression focused on single-project persistence and repeated refund blocking.

## Verification
- `make test PKG=gno.land/r/gnoswap/launchpad/v1`
- `make test PKG=gno.land/r/gnoswap/scenario/launchpad`
- `make test PKG=gno.land/r/gnoswap/launchpad/v1 RUN=TestLaunchpadProject_TransferLeftFromProjectRepeatedRefundDoesNotDrainOtherProject`

## Notes
- No schema, deployment, or migration changes.