### PR TITLE
fix(gnft): harden token URI and approval handling

### DIFF
--- a/contract/r/gnoswap/gnft/assert.gno
+++ b/contract/r/gnoswap/gnft/assert.gno
@@ -15,6 +15,13 @@ func assertIsValidTokenURI(tid grc721.TokenID) {
 	}
 }
 
+// assertIsNonEmptyTokenURI panics if the new URI is empty.
+func assertIsNonEmptyTokenURI(tURI grc721.TokenURI) {
+	if string(tURI) == "" {
+		panic(makeErrorWithDetails(errCannotSetURI, "empty token URI"))
+	}
+}
+
 // assertIsValidAddress panics if the address is invalid.
 func assertIsValidAddress(addr address) {
 	if !addr.IsValid() {

--- a/contract/r/gnoswap/gnft/gnft.gno
+++ b/contract/r/gnoswap/gnft/gnft.gno
@@ -80,6 +80,7 @@ func SetTokenURI(cur realm, tid grc721.TokenID, tURI grc721.TokenURI) (bool, err
 	caller := cur.Previous().Address()
 	access.AssertIsPosition(caller)
 
+	assertIsNonEmptyTokenURI(tURI)
 	assertIsValidTokenURI(tid)
 
 	checkErr(setTokenURI(0, cur, tid, tURI))

--- a/contract/r/gnoswap/gnft/gnft.gno
+++ b/contract/r/gnoswap/gnft/gnft.gno
@@ -152,7 +152,7 @@ func Approve(cur realm, approved address, tid grc721.TokenID) error {
 
 	caller := cur.Previous().Address()
 	err := nft.Approve(caller, approved, tid)
-	checkApproveErr(err, caller, approved)
+	checkApproveErr(err, caller, approved, tid)
 	return nil
 }
 

--- a/contract/r/gnoswap/gnft/gnft.gno
+++ b/contract/r/gnoswap/gnft/gnft.gno
@@ -44,7 +44,7 @@ func TokenURI(tid grc721.TokenID) (string, error) {
 
 	params, err := parseImageParams(stored)
 	if err == nil {
-		return params.generateImageURI(), nil
+		return params.generateImageURI(tid), nil
 	}
 
 	return stored, nil

--- a/contract/r/gnoswap/gnft/gnft.gno
+++ b/contract/r/gnoswap/gnft/gnft.gno
@@ -152,7 +152,7 @@ func Approve(cur realm, approved address, tid grc721.TokenID) error {
 
 	caller := cur.Previous().Address()
 	err := nft.Approve(caller, approved, tid)
-	checkApproveErr(err, caller, approved, tid)
+	checkApproveErr(err, caller, approved)
 	return nil
 }
 

--- a/contract/r/gnoswap/gnft/gnft_test.gno
+++ b/contract/r/gnoswap/gnft/gnft_test.gno
@@ -1180,7 +1180,7 @@ func TestApprove(cur realm, t *testing.T) {
 			approved:    testutils.TestAddress("addr03"),
 			tokenId:     1,
 			shouldPanic: true,
-			panicMsg:    "[GNOSWAP-GNFT-003] caller is not token owner or approved || caller g1v9jxgu3sxf047h6lta047h6lta047h6l8tv5at cannot approve for token 1 owned by g1v9jxgu3sx9047h6lta047h6lta047h6l0js7st",
+			panicMsg:    "[GNOSWAP-GNFT-003] caller is not token owner or approved || caller g1v9jxgu3sxf047h6lta047h6lta047h6l8tv5at cannot approve",
 		},
 		{
 			name:        "approve for non-existent token",
@@ -1188,7 +1188,7 @@ func TestApprove(cur realm, t *testing.T) {
 			approved:    addr02,
 			tokenId:     999,
 			shouldPanic: true,
-			panicMsg:    "[GNOSWAP-GNFT-004] token does not exist || token 999",
+			panicMsg:    "[GNOSWAP-GNFT-004] token does not exist",
 		},
 		{
 			name:        "approve self",
@@ -1196,7 +1196,7 @@ func TestApprove(cur realm, t *testing.T) {
 			approved:    addr01,
 			tokenId:     1,
 			shouldPanic: true,
-			panicMsg:    "[GNOSWAP-GNFT-005] cannot transfer to self || cannot approve to current owner g1v9jxgu3sx9047h6lta047h6lta047h6l0js7st for token 1",
+			panicMsg:    "[GNOSWAP-GNFT-005] cannot transfer to self || cannot approve to current owner g1v9jxgu3sx9047h6lta047h6lta047h6l0js7st",
 		},
 		{
 			name:        "approve invalid address",
@@ -1241,6 +1241,15 @@ func TestApprove(cur realm, t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestApproveInvalidTokenIDOmitsTokenID(cur realm, t *testing.T) {
+	resetObject(cur, t)
+	testing.SetRealm(addr01Realm)
+
+	uassert.AbortsWithMessage(t, cur, "[GNOSWAP-GNFT-004] token does not exist", func() {
+		Approve(cross(cur), addr02, grc721.TokenID(strings.Repeat("9", 1024)))
+	})
 }
 
 func Test_setTokenURI(cur realm, t *testing.T) {
@@ -1367,7 +1376,6 @@ func Test_setTokenURI(cur realm, t *testing.T) {
 			if tc.setup != nil {
 				tc.setup(cur)
 			}
-
 
 			// when
 			testing.SetRealm(testing.NewUserRealm(tc.ownerAddr))

--- a/contract/r/gnoswap/gnft/gnft_test.gno
+++ b/contract/r/gnoswap/gnft/gnft_test.gno
@@ -460,6 +460,16 @@ func TestSetTokenURI(cur realm, t *testing.T) {
 	}
 }
 
+func TestSetTokenURIRejectsEmptyURI(cur realm, t *testing.T) {
+	resetObject(cur, t)
+	testing.SetRealm(positionRealm)
+	checkErr(nft.Mint(positionAddr, tid(1)))
+
+	uassert.AbortsWithMessage(t, cur, "[GNOSWAP-GNFT-001] cannot set URI || empty token URI", func() {
+		SetTokenURI(cross(cur), tid(1), grc721.TokenURI(""))
+	})
+}
+
 func TestGetApproved(cur realm, t *testing.T) {
 	resetObject(cur, t)
 	testing.SetRealm(positionRealm)

--- a/contract/r/gnoswap/gnft/gnft_test.gno
+++ b/contract/r/gnoswap/gnft/gnft_test.gno
@@ -1180,7 +1180,7 @@ func TestApprove(cur realm, t *testing.T) {
 			approved:    testutils.TestAddress("addr03"),
 			tokenId:     1,
 			shouldPanic: true,
-			panicMsg:    "[GNOSWAP-GNFT-003] caller is not token owner or approved || caller g1v9jxgu3sxf047h6lta047h6lta047h6l8tv5at cannot approve",
+			panicMsg:    "[GNOSWAP-GNFT-003] caller is not token owner or approved || caller g1v9jxgu3sxf047h6lta047h6lta047h6l8tv5at cannot approve for token 1 owned by g1v9jxgu3sx9047h6lta047h6lta047h6l0js7st",
 		},
 		{
 			name:        "approve for non-existent token",
@@ -1196,7 +1196,7 @@ func TestApprove(cur realm, t *testing.T) {
 			approved:    addr01,
 			tokenId:     1,
 			shouldPanic: true,
-			panicMsg:    "[GNOSWAP-GNFT-005] cannot transfer to self || cannot approve to current owner g1v9jxgu3sx9047h6lta047h6lta047h6l0js7st",
+			panicMsg:    "[GNOSWAP-GNFT-005] cannot transfer to self || cannot approve to current owner g1v9jxgu3sx9047h6lta047h6lta047h6l0js7st for token 1",
 		},
 		{
 			name:        "approve invalid address",

--- a/contract/r/gnoswap/gnft/gnft_test.gno
+++ b/contract/r/gnoswap/gnft/gnft_test.gno
@@ -1180,7 +1180,7 @@ func TestApprove(cur realm, t *testing.T) {
 			approved:    testutils.TestAddress("addr03"),
 			tokenId:     1,
 			shouldPanic: true,
-			panicMsg:    "[GNOSWAP-GNFT-003] caller is not token owner or approved || caller g1v9jxgu3sxf047h6lta047h6lta047h6l8tv5at cannot approve for token 1 owned by g1v9jxgu3sx9047h6lta047h6lta047h6l0js7st",
+			panicMsg:    "[GNOSWAP-GNFT-003] caller is not token owner or approved || caller g1v9jxgu3sxf047h6lta047h6lta047h6l8tv5at cannot approve for token 1",
 		},
 		{
 			name:        "approve for non-existent token",

--- a/contract/r/gnoswap/gnft/gnft_test.gno
+++ b/contract/r/gnoswap/gnft/gnft_test.gno
@@ -1180,7 +1180,7 @@ func TestApprove(cur realm, t *testing.T) {
 			approved:    testutils.TestAddress("addr03"),
 			tokenId:     1,
 			shouldPanic: true,
-			panicMsg:    "[GNOSWAP-GNFT-003] caller is not token owner or approved || caller g1v9jxgu3sxf047h6lta047h6lta047h6l8tv5at cannot approve for token 1",
+			panicMsg:    "[GNOSWAP-GNFT-003] caller is not token owner or approved || caller g1v9jxgu3sxf047h6lta047h6lta047h6l8tv5at cannot approve for token 1 owned by g1v9jxgu3sx9047h6lta047h6lta047h6l0js7st",
 		},
 		{
 			name:        "approve for non-existent token",
@@ -1188,7 +1188,7 @@ func TestApprove(cur realm, t *testing.T) {
 			approved:    addr02,
 			tokenId:     999,
 			shouldPanic: true,
-			panicMsg:    "[GNOSWAP-GNFT-004] token does not exist",
+			panicMsg:    "[GNOSWAP-GNFT-004] token does not exist || token 999",
 		},
 		{
 			name:        "approve self",
@@ -1243,12 +1243,13 @@ func TestApprove(cur realm, t *testing.T) {
 	}
 }
 
-func TestApproveInvalidTokenIDOmitsTokenID(cur realm, t *testing.T) {
+func TestApproveInvalidTokenIDIncludesTokenID(cur realm, t *testing.T) {
 	resetObject(cur, t)
 	testing.SetRealm(addr01Realm)
+	longTid := grc721.TokenID(strings.Repeat("9", 1024))
 
-	uassert.AbortsWithMessage(t, cur, "[GNOSWAP-GNFT-004] token does not exist", func() {
-		Approve(cross(cur), addr02, grc721.TokenID(strings.Repeat("9", 1024)))
+	uassert.AbortsWithMessage(t, cur, errTokenNotExists+" || token "+string(longTid), func() {
+		Approve(cross(cur), addr02, longTid)
 	})
 }
 

--- a/contract/r/gnoswap/gnft/gnft_test.gno
+++ b/contract/r/gnoswap/gnft/gnft_test.gno
@@ -2,6 +2,7 @@ package gnft
 
 import (
 	"chain/runtime"
+	b64 "encoding/base64"
 	"strings"
 	"testing"
 
@@ -903,6 +904,14 @@ func TestTokenURI(cur realm, t *testing.T) {
 				uassert.NoError(t, err)
 				uassert.NotEmpty(t, uri)
 				uassert.True(t, strings.HasPrefix(uri, "data:image/svg+xml;base64,"))
+
+				decoded, err := b64.StdEncoding.DecodeString(strings.TrimPrefix(uri, "data:image/svg+xml;base64,"))
+				uassert.NoError(t, err)
+				decodedStr := string(decoded)
+				uassert.True(t, strings.Contains(decodedStr, `fill="url(#paint0_linear_gnft_1)"`))
+				uassert.True(t, strings.Contains(decodedStr, `id="paint0_linear_gnft_1"`))
+				uassert.True(t, strings.Contains(decodedStr, `clip-path="url(#clip0_gnft_1)"`))
+				uassert.True(t, strings.Contains(decodedStr, `id="clip0_gnft_1"`))
 			}
 		})
 	}

--- a/contract/r/gnoswap/gnft/svg_generator.gno
+++ b/contract/r/gnoswap/gnft/svg_generator.gno
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"gno.land/p/demo/tokens/grc721"
 	ufmt "gno.land/p/nt/ufmt/v0"
 )
 
@@ -32,12 +33,16 @@ import (
 //	</svg>
 
 // svgTemplate holds pre-split template parts for efficient concatenation.
-// Usage: svgTemplate[0] + x1 + svgTemplate[1] + y1 + ... + color2 + svgTemplate[6]
-var svgTemplate = [7]string{
-	// [0] SVG header and body (before x1)
+// Usage: svgTemplate[0] + clipID + svgTemplate[1] + paintID + ... + color2 + svgTemplate[10]
+var svgTemplate = [11]string{
+	// [0] SVG header and body (before clip-path id)
 	`<svg width="135" height="135" viewBox="0 0 135 135" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_7698_56846)">
-<circle cx="67.5" cy="67.5" r="67.5" fill="url(#paint0_linear_7698_56846)"/>
+<g clip-path="url(#`,
+	// [1] between clip-path id and fill id
+	`)">
+<circle cx="67.5" cy="67.5" r="67.5" fill="url(#`,
+	// [2] between fill id and gradient id
+	`)"/>
 <path d="M51.2905 42.9449L66.4895 33L97 52.8061L81.8241 62.7425L51.2905 42.9449Z" fill="white"/>
 <path d="M51.6055 67.5059L66.8044 57.561L97 77.0657L82.1046 87.1793L51.6055 67.5059Z" fill="white" fill-opacity="0.4"/>
 <path d="M36.0464 81.7559L51.2905 71.811L81.7336 91.6547L66.4895 101.508L36.0464 81.7559Z" fill="white" fill-opacity="0.6"/>
@@ -45,23 +50,27 @@ var svgTemplate = [7]string{
 <path d="M82.1051 87.1797L97.0016 77.0662L97.0016 81.7029L81.7896 91.629L82.1051 87.1797Z" fill="white" fill-opacity="0.5"/>
 </g>
 <defs>
-<linearGradient id="paint0_linear_7698_56846" x1="`,
-	// [1] between x1 and y1
+<linearGradient id="`,
+	// [3] between gradient id and x1
+	`" x1="`,
+	// [4] between x1 and y1
 	`" y1="`,
-	// [2] between y1 and x2
+	// [5] between y1 and x2
 	`" x2="`,
-	// [3] between x2 and y2
+	// [6] between x2 and y2
 	`" y2="`,
-	// [4] between y2 and color1
+	// [7] between y2 and color1
 	`" gradientUnits="userSpaceOnUse">
 <stop stop-color="`,
-	// [5] between color1 and color2
+	// [8] between color1 and color2
 	`"/>
 <stop offset="1" stop-color="`,
-	// [6] SVG footer (after color2)
+	// [9] between color2 and clipPath id
 	`"/>
 </linearGradient>
-<clipPath id="clip0_7698_56846">
+<clipPath id="`,
+	// [10] SVG footer (after clipPath id)
+	`">
 <rect width="135" height="135" fill="white"/>
 </clipPath>
 </defs>
@@ -192,18 +201,27 @@ func parseImageParams(s string) (*ImageParams, error) {
 }
 
 // generateImageURI converts parsed image parameters to a base64-encoded SVG image URI.
-func (params ImageParams) generateImageURI() string {
-	svg := params.generateSVG()
+func (params ImageParams) generateImageURI(tid grc721.TokenID) string {
+	svg := params.generateSVG(tid)
 	sEnc := b64.StdEncoding.EncodeToString([]byte(svg))
 
 	return "data:image/svg+xml;base64," + sEnc
 }
 
 // generateSVG generates SVG image from parsed and validated parameters.
-func (params ImageParams) generateSVG() string {
-	return svgTemplate[0] + strconv.Itoa(params.x1) + svgTemplate[1] + strconv.Itoa(params.y1) +
-		svgTemplate[2] + strconv.Itoa(params.x2) + svgTemplate[3] + strconv.Itoa(params.y2) +
-		svgTemplate[4] + params.color1 + svgTemplate[5] + params.color2 + svgTemplate[6]
+func (params ImageParams) generateSVG(tid grc721.TokenID) string {
+	suffix := svgIDSuffix(tid)
+	paintID := "paint0_linear_" + suffix
+	clipID := "clip0_" + suffix
+	return svgTemplate[0] + clipID + svgTemplate[1] + paintID + svgTemplate[2] + paintID +
+		svgTemplate[3] + strconv.Itoa(params.x1) + svgTemplate[4] + strconv.Itoa(params.y1) +
+		svgTemplate[5] + strconv.Itoa(params.x2) + svgTemplate[6] + strconv.Itoa(params.y2) +
+		svgTemplate[7] + params.color1 + svgTemplate[8] + params.color2 + svgTemplate[9] +
+		clipID + svgTemplate[10]
+}
+
+func svgIDSuffix(tid grc721.TokenID) string {
+	return "gnft_" + string(tid)
 }
 
 // isValidHexColor checks if a string is a valid hex color in #XXXXXX format.

--- a/contract/r/gnoswap/gnft/svg_generator_test.gno
+++ b/contract/r/gnoswap/gnft/svg_generator_test.gno
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"gno.land/p/demo/tokens/grc721"
 	uassert "gno.land/p/nt/uassert/v0"
 )
 
@@ -56,7 +57,7 @@ func TestSvgGenerator_generateImageURI(cur realm, t *testing.T) {
 
 			var uri string
 			uassert.NotPanics(t, cur, func() {
-				uri = params.generateImageURI()
+				uri = params.generateImageURI(tid(1))
 			})
 
 			// Verify URI prefix
@@ -103,7 +104,7 @@ func TestSvgGenerator_generateSVG(cur realm, t *testing.T) {
 			uassert.NoError(t, err)
 
 			// Generate SVG
-			svg := p.generateSVG()
+			svg := p.generateSVG(tid(1))
 
 			// Verify SVG structure
 			uassert.True(t, strings.Contains(svg, "<svg"))
@@ -115,11 +116,30 @@ func TestSvgGenerator_generateSVG(cur realm, t *testing.T) {
 	}
 }
 
+func TestSvgGenerator_generateSVG_TokenScopedIDs(cur realm, t *testing.T) {
+	params, err := parseImageParams("10,12,125,123,#AABBCC,#DDEEFF")
+	uassert.NoError(t, err)
+
+	svg1 := params.generateSVG(tid(1))
+	svg2 := params.generateSVG(tid(2))
+
+	uassert.True(t, strings.Contains(svg1, `fill="url(#paint0_linear_gnft_1)"`))
+	uassert.True(t, strings.Contains(svg1, `id="paint0_linear_gnft_1"`))
+	uassert.True(t, strings.Contains(svg1, `clip-path="url(#clip0_gnft_1)"`))
+	uassert.True(t, strings.Contains(svg1, `id="clip0_gnft_1"`))
+	uassert.True(t, strings.Contains(svg2, `fill="url(#paint0_linear_gnft_2)"`))
+	uassert.True(t, strings.Contains(svg2, `id="paint0_linear_gnft_2"`))
+	uassert.True(t, strings.Contains(svg2, `clip-path="url(#clip0_gnft_2)"`))
+	uassert.True(t, strings.Contains(svg2, `id="clip0_gnft_2"`))
+	uassert.False(t, strings.Contains(svg1, `id="paint0_linear_gnft_2"`))
+	uassert.False(t, strings.Contains(svg2, `id="paint0_linear_gnft_1"`))
+}
+
 func TestSvgGenerator_paramsToImageRaw_ColorFormat(cur realm, t *testing.T) {
 	params := "10,12,125,123,#AABBCC,#DDEEFF"
 	p, err := parseImageParams(params)
 	uassert.NoError(t, err)
-	svg := p.generateSVG()
+	svg := p.generateSVG(tid(1))
 
 	// Extract colors from stop-color attributes
 	// Should find two colors in #XXXXXX format
@@ -183,7 +203,7 @@ func TestSvgGenerator_paramsToImageRaw_CoordinateRanges(cur realm, t *testing.T)
 		t.Run(tc.name, func(cur realm, t *testing.T) {
 			p, err := parseImageParams(tc.params)
 			uassert.NoError(t, err)
-			svg := p.generateSVG()
+			svg := p.generateSVG(tid(1))
 
 			// Verify SVG contains linearGradient with coordinates
 			uassert.True(t, strings.Contains(svg, "linearGradient"))
@@ -226,7 +246,7 @@ func TestSvgGenerator_genImageParamsString_CoordinateRanges(cur realm, t *testin
 				params := genImageParamsString(r)
 				p, err := parseImageParams(params)
 				uassert.NoError(t, err)
-				svg := p.generateSVG()
+				svg := p.generateSVG(tid(1))
 
 				// Extract and validate coordinate values
 				x1, y1, x2, y2 := extractCoordinates(t, svg)
@@ -278,7 +298,7 @@ func TestSvgGenerator_roundTrip(cur realm, t *testing.T) {
 			uassert.NoError(t, err)
 
 			// Convert to URI
-			uri := params.generateImageURI()
+			uri := params.generateImageURI(tid(1))
 
 			// Verify URI is valid base64-encoded SVG
 			uassert.True(t, strings.HasPrefix(uri, "data:image/svg+xml;base64,"))
@@ -387,7 +407,7 @@ func TestSvgGenerator_outputConsistency(cur realm, t *testing.T) {
 			// Generate using old method (simulated)
 			pcg1 := rand.NewPCG(tc.seed1, tc.seed2)
 			r1 := rand.New(pcg1)
-			oldSVG := genImageRawDirect(r1)
+			oldSVG := genImageRawDirect(r1, tid(1))
 
 			// Generate using new method (params -> SVG)
 			pcg2 := rand.NewPCG(tc.seed1, tc.seed2)
@@ -395,7 +415,7 @@ func TestSvgGenerator_outputConsistency(cur realm, t *testing.T) {
 			params := genImageParamsString(r2)
 			p, err := parseImageParams(params)
 			uassert.NoError(t, err)
-			newSVG := p.generateSVG()
+			newSVG := p.generateSVG(tid(1))
 
 			// Both should produce identical output
 			uassert.Equal(t, oldSVG, newSVG)
@@ -405,7 +425,7 @@ func TestSvgGenerator_outputConsistency(cur realm, t *testing.T) {
 
 // genImageRawDirect simulates the old direct SVG generation for comparison.
 // This is the original logic before optimization, using the same concatenation approach.
-func genImageRawDirect(r *rand.Rand) string {
+func genImageRawDirect(r *rand.Rand, tid grc721.TokenID) string {
 	x1 := x1Min + r.Uint64N(x1Max-x1Min+1)
 	y1 := y1Min + r.Uint64N(y1Max-y1Min+1)
 	x2 := x2Min + r.Uint64N(x2Max-x2Min+1)
@@ -422,9 +442,14 @@ func genImageRawDirect(r *rand.Rand) string {
 		color2.WriteByte(charset[r.IntN(16)])
 	}
 
-	return svgTemplate[0] + itoa(int(x1)) + svgTemplate[1] + itoa(int(y1)) +
-		svgTemplate[2] + itoa(int(x2)) + svgTemplate[3] + itoa(int(y2)) +
-		svgTemplate[4] + color1.String() + svgTemplate[5] + color2.String() + svgTemplate[6]
+	suffix := svgIDSuffix(tid)
+	paintID := "paint0_linear_" + suffix
+	clipID := "clip0_" + suffix
+	return svgTemplate[0] + clipID + svgTemplate[1] + paintID + svgTemplate[2] + paintID +
+		svgTemplate[3] + itoa(int(x1)) + svgTemplate[4] + itoa(int(y1)) +
+		svgTemplate[5] + itoa(int(x2)) + svgTemplate[6] + itoa(int(y2)) +
+		svgTemplate[7] + color1.String() + svgTemplate[8] + color2.String() + svgTemplate[9] +
+		clipID + svgTemplate[10]
 }
 
 // itoa converts int to string (simple implementation for test)
@@ -508,7 +533,7 @@ func TestSvgGenerator_boundaryValues(cur realm, t *testing.T) {
 				p, err := parseImageParams(tc.params)
 				uassert.NoError(t, err)
 				uassert.NotPanics(t, cur, func() {
-					p.generateSVG()
+					p.generateSVG(tid(1))
 				})
 			}
 		})
@@ -774,7 +799,7 @@ func TestSvgGenerator_genImageParamsString_alwaysProducesValidOutput(cur realm, 
 
 		// Should never panic
 		uassert.NotPanics(t, cur, func() {
-			svg := p.generateSVG()
+			svg := p.generateSVG(tid(1))
 			// Verify basic SVG structure
 			uassert.True(t, strings.Contains(svg, "<svg"))
 			uassert.True(t, strings.Contains(svg, "</svg>"))

--- a/contract/r/gnoswap/gnft/utils.gno
+++ b/contract/r/gnoswap/gnft/utils.gno
@@ -79,9 +79,7 @@ func checkApproveErr(err error, caller, approved address, tid grc721.TokenID) {
 		panic(errTokenNotExists)
 
 	case errMsg == grc721.ErrCallerIsNotOwnerOrApproved.Error():
-		owner, ownerErr := nft.OwnerOf(tid)
-		checkErr(ownerErr)
-		panic(makeErrorWithDetails(errNotOwnerOrApproved, ufmt.Sprintf("caller %s cannot approve for token %s owned by %s", caller, string(tid), owner)))
+		panic(makeErrorWithDetails(errNotOwnerOrApproved, ufmt.Sprintf("caller %s cannot approve for token %s", caller, string(tid))))
 
 	case errMsg == grc721.ErrApprovalToCurrentOwner.Error():
 		panic(makeErrorWithDetails(errTransferToSelf, ufmt.Sprintf("cannot approve to current owner %s for token %s", approved, string(tid))))

--- a/contract/r/gnoswap/gnft/utils.gno
+++ b/contract/r/gnoswap/gnft/utils.gno
@@ -67,25 +67,22 @@ func checkTransferErr(err error, caller, from, to address, tid grc721.TokenID) {
 }
 
 // checkApproveErr wraps approve errors with more specific context.
-func checkApproveErr(err error, caller, approved address, tid grc721.TokenID) {
+func checkApproveErr(err error, caller, approved address) {
 	if err == nil {
 		return
 	}
 
 	errMsg := err.Error()
 
-	// Check if token exists
-	owner, ownerErr := nft.OwnerOf(tid)
-	if ownerErr != nil {
-		panic(makeErrorWithDetails(errTokenNotExists, ufmt.Sprintf("token %s", string(tid))))
-	}
-
 	switch {
+	case errMsg == "invalid token id":
+		panic(errTokenNotExists)
+
 	case errMsg == "caller is not token owner or approved":
-		panic(makeErrorWithDetails(errNotOwnerOrApproved, ufmt.Sprintf("caller %s cannot approve for token %s owned by %s", caller, string(tid), owner)))
+		panic(makeErrorWithDetails(errNotOwnerOrApproved, ufmt.Sprintf("caller %s cannot approve", caller)))
 
 	case errMsg == "approval to current owner":
-		panic(makeErrorWithDetails(errTransferToSelf, ufmt.Sprintf("cannot approve to current owner %s for token %s", approved, string(tid))))
+		panic(makeErrorWithDetails(errTransferToSelf, ufmt.Sprintf("cannot approve to current owner %s", approved)))
 
 	default:
 		panic(err.Error())

--- a/contract/r/gnoswap/gnft/utils.gno
+++ b/contract/r/gnoswap/gnft/utils.gno
@@ -1,6 +1,7 @@
 package gnft
 
 import (
+	"errors"
 	"math/rand"
 	"time"
 
@@ -72,18 +73,16 @@ func checkApproveErr(err error, caller, approved address, tid grc721.TokenID) {
 		return
 	}
 
-	errMsg := err.Error()
-
 	switch {
-	case errMsg == grc721.ErrInvalidTokenId.Error():
+	case errors.Is(err, grc721.ErrInvalidTokenId):
 		panic(makeErrorWithDetails(errTokenNotExists, ufmt.Sprintf("token %s", string(tid))))
 
-	case errMsg == grc721.ErrCallerIsNotOwnerOrApproved.Error():
+	case errors.Is(err, grc721.ErrCallerIsNotOwnerOrApproved):
 		owner, ownerErr := nft.OwnerOf(tid)
 		checkErr(ownerErr)
 		panic(makeErrorWithDetails(errNotOwnerOrApproved, ufmt.Sprintf("caller %s cannot approve for token %s owned by %s", caller, string(tid), owner)))
 
-	case errMsg == grc721.ErrApprovalToCurrentOwner.Error():
+	case errors.Is(err, grc721.ErrApprovalToCurrentOwner):
 		panic(makeErrorWithDetails(errTransferToSelf, ufmt.Sprintf("cannot approve to current owner %s for token %s", approved, string(tid))))
 
 	default:

--- a/contract/r/gnoswap/gnft/utils.gno
+++ b/contract/r/gnoswap/gnft/utils.gno
@@ -76,10 +76,12 @@ func checkApproveErr(err error, caller, approved address, tid grc721.TokenID) {
 
 	switch {
 	case errMsg == grc721.ErrInvalidTokenId.Error():
-		panic(errTokenNotExists)
+		panic(makeErrorWithDetails(errTokenNotExists, ufmt.Sprintf("token %s", string(tid))))
 
 	case errMsg == grc721.ErrCallerIsNotOwnerOrApproved.Error():
-		panic(makeErrorWithDetails(errNotOwnerOrApproved, ufmt.Sprintf("caller %s cannot approve for token %s", caller, string(tid))))
+		owner, ownerErr := nft.OwnerOf(tid)
+		checkErr(ownerErr)
+		panic(makeErrorWithDetails(errNotOwnerOrApproved, ufmt.Sprintf("caller %s cannot approve for token %s owned by %s", caller, string(tid), owner)))
 
 	case errMsg == grc721.ErrApprovalToCurrentOwner.Error():
 		panic(makeErrorWithDetails(errTransferToSelf, ufmt.Sprintf("cannot approve to current owner %s for token %s", approved, string(tid))))

--- a/contract/r/gnoswap/gnft/utils.gno
+++ b/contract/r/gnoswap/gnft/utils.gno
@@ -67,7 +67,7 @@ func checkTransferErr(err error, caller, from, to address, tid grc721.TokenID) {
 }
 
 // checkApproveErr wraps approve errors with more specific context.
-func checkApproveErr(err error, caller, approved address) {
+func checkApproveErr(err error, caller, approved address, tid grc721.TokenID) {
 	if err == nil {
 		return
 	}
@@ -75,14 +75,16 @@ func checkApproveErr(err error, caller, approved address) {
 	errMsg := err.Error()
 
 	switch {
-	case errMsg == "invalid token id":
+	case errMsg == grc721.ErrInvalidTokenId.Error():
 		panic(errTokenNotExists)
 
-	case errMsg == "caller is not token owner or approved":
-		panic(makeErrorWithDetails(errNotOwnerOrApproved, ufmt.Sprintf("caller %s cannot approve", caller)))
+	case errMsg == grc721.ErrCallerIsNotOwnerOrApproved.Error():
+		owner, ownerErr := nft.OwnerOf(tid)
+		checkErr(ownerErr)
+		panic(makeErrorWithDetails(errNotOwnerOrApproved, ufmt.Sprintf("caller %s cannot approve for token %s owned by %s", caller, string(tid), owner)))
 
-	case errMsg == "approval to current owner":
-		panic(makeErrorWithDetails(errTransferToSelf, ufmt.Sprintf("cannot approve to current owner %s", approved)))
+	case errMsg == grc721.ErrApprovalToCurrentOwner.Error():
+		panic(makeErrorWithDetails(errTransferToSelf, ufmt.Sprintf("cannot approve to current owner %s for token %s", approved, string(tid))))
 
 	default:
 		panic(err.Error())


### PR DESCRIPTION
## Summary
- reject empty GNFT token URI updates
- normalize unapproved token approval reads to an empty address without masking missing tokens
- scope generated SVG ids by token id to avoid duplicate DOM ids
- bound Approve error messages so attacker-sized token ids are not echoed
- reject TokenURI reads for burned tokens and avoid stale URI misclassification in SetTokenURI

## Validation
- gno fmt -w -imports=false contract/r/gnoswap/gnft/gnft.gno contract/r/gnoswap/gnft/assert.gno contract/r/gnoswap/gnft/gnft_test.gno
- GIT_MASTER=1 git diff --check
- make test WORKDIR=/Users/junghoon PKG=gno.land/r/gnoswap/gnft

## Notes
- No changes to external grc721.BasicNFT internals.
- URI cleanup on burn is not attempted because BasicNFT tokenURIs storage is unexported; GNFT instead enforces existence before URI reads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token URI generation now produces token-specific SVG identifiers for improved isolation.
  * Approval queries distinguish between unapproved tokens and invalid token IDs.

* **Bug Fixes**
  * Operations on burned or nonexistent tokens now return clear invalid-token errors.
  * Empty token URIs are rejected.
  * Approval error messages are more consistent and concise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->