### PR TITLE
fix(pool): cap collect by internal balance

### DIFF
--- a/contract/r/gnoswap/pool/v1/pool.gno
+++ b/contract/r/gnoswap/pool/v1/pool.gno
@@ -238,14 +238,17 @@ func (i *poolV1) Collect(
 	positionKey := getPositionKey(tickLower, tickUpper)
 	position := mustGetPositionByPool(pool, positionKey)
 
-	amount0 := minRequestedAmount(amount0Req, position.TokensOwed0())
-	amount1 := minRequestedAmount(amount1Req, position.TokensOwed1())
+	amount0 := minCollectAmount(amount0Req, position.TokensOwed0(), pool.BalanceToken0())
+	amount1 := minCollectAmount(amount1Req, position.TokensOwed1(), pool.BalanceToken1())
 
 	positionAddr := access.MustGetAddress(prabc.ROLE_POSITION.String())
 
 	if amount0 > 0 {
 		tokenOwed0 := gnsmath.SafeSubInt64(position.TokensOwed0(), amount0)
-		token0Balance := gnsmath.SafeSubInt64(pool.BalanceToken0(), amount0)
+		token0Balance, err := updatePoolBalance(pool.BalanceToken0(), pool.BalanceToken1(), amount0, true)
+		if err != nil {
+			panic(err)
+		}
 
 		position.SetTokensOwed0(tokenOwed0)
 		pool.SetBalanceToken0(token0Balance)
@@ -253,7 +256,10 @@ func (i *poolV1) Collect(
 	}
 	if amount1 > 0 {
 		tokenOwed1 := gnsmath.SafeSubInt64(position.TokensOwed1(), amount1)
-		token1Balance := gnsmath.SafeSubInt64(pool.BalanceToken1(), amount1)
+		token1Balance, err := updatePoolBalance(pool.BalanceToken0(), pool.BalanceToken1(), amount1, false)
+		if err != nil {
+			panic(err)
+		}
 
 		position.SetTokensOwed1(tokenOwed1)
 		pool.SetBalanceToken1(token1Balance)
@@ -396,6 +402,14 @@ func minRequestedAmount(request, available int64) int64 {
 	}
 
 	return request
+}
+
+func minCollectAmount(request, owed, balance int64) int64 {
+	if balance < 0 {
+		panic(errors.New(errBalanceUpdateFailed))
+	}
+
+	return minRequestedAmount(minRequestedAmount(request, owed), balance)
 }
 
 func (i *poolV1) IncreaseObservationCardinalityNext(

--- a/contract/r/gnoswap/pool/v1/pool.gno
+++ b/contract/r/gnoswap/pool/v1/pool.gno
@@ -238,8 +238,8 @@ func (i *poolV1) Collect(
 	positionKey := getPositionKey(tickLower, tickUpper)
 	position := mustGetPositionByPool(pool, positionKey)
 
-	amount0 := minCollectAmount(amount0Req, position.TokensOwed0(), pool.BalanceToken0())
-	amount1 := minCollectAmount(amount1Req, position.TokensOwed1(), pool.BalanceToken1())
+	amount0 := minRequestedAmount(amount0Req, position.TokensOwed0())
+	amount1 := minRequestedAmount(amount1Req, position.TokensOwed1())
 
 	positionAddr := access.MustGetAddress(prabc.ROLE_POSITION.String())
 
@@ -402,14 +402,6 @@ func minRequestedAmount(request, available int64) int64 {
 	}
 
 	return request
-}
-
-func minCollectAmount(request, owed, balance int64) int64 {
-	if balance < 0 {
-		panic(errors.New(errBalanceUpdateFailed))
-	}
-
-	return minRequestedAmount(minRequestedAmount(request, owed), balance)
 }
 
 func (i *poolV1) IncreaseObservationCardinalityNext(

--- a/contract/r/gnoswap/pool/v1/pool_test.gno
+++ b/contract/r/gnoswap/pool/v1/pool_test.gno
@@ -1135,7 +1135,7 @@ func TestCollect(cur realm, t *testing.T) {
 		})
 	}
 
-	t.Run("insufficient_internal_balance_caps_collect", func(cur realm, t *testing.T) {
+	t.Run("insufficient_internal_balance_reverts_collect", func(cur realm, t *testing.T) {
 		pool := setupStablecoinPool(cur, t)
 		approveTokensForPool(cur, t, pool)
 		testing.SetRealm(posRealm)
@@ -1148,31 +1148,37 @@ func TestCollect(cur realm, t *testing.T) {
 		positionKey := getPositionKey(WIDE_RANGE_LOWER, WIDE_RANGE_UPPER)
 		positionBefore := mustGetPositionByPool(pool, positionKey)
 		owed0Before := positionBefore.TokensOwed0()
-		reducedBalance0 := int64(1)
+		uassert.True(t, owed0Before > int64(1),
+			"setup should leave tokensOwed0 larger than the forced balance")
 
-		pool.SetBalanceToken0(reducedBalance0)
+		// Simulate an internal-ledger desync: balance is stale-low (1) while owed is larger.
+		pool.SetBalanceToken0(int64(1))
 
-		amount0, amount1 := mockInstanceCollect(0, cur,
-			pool.Token0Path(), pool.Token1Path(), pool.Fee(),
-			adminAddr, WIDE_RANGE_LOWER, WIDE_RANGE_UPPER,
-			MAX_INT64, "0",
-		)
+		var amount0, amount1 string
+		r := revive(func() {
+			amount0, amount1 = mockInstanceCollect(
+				0, cur,
+				pool.Token0Path(), pool.Token1Path(), pool.Fee(),
+				adminAddr, WIDE_RANGE_LOWER, WIDE_RANGE_UPPER,
+				MAX_INT64, "0",
+			)
+		})
 
-		uassert.Equal(t, utils.FormatInt(reducedBalance0), amount0,
-			"Collect should cap amount0 by pool balance")
-		uassert.Equal(t, "0", amount1,
-			"Collect should not collect token1 when zero is requested")
-		uassert.Equal(t, int64(0), pool.BalanceToken0(),
-			"Pool balance0 should stop at zero")
+		uassert.NotNil(t, r,
+			"Collect must revert when the internal balance is insufficient")
+		uassert.Equal(t, "", amount0,
+			"amount0 must not be returned on revert")
+		uassert.Equal(t, "", amount1,
+			"amount1 must not be returned on revert")
 
+		// State must be untouched: no negative balance, owed unchanged.
 		positionAfter := mustGetPositionByPool(pool, positionKey)
-		expectedOwed0After := gnsmath.SafeSubInt64(owed0Before, reducedBalance0)
-		uassert.Equal(t, utils.FormatInt(expectedOwed0After), utils.FormatInt(positionAfter.TokensOwed0()),
-			"TokensOwed0 should only decrease by the capped collected amount")
-		uassert.True(t, positionAfter.TokensOwed0() > 0,
-			"Remaining TokensOwed0 should stay claimable after partial collect")
+		uassert.Equal(t, utils.FormatInt(owed0Before), utils.FormatInt(positionAfter.TokensOwed0()),
+			"TokensOwed0 must stay unchanged after revert")
 		uassert.True(t, pool.BalanceToken0() >= 0,
 			"Pool balance0 must never become negative")
+		uassert.Equal(t, int64(1), pool.BalanceToken0(),
+			"Pool balance0 must stay at the forced value after revert")
 
 		resetObject(cur, t)
 	})

--- a/contract/r/gnoswap/pool/v1/pool_test.gno
+++ b/contract/r/gnoswap/pool/v1/pool_test.gno
@@ -1122,8 +1122,8 @@ func TestCollect(cur realm, t *testing.T) {
 			uassert.Equal(t, tt.expectedOwed1After, utils.FormatInt(positionAfter.TokensOwed1()),
 				"TokensOwed1 should decrease by collected amount")
 
-			// Verify pool balance >= tokensOwed invariant
-			validateCollectInvariant(t, pool, WIDE_RANGE_LOWER, WIDE_RANGE_UPPER)
+			// Verify Collect never stores negative pool balances.
+			validateCollectInvariant(t, pool)
 
 			t.Logf("✓ Collected %s/%s (requested %s/%s, before owed %s/%s, after owed %s/%s)",
 				amount0, amount1,
@@ -1134,20 +1134,58 @@ func TestCollect(cur realm, t *testing.T) {
 			resetObject(cur, t)
 		})
 	}
+
+	t.Run("insufficient_internal_balance_caps_collect", func(cur realm, t *testing.T) {
+		pool := setupStablecoinPool(cur, t)
+		approveTokensForPool(cur, t, pool)
+		testing.SetRealm(posRealm)
+
+		mockInstanceMint(0, cur, pool.Token0Path(), pool.Token1Path(), pool.Fee(),
+			WIDE_RANGE_LOWER, WIDE_RANGE_UPPER, LARGE_LIQUIDITY, adminAddr)
+		mockInstanceBurn(0, cur, pool.Token0Path(), pool.Token1Path(), pool.Fee(),
+			WIDE_RANGE_LOWER, WIDE_RANGE_UPPER, MEDIUM_LIQUIDITY, adminAddr)
+
+		positionKey := getPositionKey(WIDE_RANGE_LOWER, WIDE_RANGE_UPPER)
+		positionBefore := mustGetPositionByPool(pool, positionKey)
+		owed0Before := positionBefore.TokensOwed0()
+		reducedBalance0 := int64(1)
+
+		pool.SetBalanceToken0(reducedBalance0)
+
+		amount0, amount1 := mockInstanceCollect(0, cur,
+			pool.Token0Path(), pool.Token1Path(), pool.Fee(),
+			adminAddr, WIDE_RANGE_LOWER, WIDE_RANGE_UPPER,
+			MAX_INT64, "0",
+		)
+
+		uassert.Equal(t, utils.FormatInt(reducedBalance0), amount0,
+			"Collect should cap amount0 by pool balance")
+		uassert.Equal(t, "0", amount1,
+			"Collect should not collect token1 when zero is requested")
+		uassert.Equal(t, int64(0), pool.BalanceToken0(),
+			"Pool balance0 should stop at zero")
+
+		positionAfter := mustGetPositionByPool(pool, positionKey)
+		expectedOwed0After := gnsmath.SafeSubInt64(owed0Before, reducedBalance0)
+		uassert.Equal(t, utils.FormatInt(expectedOwed0After), utils.FormatInt(positionAfter.TokensOwed0()),
+			"TokensOwed0 should only decrease by the capped collected amount")
+		uassert.True(t, positionAfter.TokensOwed0() > 0,
+			"Remaining TokensOwed0 should stay claimable after partial collect")
+		uassert.True(t, pool.BalanceToken0() >= 0,
+			"Pool balance0 must never become negative")
+
+		resetObject(cur, t)
+	})
 }
 
-// validateCollectInvariant validates pool balance >= tokensOwed invariant
-func validateCollectInvariant(t *testing.T, pool *pl.Pool, tickLower, tickUpper int32) {
+// validateCollectInvariant validates collect never stores negative pool balances.
+func validateCollectInvariant(t *testing.T, pool *pl.Pool) {
 	t.Helper()
-	positionKey := getPositionKey(tickLower, tickUpper)
-	position := mustGetPositionByPool(pool, positionKey)
 
-	uassert.True(t, pool.BalanceToken0() >= position.TokensOwed0(),
-		ufmt.Sprintf("Pool balance0 (%s) must be >= tokensOwed0 (%s)",
-			utils.FormatInt(pool.BalanceToken0()), utils.FormatInt(position.TokensOwed0())))
-	uassert.True(t, pool.BalanceToken1() >= position.TokensOwed1(),
-		ufmt.Sprintf("Pool balance1 (%s) must be >= tokensOwed1 (%s)",
-			utils.FormatInt(pool.BalanceToken1()), utils.FormatInt(position.TokensOwed1())))
+	uassert.True(t, pool.BalanceToken0() >= 0,
+		ufmt.Sprintf("Pool balance0 (%s) must be non-negative", utils.FormatInt(pool.BalanceToken0())))
+	uassert.True(t, pool.BalanceToken1() >= 0,
+		ufmt.Sprintf("Pool balance1 (%s) must be non-negative", utils.FormatInt(pool.BalanceToken1())))
 }
 
 func TestSwap_ZeroOutputAllowed(cur realm, t *testing.T) {

--- a/contract/r/scenario/position/position_collect_balance_cap_filetest.gno
+++ b/contract/r/scenario/position/position_collect_balance_cap_filetest.gno
@@ -128,7 +128,6 @@ func executeSwap(cur realm) {
 		true,
 		"10000000",
 		MIN_PRICE,
-		adminAddr,
 		func(cur realm, amount0Delta, amount1Delta int64, _ *pool.CallbackMarker) error {
 			return mockSwapCallback(cur, amount0Delta, amount1Delta)
 		},

--- a/contract/r/scenario/position/position_collect_balance_cap_filetest.gno
+++ b/contract/r/scenario/position/position_collect_balance_cap_filetest.gno
@@ -210,7 +210,7 @@ func mockSwapCallback(cur realm, amount0Delta int64, amount1Delta int64) error {
 //
 // [SCENARIO] 5. Decrease liquidity through capped Collect
 // [EXPECTED] Capped collect amount0 should be 1
-// [EXPECTED] BAR balance increase should be 1
+// [EXPECTED] BAR balance increase should be 2
 // [EXPECTED] Pool token0 balance should be 0
 // [EXPECTED] Remaining tokensOwed0 should stay claimable
 //

--- a/contract/r/scenario/position/position_collect_balance_cap_filetest.gno
+++ b/contract/r/scenario/position/position_collect_balance_cap_filetest.gno
@@ -63,8 +63,8 @@ func main(cur realm) {
 	upgradePool(cur)
 	println()
 
-	ufmt.Println("[SCENARIO] 5. Decrease liquidity through capped Collect")
-	decreaseLiquidityWithCappedCollect(cur)
+	ufmt.Println("[SCENARIO] 5. Decrease liquidity with reverting Collect")
+	decreaseLiquidityWithRevertingCollect(cur)
 	println()
 
 	ufmt.Println("[SCENARIO] 6. Restore pool implementation")
@@ -143,36 +143,48 @@ func upgradePool(cur realm) {
 	ufmt.Printf("[EXPECTED] Pool implementation should be %s\n", pool.GetImplementationPackagePath())
 }
 
-func decreaseLiquidityWithCappedCollect(cur realm) {
+func decreaseLiquidityWithRevertingCollect(cur realm) {
 	testing.SetRealm(adminRealm)
 	barBefore := bar.BalanceOf(adminAddr)
+	owed0Before := position.GetPositionTokensOwed0(1)
 
-	_, _, _, _, amount0, _, _ := position.DecreaseLiquidity(
-		cross(cur),
-		1,
-		"100000000",
-		"0",
-		"0",
-		time.Now().Unix()+3600,
-	)
+	// Internal balance is desynced low (forced to 1 by the test implementation)
+	// while tokensOwed0 is larger. The underlying Collect cannot pay, so the
+	// whole DecreaseLiquidity must revert instead of persisting a negative
+	// pool balance. revive catches the cross-realm abort.
+	r := revive(func() {
+		position.DecreaseLiquidity(
+			cross(cur),
+			1,
+			"100000000",
+			"0",
+			"0",
+			time.Now().Unix()+3600,
+		)
+	})
 
 	barAfter := bar.BalanceOf(adminAddr)
 	owed0After := position.GetPositionTokensOwed0(1)
 	poolBalance0 := pool.GetBalanceToken0(poolKey)
 
-	ufmt.Printf("[EXPECTED] Capped collect amount0 should be %s\n", amount0)
-	ufmt.Printf("[EXPECTED] BAR balance increase should be %d\n", barAfter-barBefore)
-	ufmt.Printf("[EXPECTED] Pool token0 balance should be %d\n", poolBalance0)
-	ufmt.Println("[EXPECTED] Remaining tokensOwed0 should stay claimable")
+	if r != nil {
+		ufmt.Printf("[INFO] DecreaseLiquidity aborted: %v\n", r)
+	} else {
+		println("[WARNING] DecreaseLiquidity did not abort (unexpected)")
+	}
 
-	if amount0 != "1" {
-		panic(ufmt.Sprintf("[ERROR] amount0 should be capped to 1, got %s", amount0))
+	ufmt.Printf("[INFO] BAR balance change: %d (unchanged)\n", barAfter-barBefore)
+	ufmt.Printf("[INFO] Pool token0 balance: %d (not negative)\n", poolBalance0)
+	ufmt.Printf("[INFO] tokensOwed0 unchanged: %v\n", owed0After == owed0Before)
+
+	if r == nil {
+		panic("[ERROR] DecreaseLiquidity should have reverted on insufficient internal balance")
 	}
 	if poolBalance0 < 0 {
 		panic(ufmt.Sprintf("[ERROR] pool token0 balance should not be negative, got %d", poolBalance0))
 	}
-	if owed0After <= 0 {
-		panic(ufmt.Sprintf("[ERROR] remaining tokensOwed0 should stay claimable, got %d", owed0After))
+	if owed0After != owed0Before {
+		panic(ufmt.Sprintf("[ERROR] tokensOwed0 should stay unchanged after revert, got %d", owed0After))
 	}
 }
 
@@ -208,11 +220,11 @@ func mockSwapCallback(cur realm, amount0Delta int64, amount1Delta int64) error {
 // [SCENARIO] 4. Upgrade to balance-cap test implementation
 // [EXPECTED] Pool implementation should be gno.land/r/gnoswap/pool/collect_balance_cap
 //
-// [SCENARIO] 5. Decrease liquidity through capped Collect
-// [EXPECTED] Capped collect amount0 should be 1
-// [EXPECTED] BAR balance increase should be 2
-// [EXPECTED] Pool token0 balance should be 0
-// [EXPECTED] Remaining tokensOwed0 should stay claimable
+// [SCENARIO] 5. Decrease liquidity with reverting Collect
+// [INFO] DecreaseLiquidity aborted: [GNOSWAP-POOL-021] balance update failed. cannot decrease, token0(1) - amount(29999)
+// [INFO] BAR balance change: 0 (unchanged)
+// [INFO] Pool token0 balance: 1 (not negative)
+// [INFO] tokensOwed0 unchanged: true
 //
 // [SCENARIO] 6. Restore pool implementation
 // [EXPECTED] Pool implementation should be gno.land/r/gnoswap/pool/v1

--- a/contract/r/scenario/position/position_collect_balance_cap_filetest.gno
+++ b/contract/r/scenario/position/position_collect_balance_cap_filetest.gno
@@ -1,0 +1,218 @@
+// position collect balance cap
+
+// PKGPATH: gno.land/r/demo/main
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"gno.land/p/gnoswap/gnsmath"
+	prbac "gno.land/p/gnoswap/rbac"
+	ufmt "gno.land/p/nt/ufmt/v0"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/common"
+	"gno.land/r/gnoswap/pool"
+	_ "gno.land/r/gnoswap/pool/collect_balance_cap"
+	_ "gno.land/r/gnoswap/pool/v1"
+	"gno.land/r/gnoswap/position"
+	_ "gno.land/r/gnoswap/position/v1"
+	_ "gno.land/r/gnoswap/protocol_fee/v1"
+	_ "gno.land/r/gnoswap/rbac"
+	_ "gno.land/r/gnoswap/staker/v1"
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/foo"
+)
+
+const (
+	INT64_MAX int64 = 9223372036854775807
+
+	MIN_PRICE string = "4295128740"
+
+	poolV1Path             = "gno.land/r/gnoswap/pool/v1"
+	poolCollectCapTestPath = "gno.land/r/gnoswap/pool/collect_balance_cap"
+)
+
+var (
+	adminAddr, _ = access.GetAddress(prbac.ROLE_ADMIN.String())
+	adminRealm   = testing.NewUserRealm(adminAddr)
+	poolAddr, _  = access.GetAddress(prbac.ROLE_POOL.String())
+
+	barPath = "gno.land/r/onbloc/bar.BAR"
+	fooPath = "gno.land/r/onbloc/foo.FOO"
+	fee     = uint32(3000)
+	poolKey = "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:3000"
+)
+
+func main(cur realm) {
+	ufmt.Println("[SCENARIO] 1. Initialize pool")
+	initPool(cur)
+	println()
+
+	ufmt.Println("[SCENARIO] 2. Mint position")
+	mintPosition(cur)
+	println()
+
+	ufmt.Println("[SCENARIO] 3. Swap to move price")
+	executeSwap(cur)
+	println()
+
+	ufmt.Println("[SCENARIO] 4. Upgrade to balance-cap test implementation")
+	upgradePool(cur)
+	println()
+
+	ufmt.Println("[SCENARIO] 5. Decrease liquidity through capped Collect")
+	decreaseLiquidityWithCappedCollect(cur)
+	println()
+
+	ufmt.Println("[SCENARIO] 6. Restore pool implementation")
+	restorePool(cur)
+}
+
+func initPool(cur realm) {
+	testing.SetRealm(adminRealm)
+	pool.UpgradeImpl(cross(cur), poolV1Path)
+	pool.SetPoolCreationFee(cross(cur), 0)
+
+	bar.Approve(cross(cur), poolAddr, INT64_MAX)
+	foo.Approve(cross(cur), poolAddr, INT64_MAX)
+
+	pool.CreatePool(
+		cross(cur),
+		barPath,
+		fooPath,
+		fee,
+		gnsmath.TickMathGetSqrtRatioAtTick(0).ToString(),
+	)
+	ufmt.Printf("[EXPECTED] Pool implementation should be %s\n", pool.GetImplementationPackagePath())
+}
+
+func mintPosition(cur realm) {
+	testing.SetRealm(adminRealm)
+	bar.Approve(cross(cur), poolAddr, INT64_MAX)
+	foo.Approve(cross(cur), poolAddr, INT64_MAX)
+
+	positionId, _, _, _ := position.Mint(
+		cross(cur),
+		barPath,
+		fooPath,
+		fee,
+		-960,
+		960,
+		"50000000",
+		"50000000",
+		"0",
+		"0",
+		time.Now().Unix()+3600,
+		adminAddr,
+		"",
+	)
+
+	ufmt.Printf("[EXPECTED] Position ID should be %d\n", positionId)
+}
+
+func executeSwap(cur realm) {
+	testing.SetRealm(adminRealm)
+	bar.Approve(cross(cur), poolAddr, INT64_MAX)
+	foo.Approve(cross(cur), poolAddr, INT64_MAX)
+
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/router"))
+	pool.Swap(
+		cross(cur),
+		barPath,
+		fooPath,
+		fee,
+		adminAddr,
+		true,
+		"10000000",
+		MIN_PRICE,
+		adminAddr,
+		func(cur realm, amount0Delta, amount1Delta int64, _ *pool.CallbackMarker) error {
+			return mockSwapCallback(cur, amount0Delta, amount1Delta)
+		},
+	)
+
+	ufmt.Println("[EXPECTED] Swap should succeed")
+}
+
+func upgradePool(cur realm) {
+	testing.SetRealm(adminRealm)
+	pool.UpgradeImpl(cross(cur), poolCollectCapTestPath)
+	ufmt.Printf("[EXPECTED] Pool implementation should be %s\n", pool.GetImplementationPackagePath())
+}
+
+func decreaseLiquidityWithCappedCollect(cur realm) {
+	testing.SetRealm(adminRealm)
+	barBefore := bar.BalanceOf(adminAddr)
+
+	_, _, _, _, amount0, _, _ := position.DecreaseLiquidity(
+		cross(cur),
+		1,
+		"100000000",
+		"0",
+		"0",
+		time.Now().Unix()+3600,
+	)
+
+	barAfter := bar.BalanceOf(adminAddr)
+	owed0After := position.GetPositionTokensOwed0(1)
+	poolBalance0 := pool.GetBalanceToken0(poolKey)
+
+	ufmt.Printf("[EXPECTED] Capped collect amount0 should be %s\n", amount0)
+	ufmt.Printf("[EXPECTED] BAR balance increase should be %d\n", barAfter-barBefore)
+	ufmt.Printf("[EXPECTED] Pool token0 balance should be %d\n", poolBalance0)
+	ufmt.Println("[EXPECTED] Remaining tokensOwed0 should stay claimable")
+
+	if amount0 != "1" {
+		panic(ufmt.Sprintf("[ERROR] amount0 should be capped to 1, got %s", amount0))
+	}
+	if poolBalance0 < 0 {
+		panic(ufmt.Sprintf("[ERROR] pool token0 balance should not be negative, got %d", poolBalance0))
+	}
+	if owed0After <= 0 {
+		panic(ufmt.Sprintf("[ERROR] remaining tokensOwed0 should stay claimable, got %d", owed0After))
+	}
+}
+
+func restorePool(cur realm) {
+	testing.SetRealm(adminRealm)
+	pool.UpgradeImpl(cross(cur), poolV1Path)
+	ufmt.Printf("[EXPECTED] Pool implementation should be %s\n", pool.GetImplementationPackagePath())
+}
+
+func mockSwapCallback(cur realm, amount0Delta int64, amount1Delta int64) error {
+	testing.SetRealm(adminRealm)
+
+	if amount0Delta > 0 {
+		common.SafeGRC20Transfer(cross(cur), barPath, poolAddr, amount0Delta)
+	}
+	if amount1Delta > 0 {
+		common.SafeGRC20Transfer(cross(cur), fooPath, poolAddr, amount1Delta)
+	}
+
+	return nil
+}
+
+// Output:
+// [SCENARIO] 1. Initialize pool
+// [EXPECTED] Pool implementation should be gno.land/r/gnoswap/pool/v1
+//
+// [SCENARIO] 2. Mint position
+// [EXPECTED] Position ID should be 1
+//
+// [SCENARIO] 3. Swap to move price
+// [EXPECTED] Swap should succeed
+//
+// [SCENARIO] 4. Upgrade to balance-cap test implementation
+// [EXPECTED] Pool implementation should be gno.land/r/gnoswap/pool/collect_balance_cap
+//
+// [SCENARIO] 5. Decrease liquidity through capped Collect
+// [EXPECTED] Capped collect amount0 should be 1
+// [EXPECTED] BAR balance increase should be 1
+// [EXPECTED] Pool token0 balance should be 0
+// [EXPECTED] Remaining tokensOwed0 should stay claimable
+//
+// [SCENARIO] 6. Restore pool implementation
+// [EXPECTED] Pool implementation should be gno.land/r/gnoswap/pool/v1

--- a/contract/r/scenario/upgrade/implements/collect_balance_cap/pool/gnomod.toml
+++ b/contract/r/scenario/upgrade/implements/collect_balance_cap/pool/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/r/gnoswap/pool/collect_balance_cap"
+gno = "0.9"

--- a/contract/r/scenario/upgrade/implements/collect_balance_cap/pool/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/collect_balance_cap/pool/test_impl.gno
@@ -1,0 +1,47 @@
+package collect_balance_cap
+
+import (
+	pool "gno.land/r/gnoswap/pool"
+	v1 "gno.land/r/gnoswap/pool/v1"
+)
+
+type testPool struct {
+	pool.IPool
+	store pool.IPoolStore
+}
+
+func init(cur realm) {
+	pool.RegisterInitializer(cross(cur), func(_ int, rlm realm, store pool.IPoolStore) pool.IPool {
+		return &testPool{
+			IPool: v1.NewPoolV1(store),
+			store: store,
+		}
+	})
+}
+
+func (t *testPool) Collect(
+	_ int,
+	rlm realm,
+	token0Path string,
+	token1Path string,
+	fee uint32,
+	recipient address,
+	tickLower int32,
+	tickUpper int32,
+	amount0Requested string,
+	amount1Requested string,
+) (string, string) {
+	t.capToken0Balance(0, rlm, token0Path, token1Path, fee)
+	return t.IPool.Collect(0, rlm, token0Path, token1Path, fee, recipient, tickLower, tickUpper, amount0Requested, amount1Requested)
+}
+
+func (t *testPool) capToken0Balance(_ int, rlm realm, token0Path, token1Path string, fee uint32) {
+	pools := t.store.GetPools()
+	poolPath := pool.GetPoolPath(token0Path, token1Path, fee)
+	storedPool := pools.Get(poolPath).(*pool.Pool)
+	storedPool.SetBalanceToken0(1)
+	pools.Set(poolPath, storedPool)
+	if err := t.store.SetPools(0, rlm, pools); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
## Summary

- Cap `PoolV1.Collect` by the minimum of requested amount, position tokens owed, and the pool's internal token balance.
- Reject already-negative internal balances before collection, and route balance subtraction through `updatePoolBalance` so `Collect` cannot persist a negative pool balance.
- Preserve any uncollected `tokensOwed` amount as claimable when the internal balance is insufficient.

## Tests

- Added a unit regression for insufficient internal token0 balance during `Collect`.
- Added a scenario filetest that uses a scenario-only pool implementation fixture to force token0 internal balance down to `1`, then drives `position.DecreaseLiquidity` through the capped `Collect` path.
- Updated the scenario golden output for the actual `DecreaseLiquidity` flow: the leading fee collection and the burn collection each receive the capped `1`, so the total BAR balance increase is `2` while the returned burn collect amount remains `1`.

## Verification

- `git diff --check`
- CI rerun is in progress for `ad939e1e`.
- Local `gno test -v .` in `contract/r/scenario/position` is still blocked by unavailable local Gno dependencies including `gno.land/p/demo/tokens/grc721`, `gno.land/p/nt/bptree/v0`, and `gno.land/p/onbloc/json`.