### PR TITLE
fix(gns): include emission end boundary in GetEmissionAmountPerSecondInRange

### DIFF
--- a/contract/r/gnoswap/gns/getter.gno
+++ b/contract/r/gnoswap/gns/getter.gno
@@ -1,6 +1,10 @@
 package gns
 
-import "time"
+import (
+	"time"
+
+	gnsmath "gno.land/p/gnoswap/gnsmath"
+)
 
 // GetMaxEmissionAmount returns the maximum amount of emission allowed.
 func GetMaxEmissionAmount() int64 {
@@ -46,8 +50,8 @@ func GetCurrentYear() int64 {
 // Returns two slices: timestamps when halving periods start and corresponding emission rates per second.
 func GetEmissionAmountPerSecondInRange(fromTime, toTime int64) ([]int64, []int64) {
 	halvingData := getEmissionState().getHalvingData()
-	halvingTimes := make([]int64, 0, HALVING_END_YEAR)
-	halvingEmissions := make([]int64, 0, HALVING_END_YEAR)
+	halvingTimes := make([]int64, 0, HALVING_END_YEAR+1)
+	halvingEmissions := make([]int64, 0, HALVING_END_YEAR+1)
 
 	for year := HALVING_START_YEAR; year <= HALVING_END_YEAR; year++ {
 		startTimestamp := halvingData.getStartTimestamp(year)
@@ -61,6 +65,12 @@ func GetEmissionAmountPerSecondInRange(fromTime, toTime int64) ([]int64, []int64
 
 		halvingTimes = append(halvingTimes, startTimestamp)
 		halvingEmissions = append(halvingEmissions, halvingData.getAmountPerSecond(year))
+	}
+
+	emissionEndTimestamp := halvingData.getEndTimestamp(HALVING_END_YEAR)
+	if fromTime <= emissionEndTimestamp && emissionEndTimestamp < toTime {
+		halvingTimes = append(halvingTimes, gnsmath.SafeAddInt64(emissionEndTimestamp, 1))
+		halvingEmissions = append(halvingEmissions, 0)
 	}
 
 	return halvingTimes, halvingEmissions

--- a/contract/r/gnoswap/gns/getter.gno
+++ b/contract/r/gnoswap/gns/getter.gno
@@ -49,6 +49,10 @@ func GetCurrentYear() int64 {
 // GetEmissionAmountPerSecondInRange returns halving timestamps and emission rates for the given time range.
 // Returns two slices: timestamps when halving periods start and corresponding emission rates per second.
 func GetEmissionAmountPerSecondInRange(fromTime, toTime int64) ([]int64, []int64) {
+	if fromTime > toTime {
+		return nil, nil
+	}
+
 	halvingData := getEmissionState().getHalvingData()
 	halvingTimes := make([]int64, 0, HALVING_END_YEAR+1)
 	halvingEmissions := make([]int64, 0, HALVING_END_YEAR+1)

--- a/contract/r/gnoswap/gns/getter_test.gno
+++ b/contract/r/gnoswap/gns/getter_test.gno
@@ -265,6 +265,23 @@ func TestGetEmissionAmountPerSecondInRangeBoundary(cur realm, t *testing.T) {
 		times, emissions := GetEmissionAmountPerSecondInRange(year3Start, year5Start-1)
 		verifyResult(t, times, emissions, 2)
 	})
+
+	t.Run("crossing emission end includes zero emission boundary", func(cur realm, t *testing.T) {
+		year12End := GetHalvingYearEndTimestamp(12)
+		times, emissions := GetEmissionAmountPerSecondInRange(year12End-10, year12End+10)
+
+		uassert.Equal(t, 1, len(times))
+		uassert.Equal(t, 1, len(emissions))
+		uassert.Equal(t, year12End+1, times[0])
+		uassert.Equal(t, int64(0), emissions[0])
+	})
+
+	t.Run("starting after emission end excludes zero boundary", func(cur realm, t *testing.T) {
+		year12End := GetHalvingYearEndTimestamp(12)
+		times, emissions := GetEmissionAmountPerSecondInRange(year12End+1, year12End+10)
+
+		verifyResult(t, times, emissions, 0)
+	})
 }
 
 func TestGetEmissionFunctionsWithInvalidTimestamps(cur realm, t *testing.T) {

--- a/contract/r/gnoswap/gns/getter_test.gno
+++ b/contract/r/gnoswap/gns/getter_test.gno
@@ -282,6 +282,13 @@ func TestGetEmissionAmountPerSecondInRangeBoundary(cur realm, t *testing.T) {
 
 		verifyResult(t, times, emissions, 0)
 	})
+
+	t.Run("reversed from/to returns empty", func(cur realm, t *testing.T) {
+		times, emissions := GetEmissionAmountPerSecondInRange(100, 50)
+
+		uassert.Equal(t, 0, len(times))
+		uassert.Equal(t, 0, len(emissions))
+	})
 }
 
 func TestGetEmissionFunctionsWithInvalidTimestamps(cur realm, t *testing.T) {


### PR DESCRIPTION
## Summary

`GetEmissionAmountPerSecondInRange` now appends an emission-end boundary entry `(emissionEndTimestamp + 1, 0)` when the queried range `[fromTime, toTime)` crosses the end of the 12-year emission schedule.

Previously the returned halving timeline only contained year boundaries (years 1–12). Downstream consumers (emission → staker pool-tier reward cache) therefore never learned that emission drops to 0 once the schedule ends, and reward caching kept applying the year-12 rate to the post-end period.

## Changes

- `contract/r/gnoswap/gns/getter.gno`
  - Append `(emissionEndTimestamp+1, 0)` when `fromTime <= emissionEndTimestamp < toTime`
  - Replace local `safeAddInt64` with `gnsmath.SafeAddInt64` (import refactor)
- `contract/r/gnoswap/gns/getter_test.gno`
  - New: range crossing emission end includes the zero-emission boundary
  - New: range starting after emission end excludes the boundary

## Behavioral impact

- Only queries whose range crosses the emission end (year 12 end) see new output entries — existing in-schedule queries are unchanged.
- The staker-side change that consumes this boundary (pool-tier reward caching) will follow in a separate PR.

## Test

2 new `GetEmissionAmountPerSecondInRange` boundary test cases added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected emission schedule results at the end of the emission period.
  * Queries that cross the endpoint now include a zero-emission marker.
  * Queries starting after the emission period correctly return no entries.

* **Tests**
  * Added coverage for emission boundary scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->