### PR TITLE
perf(staker): prevent staker tick state growth

### DIFF
--- a/contract/r/gnoswap/staker/pool.gno
+++ b/contract/r/gnoswap/staker/pool.gno
@@ -585,17 +585,11 @@ func (t *Ticks) SetTree(tree *bptree.BPTree) {
 	t.tree = tree
 }
 
+// Get returns the tick for the given tickId, or nil if it does not exist.
 func (t *Ticks) Get(tickId int32) *Tick {
 	v := t.tree.Get(EncodeInt(tickId))
 	if v == nil {
-		tick := &Tick{
-			id:                   tickId,
-			stakedLiquidityGross: u256.Zero(),
-			stakedLiquidityDelta: i256.Zero(),
-			outsideAccumulation:  NewUintTreeN(64),
-		}
-		t.tree.Set(EncodeInt(tickId), tick)
-		return tick
+		return nil
 	}
 
 	tick, ok := v.(*Tick)

--- a/contract/r/gnoswap/staker/v1/reward_calculation_canonical_env_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_canonical_env_test.gno
@@ -420,8 +420,15 @@ func (self *canonicalRewardState) StakeToken(cur realm, positionId uint64, targe
 	// historical tick must be set regardless of the deposit's range
 	poolResolver.Pool.SetHistoricalTickAt(currentTimestamp, canonicalPool.tick)
 
-	poolResolver.TickResolver(deposit.TickLower()).modifyDepositLower(currentTimestamp, signedLiquidity)
-	poolResolver.TickResolver(deposit.TickUpper()).modifyDepositUpper(currentTimestamp, signedLiquidity)
+	// GetOrCreateTick does not persist: the modified tick must be committed
+	// via SetTick (which prunes ticks whose stakedLiquidityGross is zero).
+	lowerTick := poolResolver.GetOrCreateTick(deposit.TickLower())
+	NewTickResolver(lowerTick).modifyDepositLower(currentTimestamp, signedLiquidity)
+	pool.Ticks().SetTick(deposit.TickLower(), lowerTick)
+
+	upperTick := poolResolver.GetOrCreateTick(deposit.TickUpper())
+	NewTickResolver(upperTick).modifyDepositUpper(currentTimestamp, signedLiquidity)
+	pool.Ticks().SetTick(deposit.TickUpper(), upperTick)
 
 	return nil
 }
@@ -454,8 +461,15 @@ func (self *canonicalRewardState) UnstakeToken(positionId uint64) {
 	if self.isInRange(deposit) {
 		poolResolver.modifyDeposit(signedLiquidity, currentTimestamp, canonicalPool.tick)
 	}
-	poolResolver.TickResolver(deposit.TickLower()).modifyDepositLower(currentTimestamp, signedLiquidity)
-	poolResolver.TickResolver(deposit.TickUpper()).modifyDepositUpper(currentTimestamp, signedLiquidity)
+	// GetOrCreateTick does not persist: the modified tick must be committed
+	// via SetTick (which prunes ticks whose stakedLiquidityGross is zero).
+	lowerTick := poolResolver.GetOrCreateTick(deposit.TickLower())
+	NewTickResolver(lowerTick).modifyDepositLower(currentTimestamp, signedLiquidity)
+	pool.Ticks().SetTick(deposit.TickLower(), lowerTick)
+
+	upperTick := poolResolver.GetOrCreateTick(deposit.TickUpper())
+	NewTickResolver(upperTick).modifyDepositUpper(currentTimestamp, signedLiquidity)
+	pool.Ticks().SetTick(deposit.TickUpper(), upperTick)
 }
 
 func newExternalIncentiveBy(

--- a/contract/r/gnoswap/staker/v1/reward_calculation_canonical_env_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_canonical_env_test.gno
@@ -420,8 +420,6 @@ func (self *canonicalRewardState) StakeToken(cur realm, positionId uint64, targe
 	// historical tick must be set regardless of the deposit's range
 	poolResolver.Pool.SetHistoricalTickAt(currentTimestamp, canonicalPool.tick)
 
-	// GetOrNewTick does not persist: the modified tick must be committed
-	// via SetTick (which prunes ticks whose stakedLiquidityGross is zero).
 	lowerTick := poolResolver.GetOrNewTick(deposit.TickLower())
 	NewTickResolver(lowerTick).modifyDepositLower(currentTimestamp, signedLiquidity)
 	pool.Ticks().SetTick(deposit.TickLower(), lowerTick)
@@ -461,8 +459,6 @@ func (self *canonicalRewardState) UnstakeToken(positionId uint64) {
 	if self.isInRange(deposit) {
 		poolResolver.modifyDeposit(signedLiquidity, currentTimestamp, canonicalPool.tick)
 	}
-	// GetOrNewTick does not persist: the modified tick must be committed
-	// via SetTick (which prunes ticks whose stakedLiquidityGross is zero).
 	lowerTick := poolResolver.GetOrNewTick(deposit.TickLower())
 	NewTickResolver(lowerTick).modifyDepositLower(currentTimestamp, signedLiquidity)
 	pool.Ticks().SetTick(deposit.TickLower(), lowerTick)

--- a/contract/r/gnoswap/staker/v1/reward_calculation_canonical_env_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_canonical_env_test.gno
@@ -420,13 +420,13 @@ func (self *canonicalRewardState) StakeToken(cur realm, positionId uint64, targe
 	// historical tick must be set regardless of the deposit's range
 	poolResolver.Pool.SetHistoricalTickAt(currentTimestamp, canonicalPool.tick)
 
-	// GetOrCreateTick does not persist: the modified tick must be committed
+	// GetOrNewTick does not persist: the modified tick must be committed
 	// via SetTick (which prunes ticks whose stakedLiquidityGross is zero).
-	lowerTick := poolResolver.GetOrCreateTick(deposit.TickLower())
+	lowerTick := poolResolver.GetOrNewTick(deposit.TickLower())
 	NewTickResolver(lowerTick).modifyDepositLower(currentTimestamp, signedLiquidity)
 	pool.Ticks().SetTick(deposit.TickLower(), lowerTick)
 
-	upperTick := poolResolver.GetOrCreateTick(deposit.TickUpper())
+	upperTick := poolResolver.GetOrNewTick(deposit.TickUpper())
 	NewTickResolver(upperTick).modifyDepositUpper(currentTimestamp, signedLiquidity)
 	pool.Ticks().SetTick(deposit.TickUpper(), upperTick)
 
@@ -461,13 +461,13 @@ func (self *canonicalRewardState) UnstakeToken(positionId uint64) {
 	if self.isInRange(deposit) {
 		poolResolver.modifyDeposit(signedLiquidity, currentTimestamp, canonicalPool.tick)
 	}
-	// GetOrCreateTick does not persist: the modified tick must be committed
+	// GetOrNewTick does not persist: the modified tick must be committed
 	// via SetTick (which prunes ticks whose stakedLiquidityGross is zero).
-	lowerTick := poolResolver.GetOrCreateTick(deposit.TickLower())
+	lowerTick := poolResolver.GetOrNewTick(deposit.TickLower())
 	NewTickResolver(lowerTick).modifyDepositLower(currentTimestamp, signedLiquidity)
 	pool.Ticks().SetTick(deposit.TickLower(), lowerTick)
 
-	upperTick := poolResolver.GetOrCreateTick(deposit.TickUpper())
+	upperTick := poolResolver.GetOrNewTick(deposit.TickUpper())
 	NewTickResolver(upperTick).modifyDepositUpper(currentTimestamp, signedLiquidity)
 	pool.Ticks().SetTick(deposit.TickUpper(), upperTick)
 }

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
@@ -125,21 +125,17 @@ func (self *PoolResolver) CurrentStakedLiquidity(currentTime int64) (liquidity *
 	return liquidity
 }
 
-// GetOrCreateTick returns the tick for the given tickId, creating a fresh
+// GetOrNewTick returns the tick for the given tickId, creating a fresh
 // zero-valued tick via NewTick if it does not exist yet.
 // The returned tick is NOT persisted: the caller must set the desired fields
 // and persist it via Ticks().SetTick, which prunes ticks whose
 // stakedLiquidityGross is zero. This keeps reads from growing the tick tree.
-func (self *PoolResolver) GetOrCreateTick(tickId int32) *sr.Tick {
+func (self *PoolResolver) GetOrNewTick(tickId int32) *sr.Tick {
 	tick := self.Ticks().Get(tickId)
 	if tick == nil {
 		return sr.NewTick(tickId)
 	}
 	return tick
-}
-
-func (self *PoolResolver) TickResolver(tickId int32) *TickResolver {
-	return NewTickResolver(self.GetOrCreateTick(tickId))
 }
 
 // IsExternallyIncentivizedPool returns true if the pool has any active external incentives.
@@ -638,8 +634,8 @@ func (self *PoolResolver) CalculateRawRewardForPosition(currentTime int64, curre
 
 	globalAcc := self.calculateGlobalRewardRatioAccumulation(currentTime, self.CurrentStakedLiquidity(currentTime))
 
-	lowerAcc := self.TickResolver(deposit.TickLower()).CurrentOutsideAccumulation(currentTime)
-	upperAcc := self.TickResolver(deposit.TickUpper()).CurrentOutsideAccumulation(currentTime)
+	lowerAcc := NewTickResolver(self.GetOrNewTick(deposit.TickLower())).CurrentOutsideAccumulation(currentTime)
+	upperAcc := NewTickResolver(self.GetOrNewTick(deposit.TickUpper())).CurrentOutsideAccumulation(currentTime)
 	if currentTick < deposit.TickLower() {
 		rewardAcc = u256.Zero().Sub(lowerAcc, upperAcc)
 	} else if currentTick >= deposit.TickUpper() {

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
@@ -125,11 +125,7 @@ func (self *PoolResolver) CurrentStakedLiquidity(currentTime int64) (liquidity *
 	return liquidity
 }
 
-// GetOrNewTick returns the tick for the given tickId, creating a fresh
-// zero-valued tick via NewTick if it does not exist yet.
-// The returned tick is NOT persisted: the caller must set the desired fields
-// and persist it via Ticks().SetTick, which prunes ticks whose
-// stakedLiquidityGross is zero. This keeps reads from growing the tick tree.
+// GetOrNewTick returns the existing tick or a new zero-valued tick.
 func (self *PoolResolver) GetOrNewTick(tickId int32) *sr.Tick {
 	tick := self.Ticks().Get(tickId)
 	if tick == nil {

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
@@ -125,8 +125,21 @@ func (self *PoolResolver) CurrentStakedLiquidity(currentTime int64) (liquidity *
 	return liquidity
 }
 
+// GetOrCreateTick returns the tick for the given tickId, creating a fresh
+// zero-valued tick via NewTick if it does not exist yet.
+// The returned tick is NOT persisted: the caller must set the desired fields
+// and persist it via Ticks().SetTick, which prunes ticks whose
+// stakedLiquidityGross is zero. This keeps reads from growing the tick tree.
+func (self *PoolResolver) GetOrCreateTick(tickId int32) *sr.Tick {
+	tick := self.Ticks().Get(tickId)
+	if tick == nil {
+		return sr.NewTick(tickId)
+	}
+	return tick
+}
+
 func (self *PoolResolver) TickResolver(tickId int32) *TickResolver {
-	return NewTickResolver(self.Ticks().Get(tickId))
+	return NewTickResolver(self.GetOrCreateTick(tickId))
 }
 
 // IsExternallyIncentivizedPool returns true if the pool has any active external incentives.

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool_test.gno
@@ -651,6 +651,9 @@ func TestTickResolver(cur realm, t *testing.T) {
 
 			tickResolver := poolResolver.TickResolver(tt.tickId)
 			uassert.NotNil(t, tickResolver)
+			// TickResolver must be a pure read: resolving a missing tick must
+			// not grow the pool's tick tree.
+			uassert.False(t, pool.Ticks().Has(tt.tickId))
 		})
 	}
 }
@@ -1013,9 +1016,11 @@ func TestHistoricalTickDensity_DoesNotChangeRewardCalculation(cur realm, t *test
 					pool.SetHistoricalTickAt(h.at, h.tick)
 				}
 
-				// Ensure boundary ticks exist with zero outside accumulation.
-				pool.Ticks().Get(-10)
-				pool.Ticks().Get(10)
+				// Ensure boundary ticks are resolvable with zero outside
+				// accumulation. GetOrCreateTick is a pure read that returns a
+				// fresh zero-valued tick for missing ticks without persisting.
+				poolResolver.GetOrCreateTick(-10)
+				poolResolver.GetOrCreateTick(10)
 				return resolver
 			}
 

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool_test.gno
@@ -629,15 +629,15 @@ func TestIsExternallyIncentivizedPool(cur realm, t *testing.T) {
 	}
 }
 
-// Test TickResolver
-func TestTickResolver(cur realm, t *testing.T) {
+// Test GetOrNewTick
+func TestGetOrNewTick(cur realm, t *testing.T) {
 	tests := []struct {
 		name     string
 		poolPath string
 		tickId   int32
 	}{
 		{
-			name:     "get tick resolver",
+			name:     "get or new tick",
 			poolPath: "test_pool",
 			tickId:   0,
 		},
@@ -649,9 +649,9 @@ func TestTickResolver(cur realm, t *testing.T) {
 			pool := sr.NewPool(tt.poolPath, currentTime)
 			poolResolver := NewPoolResolver(pool)
 
-			tickResolver := poolResolver.TickResolver(tt.tickId)
+			tickResolver := NewTickResolver(poolResolver.GetOrNewTick(tt.tickId))
 			uassert.NotNil(t, tickResolver)
-			// TickResolver must be a pure read: resolving a missing tick must
+			// GetOrNewTick must be a pure read: resolving a missing tick must
 			// not grow the pool's tick tree.
 			uassert.False(t, pool.Ticks().Has(tt.tickId))
 		})
@@ -1016,11 +1016,6 @@ func TestHistoricalTickDensity_DoesNotChangeRewardCalculation(cur realm, t *test
 					pool.SetHistoricalTickAt(h.at, h.tick)
 				}
 
-				// Ensure boundary ticks are resolvable with zero outside
-				// accumulation. GetOrCreateTick is a pure read that returns a
-				// fresh zero-valued tick for missing ticks without persisting.
-				poolResolver.GetOrCreateTick(-10)
-				poolResolver.GetOrCreateTick(10)
 				return resolver
 			}
 

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool_test.gno
@@ -651,8 +651,7 @@ func TestGetOrNewTick(cur realm, t *testing.T) {
 
 			tickResolver := NewTickResolver(poolResolver.GetOrNewTick(tt.tickId))
 			uassert.NotNil(t, tickResolver)
-			// GetOrNewTick must be a pure read: resolving a missing tick must
-			// not grow the pool's tick tree.
+			// Does not insert a missing tick.
 			uassert.False(t, pool.Ticks().Has(tt.tickId))
 		})
 	}

--- a/contract/r/gnoswap/staker/v1/reward_calculation_tick.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_tick.gno
@@ -73,6 +73,15 @@ func (s *stakerV1) swapStartHook(_ int, rlm realm, poolPath string, timestamp in
 		return
 	}
 
+	// Skip batch initialization when the pool has no staking state that a swap
+	// could affect: without staked ticks there is nothing to accumulate.
+	// This prevents the staker from persisting a swap batch on every swap of an
+	// inactive pool forever, keeping swap hooks effectively disabled until the
+	// pool is actually staked.
+	if pool.Ticks().Tree().Size() == 0 {
+		return
+	}
+
 	// Initialize batch processor for this swap
 	// This will accumulate all tick crosses until swap completion
 	currentSwapBatch := sr.NewSwapBatchProcessor(poolPath, pool, timestamp)
@@ -124,6 +133,15 @@ func (s *stakerV1) swapEndHook(_ int, rlm realm, poolPath string) error {
 func (s *stakerV1) tickCrossHook(_ int, rlm realm, poolPath string, tickId int32, zeroForOne bool, timestamp int64) {
 	pool, ok := s.getPools().Get(poolPath)
 	if !ok {
+		return
+	}
+
+	// Skip ticks that were never initialized by staking (no reward impact).
+	// Use the non-mutating existence check instead of Ticks().Get(): Get
+	// auto-inserts an empty tick into the pool's tick BPTree, so a swap that
+	// crosses an arbitrary uninitialized tick would permanently grow staker
+	// tick state.
+	if !pool.Ticks().Has(tickId) {
 		return
 	}
 

--- a/contract/r/gnoswap/staker/v1/reward_calculation_tick.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_tick.gno
@@ -127,10 +127,7 @@ func (s *stakerV1) tickCrossHook(_ int, rlm realm, poolPath string, tickId int32
 		return
 	}
 
-	// Skip ticks that were never initialized by staking (no reward impact).
-	// Ticks().Get() is a pure read now (nil when missing), so a swap that
-	// crosses an arbitrary uninitialized tick is skipped without ever growing
-	// staker tick state.
+	// Skip ticks without staking state.
 	tick := pool.Ticks().Get(tickId)
 	if tick == nil {
 		return

--- a/contract/r/gnoswap/staker/v1/reward_calculation_tick.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_tick.gno
@@ -72,6 +72,9 @@ func (s *stakerV1) swapStartHook(_ int, rlm realm, poolPath string, timestamp in
 	if !ok {
 		return
 	}
+	if pool.Ticks().Tree().Size() == 0 {
+		return
+	}
 
 	// Initialize batch processor for this swap
 	// This will accumulate all tick crosses until swap completion

--- a/contract/r/gnoswap/staker/v1/reward_calculation_tick.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_tick.gno
@@ -73,15 +73,6 @@ func (s *stakerV1) swapStartHook(_ int, rlm realm, poolPath string, timestamp in
 		return
 	}
 
-	// Skip batch initialization when the pool has no staking state that a swap
-	// could affect: without staked ticks there is nothing to accumulate.
-	// This prevents the staker from persisting a swap batch on every swap of an
-	// inactive pool forever, keeping swap hooks effectively disabled until the
-	// pool is actually staked.
-	if pool.Ticks().Tree().Size() == 0 {
-		return
-	}
-
 	// Initialize batch processor for this swap
 	// This will accumulate all tick crosses until swap completion
 	currentSwapBatch := sr.NewSwapBatchProcessor(poolPath, pool, timestamp)
@@ -137,15 +128,13 @@ func (s *stakerV1) tickCrossHook(_ int, rlm realm, poolPath string, tickId int32
 	}
 
 	// Skip ticks that were never initialized by staking (no reward impact).
-	// Use the non-mutating existence check instead of Ticks().Get(): Get
-	// auto-inserts an empty tick into the pool's tick BPTree, so a swap that
-	// crosses an arbitrary uninitialized tick would permanently grow staker
-	// tick state.
-	if !pool.Ticks().Has(tickId) {
+	// Ticks().Get() is a pure read now (nil when missing), so a swap that
+	// crosses an arbitrary uninitialized tick is skipped without ever growing
+	// staker tick state.
+	tick := pool.Ticks().Get(tickId)
+	if tick == nil {
 		return
 	}
-
-	tick := pool.Ticks().Get(tickId)
 
 	// Skip ticks without staked boundary liquidity (no reward impact)
 	if tick.StakedLiquidityGross().IsZero() {

--- a/contract/r/gnoswap/staker/v1/reward_calculation_tick_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_tick_test.gno
@@ -332,3 +332,71 @@ func TestTickCrossHook_BatchesNetZeroDeltaInitializedTick(cur realm, t *testing.
 		t.Fatal("tick 10 outside accumulation was not updated")
 	}
 }
+
+// TestTickCrossHook_DoesNotAutoInsertUninitializedTick verifies that crossing
+// a tick that was never initialized by staking does not insert an empty tick
+// into the pool's tick tree.
+func TestTickCrossHook_DoesNotAutoInsertUninitializedTick(cur realm, t *testing.T) {
+	initStakerTest(cur, t)
+
+	instance := getMockInstance()
+	poolPath := "test_pool"
+	startTime := int64(1000)
+	batchTime := int64(1010)
+	liquidity := i256.NewInt(1000)
+
+	pool := sr.NewPool(poolPath, startTime)
+	poolResolver := NewPoolResolver(pool)
+	poolResolver.modifyDeposit(liquidity, startTime, 5)
+
+	tickResolver := poolResolver.TickResolver(10)
+	tickResolver.modifyDepositUpper(startTime, liquidity)
+	tickResolver.modifyDepositLower(startTime, liquidity)
+
+	instance.getPools().set(poolPath, pool)
+	instance.swapStartHook(0, cur, poolPath, batchTime)
+	if instance.store.GetCurrentSwapBatch() == nil {
+		t.Fatal("current swap batch not found for pool with staked ticks")
+	}
+
+	// Crossing an uninitialized tick must not insert it into the pool's tick tree.
+	instance.tickCrossHook(0, cur, poolPath, 999, false, batchTime)
+
+	if pool.Ticks().Has(999) {
+		t.Fatal("tickCrossHook auto-inserted uninitialized tick 999; tick state must not grow")
+	}
+
+	batch := instance.store.GetCurrentSwapBatch()
+	if crosses := batch.Crosses(); len(crosses) != 0 {
+		t.Fatalf("batch crosses length = %d, want 0 for uninitialized tick", len(crosses))
+	}
+}
+
+// TestSwapStartHook_SkipsBatchForPoolWithoutStakedTicks verifies that the swap
+// start hook does not persist a swap batch for a pool without any staked ticks,
+// keeping swap hooks inactive on pools with no staking state.
+func TestSwapStartHook_SkipsBatchForPoolWithoutStakedTicks(cur realm, t *testing.T) {
+	initStakerTest(cur, t)
+
+	instance := getMockInstance()
+	poolPath := "test_pool"
+	startTime := int64(1000)
+
+	// The mock store starts with a default inactive batch; capture it to detect
+	// whether swapStartHook replaces it.
+	before := instance.store.GetCurrentSwapBatch()
+
+	// Pool is registered but never staked: its tick tree must be empty.
+	pool := sr.NewPool(poolPath, startTime)
+	instance.getPools().set(poolPath, pool)
+
+	instance.swapStartHook(0, cur, poolPath, 1100)
+
+	after := instance.store.GetCurrentSwapBatch()
+	if after != before {
+		t.Fatal("swapStartHook must not replace the swap batch for a pool without staked ticks")
+	}
+	if after.PoolPath() == poolPath {
+		t.Fatal("swapStartHook must not create a swap batch for a pool without staked ticks")
+	}
+}

--- a/contract/r/gnoswap/staker/v1/reward_calculation_tick_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_tick_test.gno
@@ -299,7 +299,7 @@ func TestTickCrossHook_BatchesNetZeroDeltaInitializedTick(cur realm, t *testing.
 	poolResolver := NewPoolResolver(pool)
 	poolResolver.modifyDeposit(liquidity, startTime, 5)
 
-	tick := poolResolver.GetOrCreateTick(10)
+	tick := poolResolver.GetOrNewTick(10)
 	tickResolver := NewTickResolver(tick)
 	tickResolver.modifyDepositUpper(startTime, liquidity)
 	tickResolver.modifyDepositLower(startTime, liquidity)
@@ -362,7 +362,7 @@ func TestTickCrossHook_DoesNotAutoInsertUninitializedTick(cur realm, t *testing.
 	poolResolver := NewPoolResolver(pool)
 	poolResolver.modifyDeposit(liquidity, startTime, 5)
 
-	tick := poolResolver.GetOrCreateTick(10)
+	tick := poolResolver.GetOrNewTick(10)
 	tickResolver := NewTickResolver(tick)
 	tickResolver.modifyDepositUpper(startTime, liquidity)
 	tickResolver.modifyDepositLower(startTime, liquidity)

--- a/contract/r/gnoswap/staker/v1/reward_calculation_tick_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_tick_test.gno
@@ -13,14 +13,20 @@ import (
 func TestTicks(t *testing.T) {
 	ticks := sr.NewTicks()
 
-	tick := ticks.Get(100)
-	if tick == nil || tick.Id() != 100 {
-		t.Errorf("Get(100) returned %v; want Tick with ID 100", tick)
+	// Get must not auto-insert: a missing tick returns nil and the tree stays empty.
+	if tick := ticks.Get(100); tick != nil {
+		t.Errorf("Get(100) returned %v; want nil for missing tick", tick)
 	}
+	uassert.False(t, ticks.Has(100))
 
+	tick := sr.NewTick(100)
 	tick.SetStakedLiquidityGross(u256.MustFromDecimal("1"))
 	ticks.SetTick(100, tick)
 	uassert.True(t, ticks.Has(100))
+
+	if got := ticks.Get(100); got == nil || got.Id() != 100 {
+		t.Errorf("Get(100) returned %v; want Tick with ID 100", got)
+	}
 
 	tick.SetStakedLiquidityGross(u256.Zero())
 	ticks.SetTick(100, tick)
@@ -30,22 +36,31 @@ func TestTicks(t *testing.T) {
 func TestTicksBasic(t *testing.T) {
 	ticks := sr.NewTicks()
 
-	tick100 := ticks.Get(100)
+	// Get must not auto-insert: a missing tick returns nil.
+	if tick := ticks.Get(100); tick != nil {
+		t.Errorf("Get(100) returned %v; want nil for missing tick", tick)
+	}
+	uassert.False(t, ticks.Has(100))
+
+	tick100 := sr.NewTick(100)
+	tick100.SetStakedLiquidityGross(u256.MustFromDecimal("1"))
+	ticks.SetTick(100, tick100)
 	uassert.True(t, ticks.Has(100))
 	uassert.Equal(t, tick100.Id(), int32(100))
 
 	tick100Again := ticks.Get(100)
+	uassert.NotNil(t, tick100Again)
 	uassert.Equal(t, int32(tick100Again.Id()), int32(tick100.Id()))
-	uassert.True(t, tick100Again.StakedLiquidityGross().IsZero())
+	uassert.False(t, tick100Again.StakedLiquidityGross().IsZero())
 	uassert.True(t, tick100Again.StakedLiquidityDelta().IsZero())
 
-	ticks.SetTick(100, tick100)
+	// Persisting a zero-gross tick prunes it from the tree.
+	ticks.SetTick(100, sr.NewTick(100))
 	uassert.False(t, ticks.Has(100))
 }
 
 func TestModifyDepositLower(t *testing.T) {
-	ticks := sr.NewTicks()
-	tick := ticks.Get(100)
+	tick := sr.NewTick(100)
 
 	// initial value must be zero
 	uassert.True(t, tick.StakedLiquidityGross().IsZero())
@@ -74,8 +89,7 @@ func TestModifyDepositLower(t *testing.T) {
 }
 
 func TestModifyDepositUpper(t *testing.T) {
-	ticks := sr.NewTicks()
-	tick := ticks.Get(200)
+	tick := sr.NewTick(200)
 
 	// deposit +10 => modifyDepositUpper
 	tickResolver := NewTickResolver(tick)
@@ -137,8 +151,7 @@ func TestNewTickResolver(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ticks := sr.NewTicks()
-			tick := ticks.Get(tt.tickID)
+			tick := sr.NewTick(tt.tickID)
 
 			tickResolver := NewTickResolver(tick)
 
@@ -191,8 +204,7 @@ func TestCurrentOutsideAccumulation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ticks := sr.NewTicks()
-			tick := ticks.Get(tt.tickID)
+			tick := sr.NewTick(tt.tickID)
 
 			if tt.setupFunc != nil {
 				tt.setupFunc(tick)
@@ -257,8 +269,7 @@ func TestUpdateCurrentOutsideAccumulation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ticks := sr.NewTicks()
-			tick := ticks.Get(tt.tickID)
+			tick := sr.NewTick(tt.tickID)
 
 			// Set up current accumulation
 			if !tt.currentAcc.IsZero() {
@@ -288,10 +299,12 @@ func TestTickCrossHook_BatchesNetZeroDeltaInitializedTick(cur realm, t *testing.
 	poolResolver := NewPoolResolver(pool)
 	poolResolver.modifyDeposit(liquidity, startTime, 5)
 
-	tickResolver := poolResolver.TickResolver(10)
+	tick := poolResolver.GetOrCreateTick(10)
+	tickResolver := NewTickResolver(tick)
 	tickResolver.modifyDepositUpper(startTime, liquidity)
 	tickResolver.modifyDepositLower(startTime, liquidity)
-	tick := pool.Ticks().Get(10)
+	pool.Ticks().SetTick(10, tick)
+	tick = pool.Ticks().Get(10)
 	if tick.StakedLiquidityGross().IsZero() {
 		t.Fatalf("tick 10 must remain initialized")
 	}
@@ -349,9 +362,11 @@ func TestTickCrossHook_DoesNotAutoInsertUninitializedTick(cur realm, t *testing.
 	poolResolver := NewPoolResolver(pool)
 	poolResolver.modifyDeposit(liquidity, startTime, 5)
 
-	tickResolver := poolResolver.TickResolver(10)
+	tick := poolResolver.GetOrCreateTick(10)
+	tickResolver := NewTickResolver(tick)
 	tickResolver.modifyDepositUpper(startTime, liquidity)
 	tickResolver.modifyDepositLower(startTime, liquidity)
+	pool.Ticks().SetTick(10, tick)
 
 	instance.getPools().set(poolPath, pool)
 	instance.swapStartHook(0, cur, poolPath, batchTime)

--- a/contract/r/gnoswap/staker/v1/staker.gno
+++ b/contract/r/gnoswap/staker/v1/staker.gno
@@ -298,8 +298,6 @@ func (s *stakerV1) StakeToken(_ int, rlm realm, positionId uint64, referrer stri
 
 	// This could happen because of how position stores the ticks.
 	// Ticks are negated if the token1 < token0.
-	// GetOrNewTick does not persist: the modified tick must be committed
-	// via SetTick (which prunes ticks whose stakedLiquidityGross is zero).
 	upperTick := poolResolver.GetOrNewTick(tickUpper)
 	NewTickResolver(upperTick).modifyDepositUpper(currentTime, signedLiquidity)
 	pool.Ticks().SetTick(tickUpper, upperTick)
@@ -788,9 +786,6 @@ func (s *stakerV1) applyUnStake(positionId uint64) error {
 		poolResolver.modifyDeposit(signedLiquidity, currentTime, currentTick)
 	}
 
-	// GetOrNewTick does not persist: the modified tick must be committed
-	// via SetTick. When the last position at a boundary is unstaked the gross
-	// drops to zero and SetTick prunes the tick from the pool's tick tree.
 	upperTick := poolResolver.GetOrNewTick(depositResolver.TickUpper())
 	NewTickResolver(upperTick).modifyDepositUpper(currentTime, signedLiquidity)
 	pool.Ticks().SetTick(depositResolver.TickUpper(), upperTick)

--- a/contract/r/gnoswap/staker/v1/staker.gno
+++ b/contract/r/gnoswap/staker/v1/staker.gno
@@ -298,8 +298,15 @@ func (s *stakerV1) StakeToken(_ int, rlm realm, positionId uint64, referrer stri
 
 	// This could happen because of how position stores the ticks.
 	// Ticks are negated if the token1 < token0.
-	poolResolver.TickResolver(tickUpper).modifyDepositUpper(currentTime, signedLiquidity)
-	poolResolver.TickResolver(tickLower).modifyDepositLower(currentTime, signedLiquidity)
+	// GetOrCreateTick does not persist: the modified tick must be committed
+	// via SetTick (which prunes ticks whose stakedLiquidityGross is zero).
+	upperTick := poolResolver.GetOrCreateTick(tickUpper)
+	NewTickResolver(upperTick).modifyDepositUpper(currentTime, signedLiquidity)
+	pool.Ticks().SetTick(tickUpper, upperTick)
+
+	lowerTick := poolResolver.GetOrCreateTick(tickLower)
+	NewTickResolver(lowerTick).modifyDepositLower(currentTime, signedLiquidity)
+	pool.Ticks().SetTick(tickLower, lowerTick)
 	s.getPools().set(poolPath, pool)
 
 	amount0, amount1 := s.calculateAmounts(poolPath, tickLower, tickUpper, liquidity)
@@ -781,10 +788,16 @@ func (s *stakerV1) applyUnStake(positionId uint64) error {
 		poolResolver.modifyDeposit(signedLiquidity, currentTime, currentTick)
 	}
 
-	upperTick := poolResolver.TickResolver(depositResolver.TickUpper())
-	lowerTick := poolResolver.TickResolver(depositResolver.TickLower())
-	upperTick.modifyDepositUpper(currentTime, signedLiquidity)
-	lowerTick.modifyDepositLower(currentTime, signedLiquidity)
+	// GetOrCreateTick does not persist: the modified tick must be committed
+	// via SetTick. When the last position at a boundary is unstaked the gross
+	// drops to zero and SetTick prunes the tick from the pool's tick tree.
+	upperTick := poolResolver.GetOrCreateTick(depositResolver.TickUpper())
+	NewTickResolver(upperTick).modifyDepositUpper(currentTime, signedLiquidity)
+	pool.Ticks().SetTick(depositResolver.TickUpper(), upperTick)
+
+	lowerTick := poolResolver.GetOrCreateTick(depositResolver.TickLower())
+	NewTickResolver(lowerTick).modifyDepositLower(currentTime, signedLiquidity)
+	pool.Ticks().SetTick(depositResolver.TickLower(), lowerTick)
 
 	s.getDeposits().remove(positionId)
 

--- a/contract/r/gnoswap/staker/v1/staker.gno
+++ b/contract/r/gnoswap/staker/v1/staker.gno
@@ -298,13 +298,13 @@ func (s *stakerV1) StakeToken(_ int, rlm realm, positionId uint64, referrer stri
 
 	// This could happen because of how position stores the ticks.
 	// Ticks are negated if the token1 < token0.
-	// GetOrCreateTick does not persist: the modified tick must be committed
+	// GetOrNewTick does not persist: the modified tick must be committed
 	// via SetTick (which prunes ticks whose stakedLiquidityGross is zero).
-	upperTick := poolResolver.GetOrCreateTick(tickUpper)
+	upperTick := poolResolver.GetOrNewTick(tickUpper)
 	NewTickResolver(upperTick).modifyDepositUpper(currentTime, signedLiquidity)
 	pool.Ticks().SetTick(tickUpper, upperTick)
 
-	lowerTick := poolResolver.GetOrCreateTick(tickLower)
+	lowerTick := poolResolver.GetOrNewTick(tickLower)
 	NewTickResolver(lowerTick).modifyDepositLower(currentTime, signedLiquidity)
 	pool.Ticks().SetTick(tickLower, lowerTick)
 	s.getPools().set(poolPath, pool)
@@ -314,8 +314,8 @@ func (s *stakerV1) StakeToken(_ int, rlm realm, positionId uint64, referrer stri
 	// Get accumulator values for reward calculation tracking
 	_, globalAccX128 := poolResolver.CurrentGlobalRewardRatioAccumulation(currentTime)
 	stakedLiquidity := poolResolver.CurrentStakedLiquidity(currentTime)
-	lowerTickResolver := poolResolver.TickResolver(tickLower)
-	upperTickResolver := poolResolver.TickResolver(tickUpper)
+	lowerTickResolver := NewTickResolver(poolResolver.GetOrNewTick(tickLower))
+	upperTickResolver := NewTickResolver(poolResolver.GetOrNewTick(tickUpper))
 	lowerOutsideAccX128 := lowerTickResolver.CurrentOutsideAccumulation(currentTime)
 	upperOutsideAccX128 := upperTickResolver.CurrentOutsideAccumulation(currentTime)
 
@@ -535,8 +535,8 @@ func (s *stakerV1) CollectReward(_ int, rlm realm, positionId uint64) (string, s
 
 		tickLower := deposit.TickLower()
 		tickUpper := deposit.TickUpper()
-		lowerOutsideAccX128 := poolResolver.TickResolver(tickLower).CurrentOutsideAccumulation(currentTime)
-		upperOutsideAccX128 := poolResolver.TickResolver(tickUpper).CurrentOutsideAccumulation(currentTime)
+		lowerOutsideAccX128 := NewTickResolver(poolResolver.GetOrNewTick(tickLower)).CurrentOutsideAccumulation(currentTime)
+		upperOutsideAccX128 := NewTickResolver(poolResolver.GetOrNewTick(tickUpper)).CurrentOutsideAccumulation(currentTime)
 
 		chain.Emit(
 			"CollectReward",
@@ -655,8 +655,8 @@ func (s *stakerV1) CollectReward(_ int, rlm realm, positionId uint64) (string, s
 		// Get accumulator values for reward calculation tracking
 		_, globalAccX128 := poolResolver.CurrentGlobalRewardRatioAccumulation(currentTime)
 		stakedLiquidity := poolResolver.CurrentStakedLiquidity(currentTime)
-		lowerTickResolver := poolResolver.TickResolver(deposit.TickLower())
-		upperTickResolver := poolResolver.TickResolver(deposit.TickUpper())
+		lowerTickResolver := NewTickResolver(poolResolver.GetOrNewTick(deposit.TickLower()))
+		upperTickResolver := NewTickResolver(poolResolver.GetOrNewTick(deposit.TickUpper()))
 		lowerOutsideAccX128 := lowerTickResolver.CurrentOutsideAccumulation(currentTime)
 		upperOutsideAccX128 := upperTickResolver.CurrentOutsideAccumulation(currentTime)
 
@@ -788,14 +788,14 @@ func (s *stakerV1) applyUnStake(positionId uint64) error {
 		poolResolver.modifyDeposit(signedLiquidity, currentTime, currentTick)
 	}
 
-	// GetOrCreateTick does not persist: the modified tick must be committed
+	// GetOrNewTick does not persist: the modified tick must be committed
 	// via SetTick. When the last position at a boundary is unstaked the gross
 	// drops to zero and SetTick prunes the tick from the pool's tick tree.
-	upperTick := poolResolver.GetOrCreateTick(depositResolver.TickUpper())
+	upperTick := poolResolver.GetOrNewTick(depositResolver.TickUpper())
 	NewTickResolver(upperTick).modifyDepositUpper(currentTime, signedLiquidity)
 	pool.Ticks().SetTick(depositResolver.TickUpper(), upperTick)
 
-	lowerTick := poolResolver.GetOrCreateTick(depositResolver.TickLower())
+	lowerTick := poolResolver.GetOrNewTick(depositResolver.TickLower())
 	NewTickResolver(lowerTick).modifyDepositLower(currentTime, signedLiquidity)
 	pool.Ticks().SetTick(depositResolver.TickLower(), lowerTick)
 

--- a/contract/r/gnoswap/staker/v1/staker_test.gno
+++ b/contract/r/gnoswap/staker/v1/staker_test.gno
@@ -665,8 +665,8 @@ func TestUnStakeToken(cur realm, t *testing.T) {
 	uassert.True(t, len(externalRewards) >= 0, "should have external reward tracking")
 
 	// Store initial tick state for comparison
-	lowerTick := poolResolver.TickResolver(tickLower)
-	upperTick := poolResolver.TickResolver(tickUpper)
+	lowerTick := NewTickResolver(poolResolver.GetOrNewTick(tickLower))
+	upperTick := NewTickResolver(poolResolver.GetOrNewTick(tickUpper))
 	initialLowerLiquidity := lowerTick.StakedLiquidityGross().Clone()
 	initialUpperLiquidity := upperTick.StakedLiquidityGross().Clone()
 
@@ -689,8 +689,8 @@ func TestUnStakeToken(cur realm, t *testing.T) {
 	uassert.False(t, deposits.Has(positionId), "deposit should be removed after unstaking")
 
 	// Verify tick liquidity was updated (should be reduced after unstaking)
-	finalLowerLiquidity := poolResolver.TickResolver(tickLower).StakedLiquidityGross()
-	finalUpperLiquidity := poolResolver.TickResolver(tickUpper).StakedLiquidityGross()
+	finalLowerLiquidity := NewTickResolver(poolResolver.GetOrNewTick(tickLower)).StakedLiquidityGross()
+	finalUpperLiquidity := NewTickResolver(poolResolver.GetOrNewTick(tickUpper)).StakedLiquidityGross()
 	uassert.True(t, finalLowerLiquidity.Lt(initialLowerLiquidity) || finalLowerLiquidity.IsZero(),
 		"lower tick liquidity should be reduced")
 	uassert.True(t, finalUpperLiquidity.Lt(initialUpperLiquidity) || finalUpperLiquidity.IsZero(),

--- a/contract/r/gnoswap/staker/v1/staker_test.gno
+++ b/contract/r/gnoswap/staker/v1/staker_test.gno
@@ -688,6 +688,9 @@ func TestUnStakeToken(cur realm, t *testing.T) {
 	deposits := getMockInstance().getDeposits()
 	uassert.False(t, deposits.Has(positionId), "deposit should be removed after unstaking")
 
+	uassert.False(t, pool.Ticks().Has(tickLower))
+	uassert.False(t, pool.Ticks().Has(tickUpper))
+
 	// Verify tick liquidity was updated (should be reduced after unstaking)
 	finalLowerLiquidity := NewTickResolver(poolResolver.GetOrNewTick(tickLower)).StakedLiquidityGross()
 	finalUpperLiquidity := NewTickResolver(poolResolver.GetOrNewTick(tickUpper)).StakedLiquidityGross()


### PR DESCRIPTION
## Summary
- make staker tick reads return `nil` without inserting empty ticks
- explicitly create and persist boundary ticks during stake and unstake, pruning zero-gross ticks
- skip uninitialized tick crosses and make tick resolver construction explicit
- trim redundant tick-state comments

## Validation
- `gno test -v ./gno.land/r/gnoswap/staker`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing staking ticks without creating unintended pool entries.
  * Ensured tick updates during staking, unstaking, and reward collection are saved correctly.
  * Prevented reward and swap processing from creating batches when no staked tick data exists.
  * Added safeguards to skip uninitialized tick crossings and avoid unintended state changes.
  * Improved cleanup of tick data after liquidity is fully unstaked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->