### PR TITLE
fix(pool): reject numeric zero swap amounts

### DIFF
--- a/contract/r/gnoswap/pool/v1/swap.gno
+++ b/contract/r/gnoswap/pool/v1/swap.gno
@@ -178,7 +178,8 @@ func (i *poolV1) Swap(
 	assertIsNotUserCall(0, rlm)
 	assertIsValidTokenOrder(token0Path, token1Path)
 
-	if amountSpecified == "0" {
+	amounts := i256.MustFromDecimal(amountSpecified)
+	if amounts.IsZero() {
 		panic(newErrorWithDetail(
 			errInvalidSwapAmount,
 			"amountSpecified == 0",
@@ -223,7 +224,6 @@ func (i *poolV1) Swap(
 	sqrtPriceLimit := u256.MustFromDecimal(sqrtPriceLimitX96)
 	validatePriceLimits(slot0Start, zeroForOne, sqrtPriceLimit)
 
-	amounts := i256.MustFromDecimal(amountSpecified)
 	feeGrowthGlobalX128 := getFeeGrowthGlobal(pool, zeroForOne)
 	feeProtocol := getFeeProtocol(slot0Start, zeroForOne)
 	cache := newSwapCache(feeProtocol, pool.Liquidity().Clone(), blockTimestamp)
@@ -337,7 +337,8 @@ func (i *poolV1) DrySwap(
 	amountSpecified string,
 	sqrtPriceLimitX96 string,
 ) (string, string, bool) {
-	if amountSpecified == "0" {
+	amounts := i256.MustFromDecimal(amountSpecified)
+	if amounts.IsZero() {
 		return "0", "0", false
 	}
 
@@ -353,7 +354,6 @@ func (i *poolV1) DrySwap(
 	sqrtPriceLimit := u256.MustFromDecimal(sqrtPriceLimitX96)
 	validatePriceLimits(slot0Start, zeroForOne, sqrtPriceLimit)
 
-	amounts := i256.MustFromDecimal(amountSpecified)
 	feeGrowthGlobalX128 := getFeeGrowthGlobal(poolSnapshot, zeroForOne)
 	feeProtocol := getFeeProtocol(slot0Start, zeroForOne)
 	cache := newSwapCache(feeProtocol, poolSnapshot.Liquidity().Clone(), time.Now().Unix())

--- a/contract/r/gnoswap/pool/v1/swap_test.gno
+++ b/contract/r/gnoswap/pool/v1/swap_test.gno
@@ -519,6 +519,54 @@ func TestSwap_ExecutionAndSecurity(cur realm, t *testing.T) {
 			expectedError: "[GNOSWAP-POOL-011] invalid swap amount || amountSpecified == 0",
 			riskFactor:    "Prevent gas waste and system load from meaningless trade",
 		},
+		{
+			name:        "zero_amount_with_leading_zero_swap_prevention",
+			description: "Prevent meaningless zero swap encoded with leading zeros",
+			setupCondition: func(cur realm, t *testing.T) *pl.Pool {
+				InitialisePoolTest(cur, t)
+				return getMockInstance().mustGetPoolBy(barPath, bazPath, STANDARD_FEE_TIER)
+			},
+			swapParams: SwapScenario{
+				zeroForOne:      true,
+				amountSpecified: "00",
+				priceLimit:      EQUAL_PRICE_RATIO,
+			},
+			expectSuccess: false,
+			expectedError: "[GNOSWAP-POOL-011] invalid swap amount || amountSpecified == 0",
+			riskFactor:    "Prevent gas waste and system load from meaningless trade",
+		},
+		{
+			name:        "zero_amount_with_positive_sign_swap_prevention",
+			description: "Prevent meaningless zero swap encoded with a positive sign",
+			setupCondition: func(cur realm, t *testing.T) *pl.Pool {
+				InitialisePoolTest(cur, t)
+				return getMockInstance().mustGetPoolBy(barPath, bazPath, STANDARD_FEE_TIER)
+			},
+			swapParams: SwapScenario{
+				zeroForOne:      true,
+				amountSpecified: "+0",
+				priceLimit:      EQUAL_PRICE_RATIO,
+			},
+			expectSuccess: false,
+			expectedError: "[GNOSWAP-POOL-011] invalid swap amount || amountSpecified == 0",
+			riskFactor:    "Prevent gas waste and system load from meaningless trade",
+		},
+		{
+			name:        "zero_amount_with_negative_sign_swap_prevention",
+			description: "Prevent meaningless zero swap encoded with a negative sign",
+			setupCondition: func(cur realm, t *testing.T) *pl.Pool {
+				InitialisePoolTest(cur, t)
+				return getMockInstance().mustGetPoolBy(barPath, bazPath, STANDARD_FEE_TIER)
+			},
+			swapParams: SwapScenario{
+				zeroForOne:      true,
+				amountSpecified: "-0",
+				priceLimit:      EQUAL_PRICE_RATIO,
+			},
+			expectSuccess: false,
+			expectedError: "[GNOSWAP-POOL-011] invalid swap amount || amountSpecified == 0",
+			riskFactor:    "Prevent gas waste and system load from meaningless trade",
+		},
 	}
 
 	for _, test := range securityTests {


### PR DESCRIPTION
## Summary
- Parse Swap amountSpecified before zero validation
- Reject numeric zero encodings like "00", "+0", and "-0" before hooks, callbacks, and event emission
- Add regression coverage for signed/leading-zero zero amount swaps

## Tests
- python3 setup.py -w tmp
- gno test -v ./gno.land/r/gnoswap/pool/v1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap amount validation, consistently rejecting zero-valued inputs, including formatted variants such as `00`, `+0`, and `-0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
