### PR TITLE
fix(pool): seed tick oracle outside accumulators

### DIFF
--- a/contract/r/gnoswap/pool/v1/position.gno
+++ b/contract/r/gnoswap/pool/v1/position.gno
@@ -316,6 +316,23 @@ func updatePosition(p *pl.Pool, positionParams ModifyPositionParams, tick int32)
 
 	var flippedLower, flippedUpper bool
 	if !liquidityDelta.IsZero() {
+		blockTimestamp := time.Now().Unix()
+		observationState := p.ObservationState()
+		tickCumulative, secondsPerLiquidityStr, err := observeSingle(
+			observationState,
+			blockTimestamp,
+			0,
+			tick,
+			observationState.Index(),
+			p.Liquidity(),
+			observationState.Cardinality(),
+		)
+		if err != nil {
+			return pl.NewDefaultPositionInfo(), err
+		}
+
+		secondsPerLiquidityCumulativeX128 := u256.MustFromDecimal(secondsPerLiquidityStr)
+
 		flippedLower = tickUpdate(
 			p,
 			positionParams.tickLower,
@@ -323,6 +340,9 @@ func updatePosition(p *pl.Pool, positionParams ModifyPositionParams, tick int32)
 			liquidityDelta,
 			feeGrowthGlobal0X128,
 			feeGrowthGlobal1X128,
+			secondsPerLiquidityCumulativeX128,
+			tickCumulative,
+			blockTimestamp,
 			false,
 			calculateMaxLiquidityPerTick(p.TickSpacing()),
 		)
@@ -334,6 +354,9 @@ func updatePosition(p *pl.Pool, positionParams ModifyPositionParams, tick int32)
 			liquidityDelta,
 			feeGrowthGlobal0X128,
 			feeGrowthGlobal1X128,
+			secondsPerLiquidityCumulativeX128,
+			tickCumulative,
+			blockTimestamp,
 			true,
 			calculateMaxLiquidityPerTick(p.TickSpacing()),
 		)

--- a/contract/r/gnoswap/pool/v1/tick.gno
+++ b/contract/r/gnoswap/pool/v1/tick.gno
@@ -156,6 +156,10 @@ func getFeeGrowthInside(
 //   - liquidityDelta: *i256.Int, the amount of liquidity to add or remove.
 //   - feeGrowthGlobal0X128: *u256.Uint, the global fee growth value for token 0.
 //   - feeGrowthGlobal1X128: *u256.Uint, the global fee growth value for token 1.
+//   - secondsPerLiquidityCumulativeX128: *u256.Uint, the current oracle accumulator used to
+//     seed the outside accumulator of a newly initialized active tick (tick <= tickCurrent).
+//   - tickCumulative: int64, the current oracle tick accumulator used for the same seeding.
+//   - blockTimestamp: int64, the current block timestamp used for the same seeding.
 //   - upper:         bool, indicates if this is the upper boundary (true for upper, false for lower).
 //   - maxLiquidity:  *u256.Uint, the maximum allowed liquidity.
 //
@@ -186,7 +190,7 @@ func getFeeGrowthInside(
 //
 // ```gno
 //
-//	flipped := pool.tickUpdate(10, 5, liquidityDelta, feeGrowth0, feeGrowth1, true, maxLiquidity)
+//	flipped := pool.tickUpdate(10, 5, liquidityDelta, feeGrowth0, feeGrowth1, secondsPerLiquidityCumulativeX128, tickCumulative, blockTimestamp, true, maxLiquidity)
 //	println("Tick flipped:", flipped)
 //
 // ```
@@ -197,6 +201,9 @@ func tickUpdate(
 	liquidityDelta *i256.Int,
 	feeGrowthGlobal0X128 *u256.Uint,
 	feeGrowthGlobal1X128 *u256.Uint,
+	secondsPerLiquidityCumulativeX128 *u256.Uint,
+	tickCumulative int64,
+	blockTimestamp int64,
 	upper bool,
 	maxLiquidity *u256.Uint,
 ) (flipped bool) {
@@ -218,6 +225,9 @@ func tickUpdate(
 		if tick <= tickCurrent {
 			tickInfo.SetFeeGrowthOutside0X128(feeGrowthGlobal0X128.ToString())
 			tickInfo.SetFeeGrowthOutside1X128(feeGrowthGlobal1X128.ToString())
+			tickInfo.SetSecondsPerLiquidityOutsideX128(secondsPerLiquidityCumulativeX128.ToString())
+			tickInfo.SetTickCumulativeOutside(tickCumulative)
+			tickInfo.SetSecondsOutside(uint32(blockTimestamp))
 		}
 		tickInfo.SetInitialized(true)
 	}

--- a/contract/r/gnoswap/pool/v1/tick_test.gno
+++ b/contract/r/gnoswap/pool/v1/tick_test.gno
@@ -284,7 +284,7 @@ func TestTickUpdate(cur realm, t *testing.T) {
 			name: "does not flip from nonzero to greater nonzero",
 			preconditions: func() {
 				deleteTick(pool, 0)
-				tickUpdate(pool, 0, 0, i256.One(), u256.Zero(), u256.Zero(), false, u256.NewUint(3))
+				tickUpdate(pool, 0, 0, i256.One(), u256.Zero(), u256.Zero(), u256.Zero(), 0, 0, false, u256.NewUint(3))
 			},
 			tick:                 0,
 			tickCurrent:          0,
@@ -299,7 +299,7 @@ func TestTickUpdate(cur realm, t *testing.T) {
 			name: "flips from nonzero to zero",
 			preconditions: func() {
 				deleteTick(pool, 0)
-				tickUpdate(pool, 0, 0, i256.One(), u256.Zero(), u256.Zero(), false, u256.NewUint(3))
+				tickUpdate(pool, 0, 0, i256.One(), u256.Zero(), u256.Zero(), u256.Zero(), 0, 0, false, u256.NewUint(3))
 			},
 			tick:                 0,
 			tickCurrent:          0,
@@ -314,7 +314,7 @@ func TestTickUpdate(cur realm, t *testing.T) {
 			name: "does not flip from nonzero to lesser nonzero",
 			preconditions: func() {
 				deleteTick(pool, 0)
-				tickUpdate(pool, 0, 0, i256.NewInt(2), u256.Zero(), u256.Zero(), false, u256.NewUint(3))
+				tickUpdate(pool, 0, 0, i256.NewInt(2), u256.Zero(), u256.Zero(), u256.Zero(), 0, 0, false, u256.NewUint(3))
 			},
 			tick:                 0,
 			tickCurrent:          0,
@@ -329,8 +329,8 @@ func TestTickUpdate(cur realm, t *testing.T) {
 			name: "reverts if total liquidity gross is greater than max",
 			preconditions: func() {
 				deleteTick(pool, 0)
-				tickUpdate(pool, 0, 0, i256.NewInt(2), u256.Zero(), u256.Zero(), false, u256.NewUint(3))
-				tickUpdate(pool, 0, 0, i256.One(), u256.Zero(), u256.Zero(), true, u256.NewUint(3))
+				tickUpdate(pool, 0, 0, i256.NewInt(2), u256.Zero(), u256.Zero(), u256.Zero(), 0, 0, false, u256.NewUint(3))
+				tickUpdate(pool, 0, 0, i256.One(), u256.Zero(), u256.Zero(), u256.Zero(), 0, 0, true, u256.NewUint(3))
 			},
 			tick:                 0,
 			tickCurrent:          0,
@@ -345,10 +345,10 @@ func TestTickUpdate(cur realm, t *testing.T) {
 		{
 			name: "nets the liquidity based on upper flag",
 			preconditions: func() {
-				tickUpdate(pool, 0, 0, i256.NewInt(2), u256.Zero(), u256.Zero(), false, u256.NewUint(10))
-				tickUpdate(pool, 0, 0, i256.One(), u256.Zero(), u256.Zero(), true, u256.NewUint(10))
-				tickUpdate(pool, 0, 0, i256.NewInt(3), u256.Zero(), u256.Zero(), true, u256.NewUint(10))
-				tickUpdate(pool, 0, 0, i256.One(), u256.Zero(), u256.Zero(), false, u256.NewUint(10))
+				tickUpdate(pool, 0, 0, i256.NewInt(2), u256.Zero(), u256.Zero(), u256.Zero(), 0, 0, false, u256.NewUint(10))
+				tickUpdate(pool, 0, 0, i256.One(), u256.Zero(), u256.Zero(), u256.Zero(), 0, 0, true, u256.NewUint(10))
+				tickUpdate(pool, 0, 0, i256.NewInt(3), u256.Zero(), u256.Zero(), u256.Zero(), 0, 0, true, u256.NewUint(10))
+				tickUpdate(pool, 0, 0, i256.One(), u256.Zero(), u256.Zero(), u256.Zero(), 0, 0, false, u256.NewUint(10))
 			},
 			tick:                 0,
 			tickCurrent:          0,
@@ -363,7 +363,7 @@ func TestTickUpdate(cur realm, t *testing.T) {
 		{
 			name: "reverts on overflow liquidity gross",
 			preconditions: func() {
-				tickUpdate(pool, 0, 0, i256.MustFromDecimal("170141183460469231731687303715884105726"), u256.Zero(), u256.Zero(), false, u256.MustFromDecimal("340282366920938463463374607431768211455"))
+				tickUpdate(pool, 0, 0, i256.MustFromDecimal("170141183460469231731687303715884105726"), u256.Zero(), u256.Zero(), u256.Zero(), 0, 0, false, u256.MustFromDecimal("340282366920938463463374607431768211455"))
 			},
 			tick:                 0,
 			tickCurrent:          0,
@@ -380,7 +380,7 @@ func TestTickUpdate(cur realm, t *testing.T) {
 			preconditions: func() {
 				deleteTick(pool, 0)
 				deleteTick(pool, 1)
-				tickUpdate(pool, 1, 1, i256.One(), u256.One(), u256.NewUint(2), false, u256.MustFromDecimal("340282366920938463463374607431768211455"))
+				tickUpdate(pool, 1, 1, i256.One(), u256.One(), u256.NewUint(2), u256.Zero(), 0, 0, false, u256.MustFromDecimal("340282366920938463463374607431768211455"))
 			},
 			tick:                 0,
 			tickCurrent:          0,
@@ -400,8 +400,8 @@ func TestTickUpdate(cur realm, t *testing.T) {
 		{
 			name: "does not set any growth fields if tick is already initialized",
 			preconditions: func() {
-				tickUpdate(pool, 1, 1, i256.One(), u256.One(), u256.NewUint(2), false, u256.MustFromDecimal("340282366920938463463374607431768211455"))
-				tickUpdate(pool, 1, 1, i256.One(), u256.NewUint(6), u256.NewUint(7), false, u256.MustFromDecimal("340282366920938463463374607431768211455"))
+				tickUpdate(pool, 1, 1, i256.One(), u256.One(), u256.NewUint(2), u256.Zero(), 0, 0, false, u256.MustFromDecimal("340282366920938463463374607431768211455"))
+				tickUpdate(pool, 1, 1, i256.One(), u256.NewUint(6), u256.NewUint(7), u256.Zero(), 0, 0, false, u256.MustFromDecimal("340282366920938463463374607431768211455"))
 			},
 			tick:                 1,
 			tickCurrent:          1,
@@ -452,6 +452,9 @@ func TestTickUpdate(cur realm, t *testing.T) {
 						tt.liquidityDelta,
 						tt.feeGrowthGlobal0X128,
 						tt.feeGrowthGlobal1X128,
+						u256.Zero(),
+						0,
+						0,
 						tt.upper,
 						tt.maxLiquidity,
 					)
@@ -470,6 +473,9 @@ func TestTickUpdate(cur realm, t *testing.T) {
 					tt.liquidityDelta,
 					tt.feeGrowthGlobal0X128,
 					tt.feeGrowthGlobal1X128,
+					u256.Zero(),
+					0,
+					0,
 					tt.upper,
 					tt.maxLiquidity,
 				)
@@ -484,6 +490,9 @@ func TestTickUpdate(cur realm, t *testing.T) {
 						tt.liquidityDelta,
 						tt.feeGrowthGlobal0X128,
 						tt.feeGrowthGlobal1X128,
+						u256.Zero(),
+						0,
+						0,
 						tt.upper,
 						tt.maxLiquidity,
 					)
@@ -494,6 +503,72 @@ func TestTickUpdate(cur realm, t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTickUpdateSeedsOracleOutsideForActiveTick(cur realm, t *testing.T) {
+	const (
+		startTime = int64(1000)
+		initTime  = int64(1010)
+		crossTime = int64(1020)
+	)
+
+	pool := pl.NewPool("token0", "token1", STANDARD_FEE_TIER, u256.MustFromDecimal(EQUAL_PRICE_RATIO), 1, 5, 0)
+	pool.SetLiquidity(u256.NewUint(100))
+
+	observationState := pl.NewObservationState(startTime)
+	pool.SetObservationState(observationState)
+	uassert.NoError(t, writeObservation(observationState, initTime, 5, pool.Liquidity()))
+
+	tickCumulativeAtInit, secondsPerLiquidityAtInit, err := observeSingle(
+		observationState,
+		initTime,
+		0,
+		pool.Slot0Tick(),
+		observationState.Index(),
+		pool.Liquidity(),
+		observationState.Cardinality(),
+	)
+	uassert.NoError(t, err)
+
+	restoreContext := setOracleTestContext(initTime)
+	defer restoreContext()
+	_, err = updatePosition(pool, newModifyPositionParams(address("g1lp"), 0, 10, i256.NewInt(10)), pool.Slot0Tick())
+	uassert.NoError(t, err)
+
+	lowerTick := getTick(pool, 0)
+	uassert.Equal(t, tickCumulativeAtInit, lowerTick.TickCumulativeOutside())
+	uassert.Equal(t, secondsPerLiquidityAtInit, lowerTick.SecondsPerLiquidityOutsideX128())
+	uassert.Equal(t, uint32(initTime), lowerTick.SecondsOutside())
+
+	tickCumulativeAtCross, secondsPerLiquidityAtCross, err := observeSingle(
+		observationState,
+		crossTime,
+		0,
+		pool.Slot0Tick(),
+		observationState.Index(),
+		pool.Liquidity(),
+		observationState.Cardinality(),
+	)
+	uassert.NoError(t, err)
+	expectedSecondsPerLiquidityOutside := u256.Zero().Sub(
+		u256.MustFromDecimal(secondsPerLiquidityAtCross),
+		u256.MustFromDecimal(secondsPerLiquidityAtInit),
+	)
+
+	tickCross(
+		pool,
+		0,
+		u256.Zero(),
+		u256.Zero(),
+		u256.MustFromDecimal(secondsPerLiquidityAtCross),
+		tickCumulativeAtCross,
+		crossTime,
+	)
+
+	lowerTick = getTick(pool, 0)
+	uassert.Equal(t, tickCumulativeAtCross-tickCumulativeAtInit, lowerTick.TickCumulativeOutside())
+	uassert.Equal(t, expectedSecondsPerLiquidityOutside.ToString(), lowerTick.SecondsPerLiquidityOutsideX128())
+	uassert.Equal(t, uint32(crossTime-initTime), lowerTick.SecondsOutside())
 }
 
 func TestTickCross(cur realm, t *testing.T) {

--- a/contract/r/scenario/getter/pool_getter_filetest.gno
+++ b/contract/r/scenario/getter/pool_getter_filetest.gno
@@ -1086,7 +1086,7 @@ func getObservationState(cur realm) {
 //
 // [SCENARIO] 2.44. GetTickSecondsOutside
 // [INFO] Check GetTickSecondsOutside method
-// [EXPECTED] tick secondsOutside at min_tick: 0
+// [EXPECTED] tick secondsOutside at min_tick: 1234567890
 //
 // [SCENARIO] 2.45. GetTickSecondsPerLiquidityOutsideX128
 // [INFO] Check GetTickSecondsPerLiquidityOutsideX128 method

--- a/contract/r/scenario/pool/tick_cross_oracle_update_filetest.gno
+++ b/contract/r/scenario/pool/tick_cross_oracle_update_filetest.gno
@@ -271,7 +271,7 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 // [INFO] Tick -1000 initial state:
 // [INFO] Initialized: true
 // [INFO] TickCumulativeOutside: 0
-// [INFO] SecondsOutside: 0
+// [INFO] SecondsOutside: 1234567890
 // [INFO] SecondsPerLiquidityOutsideX128: 0
 //
 // [SCENARIO] 4. Wait for Time to Pass
@@ -286,7 +286,7 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 // [INFO] Tick -1000 after cross(cur):
 // [INFO] Initialized: true
 // [EXPECTED] TickCumulativeOutside updated: -500
-// [EXPECTED] SecondsOutside updated: 1234568390
+// [EXPECTED] SecondsOutside updated: 500
 // [EXPECTED] SecondsPerLiquidityOutsideX128 is set: 17014118346046923173168730371588410
 // [EXPECTED] Oracle field successfully updated (non-zero)
 //
@@ -304,7 +304,7 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 // [SCENARIO] 9. Verify Oracle Fields After Second Cross
 // [INFO] Tick -1000 after second cross(cur):
 // [EXPECTED] TickCumulativeOutside changed: -549500
-// [EXPECTED] SecondsOutside changed: 500
+// [EXPECTED] SecondsOutside changed: 1234568390
 // [EXPECTED] SecondsPerLiquidityOutsideX128 updated again: 170141183460469231731687303715884105728000
 // [EXPECTED] Oracle field values changed on second cross(cur)
 //


### PR DESCRIPTION
## Summary

`tickUpdate` left oracle outside accumulators uninitialized for ticks at or below `tickCurrent`, so the first crossing of such a tick produced corrupted oracle state (uninitialized `secondsPerLiquidityOutsideX128` / `tickCumulativeOutside` / `secondsOutside`).

When a tick is first initialized and is **active** (`tick <= tickCurrent`), `tickUpdate` now seeds its outside accumulators from the current oracle values:

- `secondsPerLiquidityOutsideX128` ← `secondsPerLiquidityCumulativeX128`
- `tickCumulativeOutside` ← `tickCumulative`
- `secondsOutside` ← `blockTimestamp`

`updatePosition` reads these via `observeSingle` (existing oracle logic) and passes them into `tickUpdate`, so the seeding matches the pool's current observation state exactly.

## Uniswap v3 alignment

This fix mirrors Uniswap v3's flow. Reference permalinks:

- [`UniswapV3Pool._updatePosition`](https://github.com/Uniswap/v3-core/blob/d0831dc6b8a318df3872b6d68f6de135c9f3ec29/contracts/UniswapV3Pool.sol#L379-L440) — calls `observeSingle(time, 0, slot0.tick, slot0.observationIndex, liquidity, slot0.observationCardinality)` before updating ticks, then passes the observed values into `ticks.update`.
- [`Tick.update`](https://github.com/Uniswap/v3-core/blob/d0831dc6b8a318df3872b6d68f6de135c9f3ec29/contracts/libraries/Tick.sol#L132-L140) — when the tick flips from uninitialized and `tick <= tickCurrent`, seeds `secondsPerLiquidityOutsideX128`, `tickCumulativeOutside`, and `secondsOutside` from those arguments.

Alignments made to match the reference:

- `tickUpdate` signature now takes `secondsPerLiquidityCumulativeX128 *u256.Uint`, `tickCumulative int64`, `blockTimestamp int64` as **flat required parameters** — identical in ordering to `Tick.update` (dropped the temporary `tickUpdateOracleState` struct / variadic fallback, so omitting the seeding args is a compile error rather than a silent regression).
- Seeding block (`liquidityGrossBefore == 0 && tick <= tickCurrent`) mirrors `Tick.update`'s flip-to-initialized branch.
- `observeSingle` is invoked with the same argument positions as `_updatePosition` (`time, 0, tick, observationIndex, liquidity, cardinality`).

## Test plan

- [x] `make test PKG=gno.land/r/gnoswap/pool/v1` — full unit suite passes.
- [x] New regression test `TestTickUpdateSeedsOracleOutsideForActiveTick` verifies seeding at initialization and correct deltas after a crossing.
- [x] Existing `tickUpdate` call sites updated to the new required signature (17 test call sites + `updatePosition`).