### PR TITLE
fix(staker): refresh per-pool emission after halving

### DIFF
--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier.gno
@@ -301,7 +301,8 @@ func (self *PoolTier) cacheRewardForPool(currentTimestamp int64, pools *Pools, p
 	poolResolver := NewPoolResolver(pool)
 
 	if len(halvingTimestamps) == 0 {
-		// No emission change within the range => use current emission.
+		// No emission change within the range => use the latest emission.
+		self.currentEmission = self.getEmission()
 		self.applyCacheToPool(poolResolver, tierNum, currentTimestamp, self.currentEmission)
 		return
 	}
@@ -314,6 +315,7 @@ func (self *PoolTier) cacheRewardForPool(currentTimestamp int64, pools *Pools, p
 	}
 
 	// Remaining range [lastTimestamp, currentTimestamp).
+	self.currentEmission = currentEmission
 	self.applyCacheToPool(poolResolver, tierNum, currentTimestamp, currentEmission)
 }
 

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier_test.gno
@@ -71,6 +71,60 @@ func TestCacheReward(cur realm, t *testing.T) {
 	}
 }
 
+func TestCacheRewardForPoolUsesLatestHalvingEmission(t *testing.T) {
+	poolPath := pl.GetPoolPath("gno.land/r/test/token1", "gno.land/r/test/token2", 3000)
+
+	t.Run("halving in range updates cached emission", func(t *testing.T) {
+		pools := NewPools()
+		pool := sr.NewPool(poolPath, 1000)
+		pools.set(poolPath, pool)
+
+		poolTier := NewPoolTierBy(
+			sr.NewBPTreeN(16),
+			sr.NewTierRatio(100, 0, 0),
+			[AllTierCount]uint64{0, 1, 0, 0},
+			1000,
+			1000,
+			func() int64 { return 500 },
+			func(start, end int64) ([]int64, []int64) {
+				if start < 1010 && end > 1010 {
+					return []int64{1010}, []int64{500}
+				}
+				return nil, nil
+			},
+		)
+		poolTier.membership.Set(poolPath, uint64(1))
+
+		poolTier.cacheRewardForPool(1020, pools, poolPath)
+
+		uassert.Equal(t, int64(500), poolTier.currentEmission)
+		uassert.Equal(t, int64(500), NewPoolResolver(pool).CurrentReward(1020))
+	})
+
+	t.Run("post-halving range uses latest emission", func(t *testing.T) {
+		pools := NewPools()
+		pool := sr.NewPool(poolPath, 1000)
+		pool.RewardCache().Set(1020, int64(500))
+		pools.set(poolPath, pool)
+
+		poolTier := NewPoolTierBy(
+			sr.NewBPTreeN(16),
+			sr.NewTierRatio(100, 0, 0),
+			[AllTierCount]uint64{0, 1, 0, 0},
+			1000,
+			1000,
+			func() int64 { return 500 },
+			func(start, end int64) ([]int64, []int64) { return nil, nil },
+		)
+		poolTier.membership.Set(poolPath, uint64(1))
+
+		poolTier.cacheRewardForPool(1030, pools, poolPath)
+
+		uassert.Equal(t, int64(500), poolTier.currentEmission)
+		uassert.Equal(t, int64(500), NewPoolResolver(pool).CurrentReward(1030))
+	})
+}
+
 var test_gnousdc = pl.GetPoolPath("gno.land/r/gnoland/wugnot.wugnot", "gno.land/r/gnoswap/gns.GNS", 3000)
 
 func SetupPoolTier(t *testing.T) *PoolTier {

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier_test.gno
@@ -125,6 +125,54 @@ func TestCacheRewardForPoolUsesLatestHalvingEmission(t *testing.T) {
 	})
 }
 
+func TestCacheRewardStopsAtEmissionEndBoundary(t *testing.T) {
+	poolPath := pl.GetPoolPath("gno.land/r/test/token1", "gno.land/r/test/token2", 3000)
+
+	newPoolTier := func() (*Pools, *sr.Pool, *PoolTier) {
+		pools := NewPools()
+		pool := sr.NewPool(poolPath, 1000)
+		pool.SetRewardCacheAt(1000, 1000)
+		pools.set(poolPath, pool)
+
+		poolTier := NewPoolTierBy(
+			sr.NewBPTreeN(16),
+			sr.NewTierRatio(100, 0, 0),
+			[AllTierCount]uint64{0, 1, 0, 0},
+			1000,
+			1000,
+			func() int64 { return 0 },
+			func(start, end int64) ([]int64, []int64) {
+				if start <= 1020 && 1020 < end {
+					return []int64{1021}, []int64{0}
+				}
+				return nil, nil
+			},
+		)
+		poolTier.membership.Set(poolPath, uint64(1))
+		return pools, pool, poolTier
+	}
+
+	t.Run("global tier cache writes zero at emission end boundary", func(t *testing.T) {
+		pools, pool, poolTier := newPoolTier()
+
+		poolTier.cacheReward(1030, pools)
+
+		uassert.Equal(t, int64(0), poolTier.currentEmission)
+		uassert.Equal(t, true, pool.RewardCache().Has(1021))
+		uassert.Equal(t, int64(0), NewPoolResolver(pool).CurrentReward(1030))
+	})
+
+	t.Run("lazy pool cache writes zero at emission end boundary", func(t *testing.T) {
+		pools, pool, poolTier := newPoolTier()
+
+		poolTier.cacheRewardForPool(1030, pools, poolPath)
+
+		uassert.Equal(t, int64(0), poolTier.currentEmission)
+		uassert.Equal(t, true, pool.RewardCache().Has(1021))
+		uassert.Equal(t, int64(0), NewPoolResolver(pool).CurrentReward(1030))
+	})
+}
+
 var test_gnousdc = pl.GetPoolPath("gno.land/r/gnoland/wugnot.wugnot", "gno.land/r/gnoswap/gns.GNS", 3000)
 
 func SetupPoolTier(t *testing.T) *PoolTier {

--- a/contract/r/scenario/staker/staker_halving_lazy_pool_cache_filetest.gno
+++ b/contract/r/scenario/staker/staker_halving_lazy_pool_cache_filetest.gno
@@ -1,0 +1,210 @@
+// PKGPATH: gno.land/r/gnoswap/v1/main
+
+package main
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"gno.land/p/demo/tokens/grc721"
+	prbac "gno.land/p/gnoswap/rbac"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/emission"
+	"gno.land/r/gnoswap/gnft"
+	"gno.land/r/gnoswap/gns"
+	pl "gno.land/r/gnoswap/pool"
+	pn "gno.land/r/gnoswap/position"
+	sr "gno.land/r/gnoswap/staker"
+
+	_ "gno.land/r/gnoswap/pool/v1"
+	_ "gno.land/r/gnoswap/position/v1"
+	_ "gno.land/r/gnoswap/rbac"
+	_ "gno.land/r/gnoswap/staker/v1"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/baz"
+)
+
+const (
+	halvingCacheBlockTime int64  = 5
+	halvingCachePoolPath  string = "gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:3000"
+)
+
+var (
+	halvingCacheAdminAddr, _ = access.GetAddress(prbac.ROLE_ADMIN.String())
+	halvingCacheAdminRealm   = testing.NewUserRealm(halvingCacheAdminAddr)
+	halvingCacheStakerAddr, _ = access.GetAddress(prbac.ROLE_STAKER.String())
+	halvingCachePoolAddr, _   = access.GetAddress(prbac.ROLE_POOL.String())
+
+	halvingCacheMaxTimeout int64 = 9999999999
+	halvingCacheMaxInt64   int64 = 9223372036854775807
+)
+
+func main(cur realm) {
+	println("[SCENARIO] 1. Initialize emission and pool")
+	initHalvingCacheScenario(cur)
+	println("[EXPECTED] initialized staker halving cache scenario")
+	println()
+
+	println("[SCENARIO] 2. Stake position and cache pre-halving reward")
+	stakeHalvingCachePosition(cur)
+	preHalvingReward := cacheBeforeHalving(cur)
+	println("[EXPECTED] pre-halving pool reward cache uses year 1 pool reward")
+	println()
+
+	println("[SCENARIO] 3. Cross first halving boundary and query once")
+	skipToFirstHalving(cur)
+	firstPostHalvingReward := queryAndAssertLatestCache()
+	assertHalvingReducedPoolReward(preHalvingReward, firstPostHalvingReward)
+	println("[EXPECTED] first post-halving query synced pool reward cache")
+	println()
+
+	println("[SCENARIO] 4. Query again after halving")
+	testing.SkipHeights(1)
+	secondPostHalvingReward := queryAndAssertLatestCache()
+	if secondPostHalvingReward != firstPostHalvingReward {
+		panic("post-halving pool reward changed without another halving")
+	}
+	println("[EXPECTED] post-halving lazy cache kept latest pool reward")
+}
+
+func initHalvingCacheScenario(cur realm) {
+	testing.SetRealm(halvingCacheAdminRealm)
+	emission.SetDistributionStartTime(cross(cur), time.Now().Unix()+1)
+	emission.ChangeDistributionPct(cross(cur), 7500, 2500, 0, 0)
+	sr.SetUnStakingFee(cross(cur), 0)
+	pl.SetPoolCreationFee(cross(cur), 0)
+
+	testing.SkipHeights(1)
+	emission.MintAndDistributeGns(cross(cur))
+
+	pl.CreatePool(cross(cur), "gno.land/r/onbloc/bar", "gno.land/r/onbloc/baz", 3000, "79228162514264337593543950337")
+	sr.SetPoolTier(cross(cur), halvingCachePoolPath, 1)
+}
+
+func stakeHalvingCachePosition(cur realm) {
+	testing.SetRealm(halvingCacheAdminRealm)
+	bar.Approve(cross(cur), halvingCachePoolAddr, halvingCacheMaxInt64)
+	baz.Approve(cross(cur), halvingCachePoolAddr, halvingCacheMaxInt64)
+
+	positionId, _, _, _ := pn.Mint(
+		cross(cur),
+		"gno.land/r/onbloc/bar",
+		"gno.land/r/onbloc/baz",
+		3000,
+		int32(-1020),
+		int32(1020),
+		"1000000",
+		"1000000",
+		"1",
+		"1",
+		halvingCacheMaxTimeout,
+		halvingCacheAdminAddr,
+		"",
+	)
+	if positionId != 1 {
+		panic("unexpected position id")
+	}
+
+	gnft.Approve(cross(cur), halvingCacheStakerAddr, halvingCachePositionIdFrom(positionId))
+	sr.StakeToken(cross(cur), positionId, "")
+}
+
+func cacheBeforeHalving(cur realm) int64 {
+	testing.SetRealm(halvingCacheAdminRealm)
+	testing.SkipHeights(10)
+	sr.CollectableEmissionReward(1)
+
+	if gns.GetCurrentYear() != 1 {
+		panic("expected pre-halving year 1")
+	}
+	return assertLatestPoolRewardCacheMatchesCurrentPoolReward("pre-halving")
+}
+
+func skipToFirstHalving(cur realm) {
+	testing.SetRealm(halvingCacheAdminRealm)
+	year3Start := gns.GetHalvingYearStartTimestamp(3)
+	now := time.Now().Unix()
+	if now >= year3Start {
+		panic("test setup already passed first halving")
+	}
+
+	blocksToYear3 := (year3Start-now)/halvingCacheBlockTime + 2
+	testing.SkipHeights(blocksToYear3)
+
+	if gns.GetCurrentYear() != 3 {
+		panic("expected first halving to enter year 3")
+	}
+	println("[INFO] crossed to halving year:", gns.GetCurrentYear())
+}
+
+func queryAndAssertLatestCache() int64 {
+	sr.CollectableEmissionReward(1)
+	return assertLatestPoolRewardCacheMatchesCurrentPoolReward("post-halving")
+}
+
+func assertLatestPoolRewardCacheMatchesCurrentPoolReward(label string) int64 {
+	latestCache := latestPoolRewardCache()
+	currentPoolReward := sr.GetPoolReward(1)
+	println("[INFO]", label, "pool reward cache:", latestCache)
+	println("[INFO]", label, "current pool reward:", currentPoolReward)
+	if latestCache != currentPoolReward {
+		panic("pool reward cache did not use the latest halving pool reward")
+	}
+	return latestCache
+}
+
+func assertHalvingReducedPoolReward(before, after int64) {
+	if after >= before {
+		panic("halving did not reduce the pool reward")
+	}
+	println("[INFO] halving reduced pool reward from", before, "to", after)
+}
+
+func latestPoolRewardCache() int64 {
+	count := int(sr.GetPoolRewardCacheCount(halvingCachePoolPath))
+	if count == 0 {
+		panic("pool reward cache is empty")
+	}
+
+	ids := sr.GetPoolRewardCacheIDs(halvingCachePoolPath, 0, count)
+	if len(ids) == 0 {
+		panic("pool reward cache ids not found")
+	}
+
+	latestId := ids[0]
+	for _, id := range ids {
+		if id > latestId {
+			latestId = id
+		}
+	}
+
+	return sr.GetPoolRewardCache(halvingCachePoolPath, uint64(latestId))
+}
+
+func halvingCachePositionIdFrom(positionId uint64) grc721.TokenID {
+	return grc721.TokenID(strconv.Itoa(int(positionId)))
+}
+
+// Output:
+// [SCENARIO] 1. Initialize emission and pool
+// [EXPECTED] initialized staker halving cache scenario
+//
+// [SCENARIO] 2. Stake position and cache pre-halving reward
+// [INFO] pre-halving pool reward cache: 2675513
+// [INFO] pre-halving current pool reward: 2675513
+// [EXPECTED] pre-halving pool reward cache uses year 1 pool reward
+//
+// [SCENARIO] 3. Cross first halving boundary and query once
+// [INFO] crossed to halving year: 3
+// [INFO] post-halving pool reward cache: 1337756
+// [INFO] post-halving current pool reward: 1337756
+// [INFO] halving reduced pool reward from 2675513 to 1337756
+// [EXPECTED] first post-halving query synced pool reward cache
+//
+// [SCENARIO] 4. Query again after halving
+// [INFO] post-halving pool reward cache: 1337756
+// [INFO] post-halving current pool reward: 1337756
+// [EXPECTED] post-halving lazy cache kept latest pool reward

--- a/contract/r/scenario/staker/staker_halving_lazy_pool_cache_filetest.gno
+++ b/contract/r/scenario/staker/staker_halving_lazy_pool_cache_filetest.gno
@@ -29,7 +29,7 @@ import (
 
 const (
 	halvingCacheBlockTime int64  = 5
-	halvingCachePoolPath  string = "gno.land/r/onbloc/bar:gno.land/r/onbloc/baz:3000"
+	halvingCachePoolPath  string = "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/baz.BAZ:3000"
 )
 
 var (
@@ -80,7 +80,7 @@ func initHalvingCacheScenario(cur realm) {
 	testing.SkipHeights(1)
 	emission.MintAndDistributeGns(cross(cur))
 
-	pl.CreatePool(cross(cur), "gno.land/r/onbloc/bar", "gno.land/r/onbloc/baz", 3000, "79228162514264337593543950337")
+	pl.CreatePool(cross(cur), "gno.land/r/onbloc/bar.BAR", "gno.land/r/onbloc/baz.BAZ", 3000, "79228162514264337593543950337")
 	sr.SetPoolTier(cross(cur), halvingCachePoolPath, 1)
 }
 
@@ -91,8 +91,8 @@ func stakeHalvingCachePosition(cur realm) {
 
 	positionId, _, _, _ := pn.Mint(
 		cross(cur),
-		"gno.land/r/onbloc/bar",
-		"gno.land/r/onbloc/baz",
+		"gno.land/r/onbloc/bar.BAR",
+		"gno.land/r/onbloc/baz.BAZ",
 		3000,
 		int32(-1020),
 		int32(1020),


### PR DESCRIPTION
## Summary
- Keep lazy per-pool reward caching aligned with the latest emission after a halving.

## Context
- A cache call that crossed a halving used the correct rate for that interval, but a later call without another boundary could reuse the stale pre-halving emission stored on the pool tier object.

## Changes
- Refresh the per-pool cache from the live emission when the interval contains no new emission transition.
- Synchronize the pool tier emission after processing transition boundaries.
- Add unit and scenario coverage for repeated post-halving cache calls and the emission-end boundary.

## Behavior Changes
- Per-pool reward checkpoints continue using the active post-halving emission on subsequent lazy cache updates.

## Verification
- `make test PKG=gno.land/r/gnoswap/staker/v1 RUN=TestCacheRewardForPoolUsesLatestHalvingEmission`
- `make test PKG=gno.land/r/gnoswap/staker/v1 RUN=TestCacheRewardStopsAtEmissionEndBoundary`
- `make test PKG=gno.land/r/gnoswap/staker/v1 RUN=TestCacheReward`
- `make test PKG=gno.land/r/gnoswap/gns RUN=TestGetEmissionAmountPerSecondInRangeBoundary`
- `make test PKG=gno.land/r/gnoswap/scenario/staker`

## Notes
- No public interface, event, or storage schema changes.
- The emission-end behavior from the base branch is preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reward caching across emission halving periods.
  * Ensured the latest emission rate is applied when calculating pool rewards.
  * Correctly handles reward caching when emissions end, including zero-value results.

* **Tests**
  * Added coverage for halving events, delayed pool caching, and emission termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->