### PR TITLE
fix(pool): prune zero tick bitmap words

### DIFF
--- a/contract/r/gnoswap/pool/pool.gno
+++ b/contract/r/gnoswap/pool/pool.gno
@@ -120,6 +120,7 @@ func (p *Pool) SetTickBitmap(wordPos int16, tickBitmap string) {
 	p.tickBitmaps[wordPos] = tickBitmap
 }
 
+// DeleteTickBitmap deletes the tick bitmap for the given word position.
 func (p *Pool) DeleteTickBitmap(wordPos int16) {
 	delete(p.tickBitmaps, wordPos)
 }

--- a/contract/r/gnoswap/pool/pool.gno
+++ b/contract/r/gnoswap/pool/pool.gno
@@ -120,6 +120,10 @@ func (p *Pool) SetTickBitmap(wordPos int16, tickBitmap string) {
 	p.tickBitmaps[wordPos] = tickBitmap
 }
 
+func (p *Pool) DeleteTickBitmap(wordPos int16) {
+	delete(p.tickBitmaps, wordPos)
+}
+
 func (p *Pool) SetTickBitmaps(tickBitmaps map[int16]string) {
 	p.tickBitmaps = tickBitmaps
 }

--- a/contract/r/gnoswap/pool/v1/tick_bitmap.gno
+++ b/contract/r/gnoswap/pool/v1/tick_bitmap.gno
@@ -50,7 +50,13 @@ func tickBitmapFlipTick(
 
 	mask := u256.Zero().Lsh(u256.One(), uint(bitPos))
 	current := getTickBitmap(p, wordPos)
-	setTickBitmap(p, wordPos, u256.Zero().Xor(current, mask))
+	next := u256.Zero().Xor(current, mask)
+	if next.IsZero() {
+		deleteTickBitmap(p, wordPos)
+		return
+	}
+
+	setTickBitmap(p, wordPos, next)
 }
 
 // tickBitmapNextInitializedTickWithInOneWord finds the next initialized tick within
@@ -87,14 +93,14 @@ func getTickBitmap(p *pl.Pool, wordPos int16) *u256.Uint {
 	return u256.MustFromDecimal(value)
 }
 
-// setTickBitmap sets the tick bitmap for the given word position
+// setTickBitmap sets the tick bitmap for the given word position.
 func setTickBitmap(p *pl.Pool, wordPos int16, tickBitmap *u256.Uint) {
-	if tickBitmap.IsZero() {
-		p.DeleteTickBitmap(wordPos)
-		return
-	}
-
 	p.SetTickBitmap(wordPos, tickBitmap.ToString())
+}
+
+// deleteTickBitmap deletes the tick bitmap for the given word position.
+func deleteTickBitmap(p *pl.Pool, wordPos int16) {
+	p.DeleteTickBitmap(wordPos)
 }
 
 // tickBitmapPosition calculates the word and bit position for a given tick

--- a/contract/r/gnoswap/pool/v1/tick_bitmap.gno
+++ b/contract/r/gnoswap/pool/v1/tick_bitmap.gno
@@ -3,7 +3,6 @@ package pool
 import (
 	"gno.land/p/gnoswap/gnsmath"
 	u256 "gno.land/p/gnoswap/uint256"
-	ufmt "gno.land/p/nt/ufmt/v0"
 	pl "gno.land/r/gnoswap/pool"
 )
 
@@ -77,19 +76,12 @@ func tickBitmapNextInitializedTickWithInOneWord(
 	return nextTick, initialized
 }
 
-// getTickBitmap gets the tick bitmap for the given word position
-// if the tick bitmap is not initialized, initialize it to zero
+// getTickBitmap gets the tick bitmap for the given word position.
+// Missing words are implicit zeroes.
 func getTickBitmap(p *pl.Pool, wordPos int16) *u256.Uint {
 	value, exist := p.TickBitmaps()[wordPos]
 	if !exist {
-		setTickBitmap(p, wordPos, u256.Zero())
-		value, exist = p.TickBitmaps()[wordPos]
-		if !exist {
-			panic(newErrorWithDetail(
-				errDataNotFound,
-				ufmt.Sprintf("failed to initialize tickBitmap(%d)", wordPos),
-			))
-		}
+		return u256.Zero()
 	}
 
 	return u256.MustFromDecimal(value)
@@ -97,6 +89,11 @@ func getTickBitmap(p *pl.Pool, wordPos int16) *u256.Uint {
 
 // setTickBitmap sets the tick bitmap for the given word position
 func setTickBitmap(p *pl.Pool, wordPos int16, tickBitmap *u256.Uint) {
+	if tickBitmap.IsZero() {
+		p.DeleteTickBitmap(wordPos)
+		return
+	}
+
 	p.SetTickBitmap(wordPos, tickBitmap.ToString())
 }
 

--- a/contract/r/gnoswap/pool/v1/tick_bitmap_test.gno
+++ b/contract/r/gnoswap/pool/v1/tick_bitmap_test.gno
@@ -134,6 +134,19 @@ func TestTickBitmap_GetMissingWordDoesNotPersist(cur realm, t *testing.T) {
 	uassert.Equal(t, 0, len(p.TickBitmaps()))
 }
 
+func TestTickBitmap_SetAndDeleteWord(cur realm, t *testing.T) {
+	p := newTickBitmapPool(t)
+
+	setTickBitmap(p, 5, u256.NewUint(1))
+	uassert.Equal(t, "1", p.TickBitmaps()[5])
+
+	setTickBitmap(p, 5, u256.Zero())
+	uassert.Equal(t, "0", p.TickBitmaps()[5])
+
+	deleteTickBitmap(p, 5)
+	uassert.Equal(t, 0, len(p.TickBitmaps()))
+}
+
 func TestTickBitmap_FlipTick_RemovesZeroWord(cur realm, t *testing.T) {
 	p := newTickBitmapPool(t)
 

--- a/contract/r/gnoswap/pool/v1/tick_bitmap_test.gno
+++ b/contract/r/gnoswap/pool/v1/tick_bitmap_test.gno
@@ -125,6 +125,25 @@ func TestTickBitmap_FlipTick_SetAndUnset(cur realm, t *testing.T) {
 	uassert.False(t, bitIsSet(t, p, 100, 20))
 }
 
+func TestTickBitmap_GetMissingWordDoesNotPersist(cur realm, t *testing.T) {
+	p := newTickBitmapPool(t)
+
+	bitmap := getTickBitmap(p, 123)
+
+	uassert.True(t, bitmap.IsZero())
+	uassert.Equal(t, 0, len(p.TickBitmaps()))
+}
+
+func TestTickBitmap_FlipTick_RemovesZeroWord(cur realm, t *testing.T) {
+	p := newTickBitmapPool(t)
+
+	tickBitmapFlipTick(p, 100, 20)
+	uassert.Equal(t, 1, len(p.TickBitmaps()))
+
+	tickBitmapFlipTick(p, 100, 20)
+	uassert.Equal(t, 0, len(p.TickBitmaps()))
+}
+
 func TestTickBitmap_FlipTick_PanicOnBadSpacing(cur realm, t *testing.T) {
 	p := newTickBitmapPool(t)
 	defer func() {


### PR DESCRIPTION
## Summary
- Treat missing tick bitmap words as implicit zero without writing to pool storage
- Delete tick bitmap entries when a word becomes zero
- Add regression coverage for missing-word reads and zero-word pruning

## Test
- gno fmt -w -imports=false contract/r/gnoswap/pool/pool.gno contract/r/gnoswap/pool/v1/tick_bitmap.gno contract/r/gnoswap/pool/v1/tick_bitmap_test.gno
- make test WORKDIR=tmp PKG=gno.land/r/gnoswap/pool/v1 RUN=TestTickBitmap
- make test WORKDIR=tmp PKG=gno.land/r/gnoswap/pool/v1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tick bitmap handling for missing entries by returning an empty bitmap without creating unnecessary state.
  * Removed empty bitmap entries after ticks are cleared, reducing redundant stored data.
  * Added support for explicitly removing tick bitmap entries.

* **Tests**
  * Added coverage for missing bitmap reads and cleanup after toggling ticks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->