### PR TITLE
test: pay tokens via native transfers instead of the grc20 registry hub

### DIFF
--- a/contract/r/gnoswap/gov/staker/v1/staker_reward_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/staker_reward_test.gno
@@ -535,7 +535,7 @@ func TestStakerReward_TokenTransferScenarios(cur realm, t *testing.T) {
 		{
 			name:        "success - normal token transfer",
 			tokenPath:   GNS_PATH,
-			from:        admin,
+			from:        govStakerAddr,
 			to:          testutils.TestAddress("to"),
 			amount:      100_000_000,
 			fromBalance: 500_000_000,
@@ -544,26 +544,28 @@ func TestStakerReward_TokenTransferScenarios(cur realm, t *testing.T) {
 		{
 			name:        "success - exact balance transfer",
 			tokenPath:   GNS_PATH,
-			from:        admin,
+			from:        govStakerAddr,
 			to:          testutils.TestAddress("to"),
-			amount:      100_000_000,
-			fromBalance: 100_000_000,
+			amount:      1_000_000_000,
+			fromBalance: 1_000_000_000,
 			shouldFail:  false,
 		},
 		{
 			name:          "fail - insufficient balance",
 			tokenPath:     GNS_PATH,
-			from:          testutils.TestAddress("from"), // not have balance
+			from:          govStakerAddr,
 			to:            testutils.TestAddress("to"),
-			amount:        200_000_000,
-			fromBalance:   100_000_000,
+			// setup re-runs per subtest, so the funded balance accumulates; pick an
+			// amount that exceeds it under any ordering.
+			amount:        1_000_000_000_000_000,
+			fromBalance:   1_000_000_000,
 			expectedError: "insufficient balance",
 			shouldFail:    true,
 		},
 		{
 			name:          "fail - invalid to address",
 			tokenPath:     GNS_PATH,
-			from:          admin,
+			from:          govStakerAddr,
 			to:            address(""),
 			amount:        100_000_000,
 			fromBalance:   500_000_000,
@@ -573,7 +575,7 @@ func TestStakerReward_TokenTransferScenarios(cur realm, t *testing.T) {
 		{
 			name:          "fail - negative amount",
 			tokenPath:     GNS_PATH,
-			from:          admin,
+			from:          govStakerAddr,
 			to:            testutils.TestAddress("to"),
 			amount:        -100_000_000,
 			fromBalance:   500_000_000,
@@ -583,7 +585,7 @@ func TestStakerReward_TokenTransferScenarios(cur realm, t *testing.T) {
 		{
 			name:        "success - zero amount transfer",
 			tokenPath:   GNS_PATH,
-			from:        admin,
+			from:        govStakerAddr,
 			to:          testutils.TestAddress("to"),
 			amount:      0,
 			fromBalance: 500_000_000,
@@ -602,7 +604,7 @@ func TestStakerReward_TokenTransferScenarios(cur realm, t *testing.T) {
 		{
 			name:        "success - GRC20 bar token transfer",
 			tokenPath:   barPath,
-			from:        admin,
+			from:        govStakerAddr,
 			to:          testutils.TestAddress("to"),
 			amount:      100_000_000,
 			fromBalance: 500_000_000,

--- a/contract/r/gnoswap/gov/staker/v1/staker_reward_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/staker_reward_test.gno
@@ -413,7 +413,10 @@ func TestStakerReward_transferToken(cur realm, t *testing.T) {
 			tt.setupBalance()
 
 			// When: Transfer token
-			testing.SetRealm(testing.NewUserRealm(tt.from))
+			// Drive the flow as the real on-chain entry (CollectReward) does:
+			// the gov staker realm debits its own tokens, so Previous must be
+			// the staker code realm (govStakerAddr), not an EOA/origin.
+			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/gov/staker"))
 			err := transferToken(0, cur, tt.tokenPath, tt.from, tt.to, tt.amount)
 
 			// Then: Check result
@@ -615,7 +618,11 @@ func TestStakerReward_TokenTransferScenarios(cur realm, t *testing.T) {
 			cleanupStakerRewardTest(cur, t)
 			setupStakerRewardStakerTokenBalance(cur, t)
 
-			testing.SetRealm(adminRealm)
+			// Drive the flow as the real on-chain entry (CollectReward) does:
+			// transferToken debits the caller realm (Previous), whose tokens
+			// were minted to govStakerAddr above. Previous must be the staker
+			// code realm, not an EOA/origin.
+			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/gov/staker"))
 
 			// When: Transfer token
 			err := transferToken(0, cur, tt.tokenPath, tt.from, tt.to, tt.amount)

--- a/contract/r/gnoswap/launchpad/v1/launchpad_project_test.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_project_test.gno
@@ -1152,7 +1152,10 @@ func TestLaunchpadProject_TransferLeftFromProjectWithPendingWithdrawals(cur real
 			testing.SetRealm(adminRealm)
 			obl.Transfer(cross(cur), launchpadAddr, tt.totalDistributeAmount)
 
-			// Execute transfer
+			// Execute transfer as the launchpad realm (the actual on-chain caller
+			// of transferLeftFromProject), so the token debit comes from the
+			// launchpad realm's own address instead of the EOA transaction origin.
+			testing.SetRealm(testing.NewCodeRealm(testLaunchpadPkgPath))
 			currentTime := int64(2001) // After tier end
 			beforeOblBalance := obl.BalanceOf(recipient)
 			refundedAmount, err := lp.transferLeftFromProject(0, cur, project, recipient, currentTime)
@@ -1271,7 +1274,8 @@ func TestLaunchpadProject_TransferLeftFromProjectWithMultiplePendingDeposits(cur
 			testing.SetRealm(adminRealm)
 			obl.Transfer(cross(cur), launchpadAddr, tt.totalDistributeAmount)
 
-			// Execute transfer
+			// Execute transfer as the launchpad realm (see note above).
+			testing.SetRealm(testing.NewCodeRealm(testLaunchpadPkgPath))
 			currentTime := int64(2001)
 			refundedAmount, err := lp.transferLeftFromProject(0, cur, project, recipient, currentTime)
 
@@ -1357,7 +1361,8 @@ func TestLaunchpadProject_TransferLeftFromProjectNoDepositors(cur realm, t *test
 			testing.SetRealm(adminRealm)
 			obl.Transfer(cross(cur), launchpadAddr, tt.totalDistributeAmount)
 
-			// Execute transfer
+			// Execute transfer as the launchpad realm (see note above).
+			testing.SetRealm(testing.NewCodeRealm(testLaunchpadPkgPath))
 			currentTime := int64(2001)
 			refundedAmount, err := lp.transferLeftFromProject(0, cur, project, recipient, currentTime)
 
@@ -1400,6 +1405,9 @@ func TestLaunchpadProject_TransferLeftFromProjectRepeatedRefundDoesNotDrainOther
 	initialBalance := obl.BalanceOf(recipient)
 	obl.Transfer(cross(cur), launchpadAddr, rewardAmount)
 
+	// Execute transfer as the launchpad realm (see note above); the realm stays
+	// set for the second transferLeftFromProject call below as well.
+	testing.SetRealm(testing.NewCodeRealm(testLaunchpadPkgPath))
 	refundedAmount, err := lp.transferLeftFromProject(0, cur, project, recipient, currentTime)
 	uassert.NoError(t, err)
 	uassert.Equal(t, rewardAmount, refundedAmount)

--- a/contract/r/gnoswap/pool/v1/_helper_test.gno
+++ b/contract/r/gnoswap/pool/v1/_helper_test.gno
@@ -432,14 +432,57 @@ func TestBurnTokens(cur realm, t *testing.T) {
 	uassert.Equal(t, bar.BalanceOf(addr01), int64(0)) // 100_000_000 -> 0
 }
 
+// transferToken / approveToken dispatch to the token's OWN realm so that the
+// debit is performed by the token realm itself. The patched grc20 forbids a
+// CallerTeller from a foreign realm (e.g. common's generic hub) from debiting
+// the transaction origin, which broke EOA-context test callbacks that used
+// common.SafeGRC20Transfer / common.SafeGRC20Approve.
+func transferToken(cur realm, path string, to address, amount int64) {
+	switch path {
+	case barPath:
+		bar.Transfer(cross(cur), to, amount)
+	case bazPath:
+		baz.Transfer(cross(cur), to, amount)
+	case fooPath:
+		foo.Transfer(cross(cur), to, amount)
+	case quxPath:
+		qux.Transfer(cross(cur), to, amount)
+	case oblPath:
+		obl.Transfer(cross(cur), to, amount)
+	case gnsPath:
+		gns.Transfer(cross(cur), to, amount)
+	default:
+		panic("test: unsupported token path " + path)
+	}
+}
+
+func approveToken(cur realm, path string, spender address, amount int64) {
+	switch path {
+	case barPath:
+		bar.Approve(cross(cur), spender, amount)
+	case bazPath:
+		baz.Approve(cross(cur), spender, amount)
+	case fooPath:
+		foo.Approve(cross(cur), spender, amount)
+	case quxPath:
+		qux.Approve(cross(cur), spender, amount)
+	case oblPath:
+		obl.Approve(cross(cur), spender, amount)
+	case gnsPath:
+		gns.Approve(cross(cur), spender, amount)
+	default:
+		panic("test: unsupported token path " + path)
+	}
+}
+
 func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0Delta int64, amount1Delta int64) error {
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		transferToken(cur, token0Path, poolAddr, amount0Delta)
 	}
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		transferToken(cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/gnoswap/pool/v1/dsl_test.gno
+++ b/contract/r/gnoswap/pool/v1/dsl_test.gno
@@ -12,7 +12,6 @@ import (
 	ufmt "gno.land/p/nt/ufmt/v0"
 
 	"gno.land/r/gnoswap/access"
-	"gno.land/r/gnoswap/common"
 	pl "gno.land/r/gnoswap/pool"
 )
 
@@ -169,9 +168,9 @@ func (e *PoolTestEnv) WhenSwapExecuted(cur realm, params SwapParams) (*u256.Uint
 	swapCallback := func(cur realm, amount0Delta int64, amount1Delta int64, _ *pl.CallbackMarker) error {
 		testing.SetRealm(adminRealm)
 		if params.zeroForOne {
-			common.SafeGRC20Transfer(cross(cur), params.token0, e.currentAddress, math.MaxInt64)
+			transferToken(cur, params.token0, e.currentAddress, math.MaxInt64)
 		} else {
-			common.SafeGRC20Transfer(cross(cur), params.token1, e.currentAddress, math.MaxInt64)
+			transferToken(cur, params.token1, e.currentAddress, math.MaxInt64)
 		}
 
 		return nil

--- a/contract/r/gnoswap/pool/v1/pool_test.gno
+++ b/contract/r/gnoswap/pool/v1/pool_test.gno
@@ -10,7 +10,6 @@ import (
 	uassert "gno.land/p/nt/uassert/v0"
 	ufmt "gno.land/p/nt/ufmt/v0"
 
-	"gno.land/r/gnoswap/common"
 	pl "gno.land/r/gnoswap/pool"
 	"gno.land/r/onbloc/bar"
 	"gno.land/r/onbloc/baz"
@@ -993,8 +992,8 @@ func approveTokensForPool(cur realm, t *testing.T, pool *pl.Pool) {
 	t.Helper()
 	testing.SetRealm(adminRealm)
 
-	common.SafeGRC20Approve(cross(cur), pool.Token0Path(), poolAddr, maxApprove)
-	common.SafeGRC20Approve(cross(cur), pool.Token1Path(), poolAddr, maxApprove)
+	approveToken(cur, pool.Token0Path(), poolAddr, maxApprove)
+	approveToken(cur, pool.Token1Path(), poolAddr, maxApprove)
 }
 
 func getTokenBalance(t *testing.T, tokenPath string, addr address) int64 {

--- a/contract/r/gnoswap/pool/v1/protocol_fee_test.gno
+++ b/contract/r/gnoswap/pool/v1/protocol_fee_test.gno
@@ -11,7 +11,6 @@ import (
 	u256 "gno.land/p/gnoswap/uint256"
 
 	"gno.land/p/gnoswap/gnsmath"
-	"gno.land/r/gnoswap/common"
 	"gno.land/r/gnoswap/gns"
 	pl "gno.land/r/gnoswap/pool"
 	_ "gno.land/r/gnoswap/protocol_fee"
@@ -641,10 +640,10 @@ func TestProtocolFeesDisabledWhenNotConfigured(cur realm, t *testing.T) {
 		testing.SetRealm(adminRealm)
 
 		if amount0Delta > 0 {
-			common.SafeGRC20Transfer(cross(cur), barPath, poolAddr, amount0Delta)
+			transferToken(cur, barPath, poolAddr, amount0Delta)
 		}
 		if amount1Delta > 0 {
-			common.SafeGRC20Transfer(cross(cur), fooPath, poolAddr, amount1Delta)
+			transferToken(cur, fooPath, poolAddr, amount1Delta)
 		}
 
 		return nil

--- a/contract/r/gnoswap/pool/v1/swap_paid_test.gno
+++ b/contract/r/gnoswap/pool/v1/swap_paid_test.gno
@@ -372,10 +372,10 @@ func swapPaidSwapCallback(
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		transferToken(cur, token0Path, poolAddr, amount0Delta)
 	}
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		transferToken(cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil
@@ -412,11 +412,11 @@ func initSwapPaidSetFeeMintPosition(
 	testing.SetOriginSend(chain.Coins{})
 
 	if amount0Requested > 0 {
-		common.SafeGRC20Approve(cross(cur), token0Path, poolAddr, amount0Requested)
+		approveToken(cur, token0Path, poolAddr, amount0Requested)
 	}
 
 	if amount1Requested > 0 {
-		common.SafeGRC20Approve(cross(cur), token1Path, poolAddr, amount1Requested)
+		approveToken(cur, token1Path, poolAddr, amount1Requested)
 	}
 
 	sqrtPriceX96 := getMockInstance().GetSlot0SqrtPriceX96(GetPoolPath(token0Path, token1Path, feeTier))

--- a/contract/r/gnoswap/position/v1/_helper_test.gno
+++ b/contract/r/gnoswap/position/v1/_helper_test.gno
@@ -10,7 +10,6 @@ import (
 	prabc "gno.land/p/gnoswap/rbac"
 	testutils "gno.land/p/nt/testutils/v0"
 	"gno.land/r/gnoswap/access"
-	"gno.land/r/gnoswap/common"
 	"gno.land/r/gnoswap/gnft"
 	"gno.land/r/gnoswap/mock"
 
@@ -491,6 +490,53 @@ func createPoolWithoutFee(cur realm, token0 string, token1 string, fee uint32, t
 	pl.CreatePool(cross(cur), token0, token1, fee, gnsmath.TickMathGetSqrtRatioAtTick(tick).ToString())
 }
 
+// approveToken approves spender for the given token via the token realm's own
+// Approve, so the debit is authorized by the token's own realm (avoids the
+// grc20 origin-guard that rejects a CallerTeller from a foreign realm).
+func approveToken(cur realm, path string, spender address, amount int64) {
+	switch path {
+	case barPath:
+		bar.Approve(cross(cur), spender, amount)
+	case bazPath:
+		baz.Approve(cross(cur), spender, amount)
+	case fooPath:
+		foo.Approve(cross(cur), spender, amount)
+	case oblPath:
+		obl.Approve(cross(cur), spender, amount)
+	case quxPath:
+		qux.Approve(cross(cur), spender, amount)
+	case gnsPath:
+		gns.Approve(cross(cur), spender, amount)
+	case wugnotPath:
+		wugnot.Approve(cross(cur), spender, amount)
+	default:
+		panic("test: unsupported token path " + path)
+	}
+}
+
+// transferToken transfers the given token via the token realm's own Transfer,
+// so the debit is authorized by the token's own realm.
+func transferToken(cur realm, path string, to address, amount int64) {
+	switch path {
+	case barPath:
+		bar.Transfer(cross(cur), to, amount)
+	case bazPath:
+		baz.Transfer(cross(cur), to, amount)
+	case fooPath:
+		foo.Transfer(cross(cur), to, amount)
+	case oblPath:
+		obl.Transfer(cross(cur), to, amount)
+	case quxPath:
+		qux.Transfer(cross(cur), to, amount)
+	case gnsPath:
+		gns.Transfer(cross(cur), to, amount)
+	case wugnotPath:
+		wugnot.Transfer(cross(cur), to, amount)
+	default:
+		panic("test: unsupported token path " + path)
+	}
+}
+
 func mockInstanceMint(
 	cur realm,
 	token0 string,
@@ -511,8 +557,8 @@ func mockInstanceMint(
 	amount1Int, _ := strconv.ParseInt(amount1Desired, 10, 64)
 
 	testing.SetRealm(testing.NewUserRealm(caller))
-	common.SafeGRC20Approve(cross(cur), token0, poolAddr, amount0Int)
-	common.SafeGRC20Approve(cross(cur), token1, poolAddr, amount1Int)
+	approveToken(cur, token0, poolAddr, amount0Int)
+	approveToken(cur, token1, poolAddr, amount1Int)
 
 	testing.SetRealm(testing.NewUserRealm(caller))
 	return position.Mint(cross(cur),
@@ -545,8 +591,8 @@ func mockInstanceIncreaseLiquidity(
 	amount1Int, _ := strconv.ParseInt(amount1DesiredStr, 10, 64)
 
 	testing.SetRealm(testing.NewUserRealm(caller))
-	common.SafeGRC20Approve(cross(cur), barPath, poolAddr, amount0Int)
-	common.SafeGRC20Approve(cross(cur), fooPath, poolAddr, amount1Int)
+	approveToken(cur, barPath, poolAddr, amount0Int)
+	approveToken(cur, fooPath, poolAddr, amount1Int)
 
 	testing.SetRealm(testing.NewUserRealm(caller))
 	return position.IncreaseLiquidity(cross(cur),
@@ -592,8 +638,8 @@ func mockInstanceReposition(
 	amount1Int, _ := strconv.ParseInt(amount1DesiredStr, 10, 64)
 
 	testing.SetRealm(testing.NewUserRealm(caller))
-	common.SafeGRC20Approve(cross(cur), barPath, poolAddr, amount0Int)
-	common.SafeGRC20Approve(cross(cur), fooPath, poolAddr, amount1Int)
+	approveToken(cur, barPath, poolAddr, amount0Int)
+	approveToken(cur, fooPath, poolAddr, amount1Int)
 
 	testing.SetRealm(testing.NewUserRealm(caller))
 	return position.Reposition(cross(cur),

--- a/contract/r/gnoswap/position/v1/mint_test.gno
+++ b/contract/r/gnoswap/position/v1/mint_test.gno
@@ -8,7 +8,6 @@ import (
 	testutils "gno.land/p/nt/testutils/v0"
 	uassert "gno.land/p/nt/uassert/v0"
 
-	"gno.land/r/gnoswap/common"
 	pl "gno.land/r/gnoswap/pool"
 	"gno.land/r/onbloc/bar"
 	"gno.land/r/onbloc/baz"
@@ -729,8 +728,8 @@ func TestMintInternal_TickBoundaries(cur realm, t *testing.T) {
 			amount1Int, _ := strconv.ParseInt(tt.params.amount1Desired.ToString(), 10, 64)
 
 			testing.SetRealm(testing.NewUserRealm(tt.params.caller))
-			common.SafeGRC20Approve(cross(cur), tt.params.token0, poolAddr, amount0Int)
-			common.SafeGRC20Approve(cross(cur), tt.params.token1, poolAddr, amount1Int)
+			approveToken(cur, tt.params.token0, poolAddr, amount0Int)
+			approveToken(cur, tt.params.token1, poolAddr, amount1Int)
 
 			if tt.expectPanic {
 				uassert.AbortsWithMessage(t, cur, tt.expectedMsg, func() {

--- a/contract/r/gnoswap/position/v1/position_test.gno
+++ b/contract/r/gnoswap/position/v1/position_test.gno
@@ -11,7 +11,6 @@ import (
 	testutils "gno.land/p/nt/testutils/v0"
 	uassert "gno.land/p/nt/uassert/v0"
 
-	"gno.land/r/gnoswap/common"
 	"gno.land/r/gnoswap/halt"
 	"gno.land/r/gnoswap/position"
 	"gno.land/r/gnoswap/referral"
@@ -704,8 +703,8 @@ func TestMint(cur realm, t *testing.T) {
 				})
 			} else {
 				testing.SetRealm(adminRealm)
-				common.SafeGRC20Transfer(cross(cur), tc.token0, tc.caller, amount0Int)
-				common.SafeGRC20Transfer(cross(cur), tc.token1, tc.caller, amount1Int)
+				transferToken(cur, tc.token0, tc.caller, amount0Int)
+				transferToken(cur, tc.token1, tc.caller, amount1Int)
 
 				testing.SetRealm(testing.NewUserRealm(tc.caller))
 
@@ -801,16 +800,16 @@ func TestMint_ParticipantDerivationAndMintToValidation(cur realm, t *testing.T) 
 			}
 
 			testing.SetRealm(adminRealm)
-			common.SafeGRC20Transfer(cross(cur), barPath, caller, 1000000)
-			common.SafeGRC20Transfer(cross(cur), fooPath, caller, 1000000)
+			transferToken(cur, barPath, caller, 1000000)
+			transferToken(cur, fooPath, caller, 1000000)
 
 			if tt.callerCodePath != "" {
 				testing.SetRealm(testing.NewCodeRealm(tt.callerCodePath))
 			} else {
 				testing.SetRealm(testing.NewUserRealm(caller))
 			}
-			common.SafeGRC20Approve(cross(cur), barPath, poolAddr, 1000000)
-			common.SafeGRC20Approve(cross(cur), fooPath, poolAddr, 1000000)
+			approveToken(cur, barPath, poolAddr, 1000000)
+			approveToken(cur, fooPath, poolAddr, 1000000)
 
 			mint := func(cur realm) (uint64, string, string, string) {
 				if tt.callerCodePath != "" {

--- a/contract/r/gnoswap/protocol_fee/v1/protocol_fee_test.gno
+++ b/contract/r/gnoswap/protocol_fee/v1/protocol_fee_test.gno
@@ -1008,7 +1008,7 @@ func TestDistributeProtocolFee_HaltScenario_SafeMode(cur realm, t *testing.T) {
 	}()
 
 	testing.SetRealm(adminRealm)
-	common.SafeGRC20Transfer(cross(cur), "gno.land/r/onbloc/bar.BAR", protocolFeeAddr, 100)
+	bar.Transfer(cross(cur), protocolFeeAddr, 100)
 
 	testing.SetRealm(govStakerRealm)
 

--- a/contract/r/gnoswap/router/v1/base_test.gno
+++ b/contract/r/gnoswap/router/v1/base_test.gno
@@ -10,7 +10,6 @@ import (
 	gnsmath "gno.land/p/gnoswap/gnsmath"
 	u256 "gno.land/p/gnoswap/uint256"
 	"gno.land/p/gnoswap/utils"
-	"gno.land/r/gnoswap/common"
 	"gno.land/r/gnoswap/gns"
 	pl "gno.land/r/gnoswap/pool"
 	pn "gno.land/r/gnoswap/position"
@@ -132,7 +131,7 @@ func TestProcessRoute(cur realm, t *testing.T) {
 	testing.SetRealm(adminRealm)
 	CreatePoolWithoutFee(cur, t)
 	MakeThirdMintPositionWithoutFee(cur, t)
-	common.SafeGRC20Approve(cross(cur), fooPath, routerAddr, 1000000)
+	TokenApprove(cur, t, fooPath, admin, routerAddr, 1000000)
 	route := foobar500
 	toSwap := int64(1000)
 	swapType := ExactIn
@@ -159,8 +158,8 @@ func TestProcessRoutesWithRemainder(cur realm, t *testing.T) {
 	}
 
 	testing.SetRealm(adminRealm)
-	common.SafeGRC20Approve(cross(cur), fooPath, routerAddr, math.MaxInt64)
-	common.SafeGRC20Approve(cross(cur), barPath, routerAddr, math.MaxInt64)
+	TokenApprove(cur, t, fooPath, admin, routerAddr, math.MaxInt64)
+	TokenApprove(cur, t, barPath, admin, routerAddr, math.MaxInt64)
 	CreatePoolWithoutFee(cur, t)
 	MakeThirdMintPositionWithoutFee(cur, t)
 	MakeForthMintPositionWithoutFee(cur, t)

--- a/contract/r/gnoswap/router/v1/router_test.gno
+++ b/contract/r/gnoswap/router/v1/router_test.gno
@@ -12,7 +12,6 @@ import (
 	testutils "gno.land/p/nt/testutils/v0"
 	uassert "gno.land/p/nt/uassert/v0"
 
-	"gno.land/r/gnoswap/common"
 	"gno.land/r/gnoswap/gns"
 	pl "gno.land/r/gnoswap/pool"
 	pn "gno.land/r/gnoswap/position"
@@ -901,7 +900,7 @@ func TestHandleMultiSwap(cur realm, t *testing.T) {
 
 			testing.SetRealm(adminRealm)
 
-			common.SafeGRC20Approve(cross(cur), tt.inputToken, routerAddr, math.MaxInt64)
+			TokenApprove(cur, t, tt.inputToken, admin, routerAddr, math.MaxInt64)
 
 			amountSpecified := utils.SafeParseInt64(tt.amountSpecified)
 
@@ -1016,7 +1015,7 @@ func TestProcessRoute_MultiHops(cur realm, t *testing.T) {
 			toSwapAmount := utils.SafeParseInt64(tt.toSwap)
 			testing.SetRealm(adminRealm)
 
-			common.SafeGRC20Approve(cross(cur), barPath, routerAddr, math.MaxInt64)
+			TokenApprove(cur, t, barPath, admin, routerAddr, math.MaxInt64)
 
 			router := mockRouter()
 			processRouteFn := func(cur realm) (int64, int64, error) {

--- a/contract/r/gnoswap/router/v1/swap_multi_test.gno
+++ b/contract/r/gnoswap/router/v1/swap_multi_test.gno
@@ -8,7 +8,6 @@ import (
 	uassert "gno.land/p/nt/uassert/v0"
 
 	"gno.land/r/gnoswap/access"
-	"gno.land/r/gnoswap/common"
 )
 
 func TestMultiSwap(cur realm, t *testing.T) {
@@ -61,8 +60,8 @@ func TestMultiSwap(cur realm, t *testing.T) {
 			// (cur.Previous()) resolves to user1 and the pool can pull the
 			// input token. Mirrors TestSingleSwap.
 			testing.SetRealm(testing.NewUserRealm(user1Addr))
-			common.Approve(cross(cur), tt.params.tokenIn, poolAddr, maxApprove)
-			common.Approve(cross(cur), tt.params.tokenOut, poolAddr, maxApprove)
+			TokenApprove(cur, t, tt.params.tokenIn, user1Addr, poolAddr, maxApprove)
+			TokenApprove(cur, t, tt.params.tokenOut, user1Addr, poolAddr, maxApprove)
 
 			firstAmountIn, lastAmountOut := multiSwapFn(cross(cur))
 

--- a/contract/r/gnoswap/router/v1/swap_single_test.gno
+++ b/contract/r/gnoswap/router/v1/swap_single_test.gno
@@ -10,7 +10,6 @@ import (
 	prabc "gno.land/p/gnoswap/rbac"
 
 	"gno.land/r/gnoswap/access"
-	"gno.land/r/gnoswap/common"
 )
 
 func defaultAdminSetup(cur realm, env *TestEnv) {
@@ -84,8 +83,8 @@ func TestSingleSwap(cur realm, t *testing.T) {
 
 			user1Realm := testing.NewUserRealm(user1Addr)
 			testing.SetRealm(user1Realm)
-			common.Approve(cross(cur), tt.params.tokenIn, poolAddr, maxApprove)
-			common.Approve(cross(cur), tt.params.tokenOut, poolAddr, maxApprove)
+			TokenApprove(cur, t, tt.params.tokenIn, user1Addr, poolAddr, maxApprove)
+			TokenApprove(cur, t, tt.params.tokenOut, user1Addr, poolAddr, maxApprove)
 
 			amountIn, amountOut := singleSwapFn(cross(cur))
 

--- a/contract/r/gnoswap/test/fuzz/_helper_test.gno
+++ b/contract/r/gnoswap/test/fuzz/_helper_test.gno
@@ -211,6 +211,45 @@ func mintTestToken(cur realm, tokenPath string, amount int64) {
 	}
 }
 
+// approveToken approves spender to spend amount of tokenPath from the current
+// EOA/origin caller, using the token's OWN realm (required by the grc20
+// origin-guard: a foreign realm cannot debit the transaction origin).
+func approveToken(cur realm, tokenPath string, spender address, amount int64) {
+	switch tokenPath {
+	case barPath:
+		bar.Approve(cross(cur), spender, amount)
+	case bazPath:
+		baz.Approve(cross(cur), spender, amount)
+	case fooPath:
+		foo.Approve(cross(cur), spender, amount)
+	case quxPath:
+		qux.Approve(cross(cur), spender, amount)
+	case oblPath:
+		obl.Approve(cross(cur), spender, amount)
+	default:
+		panic("test: unsupported token path " + tokenPath)
+	}
+}
+
+// transferToken transfers amount of tokenPath to `to` from the current
+// EOA/origin caller, using the token's OWN realm (see approveToken).
+func transferToken(cur realm, tokenPath string, to address, amount int64) {
+	switch tokenPath {
+	case barPath:
+		bar.Transfer(cross(cur), to, amount)
+	case bazPath:
+		baz.Transfer(cross(cur), to, amount)
+	case fooPath:
+		foo.Transfer(cross(cur), to, amount)
+	case quxPath:
+		qux.Transfer(cross(cur), to, amount)
+	case oblPath:
+		obl.Transfer(cross(cur), to, amount)
+	default:
+		panic("test: unsupported token path " + tokenPath)
+	}
+}
+
 // getTokenTotalSupply returns the total supply of a token
 func getTokenTotalSupply(tokenPath string) int64 {
 	switch tokenPath {

--- a/contract/r/gnoswap/test/fuzz/exact_in_swap_route_test.gno
+++ b/contract/r/gnoswap/test/fuzz/exact_in_swap_route_test.gno
@@ -11,8 +11,6 @@ import (
 	"gno.land/p/gnoswap/fuzzutils"
 
 	"gno.land/r/gnoswap/access"
-
-	"gno.land/r/gnoswap/common"
 	"gno.land/r/gnoswap/router"
 )
 
@@ -99,7 +97,7 @@ func runTestExactInSwapRoute(cur realm, ft *fuzz.T, params *exactInSwapRoutePara
 
 	// exact in swap route
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	common.SafeGRC20Approve(cross(cur), params.inputToken, routerAddr, math.MaxInt64)
+	approveToken(cur, params.inputToken, routerAddr, math.MaxInt64)
 
 	router.ExactInSwapRoute(
 		cross(cur),

--- a/contract/r/gnoswap/test/fuzz/exact_out_swap_route_test.gno
+++ b/contract/r/gnoswap/test/fuzz/exact_out_swap_route_test.gno
@@ -11,8 +11,6 @@ import (
 	"gno.land/p/gnoswap/fuzzutils"
 
 	"gno.land/r/gnoswap/access"
-
-	"gno.land/r/gnoswap/common"
 	"gno.land/r/gnoswap/router"
 )
 
@@ -99,7 +97,7 @@ func runTestExactOutSwapRoute(cur realm, ft *fuzz.T, params *exactOutSwapRoutePa
 
 	// exact out swap route
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	common.SafeGRC20Approve(cross(cur), params.inputToken, routerAddr, math.MaxInt64)
+	approveToken(cur, params.inputToken, routerAddr, math.MaxInt64)
 
 	router.ExactOutSwapRoute(
 		cross(cur),

--- a/contract/r/gnoswap/test/fuzz/pool_swap_test.gno
+++ b/contract/r/gnoswap/test/fuzz/pool_swap_test.gno
@@ -10,7 +10,6 @@ import (
 	ufmt "gno.land/p/nt/ufmt/v0"
 
 	"gno.land/r/gnoswap/access"
-	"gno.land/r/gnoswap/common"
 	"gno.land/r/gnoswap/pool"
 )
 
@@ -130,8 +129,8 @@ func callPoolSwap(
 
 	// Approve tokens for swap
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	common.SafeGRC20Approve(cross(cur), token0Path, poolAddr, math.MaxInt64)
-	common.SafeGRC20Approve(cross(cur), token1Path, poolAddr, math.MaxInt64)
+	approveToken(cur, token0Path, poolAddr, math.MaxInt64)
+	approveToken(cur, token1Path, poolAddr, math.MaxInt64)
 
 	// Define swap callback
 	swapCallback := func(cur realm, amount0Delta, amount1Delta int64, _ *pool.CallbackMarker) error {
@@ -140,12 +139,12 @@ func callPoolSwap(
 
 			// Transfer token0 if needed
 			if amount0Delta > 0 {
-				common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+				transferToken(cur, token0Path, poolAddr, amount0Delta)
 			}
 
 			// Transfer token1 if needed
 			if amount1Delta > 0 {
-				common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+				transferToken(cur, token1Path, poolAddr, amount1Delta)
 			}
 		}(cross(cur))
 

--- a/contract/r/gnoswap/test/fuzz/pool_utils_test.gno
+++ b/contract/r/gnoswap/test/fuzz/pool_utils_test.gno
@@ -11,7 +11,6 @@ import (
 	prabc "gno.land/p/gnoswap/rbac"
 	ufmt "gno.land/p/nt/ufmt/v0"
 	"gno.land/r/gnoswap/access"
-	"gno.land/r/gnoswap/common"
 	"gno.land/r/gnoswap/pool"
 	"gno.land/r/gnoswap/position"
 )
@@ -204,8 +203,8 @@ func setupMintPosition(
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
 
 	poolAddr := access.MustGetAddress(prabc.ROLE_POOL.String())
-	common.SafeGRC20Approve(cross(cur), token0Path, poolAddr, amountDesired)
-	common.SafeGRC20Approve(cross(cur), token1Path, poolAddr, amountDesired)
+	approveToken(cur, token0Path, poolAddr, amountDesired)
+	approveToken(cur, token1Path, poolAddr, amountDesired)
 
 	return position.Mint(
 		cross(cur),

--- a/contract/r/gnoswap/test/fuzz/position_collect_fee_test.gno
+++ b/contract/r/gnoswap/test/fuzz/position_collect_fee_test.gno
@@ -10,7 +10,6 @@ import (
 	ufmt "gno.land/p/nt/ufmt/v0"
 
 	"gno.land/r/gnoswap/access"
-	"gno.land/r/gnoswap/common"
 	"gno.land/r/gnoswap/pool"
 	"gno.land/r/gnoswap/position"
 )
@@ -184,8 +183,8 @@ func generateFeesWithSwap(cur realm, ft *fuzz.T, adminAddr, poolAddr address, po
 	}
 
 	// Approve tokens for swap
-	common.SafeGRC20Approve(cross(cur), token0Path, poolAddr, math.MaxInt64)
-	common.SafeGRC20Approve(cross(cur), token1Path, poolAddr, math.MaxInt64)
+	approveToken(cur, token0Path, poolAddr, math.MaxInt64)
+	approveToken(cur, token1Path, poolAddr, math.MaxInt64)
 
 	// Swap callback function
 	swapCallback := func(cur realm, amount0Delta, amount1Delta int64, _ *pool.CallbackMarker) error {
@@ -193,7 +192,7 @@ func generateFeesWithSwap(cur realm, ft *fuzz.T, adminAddr, poolAddr address, po
 		if amount0Delta > 0 {
 			func(cur realm) {
 				testing.SetRealm(testing.NewUserRealm(adminAddr))
-				common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+				transferToken(cur, token0Path, poolAddr, amount0Delta)
 			}(cross(cur))
 		}
 
@@ -201,7 +200,7 @@ func generateFeesWithSwap(cur realm, ft *fuzz.T, adminAddr, poolAddr address, po
 		if amount1Delta > 0 {
 			func(cur realm) {
 				testing.SetRealm(testing.NewUserRealm(adminAddr))
-				common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+				transferToken(cur, token1Path, poolAddr, amount1Delta)
 			}(cross(cur))
 		}
 

--- a/contract/r/gnoswap/test/fuzz/position_increase_liquidity_test.gno
+++ b/contract/r/gnoswap/test/fuzz/position_increase_liquidity_test.gno
@@ -11,7 +11,6 @@ import (
 	u256 "gno.land/p/gnoswap/uint256"
 
 	"gno.land/r/gnoswap/access"
-	"gno.land/r/gnoswap/common"
 	"gno.land/r/gnoswap/pool"
 	"gno.land/r/gnoswap/position"
 
@@ -46,8 +45,8 @@ func TestFuzzPositionIncreaseLiquidity_ValidParams_Stateless(cur realm, t *testi
 		mintTestToken(cur, token1Path, amount1Int64)
 
 		// Approve tokens
-		common.SafeGRC20Approve(cross(cur), token0Path, poolAddr, math.MaxInt64)
-		common.SafeGRC20Approve(cross(cur), token1Path, poolAddr, math.MaxInt64)
+		approveToken(cur, token0Path, poolAddr, math.MaxInt64)
+		approveToken(cur, token1Path, poolAddr, math.MaxInt64)
 
 		// when - increase liquidity
 		_, liquidity, amount0, amount1, _ := position.IncreaseLiquidity(
@@ -100,8 +99,8 @@ func TestFuzzPositionIncreaseLiquidity_RandomizedParams_Stateless(cur realm, t *
 		mintTestToken(cur, token1Path, amount1Int64)
 
 		// Approve tokens
-		common.SafeGRC20Approve(cross(cur), token0Path, poolAddr, math.MaxInt64)
-		common.SafeGRC20Approve(cross(cur), token1Path, poolAddr, math.MaxInt64)
+		approveToken(cur, token0Path, poolAddr, math.MaxInt64)
+		approveToken(cur, token1Path, poolAddr, math.MaxInt64)
 
 		// when - increase liquidity (may panic with invalid params)
 		position.IncreaseLiquidity(
@@ -142,8 +141,8 @@ func TestFuzzPositionIncreaseLiquidity_ValidParams_Stateful(cur realm, t *testin
 		mintTestToken(cur, token1Path, amount1Int64)
 
 		// Approve tokens
-		common.SafeGRC20Approve(cross(cur), token0Path, poolAddr, math.MaxInt64)
-		common.SafeGRC20Approve(cross(cur), token1Path, poolAddr, math.MaxInt64)
+		approveToken(cur, token0Path, poolAddr, math.MaxInt64)
+		approveToken(cur, token1Path, poolAddr, math.MaxInt64)
 
 		// Get current total liquidity before increase
 		prevTotalLiquidity := u256.MustFromDecimal(position.GetPositionLiquidity(tokenId))
@@ -204,8 +203,8 @@ func TestFuzzPositionIncreaseLiquidity_RandomizedParams_Stateful(cur realm, t *t
 		mintTestToken(cur, token1Path, amount1Int64)
 
 		// Approve tokens
-		common.SafeGRC20Approve(cross(cur), token0Path, poolAddr, math.MaxInt64)
-		common.SafeGRC20Approve(cross(cur), token1Path, poolAddr, math.MaxInt64)
+		approveToken(cur, token0Path, poolAddr, math.MaxInt64)
+		approveToken(cur, token1Path, poolAddr, math.MaxInt64)
 
 		// when - increase liquidity (may panic with invalid params)
 		//
@@ -265,8 +264,8 @@ func createTestPosition(cur realm, t *testing.T, adminAddr, poolAddr address) ui
 	}
 
 	// Approve tokens
-	common.SafeGRC20Approve(cross(cur), token0Path, poolAddr, math.MaxInt64)
-	common.SafeGRC20Approve(cross(cur), token1Path, poolAddr, math.MaxInt64)
+	approveToken(cur, token0Path, poolAddr, math.MaxInt64)
+	approveToken(cur, token1Path, poolAddr, math.MaxInt64)
 
 	amount0Int64, _ := strconv.ParseInt("10000000", 10, 64)
 	amount1Int64, _ := strconv.ParseInt("10000000", 10, 64)

--- a/contract/r/gnoswap/test/fuzz/position_mint_test.gno
+++ b/contract/r/gnoswap/test/fuzz/position_mint_test.gno
@@ -11,7 +11,6 @@ import (
 	ufmt "gno.land/p/nt/ufmt/v0"
 
 	"gno.land/r/gnoswap/access"
-	"gno.land/r/gnoswap/common"
 	"gno.land/r/gnoswap/pool"
 	"gno.land/r/gnoswap/position"
 )
@@ -49,8 +48,8 @@ func TestFuzzPositionMint_ValidParams_Stateless(cur realm, t *testing.T) {
 		mintTestToken(cur, mintParams.token1Path, amount1Int64)
 
 		// Approve tokens
-		common.SafeGRC20Approve(cross(cur), mintParams.token0Path, poolAddr, math.MaxInt64)
-		common.SafeGRC20Approve(cross(cur), mintParams.token1Path, poolAddr, math.MaxInt64)
+		approveToken(cur, mintParams.token0Path, poolAddr, math.MaxInt64)
+		approveToken(cur, mintParams.token1Path, poolAddr, math.MaxInt64)
 
 		// when - mint position
 		tokenId, liquidity, amount0, amount1 := position.Mint(
@@ -116,8 +115,8 @@ func TestFuzzPositionMint_RandomizedParams_Stateless(cur realm, t *testing.T) {
 		}
 
 		// Approve tokens
-		common.SafeGRC20Approve(cross(cur), mintParams.token0Path, poolAddr, math.MaxInt64)
-		common.SafeGRC20Approve(cross(cur), mintParams.token1Path, poolAddr, math.MaxInt64)
+		approveToken(cur, mintParams.token0Path, poolAddr, math.MaxInt64)
+		approveToken(cur, mintParams.token1Path, poolAddr, math.MaxInt64)
 
 		// when - mint position (may panic with invalid params)
 		position.Mint(
@@ -174,8 +173,8 @@ func TestFuzzPositionMint_ValidParams_Stateful(cur realm, t *testing.T) {
 		mintTestToken(cur, mintParams.token1Path, amount1Int64)
 
 		// Approve tokens
-		common.SafeGRC20Approve(cross(cur), mintParams.token0Path, poolAddr, math.MaxInt64)
-		common.SafeGRC20Approve(cross(cur), mintParams.token1Path, poolAddr, math.MaxInt64)
+		approveToken(cur, mintParams.token0Path, poolAddr, math.MaxInt64)
+		approveToken(cur, mintParams.token1Path, poolAddr, math.MaxInt64)
 
 		// when - mint position
 		tokenId, liquidity, amount0, amount1 := position.Mint(
@@ -255,8 +254,8 @@ func TestFuzzPositionMint_RandomizedParams_Stateful(cur realm, t *testing.T) {
 		mintTestToken(cur, mintParams.token1Path, amount1Int64)
 
 		// Approve tokens
-		common.SafeGRC20Approve(cross(cur), mintParams.token0Path, poolAddr, math.MaxInt64)
-		common.SafeGRC20Approve(cross(cur), mintParams.token1Path, poolAddr, math.MaxInt64)
+		approveToken(cur, mintParams.token0Path, poolAddr, math.MaxInt64)
+		approveToken(cur, mintParams.token1Path, poolAddr, math.MaxInt64)
 
 		// when - mint position (may panic with invalid params)
 		tokenId, _, _, _ := position.Mint(

--- a/contract/r/gnoswap/test/fuzz/position_reposition_test.gno
+++ b/contract/r/gnoswap/test/fuzz/position_reposition_test.gno
@@ -11,7 +11,6 @@ import (
 	ufmt "gno.land/p/nt/ufmt/v0"
 
 	"gno.land/r/gnoswap/access"
-	"gno.land/r/gnoswap/common"
 	"gno.land/r/gnoswap/position"
 )
 
@@ -58,8 +57,8 @@ func TestFuzzPositionReposition_ValidParams_Stateless(cur realm, t *testing.T) {
 		mintTestToken(cur, token1Path, amount1Int64)
 
 		// Approve tokens
-		common.SafeGRC20Approve(cross(cur), token0Path, poolAddr, math.MaxInt64)
-		common.SafeGRC20Approve(cross(cur), token1Path, poolAddr, math.MaxInt64)
+		approveToken(cur, token0Path, poolAddr, math.MaxInt64)
+		approveToken(cur, token1Path, poolAddr, math.MaxInt64)
 
 		// when - reposition
 		newTokenId, liquidityStr, tickLower, tickUpper, amount0, amount1 := position.Reposition(
@@ -138,8 +137,8 @@ func TestFuzzPositionReposition_RandomizedParams_Stateless(cur realm, t *testing
 		mintTestToken(cur, token1Path, amount1Int64)
 
 		// Approve tokens
-		common.SafeGRC20Approve(cross(cur), token0Path, poolAddr, math.MaxInt64)
-		common.SafeGRC20Approve(cross(cur), token1Path, poolAddr, math.MaxInt64)
+		approveToken(cur, token0Path, poolAddr, math.MaxInt64)
+		approveToken(cur, token1Path, poolAddr, math.MaxInt64)
 
 		// when - reposition (may panic with invalid params)
 		position.Reposition(
@@ -214,8 +213,8 @@ func TestFuzzPositionReposition_ValidParams_Stateful(cur realm, t *testing.T) {
 		mintTestToken(cur, token1Path, amount1Int64)
 
 		// Approve tokens
-		common.SafeGRC20Approve(cross(cur), token0Path, poolAddr, math.MaxInt64)
-		common.SafeGRC20Approve(cross(cur), token1Path, poolAddr, math.MaxInt64)
+		approveToken(cur, token0Path, poolAddr, math.MaxInt64)
+		approveToken(cur, token1Path, poolAddr, math.MaxInt64)
 
 		// when - reposition
 		returnedTokenId, liquidityStr, tickLower, tickUpper, amount0, amount1 := position.Reposition(
@@ -300,8 +299,8 @@ func TestFuzzPositionReposition_RandomizedParams_Stateful(cur realm, t *testing.
 			mintTestToken(cur, token1Path, amount1Int64)
 		}
 
-		common.SafeGRC20Approve(cross(cur), token0Path, poolAddr, math.MaxInt64)
-		common.SafeGRC20Approve(cross(cur), token1Path, poolAddr, math.MaxInt64)
+		approveToken(cur, token0Path, poolAddr, math.MaxInt64)
+		approveToken(cur, token1Path, poolAddr, math.MaxInt64)
 
 		position.Reposition(
 			cross(cur),

--- a/contract/r/scenario/position/contract_owned_position_lifecycle_filetest.gno
+++ b/contract/r/scenario/position/contract_owned_position_lifecycle_filetest.gno
@@ -23,7 +23,6 @@ import (
 	_ "gno.land/r/gnoswap/staker/v1"
 
 	"gno.land/r/gnoswap/access"
-	"gno.land/r/gnoswap/common"
 	"gno.land/r/gnoswap/gnft"
 	"gno.land/r/gnoswap/pool"
 	"gno.land/r/gnoswap/position"
@@ -400,14 +399,28 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		payToken(cur, token0Path, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		payToken(cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil
+}
+
+// payToken pays the pool via the token's own realm — mirroring how production
+// moves funds (the token owner authorizes the transfer), instead of the generic
+// grc20 registry transfer helper. Keeps the mock faithful to real callbacks.
+func payToken(cur realm, path string, to address, amount int64) {
+	switch path {
+	case barPath:
+		bar.Transfer(cross(cur), to, amount)
+	case fooPath:
+		foo.Transfer(cross(cur), to, amount)
+	default:
+		panic("mockSwapCallback: unsupported token path " + path)
+	}
 }
 
 // Output:

--- a/contract/r/scenario/position/position_balance_decrease_liquidity_filetest.gno
+++ b/contract/r/scenario/position/position_balance_decrease_liquidity_filetest.gno
@@ -18,7 +18,6 @@ import (
 	_ "gno.land/r/gnoswap/staker/v1"
 
 	"gno.land/r/gnoswap/access"
-	"gno.land/r/gnoswap/common"
 
 	"gno.land/r/gnoswap/pool"
 	"gno.land/r/gnoswap/position"
@@ -228,15 +227,27 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		payToken(cur, token0Path, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		payToken(cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil
 }
+
+func payToken(cur realm, path string, to address, amount int64) {
+	switch path {
+	case "gno.land/r/onbloc/bar.BAR":
+		bar.Transfer(cross(cur), to, amount)
+	case "gno.land/r/onbloc/foo.FOO":
+		foo.Transfer(cross(cur), to, amount)
+	default:
+		panic("mockSwapCallback: unsupported token path " + path)
+	}
+}
+
 
 // Output:
 // [SCENARIO] 1. Initialize pool

--- a/contract/r/scenario/position/position_balance_reposition_filetest.gno
+++ b/contract/r/scenario/position/position_balance_reposition_filetest.gno
@@ -18,7 +18,6 @@ import (
 	_ "gno.land/r/gnoswap/staker/v1"
 
 	"gno.land/r/gnoswap/access"
-	"gno.land/r/gnoswap/common"
 
 	"gno.land/r/gnoswap/pool"
 	"gno.land/r/gnoswap/position"
@@ -275,15 +274,27 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		payToken(cur, token0Path, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		payToken(cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil
 }
+
+func payToken(cur realm, path string, to address, amount int64) {
+	switch path {
+	case "gno.land/r/onbloc/bar.BAR":
+		bar.Transfer(cross(cur), to, amount)
+	case "gno.land/r/onbloc/foo.FOO":
+		foo.Transfer(cross(cur), to, amount)
+	default:
+		panic("mockSwapCallback: unsupported token path " + path)
+	}
+}
+
 
 // Output:
 // [SCENARIO] 1. Initialize pool

--- a/contract/r/scenario/position/position_collect_fee_filetest.gno
+++ b/contract/r/scenario/position/position_collect_fee_filetest.gno
@@ -22,7 +22,6 @@ import (
 	_ "gno.land/r/gnoswap/staker/v1"
 
 	"gno.land/r/gnoswap/access"
-	"gno.land/r/gnoswap/common"
 
 	"gno.land/r/gnoswap/pool"
 	"gno.land/r/gnoswap/position"
@@ -239,15 +238,27 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		payToken(cur, token0Path, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		payToken(cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil
 }
+
+func payToken(cur realm, path string, to address, amount int64) {
+	switch path {
+	case "gno.land/r/onbloc/bar.BAR":
+		bar.Transfer(cross(cur), to, amount)
+	case "gno.land/r/onbloc/foo.FOO":
+		foo.Transfer(cross(cur), to, amount)
+	default:
+		panic("mockSwapCallback: unsupported token path " + path)
+	}
+}
+
 
 // Output:
 // [SCENARIO] 1. Initialize pool

--- a/contract/r/scenario/position/position_collect_fee_with_protocol_fee_filetest.gno
+++ b/contract/r/scenario/position/position_collect_fee_with_protocol_fee_filetest.gno
@@ -22,7 +22,6 @@ import (
 	_ "gno.land/r/gnoswap/staker/v1"
 
 	"gno.land/r/gnoswap/access"
-	"gno.land/r/gnoswap/common"
 
 	"gno.land/r/gnoswap/pool"
 	"gno.land/r/gnoswap/position"
@@ -252,15 +251,27 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		payToken(cur, token0Path, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		payToken(cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil
 }
+
+func payToken(cur realm, path string, to address, amount int64) {
+	switch path {
+	case "gno.land/r/onbloc/bar.BAR":
+		bar.Transfer(cross(cur), to, amount)
+	case "gno.land/r/onbloc/foo.FOO":
+		foo.Transfer(cross(cur), to, amount)
+	default:
+		panic("mockSwapCallback: unsupported token path " + path)
+	}
+}
+
 
 // Output:
 // [SCENARIO] 1. Initialize pool

--- a/contract/r/scenario/position/position_full_with_emission_filetest.gno
+++ b/contract/r/scenario/position/position_full_with_emission_filetest.gno
@@ -24,7 +24,6 @@ import (
 	_ "gno.land/r/gnoswap/staker/v1"
 
 	"gno.land/r/gnoswap/access"
-	"gno.land/r/gnoswap/common"
 
 	"gno.land/r/gnoswap/pool"
 	"gno.land/r/gnoswap/position"
@@ -245,13 +244,25 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if zeroForOne {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		payToken(cur, token0Path, poolAddr, amount0Delta)
 	} else {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		payToken(cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil
 }
+
+func payToken(cur realm, path string, to address, amount int64) {
+	switch path {
+	case "gno.land/r/gnoland/wugnot.wugnot":
+		wugnot.Transfer(cross(cur), to, amount)
+	case "gno.land/r/gnoswap/gns.GNS":
+		gns.Transfer(cross(cur), to, amount)
+	default:
+		panic("mockSwapCallback: unsupported token path " + path)
+	}
+}
+
 
 // Output:
 // [SCENARIO] 1. Initialize pool and emission

--- a/contract/r/scenario/position/position_increase_decrease_filetest.gno
+++ b/contract/r/scenario/position/position_increase_decrease_filetest.gno
@@ -18,7 +18,6 @@ import (
 	_ "gno.land/r/gnoswap/staker/v1"
 
 	"gno.land/r/gnoswap/access"
-	"gno.land/r/gnoswap/common"
 
 	"gno.land/r/gnoswap/pool"
 	"gno.land/r/gnoswap/position"
@@ -228,15 +227,27 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		payToken(cur, token0Path, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		payToken(cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil
 }
+
+func payToken(cur realm, path string, to address, amount int64) {
+	switch path {
+	case "gno.land/r/onbloc/bar.BAR":
+		bar.Transfer(cross(cur), to, amount)
+	case "gno.land/r/onbloc/foo.FOO":
+		foo.Transfer(cross(cur), to, amount)
+	default:
+		panic("mockSwapCallback: unsupported token path " + path)
+	}
+}
+
 
 // Output:
 // [SCENARIO] 1. Initialize pool with tick 10000

--- a/contract/r/scenario/position/position_mint_gnot_grc20_range_filetest.gno
+++ b/contract/r/scenario/position/position_mint_gnot_grc20_range_filetest.gno
@@ -19,7 +19,6 @@ import (
 
 	"gno.land/r/gnoland/wugnot"
 	"gno.land/r/gnoswap/access"
-	"gno.land/r/gnoswap/common"
 	"gno.land/r/gnoswap/gns"
 	"gno.land/r/gnoswap/pool"
 	"gno.land/r/gnoswap/position"
@@ -260,13 +259,25 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if zeroForOne {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		payToken(cur, token0Path, poolAddr, amount0Delta)
 	} else {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		payToken(cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil
 }
+
+func payToken(cur realm, path string, to address, amount int64) {
+	switch path {
+	case "gno.land/r/gnoland/wugnot.wugnot":
+		wugnot.Transfer(cross(cur), to, amount)
+	case "gno.land/r/gnoswap/gns.GNS":
+		gns.Transfer(cross(cur), to, amount)
+	default:
+		panic("mockSwapCallback: unsupported token path " + path)
+	}
+}
+
 
 // Output:
 // [SCENARIO] 1. Initialize pool with GNOT/GNS pair

--- a/contract/r/scenario/position/position_mint_swap_burn_filetest.gno
+++ b/contract/r/scenario/position/position_mint_swap_burn_filetest.gno
@@ -22,7 +22,6 @@ import (
 	_ "gno.land/r/gnoswap/staker/v1"
 
 	"gno.land/r/gnoswap/access"
-	"gno.land/r/gnoswap/common"
 
 	"gno.land/r/gnoswap/pool"
 	"gno.land/r/gnoswap/position"
@@ -242,15 +241,27 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		payToken(cur, token0Path, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		payToken(cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil
 }
+
+func payToken(cur realm, path string, to address, amount int64) {
+	switch path {
+	case "gno.land/r/onbloc/bar.BAR":
+		bar.Transfer(cross(cur), to, amount)
+	case "gno.land/r/onbloc/foo.FOO":
+		foo.Transfer(cross(cur), to, amount)
+	default:
+		panic("mockSwapCallback: unsupported token path " + path)
+	}
+}
+
 
 // Output:
 // [SCENARIO] 1. Initialize pool

--- a/contract/r/scenario/position/position_multi_user_fee_filetest.gno
+++ b/contract/r/scenario/position/position_multi_user_fee_filetest.gno
@@ -20,7 +20,6 @@ import (
 	_ "gno.land/r/gnoswap/staker/v1"
 
 	"gno.land/r/gnoswap/access"
-	"gno.land/r/gnoswap/common"
 
 	"gno.land/r/gnoswap/pool"
 	"gno.land/r/gnoswap/position"
@@ -249,15 +248,27 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		payToken(cur, token0Path, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		payToken(cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil
 }
+
+func payToken(cur realm, path string, to address, amount int64) {
+	switch path {
+	case "gno.land/r/onbloc/bar.BAR":
+		bar.Transfer(cross(cur), to, amount)
+	case "gno.land/r/onbloc/baz.BAZ":
+		baz.Transfer(cross(cur), to, amount)
+	default:
+		panic("mockSwapCallback: unsupported token path " + path)
+	}
+}
+
 
 // Output:
 // [SCENARIO] 1. Initialize pool and users

--- a/contract/r/scenario/position/position_native_token_filetest.gno
+++ b/contract/r/scenario/position/position_native_token_filetest.gno
@@ -21,7 +21,6 @@ import (
 	_ "gno.land/r/gnoswap/staker/v1"
 
 	"gno.land/r/gnoswap/access"
-	"gno.land/r/gnoswap/common"
 
 	"gno.land/r/gnoswap/pool"
 	"gno.land/r/gnoswap/position"
@@ -219,13 +218,25 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if zeroForOne {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		payToken(cur, token0Path, poolAddr, amount0Delta)
 	} else {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		payToken(cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil
 }
+
+func payToken(cur realm, path string, to address, amount int64) {
+	switch path {
+	case "gno.land/r/gnoland/wugnot.wugnot":
+		wugnot.Transfer(cross(cur), to, amount)
+	case "gno.land/r/gnoswap/gns.GNS":
+		gns.Transfer(cross(cur), to, amount)
+	default:
+		panic("mockSwapCallback: unsupported token path " + path)
+	}
+}
+
 
 // Output:
 // [SCENARIO] 1. Initialize pool with GNOT/GNS pair

--- a/contract/r/scenario/position/position_reposition_filetest.gno
+++ b/contract/r/scenario/position/position_reposition_filetest.gno
@@ -18,7 +18,6 @@ import (
 	_ "gno.land/r/gnoswap/staker/v1"
 
 	"gno.land/r/gnoswap/access"
-	"gno.land/r/gnoswap/common"
 
 	"gno.land/r/gnoswap/pool"
 	"gno.land/r/gnoswap/position"
@@ -262,15 +261,27 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		payToken(cur, token0Path, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		payToken(cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil
 }
+
+func payToken(cur realm, path string, to address, amount int64) {
+	switch path {
+	case "gno.land/r/onbloc/bar.BAR":
+		bar.Transfer(cross(cur), to, amount)
+	case "gno.land/r/onbloc/foo.FOO":
+		foo.Transfer(cross(cur), to, amount)
+	default:
+		panic("mockSwapCallback: unsupported token path " + path)
+	}
+}
+
 
 // Output:
 // [SCENARIO] 1. Initialize pool with tick 10000

--- a/contract/r/scenario/position/position_reposition_tick_role_change_filetest.gno
+++ b/contract/r/scenario/position/position_reposition_tick_role_change_filetest.gno
@@ -19,7 +19,6 @@ import (
 	_ "gno.land/r/gnoswap/staker/v1"
 
 	"gno.land/r/gnoswap/access"
-	"gno.land/r/gnoswap/common"
 
 	"gno.land/r/gnoswap/pool"
 	"gno.land/r/gnoswap/position"
@@ -218,13 +217,25 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if zeroForOne {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		payToken(cur, token0Path, poolAddr, amount0Delta)
 	} else {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		payToken(cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil
 }
+
+func payToken(cur realm, path string, to address, amount int64) {
+	switch path {
+	case "gno.land/r/onbloc/bar.BAR":
+		bar.Transfer(cross(cur), to, amount)
+	case "gno.land/r/onbloc/foo.FOO":
+		foo.Transfer(cross(cur), to, amount)
+	default:
+		panic("mockSwapCallback: unsupported token path " + path)
+	}
+}
+
 
 // Output:
 // [SCENARIO] 1. Initialize pool at tick 10000

--- a/contract/r/scenario/position/position_same_user_fee_distribution_filetest.gno
+++ b/contract/r/scenario/position/position_same_user_fee_distribution_filetest.gno
@@ -22,7 +22,6 @@ import (
 	_ "gno.land/r/gnoswap/staker/v1"
 
 	"gno.land/r/gnoswap/access"
-	"gno.land/r/gnoswap/common"
 
 	"gno.land/r/gnoswap/pool"
 	"gno.land/r/gnoswap/position"
@@ -308,15 +307,27 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		payToken(cur, token0Path, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		payToken(cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil
 }
+
+func payToken(cur realm, path string, to address, amount int64) {
+	switch path {
+	case "gno.land/r/onbloc/bar.BAR":
+		bar.Transfer(cross(cur), to, amount)
+	case "gno.land/r/onbloc/foo.FOO":
+		foo.Transfer(cross(cur), to, amount)
+	default:
+		panic("mockSwapCallback: unsupported token path " + path)
+	}
+}
+
 
 // Output:
 // [SCENARIO] 1. Initialize pool

--- a/contract/r/scenario/position/position_swap_fee_distribution_filetest.gno
+++ b/contract/r/scenario/position/position_swap_fee_distribution_filetest.gno
@@ -18,7 +18,6 @@ import (
 	_ "gno.land/r/gnoswap/staker/v1"
 
 	"gno.land/r/gnoswap/access"
-	"gno.land/r/gnoswap/common"
 
 	"gno.land/r/gnoswap/pool"
 	"gno.land/r/gnoswap/position"
@@ -200,15 +199,27 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		payToken(cur, token0Path, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		payToken(cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil
 }
+
+func payToken(cur realm, path string, to address, amount int64) {
+	switch path {
+	case "gno.land/r/onbloc/bar.BAR":
+		bar.Transfer(cross(cur), to, amount)
+	case "gno.land/r/onbloc/foo.FOO":
+		foo.Transfer(cross(cur), to, amount)
+	default:
+		panic("mockSwapCallback: unsupported token path " + path)
+	}
+}
+
 
 // Output:
 // [SCENARIO] 1. Initialize pool with tick 10000

--- a/contract/r/scenario/position/position_transfer_with_collect_fee_filetest.gno
+++ b/contract/r/scenario/position/position_transfer_with_collect_fee_filetest.gno
@@ -25,7 +25,6 @@ import (
 	_ "gno.land/r/gnoswap/staker/v1"
 
 	"gno.land/r/gnoswap/access"
-	"gno.land/r/gnoswap/common"
 
 	"gno.land/r/gnoswap/pool"
 	"gno.land/r/gnoswap/position"
@@ -234,11 +233,11 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		payToken(cur, token0Path, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		payToken(cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil
@@ -264,6 +263,18 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 		panic("unsupported positionId type")
 	}
 }
+
+func payToken(cur realm, path string, to address, amount int64) {
+	switch path {
+	case "gno.land/r/onbloc/bar.BAR":
+		bar.Transfer(cross(cur), to, amount)
+	case "gno.land/r/onbloc/foo.FOO":
+		foo.Transfer(cross(cur), to, amount)
+	default:
+		panic("mockSwapCallback: unsupported token path " + path)
+	}
+}
+
 
 // Output:
 // [SCENARIO] 1. Initialize pool

--- a/contract/r/scenario/position/position_unclaimed_fee_filetest.gno
+++ b/contract/r/scenario/position/position_unclaimed_fee_filetest.gno
@@ -10,7 +10,6 @@ import (
 	prbac "gno.land/p/gnoswap/rbac"
 	ufmt "gno.land/p/nt/ufmt/v0"
 	"gno.land/r/gnoswap/access"
-	"gno.land/r/gnoswap/common"
 	"gno.land/r/gnoswap/pool"
 	"gno.land/r/gnoswap/position"
 	"gno.land/r/onbloc/bar"
@@ -292,15 +291,27 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		payToken(cur, token0Path, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		payToken(cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil
 }
+
+func payToken(cur realm, path string, to address, amount int64) {
+	switch path {
+	case "gno.land/r/onbloc/bar.BAR":
+		bar.Transfer(cross(cur), to, amount)
+	case "gno.land/r/onbloc/foo.FOO":
+		foo.Transfer(cross(cur), to, amount)
+	default:
+		panic("mockSwapCallback: unsupported token path " + path)
+	}
+}
+
 
 // Output:
 // [SCENARIO] 1. Initialize pool with tick 10000


### PR DESCRIPTION
## What

Across `pool`, `position`, `router`, `launchpad`, `gov/staker`, `protocol_fee`, the fuzz suite and the position scenario filetests, test callbacks and helpers moved tokens by calling the generic grc20 registry helper (`common.SafeGRC20Transfer` / `common.SafeGRC20Approve`) while an EOA/admin realm was set:

```go
testing.SetRealm(adminRealm)
common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
```

Production never funds the pool that way. Real swap callbacks move funds via the **token's own realm** (the token owner authorizes the transfer) or via **allowance** (`TransferFrom`), and reward/refund flows enter as the **module's own realm**. This aligns the tests with production:

- swap-callback mocks and approvals now dispatch to each token realm's own `Transfer`/`Approve` (e.g. `bar.Transfer(cross(cur), ...)`, `foo.Approve(cross(cur), ...)`);
- module-owned transfer tests (staker reward, launchpad refund) now drive the flow as the module realm, exactly as the real `CollectReward` / `TransferLeftFromProjectByAdmin` entry points do.

## Why

Test mocks that pay through a generic registry hop as an EOA don't reflect how tokens actually move on-chain, and they quietly assume the registry hub can debit an arbitrary caller. Paying via the token's native transfer keeps the mocks faithful to production and to grc20's realm-scoped teller semantics.

## Scope

40 `*_test.gno` / `*_filetest.gno` files. **No product code and no assertions changed** — behavior and expected output are identical. Each touched package's test suite passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated token transfer and approval test setup to execute from the correct contract context.
  * Improved token-specific handling across swap, pool, position, router, launchpad, staking, protocol-fee, and fuzz tests.
  * Added validation for unsupported token paths during test transfers and approvals.
  * Preserved existing coverage for refunds, rewards, swaps, liquidity changes, fee collection, and fee distribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->