### PR TITLE
fix(staker): decrement RewardAmount on external incentive refund

### DIFF
--- a/contract/r/gnoswap/staker/v1/external_incentive.gno
+++ b/contract/r/gnoswap/staker/v1/external_incentive.gno
@@ -214,6 +214,7 @@ func (s *stakerV1) EndExternalIncentive(_ int, rlm realm, targetPoolPath, incent
 	// After this update, attempts to re-claim GNS or rewards that were deposited
 	// through the `endExternalIncentive` function will be blocked.
 	incentiveResolver.SetRefunded(true)
+	incentiveResolver.SetRewardAmount(gnsmath.SafeSubInt64(incentiveResolver.RewardAmount(), refund))
 	incentiveResolver.addDistributedRewardAmount(refund)
 	incentivesResolver.update(incentive)
 
@@ -280,7 +281,7 @@ func (s *stakerV1) endExternalIncentive(resolver *PoolResolver, incentiveResolve
 
 	refund := gnsmath.SafeAddInt64(unclaimableReward, remainder)
 
-	maxRefund := gnsmath.SafeSubInt64(incentiveResolver.TotalRewardAmount(), incentiveResolver.DistributedRewardAmount())
+	maxRefund := incentiveResolver.RewardAmount()
 	if refund > maxRefund {
 		refund = maxRefund
 	}

--- a/contract/r/gnoswap/staker/v1/external_incentive_test.gno
+++ b/contract/r/gnoswap/staker/v1/external_incentive_test.gno
@@ -2800,6 +2800,236 @@ func TestEndExternalIncentiveRefundWithPenalty(cur realm, t *testing.T) {
 	}
 }
 
+// TestEndExternalIncentive_RewardAmountInvariantAfterRefund is a regression test: previously
+// EndExternalIncentive transferred `refund` reward tokens out of the staker and added it to
+// DistributedRewardAmount, but never decremented RewardAmount. That left
+// TotalRewardAmount != RewardAmount + DistributedRewardAmount + AccumulatedPenaltyAmount
+// and made GetIncentiveRemainingRewardAmount report stale, inflated values after a refund.
+func TestEndExternalIncentive_RewardAmountInvariantAfterRefund(cur realm, t *testing.T) {
+	initStakerTest(cur, t)
+	s := getMockInstance()
+
+	poolPath := "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:3000"
+	creator := testutils.TestAddress("creator")
+	refundee := testutils.TestAddress("refundee")
+
+	currentTime := time.Now().Unix()
+	startTime := currentTime - 86400*10 // 10 days ago
+	endTime := currentTime - 86400      // ended 1 day ago
+	totalRewardAmount := int64(1_000_000_000)
+	depositGnsAmount := int64(100_000_000)
+	incentiveId := "invariant-test"
+
+	// Register a real pool so EndExternalIncentive's assertIsPoolExists passes.
+	testing.SetRealm(adminRealm)
+	gns.Approve(cross(cur), poolAddr, math.MaxInt)
+	CreatePool(cur, barPath, fooPath, fee3000, "79228162514264337593543950336", adminAddr)
+
+	pool := sr.NewPool(poolPath, startTime)
+	s.getPools().set(poolPath, pool)
+
+	incentive := sr.NewExternalIncentive(
+		incentiveId, poolPath, barPath, totalRewardAmount,
+		startTime, endTime, creator, depositGnsAmount,
+		runtime.ChainHeight(), startTime-100,
+	)
+
+	poolResolver := NewPoolResolver(pool)
+	poolResolver.IncentivesResolver().create(incentive)
+
+	// Carve out a genuine (non-dust) unclaimable window: liquidity present, then zero for
+	// 3 of the 9 remaining days, then present again. This is money nobody could ever have
+	// claimed, as opposed to money a staker simply hasn't collected yet.
+	zeroStart := startTime + 86400*2
+	zeroEnd := startTime + 86400*5
+	poolResolver.modifyDeposit(i256.NewInt(1000), startTime+100, 0)
+	poolResolver.modifyDeposit(i256.NewInt(-1000), zeroStart, 0)
+	poolResolver.modifyDeposit(i256.NewInt(1000), zeroEnd, 0)
+
+	// Simulate two users who already collected part of the reward via CollectReward,
+	// exactly as staker.gno's CollectReward loop does.
+	incentiveResolver := NewExternalIncentiveResolver(incentive)
+	collected := int64(300_000_000)
+	penalty := int64(50_000_000)
+	incentiveResolver.addDistributedRewardAmount(collected)
+	incentiveResolver.addAccumulatedPenaltyAmount(penalty)
+	incentive.SetRewardAmount(gnsmath.SafeSubInt64(incentive.RewardAmount(), collected+penalty))
+
+	rewardBefore := incentive.RewardAmount()
+	distributedBefore := incentive.DistributedRewardAmount()
+
+	// Fund the staker so the refund + GNS deposit transfers succeed.
+	testing.SetRealm(adminRealm)
+	gns.Transfer(cross(cur), stakerAddr, depositGnsAmount)
+	bar.Transfer(cross(cur), stakerAddr, totalRewardAmount)
+
+	refundeeBarBefore := bar.BalanceOf(refundee)
+
+	testing.SetRealm(testing.NewUserRealm(creator))
+	sr.EndExternalIncentive(cross(cur), poolPath, incentiveId, refundee)
+
+	updated, exists := poolResolver.IncentivesResolver().Get(incentiveId)
+	uassert.True(t, exists)
+	uassert.True(t, updated.Refunded())
+
+	actualRefund := bar.BalanceOf(refundee) - refundeeBarBefore
+	if actualRefund <= 0 {
+		t.Fatalf("expected a substantial non-zero refund from the unclaimable window, got %d", actualRefund)
+	}
+
+	// The core bug: RewardAmount must decrease by exactly the amount actually refunded.
+	uassert.Equal(t, rewardBefore-actualRefund, updated.RewardAmount())
+	uassert.Equal(t, distributedBefore+actualRefund, updated.DistributedRewardAmount())
+
+	// AccumulatedPenaltyAmount must be untouched by the refund; it is only released via
+	// CollectExternalIncentivePenalty.
+	uassert.Equal(t, penalty, updated.AccumulatedPenaltyAmount())
+
+	// Invariant: TotalRewardAmount == RewardAmount + DistributedRewardAmount + AccumulatedPenaltyAmount.
+	sum := updated.RewardAmount() + updated.DistributedRewardAmount() + updated.AccumulatedPenaltyAmount()
+	uassert.Equal(t, totalRewardAmount, sum)
+
+	// GetIncentiveRemainingRewardAmount must reflect the post-refund value, not the stale
+	// pre-refund one.
+	remaining := s.GetIncentiveRemainingRewardAmount(poolPath, incentiveId)
+	uassert.Equal(t, updated.RewardAmount(), remaining)
+}
+
+// TestEndExternalIncentive_RefundCappedByRewardAmountNotPenalty verifies that the refund cap
+// is RewardAmount alone, not TotalRewardAmount-DistributedRewardAmount (which also includes
+// AccumulatedPenaltyAmount). AccumulatedPenaltyAmount belongs to CollectExternalIncentivePenalty,
+// not to the creator refund, so a raw unclaimable-reward calculation must never be allowed to
+// dip into it.
+func TestEndExternalIncentive_RefundCappedByRewardAmountNotPenalty(cur realm, t *testing.T) {
+	initStakerTest(cur, t)
+	s := getMockInstance()
+
+	poolPath := "gno.land/r/test/refund_cap"
+	creator := testutils.TestAddress("creator")
+
+	currentTime := time.Now().Unix()
+	startTime := currentTime - 86400*10 // 10 days ago
+	endTime := startTime + 86400*10     // 10 day duration, already ended
+	totalRewardAmount := int64(864_000) // divisible by the 864000s duration: 1 wei/sec, no truncation dust
+
+	pool := sr.NewPool(poolPath, startTime)
+	s.getPools().set(poolPath, pool)
+
+	incentiveId := "refund-cap-test"
+	incentive := sr.NewExternalIncentive(
+		incentiveId, poolPath, WUGNOT_TOKEN_KEY, totalRewardAmount,
+		startTime, endTime, creator, 100_000_000,
+		runtime.ChainHeight(), startTime-100,
+	)
+
+	poolResolver := NewPoolResolver(pool)
+	poolResolver.IncentivesResolver().create(incentive)
+
+	// Zero liquidity for 9 of the 10 days: a large, legitimate unclaimable window.
+	zeroStart := startTime + 86400
+	poolResolver.modifyDeposit(i256.NewInt(1000), startTime, 0)
+	poolResolver.modifyDeposit(i256.NewInt(-1000), zeroStart, 0)
+
+	// No one has collected yet, but a large penalty has already accumulated (e.g. from an
+	// unrelated, already-unstaked position) and is waiting on CollectExternalIncentivePenalty.
+	penalty := int64(400_000)
+	incentiveResolver := NewExternalIncentiveResolver(incentive)
+	incentiveResolver.addAccumulatedPenaltyAmount(penalty)
+	incentive.SetRewardAmount(gnsmath.SafeSubInt64(incentive.RewardAmount(), penalty))
+	rewardAmount := incentive.RewardAmount() // 464,000
+
+	_, refund, err := s.endExternalIncentive(poolResolver, incentiveResolver, creator, endTime+100)
+	uassert.NoError(t, err)
+
+	// The raw unclaimable-reward calculation (9 of 10 days) is ~777,600 -- more than
+	// RewardAmount (464,000) but less than the old, looser cap of
+	// TotalRewardAmount-DistributedRewardAmount (864,000). It must be clamped to
+	// RewardAmount, not merely to the looser bound.
+	oldLooseCap := gnsmath.SafeSubInt64(incentive.TotalRewardAmount(), incentive.DistributedRewardAmount())
+	if refund > rewardAmount {
+		t.Fatalf("refund(%d) must never exceed RewardAmount(%d), even though it stays within the old cap(%d)", refund, rewardAmount, oldLooseCap)
+	}
+	uassert.Equal(t, rewardAmount, refund)
+
+	// AccumulatedPenaltyAmount must remain fully intact; none of it leaked into the refund.
+	uassert.Equal(t, penalty, incentiveResolver.AccumulatedPenaltyAmount())
+}
+
+// TestEndExternalIncentive_DoesNotStealUncollectedUserReward simulates the full lifecycle:
+// a refund happens for a genuinely-unclaimable window, and afterwards a staker who was
+// present the rest of the time (but never called CollectReward) can still collect their full,
+// legitimate share -- proving the refund fix doesn't touch money owed to real stakers, and
+// that 100% of TotalRewardAmount is eventually accounted for across refund + payout.
+func TestEndExternalIncentive_DoesNotStealUncollectedUserReward(cur realm, t *testing.T) {
+	initStakerTest(cur, t)
+	s := getMockInstance()
+
+	poolPath := "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:3000"
+	creator := testutils.TestAddress("creator")
+	refundee := testutils.TestAddress("refundee")
+
+	currentTime := time.Now().Unix()
+	startTime := currentTime - 86400*10
+	endTime := currentTime - 86400
+	totalRewardAmount := int64(1_000_000_000)
+	depositGnsAmount := int64(100_000_000)
+	incentiveId := "no-steal-test"
+
+	testing.SetRealm(adminRealm)
+	gns.Approve(cross(cur), poolAddr, math.MaxInt)
+	CreatePool(cur, barPath, fooPath, fee3000, "79228162514264337593543950336", adminAddr)
+
+	pool := sr.NewPool(poolPath, startTime)
+	s.getPools().set(poolPath, pool)
+
+	incentive := sr.NewExternalIncentive(
+		incentiveId, poolPath, barPath, totalRewardAmount,
+		startTime, endTime, creator, depositGnsAmount,
+		runtime.ChainHeight(), startTime-100,
+	)
+
+	poolResolver := NewPoolResolver(pool)
+	poolResolver.IncentivesResolver().create(incentive)
+
+	// Zero liquidity for the first 2 of 9 days only; a real staker held liquidity for the
+	// remaining 7 days but never called CollectReward.
+	poolResolver.modifyDeposit(i256.NewInt(1000), startTime+86400*2, 0)
+
+	// Nobody has collected anything yet.
+	testing.SetRealm(adminRealm)
+	gns.Transfer(cross(cur), stakerAddr, depositGnsAmount)
+	bar.Transfer(cross(cur), stakerAddr, totalRewardAmount)
+
+	testing.SetRealm(testing.NewUserRealm(creator))
+	sr.EndExternalIncentive(cross(cur), poolPath, incentiveId, refundee)
+
+	updated, exists := poolResolver.IncentivesResolver().Get(incentiveId)
+	uassert.True(t, exists)
+
+	rewardLeftForStaker := updated.RewardAmount()
+	if rewardLeftForStaker <= 0 {
+		t.Fatalf("expected a positive reward balance left for the still-uncollected staker, got %d", rewardLeftForStaker)
+	}
+
+	// The still-uncollected staker's due is at most what's left in RewardAmount -- the
+	// staker.gno:459 guard (RewardAmount() < totalRewardAmount) must accept it.
+	dueToStaker := rewardLeftForStaker
+	if updated.RewardAmount() < dueToStaker {
+		t.Fatalf("staker's legitimate due(%d) exceeds available RewardAmount(%d) after refund", dueToStaker, updated.RewardAmount())
+	}
+
+	// Apply the same bookkeeping CollectReward would apply for this payout.
+	updatedResolver := NewExternalIncentiveResolver(updated)
+	updated.SetRewardAmount(gnsmath.SafeSubInt64(updated.RewardAmount(), dueToStaker))
+	updatedResolver.addDistributedRewardAmount(dueToStaker)
+
+	// Every token is now accounted for: nothing left in RewardAmount, and refund + user
+	// payout together exactly equal TotalRewardAmount.
+	uassert.Equal(t, int64(0), updated.RewardAmount())
+	sum := updated.RewardAmount() + updated.DistributedRewardAmount() + updated.AccumulatedPenaltyAmount()
+	uassert.Equal(t, totalRewardAmount, sum)
+}
+
 func TestCreateExternalIncentive_NonAdminBlocked(cur realm, t *testing.T) {
 	initStakerTest(cur, t)
 	poolPath := "gno.land/r/onbloc/bar:gno.land/r/onbloc/foo:3000"

--- a/contract/r/gnoswap/staker/v1/external_incentive_test.gno
+++ b/contract/r/gnoswap/staker/v1/external_incentive_test.gno
@@ -2967,6 +2967,7 @@ func TestEndExternalIncentive_DoesNotStealUncollectedUserReward(cur realm, t *te
 	poolPath := "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:3000"
 	creator := testutils.TestAddress("creator")
 	refundee := testutils.TestAddress("refundee")
+	staker := testutils.TestAddress("staker")
 
 	currentTime := time.Now().Unix()
 	startTime := currentTime - 86400*10
@@ -2974,6 +2975,7 @@ func TestEndExternalIncentive_DoesNotStealUncollectedUserReward(cur realm, t *te
 	totalRewardAmount := int64(1_000_000_000)
 	depositGnsAmount := int64(100_000_000)
 	incentiveId := "no-steal-test"
+	positionId := uint64(1)
 
 	testing.SetRealm(adminRealm)
 	gns.Approve(cross(cur), poolAddr, math.MaxInt)
@@ -2990,10 +2992,31 @@ func TestEndExternalIncentive_DoesNotStealUncollectedUserReward(cur realm, t *te
 
 	poolResolver := NewPoolResolver(pool)
 	poolResolver.IncentivesResolver().create(incentive)
+	s.getExternalIncentives().set(incentiveId, incentive)
 
 	// Zero liquidity for the first 2 of 9 days only; a real staker held liquidity for the
 	// remaining 7 days but never called CollectReward.
-	poolResolver.modifyDeposit(i256.NewInt(1000), startTime+86400*2, 0)
+	stakeTime := startTime + 86400*2
+	poolResolver.IncentivesResolver().startUnclaimablePeriod(startTime)
+	poolResolver.IncentivesResolver().endUnclaimablePeriod(stakeTime)
+	liquidity := u256.NewUint(1000)
+	poolResolver.modifyDeposit(i256.FromUint256(liquidity), stakeTime, 0)
+
+	warmups := []sr.Warmup{sr.NewWarmup(math.MaxInt64, math.MaxInt64, 100)}
+	deposit := sr.NewDeposit(staker, poolPath, liquidity, stakeTime, -10000, 10000, warmups)
+	deposit.AddExternalIncentiveId(incentiveId)
+	deposit.SetLastExternalIncentiveUpdatedAt(stakeTime)
+	s.getDeposits().set(positionId, deposit)
+
+	claimableDuration := endTime - stakeTime
+	accX128 := u256.MulDiv(u256.NewUintFromInt64(claimableDuration), q128, liquidity)
+	positionAccX128, overflow := u256.Zero().MulOverflow(accX128, liquidity)
+	if overflow {
+		t.Fatal("expected reward accumulation to fit uint256")
+	}
+	expectedRewardU256 := u256.MulDiv(positionAccX128, incentive.RewardPerSecondX128(), q128)
+	expectedRewardU256 = u256.Zero().Rsh(expectedRewardU256, 128)
+	expectedReward := gnsmath.SafeConvertToInt64(expectedRewardU256)
 
 	// Nobody has collected anything yet.
 	testing.SetRealm(adminRealm)
@@ -3010,18 +3033,25 @@ func TestEndExternalIncentive_DoesNotStealUncollectedUserReward(cur realm, t *te
 	if rewardLeftForStaker <= 0 {
 		t.Fatalf("expected a positive reward balance left for the still-uncollected staker, got %d", rewardLeftForStaker)
 	}
+	uassert.Equal(t, expectedReward, rewardLeftForStaker)
 
-	// The still-uncollected staker's due is at most what's left in RewardAmount -- the
-	// staker.gno:459 guard (RewardAmount() < totalRewardAmount) must accept it.
-	dueToStaker := rewardLeftForStaker
-	if updated.RewardAmount() < dueToStaker {
-		t.Fatalf("staker's legitimate due(%d) exceeds available RewardAmount(%d) after refund", dueToStaker, updated.RewardAmount())
+	stakerBarBefore := bar.BalanceOf(staker)
+
+	testing.SetRealm(testing.NewUserRealm(staker))
+	_, _, externalRewards, externalPenalties := sr.CollectReward(cross(cur), positionId)
+
+	uassert.Equal(t, expectedReward, externalRewards[barPath])
+	uassert.Equal(t, int64(0), externalPenalties[barPath])
+	uassert.Equal(t, expectedReward, bar.BalanceOf(staker)-stakerBarBefore)
+
+	depositResolver := NewDepositResolver(deposit)
+	uassert.Equal(t, expectedReward, depositResolver.CollectedExternalReward(incentiveId))
+	if depositResolver.ExternalRewardLastCollectTime(incentiveId) <= endTime {
+		t.Fatalf("expected external reward last collect time after incentive end, got %d", depositResolver.ExternalRewardLastCollectTime(incentiveId))
 	}
 
-	// Apply the same bookkeeping CollectReward would apply for this payout.
-	updatedResolver := NewExternalIncentiveResolver(updated)
-	updated.SetRewardAmount(gnsmath.SafeSubInt64(updated.RewardAmount(), dueToStaker))
-	updatedResolver.addDistributedRewardAmount(dueToStaker)
+	updated, exists = poolResolver.IncentivesResolver().Get(incentiveId)
+	uassert.True(t, exists)
 
 	// Every token is now accounted for: nothing left in RewardAmount, and refund + user
 	// payout together exactly equal TotalRewardAmount.

--- a/contract/r/scenario/staker/end_external_incentive_reward_amount_invariant_filetest.gno
+++ b/contract/r/scenario/staker/end_external_incentive_reward_amount_invariant_filetest.gno
@@ -1,0 +1,321 @@
+// PKGPATH: gno.land/r/gnoswap/v1/main
+
+// POOLs:
+// 1. bar:qux:100
+//
+// POSITIONs:
+// 1. Single position staked 10 days after incentive start (leaves a real,
+//    unclaimable gap at the beginning that nobody could ever have collected)
+//
+// SCENARIO:
+// Regression test: EndExternalIncentive used to transfer `refund` reward tokens
+// out of the staker and add it to DistributedRewardAmount, but never decremented
+// RewardAmount. That broke the accounting invariant
+//   TotalRewardAmount == RewardAmount + DistributedRewardAmount + AccumulatedPenaltyAmount
+// and made GetIncentiveRemainingRewardAmount report stale, inflated values after a refund.
+//
+// 1. Create a 90-day external incentive, but stake the position 10 days after start
+//    (a real, unclaimable gap nobody could ever collect for).
+// 2. Skip past incentive end without collecting.
+// 3. Creator calls EndExternalIncentive to refund the unclaimable gap.
+// 4. Verify RewardAmount + DistributedRewardAmount + AccumulatedPenaltyAmount == TotalRewardAmount.
+// 5. The staked position still collects its full, legitimate share afterwards -- the
+//    refund must not have touched money owed to a real, still-uncollected staker.
+
+package main
+
+import (
+	"gno.land/p/gnoswap/gnsmath"
+	"strconv"
+	"testing"
+	"time"
+
+	"gno.land/p/demo/tokens/grc721"
+	testutils "gno.land/p/nt/testutils/v0"
+	ufmt "gno.land/p/nt/ufmt/v0"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/gnft"
+	"gno.land/r/gnoswap/gns"
+
+	pl "gno.land/r/gnoswap/pool"
+	pn "gno.land/r/gnoswap/position"
+	sr "gno.land/r/gnoswap/staker"
+
+	prabc "gno.land/p/gnoswap/rbac"
+	_ "gno.land/r/gnoswap/rbac"
+
+	_ "gno.land/r/gnoswap/pool/v1"
+	_ "gno.land/r/gnoswap/position/v1"
+	_ "gno.land/r/gnoswap/staker/v1"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/qux"
+)
+
+var (
+	adminAddr, _ = access.GetAddress(prabc.ROLE_ADMIN.String())
+	adminUser    = adminAddr
+	adminRealm   = testing.NewUserRealm(adminAddr)
+
+	userAddr  = testutils.TestAddress("user1")
+	userUser  = userAddr
+	userRealm = testing.NewUserRealm(userAddr)
+
+	externalCreatorAddr = testutils.TestAddress("externalCreator")
+	externalCreatorUser = externalCreatorAddr
+
+	stakerAddr, _ = access.GetAddress(prabc.ROLE_STAKER.String())
+	poolAddr, _   = access.GetAddress(prabc.ROLE_POOL.String())
+
+	barPath = "gno.land/r/onbloc/bar.BAR"
+	quxPath = "gno.land/r/onbloc/qux.QUX"
+	gnsPath = "gno.land/r/gnoswap/gns.GNS"
+
+	fee100 uint32 = 100
+
+	maxTimeout int64 = 9999999999
+	maxInt64   int64 = 9223372036854775807
+
+	depositGnsAmount int64 = 1_000_000_000
+
+	INCENTIVE_DURATION int64 = 90 * 24 * 60 * 60 // 90 days
+	REWARD_AMOUNT      int64 = 7_776_000_000     // divides evenly by duration: 1000/sec
+	STAKE_DELAY        int64 = 10 * 24 * 60 * 60 // stake 10 days after incentive start
+
+	actualIncentiveID string
+	targetPoolPath    = "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/qux.QUX:100"
+)
+
+func main(cur realm) {
+	println("[SCENARIO] EndExternalIncentive keeps RewardAmount accounting consistent after refund")
+	println()
+
+	println("[SCENARIO] 1. Initialize")
+	initialize(cur)
+	println()
+
+	println("[SCENARIO] 2. Create pool and set tier")
+	createPoolAndSetTier(cur)
+	println()
+
+	println("[SCENARIO] 3. Create external incentive and wait for start")
+	createAndStartIncentive(cur)
+	println()
+
+	println("[SCENARIO] 4. Skip 10 days with nobody staked (unclaimable gap)")
+	skipStakeDelay(cur)
+	println()
+
+	println("[SCENARIO] 5. User mints and stakes position")
+	userMintThenStake(cur)
+	println()
+
+	println("[SCENARIO] 6. Skip until after incentive end (no collect)")
+	skipUntilAfterEnd(cur)
+	println()
+
+	println("[SCENARIO] 7. Creator ends incentive (refund path)")
+	endExternalIncentive(cur)
+	println()
+
+	println("[SCENARIO] 8. Verify accounting invariant after refund")
+	verifyAccountingInvariant(cur)
+	println()
+
+	println("[SCENARIO] 9. Staked user still collects their full legitimate share")
+	collectExternalIncentive(cur)
+	println()
+}
+
+func initialize(cur realm) {
+	testing.SetRealm(adminRealm)
+
+	sr.SetUnStakingFee(cross(cur), 0)
+	pl.SetPoolCreationFee(cross(cur), 0)
+	testing.SkipHeights(1)
+
+	bar.Transfer(cross(cur), userUser, 10000)
+	qux.Transfer(cross(cur), userUser, 10000)
+
+	gns.Transfer(cross(cur), externalCreatorUser, REWARD_AMOUNT+depositGnsAmount)
+
+	println("[INFO] initialized accounts")
+}
+
+func createPoolAndSetTier(cur realm) {
+	testing.SetRealm(adminRealm)
+
+	testing.SkipHeights(1)
+	pl.CreatePool(
+		cross(cur),
+		barPath,
+		quxPath,
+		fee100,
+		gnsmath.TickMathGetSqrtRatioAtTick(0).ToString(),
+	)
+
+	sr.SetPoolTier(cross(cur), targetPoolPath, 1)
+	println("[INFO] created pool and set tier")
+}
+
+func createAndStartIncentive(cur realm) {
+	testing.SetRealm(adminRealm)
+
+	gns.Approve(cross(cur), stakerAddr, maxInt64)
+
+	createTimestamp := time.Now().Unix()
+
+	// Start at the next UTC midnight to satisfy start-time validation
+	startTime := ((createTimestamp / 86400) + 1) * 86400
+	endTime := startTime + INCENTIVE_DURATION
+
+	actualIncentiveID = ufmt.Sprintf("%s:%d:%d", adminAddr, createTimestamp, 1)
+
+	sr.CreateExternalIncentive(
+		cross(cur),
+		targetPoolPath,
+		gnsPath,
+		REWARD_AMOUNT,
+		startTime,
+		endTime,
+	)
+
+	// Move chain time to incentive start
+	nowTime := time.Now().Unix()
+	timeLeft := startTime - nowTime
+	if timeLeft > 0 {
+		testing.SkipHeights(timeLeft / 5)
+	}
+
+	ufmt.Printf("[INFO] created external incentive %s\n", actualIncentiveID)
+}
+
+func skipStakeDelay(cur realm) {
+	testing.SkipHeights(STAKE_DELAY / 5)
+	println("[INFO] skipped 10 days with zero staked liquidity")
+}
+
+func userMintThenStake(cur realm) {
+	testing.SetRealm(userRealm)
+
+	bar.Approve(cross(cur), poolAddr, maxInt64)
+	qux.Approve(cross(cur), poolAddr, maxInt64)
+
+	testing.SkipHeights(1)
+	lpTokenId, _, _, _ := pn.Mint(
+		cross(cur),
+		barPath,
+		quxPath,
+		fee100,
+		int32(-100),
+		int32(100),
+		"1000",
+		"1000",
+		"1",
+		"1",
+		maxTimeout,
+		userAddr,
+		"",
+	)
+
+	gnft.Approve(cross(cur), stakerAddr, positionIdFrom(cur, int(lpTokenId)))
+	sr.StakeToken(cross(cur), lpTokenId, "")
+
+	ufmt.Printf("[INFO] user staked position %d\n", lpTokenId)
+}
+
+func skipUntilAfterEnd(cur realm) {
+	// Skip the rest of the 90-day period plus a 1-day buffer past end.
+	blocksToSkip := ((INCENTIVE_DURATION - STAKE_DELAY) + 24*60*60) / 5
+	testing.SkipHeights(blocksToSkip)
+	println("[INFO] skipped to after incentive end without collecting")
+}
+
+func endExternalIncentive(cur realm) {
+	testing.SetRealm(adminRealm)
+
+	sr.EndExternalIncentive(
+		cross(cur),
+		targetPoolPath,
+		actualIncentiveID,
+		externalCreatorUser,
+	)
+
+	println("[INFO] external incentive ended via refund path")
+}
+
+func verifyAccountingInvariant(cur realm) {
+	total := sr.GetIncentiveTotalRewardAmount(targetPoolPath, actualIncentiveID)
+	remaining := sr.GetIncentiveRemainingRewardAmount(targetPoolPath, actualIncentiveID)
+	distributed := sr.GetIncentiveDistributedRewardAmount(targetPoolPath, actualIncentiveID)
+	penalty := sr.GetIncentiveAccumulatedPenaltyAmount(targetPoolPath, actualIncentiveID)
+
+	sum := remaining + distributed + penalty
+
+	ufmt.Printf("[INFO] TotalRewardAmount: %d\n", total)
+	ufmt.Printf("[INFO] RemainingRewardAmount: %d\n", remaining)
+	ufmt.Printf("[INFO] DistributedRewardAmount: %d\n", distributed)
+	ufmt.Printf("[INFO] AccumulatedPenaltyAmount: %d\n", penalty)
+	ufmt.Printf("[RESULT] remaining+distributed+penalty == total: %t (%d == %d)\n", sum == total, sum, total)
+
+	if sum != total {
+		panic("accounting invariant broken: remaining+distributed+penalty != total")
+	}
+	if distributed == 0 {
+		panic("expected a non-zero refund from the unclaimable gap")
+	}
+}
+
+func collectExternalIncentive(cur realm) {
+	testing.SetRealm(userRealm)
+
+	gnsBefore := gns.BalanceOf(userUser)
+	sr.CollectReward(cross(cur), 1)
+	gnsAfter := gns.BalanceOf(userUser)
+
+	rewards := gnsAfter - gnsBefore
+	ufmt.Printf("[INFO] user collected %d GNS after incentive end\n", rewards)
+
+	if rewards <= 0 {
+		panic("expected a positive collect for the staked position after incentive end")
+	}
+}
+
+func positionIdFrom(cur realm, positionId int) grc721.TokenID {
+	return grc721.TokenID(strconv.Itoa(positionId))
+}
+
+// Output:
+// [SCENARIO] EndExternalIncentive keeps RewardAmount accounting consistent after refund
+//
+// [SCENARIO] 1. Initialize
+// [INFO] initialized accounts
+//
+// [SCENARIO] 2. Create pool and set tier
+// [INFO] created pool and set tier
+//
+// [SCENARIO] 3. Create external incentive and wait for start
+// [INFO] created external incentive g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5:1234567900:1
+//
+// [SCENARIO] 4. Skip 10 days with nobody staked (unclaimable gap)
+// [INFO] skipped 10 days with zero staked liquidity
+//
+// [SCENARIO] 5. User mints and stakes position
+// [INFO] user staked position 1
+//
+// [SCENARIO] 6. Skip until after incentive end (no collect)
+// [INFO] skipped to after incentive end without collecting
+//
+// [SCENARIO] 7. Creator ends incentive (refund path)
+// [INFO] external incentive ended via refund path
+//
+// [SCENARIO] 8. Verify accounting invariant after refund
+// [INFO] TotalRewardAmount: 7776000000
+// [INFO] RemainingRewardAmount: 6911995000
+// [INFO] DistributedRewardAmount: 864005000
+// [INFO] AccumulatedPenaltyAmount: 0
+// [RESULT] remaining+distributed+penalty == total: true (7776000000 == 7776000000)
+//
+// [SCENARIO] 9. Staked user still collects their full legitimate share
+// [INFO] user collected 5399994997 GNS after incentive end


### PR DESCRIPTION
## Summary
- `EndExternalIncentive` transferred the leftover `refund` reward tokens out of the staker and added it to `DistributedRewardAmount`, but never decremented `RewardAmount`, breaking the invariant `TotalRewardAmount == RewardAmount + DistributedRewardAmount + AccumulatedPenaltyAmount` and inflating `GetIncentiveRemainingRewardAmount` after a refund.
- The refund cap is now `RewardAmount` instead of `TotalRewardAmount - DistributedRewardAmount` (which implicitly included `AccumulatedPenaltyAmount`), so a refund can never draw from the still-uncollected penalty pool reserved for `CollectExternalIncentivePenalty`.

## Test plan
- [x] `make test PKG=gno.land/r/gnoswap/staker/v1` — full unit suite passes, including 3 new regression tests covering the invariant, the penalty-safety cap, and conservation across refund + a still-uncollected staker's later collect.
- [x] `make test PKG=gno.land/r/gnoswap/scenario/staker` — full existing filetest suite (80+ scenarios) passes unchanged, plus a new filetest asserting the accounting invariant end-to-end through the real staking/incentive/refund flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-of-external-incentive refund accounting so the refunded token amount is accurately removed from remaining rewards.
  * Updated refund capping to ensure refunds are limited by the incentive’s available reward amount (not derived from remaining distribution totals).
  * Ensured penalties are not incorrectly included in creator refunds and that uncollected staker rewards are preserved.

* **Tests**
  * Added regression tests covering refund correctness, reward accounting invariants after refund, and protection against stealing uncollected user rewards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->