### PR TITLE
perf(staker): reduce append-only storage growth from redundant writes

### DIFF
--- a/contract/r/gnoswap/staker/v1/cache_internal_reward_test.gno
+++ b/contract/r/gnoswap/staker/v1/cache_internal_reward_test.gno
@@ -1,0 +1,103 @@
+package staker
+
+import (
+	"testing"
+
+	i256 "gno.land/p/gnoswap/int256"
+	u256 "gno.land/p/gnoswap/uint256"
+	uassert "gno.land/p/nt/uassert/v0"
+
+	sr "gno.land/r/gnoswap/staker"
+)
+
+// cacheInternalReward must NOT append global reward ratio accumulation checkpoints. That tree is
+// maintained by modifyDeposit on liquidity changes; over a constant-liquidity span the accumulation for
+// any timestamp is derived on demand. Repeated caching (per position reward calc / per emission
+// distribution) therefore must not grow the tree, while emission caching (CurrentReward) still works
+// and the on-demand accumulation stays correct (gas report issue 3).
+func TestCacheInternalReward_DoesNotCheckpointGlobalAccumulation(cur realm, t *testing.T) {
+	const createTime = int64(1000)
+
+	type call struct {
+		at       int64
+		emission int64
+	}
+	tests := []struct {
+		name             string
+		stakeDelta       int64 // staked liquidity established via modifyDeposit at createTime (0 = none)
+		calls            []call
+		wantCurrentAt    int64
+		wantCurrentValue int64  // expected CurrentReward at wantCurrentAt
+		accQueryLiq      int64  // liquidity used to verify on-demand accumulation (0 = skip acc check)
+		accQueryAt       int64  // timestamp for the accumulation check
+		wantAccString    string // expected accumulation value at accQueryAt
+	}{
+		{
+			name:       "constant positive liquidity: many caches, no accumulation growth",
+			stakeDelta: 1000,
+			calls: []call{
+				{at: createTime + 100, emission: 500},
+				{at: createTime + 200, emission: 500},
+				{at: createTime + 300, emission: 700},
+			},
+			wantCurrentAt:    createTime + 300,
+			wantCurrentValue: 700,
+			accQueryLiq:      1000,
+			accQueryAt:       createTime + 300,
+			wantAccString:    u256.MulDiv(u256.NewUintFromInt64(300), q128, u256.NewUintFromInt64(1000)).ToString(),
+		},
+		{
+			name:       "zero liquidity: caches never touch the accumulation tree",
+			stakeDelta: 0,
+			calls: []call{
+				{at: createTime + 100, emission: 500},
+				{at: createTime + 200, emission: 900},
+			},
+			wantCurrentAt:    createTime + 200,
+			wantCurrentValue: 900,
+			accQueryLiq:      0, // skip acc check (no liquidity established)
+		},
+		{
+			name:       "repeated identical emission is cached once",
+			stakeDelta: 1000,
+			calls: []call{
+				{at: createTime + 100, emission: 500},
+				{at: createTime + 200, emission: 500},
+			},
+			wantCurrentAt:    createTime + 200,
+			wantCurrentValue: 500,
+			accQueryLiq:      1000,
+			accQueryAt:       createTime + 200,
+			wantAccString:    u256.MulDiv(u256.NewUintFromInt64(200), q128, u256.NewUintFromInt64(1000)).ToString(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
+			pool := sr.NewPool("test_pool", createTime)
+			poolResolver := NewPoolResolver(pool)
+
+			if tt.stakeDelta != 0 {
+				poolResolver.modifyDeposit(i256.NewInt(tt.stakeDelta), createTime, 0)
+			}
+
+			sizeAfterStake := pool.GlobalRewardRatioAccumulation().Size()
+
+			for _, c := range tt.calls {
+				poolResolver.cacheInternalReward(c.at, c.emission)
+			}
+
+			// cacheInternalReward wrote no global accumulation checkpoint.
+			uassert.Equal(t, sizeAfterStake, pool.GlobalRewardRatioAccumulation().Size())
+
+			// Emission caching itself still records the latest reward.
+			uassert.Equal(t, tt.wantCurrentValue, poolResolver.CurrentReward(tt.wantCurrentAt))
+
+			// The accumulation is still derived correctly on demand from the constant liquidity.
+			if tt.accQueryLiq != 0 {
+				acc := poolResolver.calculateGlobalRewardRatioAccumulation(tt.accQueryAt, u256.NewUintFromInt64(tt.accQueryLiq))
+				uassert.Equal(t, tt.wantAccString, acc.ToString())
+			}
+		})
+	}
+}

--- a/contract/r/gnoswap/staker/v1/cache_internal_reward_test.gno
+++ b/contract/r/gnoswap/staker/v1/cache_internal_reward_test.gno
@@ -84,7 +84,7 @@ func TestCacheInternalReward_DoesNotCheckpointGlobalAccumulation(cur realm, t *t
 			sizeAfterStake := pool.GlobalRewardRatioAccumulation().Size()
 
 			for _, c := range tt.calls {
-				poolResolver.cacheInternalReward(c.at, c.emission)
+				poolResolver.cacheReward(c.at, c.emission)
 			}
 
 			// cacheInternalReward wrote no global accumulation checkpoint.

--- a/contract/r/gnoswap/staker/v1/modify_deposit_write_guards_test.gno
+++ b/contract/r/gnoswap/staker/v1/modify_deposit_write_guards_test.gno
@@ -1,0 +1,230 @@
+package staker
+
+import (
+	"testing"
+
+	i256 "gno.land/p/gnoswap/int256"
+	u256 "gno.land/p/gnoswap/uint256"
+	uassert "gno.land/p/nt/uassert/v0"
+
+	sr "gno.land/r/gnoswap/staker"
+)
+
+// modifyDeposit must append a StakedLiquidity entry only when the value actually changes.
+// A zero-net-delta update (e.g. a balanced tick cross) must not grow the append-only tree, while a
+// genuine change must be recorded (gas report issue 3, SetStakedLiquidityAt).
+func TestModifyDeposit_StakedLiquidityWriteGuard(cur realm, t *testing.T) {
+	const createTime = int64(1000)
+
+	type op struct {
+		delta int64
+		at    int64
+		tick  int32
+	}
+	tests := []struct {
+		name               string
+		ops                []op
+		wantSize           int // includes the single zero entry NewPool seeds at createTime
+		wantHasKeys        []int64
+		wantFinalLiquidity string
+	}{
+		{
+			name:               "no ops keeps only the initial entry",
+			ops:                nil,
+			wantSize:           1,
+			wantFinalLiquidity: "0",
+		},
+		{
+			name: "zero-delta updates never grow the tree",
+			ops: []op{
+				{delta: 0, at: createTime + 10, tick: 5},
+				{delta: 0, at: createTime + 20, tick: 6},
+			},
+			wantSize:           1,
+			wantFinalLiquidity: "0",
+		},
+		{
+			name:               "single positive delta appends one entry",
+			ops:                []op{{delta: 1000, at: createTime + 10, tick: 5}},
+			wantSize:           2,
+			wantHasKeys:        []int64{createTime + 10},
+			wantFinalLiquidity: "1000",
+		},
+		{
+			name: "zero-delta after a change does not grow",
+			ops: []op{
+				{delta: 1000, at: createTime + 10, tick: 5},
+				{delta: 0, at: createTime + 20, tick: 6},
+				{delta: 0, at: createTime + 30, tick: 7},
+			},
+			wantSize:           2,
+			wantHasKeys:        []int64{createTime + 10},
+			wantFinalLiquidity: "1000",
+		},
+		{
+			name: "successive increases each append",
+			ops: []op{
+				{delta: 1000, at: createTime + 10, tick: 5},
+				{delta: 500, at: createTime + 20, tick: 6},
+			},
+			wantSize:           3,
+			wantHasKeys:        []int64{createTime + 10, createTime + 20},
+			wantFinalLiquidity: "1500",
+		},
+		{
+			name: "decrease back to zero appends",
+			ops: []op{
+				{delta: 1000, at: createTime + 10, tick: 5},
+				{delta: -1000, at: createTime + 20, tick: 6},
+			},
+			wantSize:           3,
+			wantHasKeys:        []int64{createTime + 10, createTime + 20},
+			wantFinalLiquidity: "0",
+		},
+		{
+			name: "alternating changes append every time",
+			ops: []op{
+				{delta: 1000, at: createTime + 10, tick: 1},
+				{delta: -1000, at: createTime + 20, tick: 1},
+				{delta: 1000, at: createTime + 30, tick: 1},
+			},
+			wantSize:           4,
+			wantHasKeys:        []int64{createTime + 10, createTime + 20, createTime + 30},
+			wantFinalLiquidity: "1000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
+			pool := sr.NewPool("test_pool", createTime)
+			poolResolver := NewPoolResolver(pool)
+
+			// NewPool seeds a single zero staked-liquidity entry at creation time.
+			uassert.Equal(t, 1, pool.StakedLiquidity().Size())
+
+			lastAt := createTime
+			for _, o := range tt.ops {
+				poolResolver.modifyDeposit(i256.NewInt(o.delta), o.at, o.tick)
+				lastAt = o.at
+			}
+
+			uassert.Equal(t, tt.wantSize, pool.StakedLiquidity().Size())
+			for _, key := range tt.wantHasKeys {
+				uassert.True(t, pool.StakedLiquidity().Has(key))
+			}
+			uassert.Equal(t, tt.wantFinalLiquidity, poolResolver.CurrentStakedLiquidity(lastAt).ToString())
+		})
+	}
+}
+
+// modifyDeposit must reject a delta that would drive staked liquidity below zero.
+func TestModifyDeposit_PanicsOnNegativeLiquidity(cur realm, t *testing.T) {
+	const createTime = int64(1000)
+
+	tests := []struct {
+		name       string
+		setupDelta int64 // applied first (0 means no setup)
+		badDelta   int64
+	}{
+		{
+			name:       "underflow from zero liquidity",
+			setupDelta: 0,
+			badDelta:   -1000,
+		},
+		{
+			name:       "underflow below current liquidity",
+			setupDelta: 500,
+			badDelta:   -1000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
+			pool := sr.NewPool("test_pool", createTime)
+			poolResolver := NewPoolResolver(pool)
+
+			if tt.setupDelta != 0 {
+				poolResolver.modifyDeposit(i256.NewInt(tt.setupDelta), createTime+10, 0)
+			}
+
+			uassert.PanicsContains(t, cur, "underflow", func() {
+				poolResolver.modifyDeposit(i256.NewInt(tt.badDelta), createTime+20, 0)
+			})
+		})
+	}
+}
+
+// updateGlobalRewardRatioAccumulation must advance the checkpoint timestamp on every write, even when the
+// value is unchanged (zero staked liquidity). Each entry doubles as a time checkpoint from which the next
+// accumulation derives timeDiff, so a zero-liquidity span must be excluded from later accumulation.
+func TestUpdateGlobalRewardRatioAccumulation_Checkpoint(cur realm, t *testing.T) {
+	const createTime = int64(1000)
+
+	type upd struct {
+		at  int64
+		liq int64
+	}
+	tests := []struct {
+		name    string
+		updates []upd // applied in order; timestamps strictly increasing
+	}{
+		{
+			name: "zero-liquidity span is excluded from accumulation",
+			updates: []upd{
+				{at: createTime + 100, liq: 0},
+				{at: createTime + 200, liq: 1000},
+			},
+		},
+		{
+			name: "constant positive liquidity accumulates linearly",
+			updates: []upd{
+				{at: createTime + 100, liq: 1000},
+				{at: createTime + 200, liq: 1000},
+			},
+		},
+		{
+			name: "repeated zero-liquidity keeps advancing the checkpoint",
+			updates: []upd{
+				{at: createTime + 100, liq: 0},
+				{at: createTime + 150, liq: 0},
+				{at: createTime + 200, liq: 1000},
+			},
+		},
+		{
+			name: "varying liquidity sums per-segment accumulation",
+			updates: []upd{
+				{at: createTime + 100, liq: 1000},
+				{at: createTime + 200, liq: 2000},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
+			pool := sr.NewPool("test_pool", createTime)
+			poolResolver := NewPoolResolver(pool)
+
+			// Independently reproduce the expected accumulation: each write advances the checkpoint, and a
+			// segment contributes duration*q128/liquidity only when liquidity is positive.
+			expected := u256.Zero()
+			lastTime := createTime
+			var lastReturned *u256.Uint
+
+			for _, u := range tt.updates {
+				lastReturned = poolResolver.updateGlobalRewardRatioAccumulation(u.at, u256.NewUintFromInt64(u.liq))
+				if u.liq > 0 && u.at > lastTime {
+					seg := u256.MulDiv(u256.NewUintFromInt64(u.at-lastTime), q128, u256.NewUintFromInt64(u.liq))
+					expected = u256.Zero().Add(expected, seg)
+				}
+				lastTime = u.at
+			}
+
+			uassert.Equal(t, expected.ToString(), lastReturned.ToString())
+
+			// The stored checkpoint is at the last write time and carries the same value.
+			checkpointTime, checkpointAcc := poolResolver.CurrentGlobalRewardRatioAccumulation(lastTime)
+			uassert.Equal(t, lastTime, checkpointTime)
+			uassert.Equal(t, expected.ToString(), checkpointAcc)
+		})
+	}
+}

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
@@ -236,6 +236,12 @@ func (self *PoolResolver) calculateGlobalRewardRatioAccumulation(currentTime int
 }
 
 // updateGlobalRewardRatioAccumulation updates the global reward ratio accumulation and returns the new accumulation.
+//
+// NOTE: the write below cannot be skipped even when the accumulation value is unchanged (e.g. zero staked
+// liquidity or zero elapsed time). Each entry doubles as a *time checkpoint*: calculateGlobalRewardRatioAccumulation
+// derives timeDiff from the latest entry's timestamp. Omitting a same-valued write would fail to advance that
+// checkpoint, so a later non-zero-liquidity interval would over-accumulate across the skipped (zero-liquidity)
+// span. Bounding this append-only tree must therefore be done via watermark pruning, not by suppressing writes.
 func (self *PoolResolver) updateGlobalRewardRatioAccumulation(currentTime int64, currentStakedLiquidity *u256.Uint) *u256.Uint {
 	newAcc := self.calculateGlobalRewardRatioAccumulation(currentTime, currentStakedLiquidity)
 
@@ -546,7 +552,14 @@ func (self *PoolResolver) modifyDeposit(delta *i256.Int, currentTime int64, next
 		}
 	}
 
-	self.Pool.SetStakedLiquidityAt(currentTime, deltaApplied)
+	// Only append a staked-liquidity entry when the value actually changes (e.g. a tick cross whose
+	// net delta is zero leaves it unchanged). Unlike the global reward ratio accumulation, this tree
+	// carries no time-checkpoint semantics: it is read purely as a point-in-time value via
+	// CurrentStakedLiquidity (latest entry <= t), so omitting a duplicate-valued entry preserves
+	// behavior while keeping this append-only tree from growing on no-op updates.
+	if !lastStakedLiquidity.Eq(deltaApplied) {
+		self.Pool.SetStakedLiquidityAt(currentTime, deltaApplied)
+	}
 
 	return result
 }

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
@@ -204,12 +204,23 @@ func (self *PoolResolver) cacheReward(currentTime int64, currentTierReward int64
 	}
 }
 
-// cacheInternalReward caches the current emission and updates the global reward ratio accumulation.
+// cacheInternalReward caches the current emission for the pool.
+//
+// It deliberately does NOT write a global reward ratio accumulation checkpoint. That accumulation is a
+// function of staked liquidity only (emission is applied later, per-warmup), and staked liquidity changes
+// exclusively through modifyDeposit, which already checkpoints the accumulation (with the pre-change
+// liquidity) at every change. Between liquidity changes the accumulation for any timestamp is derived on
+// demand as lastCheckpoint + (t - lastCheckpointTime) * q128 / liquidity, so writing an extra checkpoint
+// here only subdivides a constant-liquidity interval without changing any computed value.
+//
+// cacheInternalReward runs on every position reward calculation (via cacheRewardForPool) and every emission
+// distribution across all tiered pools, so emitting a redundant checkpoint per call was a dominant driver
+// of the staker realm's unbounded storage growth (gas report issue 3).
+//
+// INVARIANT: if a future code path mutates staked liquidity outside modifyDeposit, it MUST checkpoint the
+// accumulation there (as modifyDeposit does) or on-demand reads will over-accumulate across the change.
 func (self *PoolResolver) cacheInternalReward(currentTime int64, currentEmission int64) {
 	self.cacheReward(currentTime, currentEmission)
-
-	currentStakedLiquidity := self.CurrentStakedLiquidity(currentTime)
-	self.updateGlobalRewardRatioAccumulation(currentTime, currentStakedLiquidity)
 }
 
 func (self *PoolResolver) calculateGlobalRewardRatioAccumulation(currentTime int64, currentStakedLiquidity *u256.Uint) *u256.Uint {

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
@@ -204,25 +204,6 @@ func (self *PoolResolver) cacheReward(currentTime int64, currentTierReward int64
 	}
 }
 
-// cacheInternalReward caches the current emission for the pool.
-//
-// It deliberately does NOT write a global reward ratio accumulation checkpoint. That accumulation is a
-// function of staked liquidity only (emission is applied later, per-warmup), and staked liquidity changes
-// exclusively through modifyDeposit, which already checkpoints the accumulation (with the pre-change
-// liquidity) at every change. Between liquidity changes the accumulation for any timestamp is derived on
-// demand as lastCheckpoint + (t - lastCheckpointTime) * q128 / liquidity, so writing an extra checkpoint
-// here only subdivides a constant-liquidity interval without changing any computed value.
-//
-// cacheInternalReward runs on every position reward calculation (via cacheRewardForPool) and every emission
-// distribution across all tiered pools, so emitting a redundant checkpoint per call was a dominant driver
-// of the staker realm's unbounded storage growth (gas report issue 3).
-//
-// INVARIANT: if a future code path mutates staked liquidity outside modifyDeposit, it MUST checkpoint the
-// accumulation there (as modifyDeposit does) or on-demand reads will over-accumulate across the change.
-func (self *PoolResolver) cacheInternalReward(currentTime int64, currentEmission int64) {
-	self.cacheReward(currentTime, currentEmission)
-}
-
 func (self *PoolResolver) calculateGlobalRewardRatioAccumulation(currentTime int64, currentStakedLiquidity *u256.Uint) *u256.Uint {
 	oldAccTime, oldAccStr := self.CurrentGlobalRewardRatioAccumulation(currentTime)
 	timeDiff := gnsmath.SafeSubInt64(currentTime, oldAccTime)
@@ -247,12 +228,6 @@ func (self *PoolResolver) calculateGlobalRewardRatioAccumulation(currentTime int
 }
 
 // updateGlobalRewardRatioAccumulation updates the global reward ratio accumulation and returns the new accumulation.
-//
-// NOTE: the write below cannot be skipped even when the accumulation value is unchanged (e.g. zero staked
-// liquidity or zero elapsed time). Each entry doubles as a *time checkpoint*: calculateGlobalRewardRatioAccumulation
-// derives timeDiff from the latest entry's timestamp. Omitting a same-valued write would fail to advance that
-// checkpoint, so a later non-zero-liquidity interval would over-accumulate across the skipped (zero-liquidity)
-// span. Bounding this append-only tree must therefore be done via watermark pruning, not by suppressing writes.
 func (self *PoolResolver) updateGlobalRewardRatioAccumulation(currentTime int64, currentStakedLiquidity *u256.Uint) *u256.Uint {
 	newAcc := self.calculateGlobalRewardRatioAccumulation(currentTime, currentStakedLiquidity)
 

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool_test.gno
@@ -402,35 +402,6 @@ func TestCacheRewardPool(cur realm, t *testing.T) {
 	}
 }
 
-// Test cacheInternalReward
-func TestCacheInternalReward(cur realm, t *testing.T) {
-	tests := []struct {
-		name            string
-		poolPath        string
-		currentTime     int64
-		currentEmission int64
-	}{
-		{
-			name:            "cache internal reward",
-			poolPath:        "test_pool",
-			currentTime:     1000,
-			currentEmission: 10000,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(cur realm, t *testing.T) {
-			pool := sr.NewPool(tt.poolPath, tt.currentTime)
-			poolResolver := NewPoolResolver(pool)
-
-			poolResolver.cacheInternalReward(tt.currentTime, tt.currentEmission)
-
-			reward := poolResolver.CurrentReward(tt.currentTime)
-			uassert.Equal(t, tt.currentEmission, reward)
-		})
-	}
-}
-
 // Test calculateGlobalRewardRatioAccumulation
 func TestCalculateGlobalRewardRatioAccumulation(cur realm, t *testing.T) {
 	tests := []struct {

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier.gno
@@ -325,7 +325,7 @@ func (self *PoolTier) applyCacheToPool(poolResolver *PoolResolver, tierNum uint6
 		return
 	}
 
-	poolResolver.cacheInternalReward(currentTimestamp, poolReward)
+	poolResolver.cacheReward(currentTimestamp, poolReward)
 }
 
 // applyCacheToAllPools applies the cached reward to all tiered pools.
@@ -361,7 +361,7 @@ func (self *PoolTier) applyCacheToAllPools(pools *Pools, currentTimestamp, emiss
 
 		// accumulate the reward for the interval (startBlock to endBlock) in the Pool
 		poolResolver := NewPoolResolver(pool)
-		poolResolver.cacheInternalReward(currentTimestamp, poolReward)
+		poolResolver.cacheReward(currentTimestamp, poolReward)
 		return false
 	})
 }

--- a/contract/r/scenario/staker/collect_external_incentive_penalty_with_multi_staking_filetest.gno
+++ b/contract/r/scenario/staker/collect_external_incentive_penalty_with_multi_staking_filetest.gno
@@ -361,11 +361,11 @@ func positionIdFrom(cur realm, positionId uint64) grc721.TokenID {
 //   - qux collected: 1849996719
 // [INFO] position 3 CollectReward:
 //   - accumulatedPenaltyAmount: 883332176
-//   - distributedRewardAmount: 7249999990
-//   - qux collected: 2416664734
+//   - distributedRewardAmount: 7249999991
+//   - qux collected: 2416664735
 //
 // [SCENARIO] 9. Verify new penalty accrues and can be collected again
 // [INFO] second collection returned: 883332176
 // [EXPECTED] new penalty accrued after later CollectReward is collected again
 // [EXPECTED] staker gns balance: 0
-// [EXPECTED] staker qux balance: 8
+// [EXPECTED] staker qux balance: 7

--- a/contract/r/scenario/staker/external_incentive_complete_distribution_filetest.gno
+++ b/contract/r/scenario/staker/external_incentive_complete_distribution_filetest.gno
@@ -482,36 +482,36 @@ func positionIdFrom(cur realm, positionId int) grc721.TokenID {
 //
 // [SCENARIO] 10. Collect final rewards
 // [INFO] collecting final rewards
-// [INFO] final rewards collected: 3887999999 QUX
+// [INFO] final rewards collected: 3888000000 QUX
 // [EXPECTED] community pool QUX unchanged on collect: 0 -> 0
 //
 // [SCENARIO] 11. Unstake position to collect all remaining rewards
 // [INFO] unstaking position to collect remaining rewards
 // [INFO] rewards collected from unstaking: 0 QUX
-// [INFO] total rewards collected so far: 6263999997 QUX
+// [INFO] total rewards collected so far: 6263999998 QUX
 // [INFO] position owner after unstaking: g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5
 //
 // [SCENARIO] 12. End external incentive and verify no dust
 // [INFO] ending external incentive
 // [INFO] before ending incentive:
 //   - Creator QUX: 7776000000
-//   - Staker contract QUX: 1512000003
+//   - Staker contract QUX: 1512000002
 //   - Creator GNS (deposit): 1000000000
-//   - Admin total rewards collected (QUX): 6263999997
+//   - Admin total rewards collected (QUX): 6263999998
 // [INFO] after ending incentive:
 //   - Creator QUX: 7776000000
-//   - Staker contract QUX: 1512000003
+//   - Staker contract QUX: 1512000002
 //   - Creator GNS (deposit): 2000000000
-//   - Admin QUX balances: 99990711998997
+//   - Admin QUX balances: 99990711998998
 // [RESULT] refund breakdown:
 //   - Total refunded reward token (QUX): 0
 //   - Total reduced from staker QUX: 0
 //   - Refunded GNS deposit: 1000000000
-// [EXPECTED] creator receives all remaining reward token: 1512000003
+// [EXPECTED] creator receives all remaining reward token: 1512000002
 // [EXPECTED] creator receives fixed GNS deposit: 1000000000
 // [EXPECTED] Total reward distribution:
 //   - Initial reward amount: 7776000000 QUX
-//   - Rewards collected by staker: 6263999997 QUX
+//   - Rewards collected by staker: 6263999998 QUX
 //   - Undistributed reward refunded: 0 QUX
-//   - Total accounted for: 6263999997 QUX
-//   - Staker-retained penalty QUX: 1512000003
+//   - Total accounted for: 6263999998 QUX
+//   - Staker-retained penalty QUX: 1512000002

--- a/contract/r/scenario/staker/full_internal_external_filetest.gno
+++ b/contract/r/scenario/staker/full_internal_external_filetest.gno
@@ -555,7 +555,7 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 //
 // [SCENARIO] 12. Unstake token 01
 // [INFO] unstake token 01
-// [EXPECTED] reward from unstaking: 38798151
+// [EXPECTED] reward from unstaking: 38798152
 //
 // [SCENARIO] 13. Create pool with external incentive only
 // [INFO] create baz:qux:3000 pool (external only)

--- a/contract/r/scenario/staker/more_01_single_position_for_each_warmup_tier_total_4_position_internal_only_filetest.gno
+++ b/contract/r/scenario/staker/more_01_single_position_for_each_warmup_tier_total_4_position_internal_only_filetest.gno
@@ -423,7 +423,7 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 // [EXPECTED] community pool reward (unclaimable + penalty): 73576607
 // [INFO] progress to 50% warm-up
 // [EXPECTED] user reward (50% warm-up): 6688782
-// [EXPECTED] community pool reward (50% penalty): 6688782
+// [EXPECTED] community pool reward (50% penalty): 6688783
 // [INFO] progress to 70% warm-up
 // [EXPECTED] user reward (70% warm-up): 9364294
 // [EXPECTED] community pool reward (30% penalty): 4013270

--- a/contract/r/scenario/staker/multi_tier_pool_with_position_rewards_filetest.gno
+++ b/contract/r/scenario/staker/multi_tier_pool_with_position_rewards_filetest.gno
@@ -473,7 +473,7 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 //
 // [SCENARIO] 8. Collect rewards from one position 1
 // [INFO] collect reward by tokenID: 1
-// [EXPECTED] reward: 802652 (should be > 0)
+// [EXPECTED] reward: 802653 (should be > 0)
 //
 // [SCENARIO] 9. ExactInSwapRoute BAZ -> BAR, baz:bar:100 to in-range 2
 // [INFO] ExactInSwapRoute

--- a/contract/r/scenario/staker/pool_add_to_tier2_and_change_to_tier3_internal_filetest.gno
+++ b/contract/r/scenario/staker/pool_add_to_tier2_and_change_to_tier3_internal_filetest.gno
@@ -344,7 +344,7 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 // [SCENARIO] 7. Collect reward with tier 3
 // [INFO] skip blocks to accumulate rewards with tier 3
 // [INFO] collect reward with tier 3
-// [EXPECTED] reward with tier 3: 16053074
+// [EXPECTED] reward with tier 3: 16053075
 // [INFO] tier 3 reward recorded for comparison
 //
 // [SCENARIO] 8. Compare tier rewards

--- a/contract/r/scenario/staker/pool_partial_collect_tier_removal_filetest.gno
+++ b/contract/r/scenario/staker/pool_partial_collect_tier_removal_filetest.gno
@@ -319,7 +319,7 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 //
 // [SCENARIO] 6. Second collect after tier removal
 // [INFO] collect remaining rewards from before tier removal
-// [EXPECTED] second collect reward: 12039809 (remaining 5 blocks worth)
+// [EXPECTED] second collect reward: 12039810 (remaining 5 blocks worth)
 // [INFO] confirmed: past rewards can be collected after tier removal
 //
 // [SCENARIO] 7. Wait and collect again (should be 0)
@@ -331,8 +331,8 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 // [SCENARIO] 8. Verify partial collection logic
 // [INFO] verify partial collection logic
 // [ANALYSIS] first collect: 14447771 GNS (5 blocks)
-// [ANALYSIS] second collect: 12039809 GNS (5 blocks)
+// [ANALYSIS] second collect: 12039810 GNS (5 blocks)
 // [ANALYSIS] third collect: 0 GNS (should be 0)
-// [SUMMARY] total rewards collected: 26487580 GNS (10 blocks in tier 2)
+// [SUMMARY] total rewards collected: 26487581 GNS (10 blocks in tier 2)
 // [INFO] partial collection scenario completed successfully
 // [INFO] confirmed: rewards can be partially collected and tier removal preserves uncollected rewards

--- a/contract/r/scenario/staker/pool_tier_change_reward_filetest.gno
+++ b/contract/r/scenario/staker/pool_tier_change_reward_filetest.gno
@@ -369,7 +369,7 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 // [EXPECTED] pool tier after change: 1 (should be 1)
 // [INFO] skip 5 blocks to accumulate rewards in tier 1
 // [INFO] collect rewards while in tier 1
-// [EXPECTED] tier 1 rewards: 10033169 GNS (5 blocks)
+// [EXPECTED] tier 1 rewards: 10033170 GNS (5 blocks)
 // [INFO] tier 1 rewards should be higher than tier 2 (better tier)
 //
 // [SCENARIO] 6. Remove from tier system and collect
@@ -390,11 +390,11 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 // [SCENARIO] 8. Verify tier change scenario
 // [INFO] verify tier change scenario
 // [ANALYSIS] Tier 2 rewards (30% share): 12039809 GNS
-// [ANALYSIS] Tier 1 rewards (50% share): 10033169 GNS
+// [ANALYSIS] Tier 1 rewards (50% share): 10033170 GNS
 // [ANALYSIS] Tier 0 rewards (no tier): 0 GNS
 // [ANALYSIS] Tier 3 rewards (20% share): 8026537 GNS
 // [WARNING] Tier 1 rewards not higher than Tier 2
-// [SUMMARY] Total rewards collected: 30099515 GNS
+// [SUMMARY] Total rewards collected: 30099516 GNS
 // [INFO] tier change scenario completed successfully
 // [INFO] confirmed: rewards correctly calculated for each tier period
 // [INFO] confirmed: tier removal preserves past rewards

--- a/contract/r/scenario/staker/pool_tier_removal_readd_check_rewards_filetest.gno
+++ b/contract/r/scenario/staker/pool_tier_removal_readd_check_rewards_filetest.gno
@@ -293,7 +293,7 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 // [INFO] skip 2592000 blocks, current height: 125, current time: 1234567900
 // [EXPECTED] collected GNS amount: 30629272823998 GNS
 // [INFO] skip 1 blocks, current height: 2592125, current time: 1247527900
-// [EXPECTED] reward amount per second: 2675512 GNS
+// [EXPECTED] reward amount per second: 2675513 GNS
 //
 // [SCENARIO] 4. Check tier 1 reward (tier 1: 100%, tier 2: 0%, tier 3: 0%)
 // [SCENARIO] 4.1. Set pool tier to tier 1
@@ -305,7 +305,7 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 // [INFO] skip 10 blocks, current height: 2592126, current time: 1247527905
 // [EXPECTED] collected GNS amount: 133775649 GNS
 // [INFO] skip 1 blocks, current height: 2592136, current time: 1247527955
-// [EXPECTED] reward amount per second: 2675512 GNS
+// [EXPECTED] reward amount per second: 2675513 GNS
 //
 // [SCENARIO] 5. Check non-tier reward (tier 1: 100%, tier 2: 0%, tier 3: 0%)
 // [SCENARIO] 5.1. Remove pool tier from tier 1
@@ -327,9 +327,9 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 // [SCENARIO] 6.2. Collect emission rewards in tier 2 with after 10 blocks
 // [INFO] pool tier: 2
 // [INFO] skip 10 blocks, current height: 2592148, current time: 1247528015
-// [EXPECTED] collected GNS amount: 80265399 GNS
+// [EXPECTED] collected GNS amount: 80265400 GNS
 // [INFO] skip 1 blocks, current height: 2592158, current time: 1247528065
-// [EXPECTED] reward amount per second: 1605307 GNS
+// [EXPECTED] reward amount per second: 1605308 GNS
 //
 // [SCENARIO] 6.3. Skip 10 blocks to rewards
 // [INFO] skip 10 blocks, current height: 2592159, current time: 1247528070
@@ -350,4 +350,4 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 // [INFO] skip 10 blocks, current height: 2592179, current time: 1247528170
 // [EXPECTED] collected GNS amount: 133775648 GNS
 // [INFO] skip 1 blocks, current height: 2592189, current time: 1247528220
-// [EXPECTED] reward amount per second: 1070204 GNS
+// [EXPECTED] reward amount per second: 1070205 GNS

--- a/contract/r/scenario/staker/reward_for_user_collect_change_by_collecting_reward_internal_filetest.gno
+++ b/contract/r/scenario/staker/reward_for_user_collect_change_by_collecting_reward_internal_filetest.gno
@@ -363,28 +363,28 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 // [SCENARIO] 6. Third reward collection with longer interval
 // [INFO] skip 10 blocks for third reward accumulation (longer period)
 // [INFO] collect third reward
-// [EXPECTED] third reward (10 blocks): 40132694
+// [EXPECTED] third reward (10 blocks): 40132695
 // [INFO] third reward collection completed
 //
 // [SCENARIO] 7. Compare reward accumulation patterns
 // [INFO] analyze reward accumulation patterns
 // [INFO] test pattern: frequent small collections
 // [INFO] small collection 1 (2 blocks): 8026538
-// [INFO] small collection 2 (2 blocks): 8026538
-// [INFO] small collection 3 (2 blocks): 8026538
+// [INFO] small collection 2 (2 blocks): 8026539
+// [INFO] small collection 3 (2 blocks): 8026539
 // [INFO] small collection 4 (2 blocks): 8026538
-// [INFO] small collection 5 (2 blocks): 8026538
-// [EXPECTED] total from frequent collections (10 blocks): 40132690
+// [INFO] small collection 5 (2 blocks): 8026539
+// [EXPECTED] total from frequent collections (10 blocks): 40132693
 // [INFO] test pattern: single large collection
 // [EXPECTED] single large collection (10 blocks): 40132694
 // [INFO] reward pattern analysis:
-// [INFO] - Frequent collections total: 40132690
+// [INFO] - Frequent collections total: 40132693
 // [INFO] - Single large collection: 40132694
 // [INFO] reward amounts may vary due to emission timing and block-based calculations
 //
 // [SCENARIO] 8. Final verification with multiple collections
 // [INFO] final verification with multiple rapid collections
-// [INFO] initial GNS balance: 100000164544041
+// [INFO] initial GNS balance: 100000164544045
 // [INFO] perform 3 consecutive collections
 // [EXPECTED] consecutive collection 1: 60199042
 // [EXPECTED] consecutive collection 2: 0

--- a/contract/r/scenario/upgrade/staker_collect_reward_distribution_rollback_with_validate_data_filetest.gno
+++ b/contract/r/scenario/upgrade/staker_collect_reward_distribution_rollback_with_validate_data_filetest.gno
@@ -4,11 +4,12 @@
 package main
 
 import (
-	"gno.land/p/gnoswap/gnsmath"
 	"math"
 	"strconv"
 	"testing"
 	"time"
+
+	"gno.land/p/gnoswap/gnsmath"
 
 	"gno.land/p/demo/tokens/grc721"
 	prbac "gno.land/p/gnoswap/rbac"
@@ -308,8 +309,8 @@ func withAbortsWithMessage(cur realm, callback func(), logMessage string) {
 //
 // [SCENARIO] 13. Collect reward with v1
 // [INFO] Collect reward
-// [EXPECTED] Total reward: 133374323
-// [EXPECTED] Reward to user: 39731368
+// [EXPECTED] Total reward: 133374324
+// [EXPECTED] Reward to user: 39731369
 // [EXPECTED] Reward penalty: 93642955
 //
 // [SCENARIO] 14. Check staking info after reward collection with v1

--- a/contract/r/scenario/upgrade/staker_collect_reward_distribution_upgrade_with_validate_data_filetest.gno
+++ b/contract/r/scenario/upgrade/staker_collect_reward_distribution_upgrade_with_validate_data_filetest.gno
@@ -4,11 +4,12 @@
 package main
 
 import (
-	"gno.land/p/gnoswap/gnsmath"
 	"math"
 	"strconv"
 	"testing"
 	"time"
+
+	"gno.land/p/gnoswap/gnsmath"
 
 	"gno.land/p/demo/tokens/grc721"
 	prbac "gno.land/p/gnoswap/rbac"
@@ -310,8 +311,8 @@ func withAbortsWithMessage(cur realm, callback func(), logMessage string) {
 //
 // [SCENARIO] 13. Collect reward with v3_valid
 // [INFO] Collect reward
-// [EXPECTED] Total reward: 133374323
-// [EXPECTED] Reward to user: 39731368
+// [EXPECTED] Total reward: 133374324
+// [EXPECTED] Reward to user: 39731369
 // [EXPECTED] Reward penalty: 93642955
 //
 // [SCENARIO] 14. Check staking info after reward collection

--- a/contract/r/scenario/upgrade/staker_collect_reward_upgrade_with_validate_data_filetest.gno
+++ b/contract/r/scenario/upgrade/staker_collect_reward_upgrade_with_validate_data_filetest.gno
@@ -4,11 +4,12 @@
 package main
 
 import (
-	"gno.land/p/gnoswap/gnsmath"
 	"math"
 	"strconv"
 	"testing"
 	"time"
+
+	"gno.land/p/gnoswap/gnsmath"
 
 	"gno.land/p/demo/tokens/grc721"
 	prbac "gno.land/p/gnoswap/rbac"
@@ -298,8 +299,8 @@ func withAbortsWithMessage(cur realm, callback func(), logMessage string) {
 //
 // [SCENARIO] 13. Collect reward with v3_valid
 // [INFO] Collect reward
-// [EXPECTED] Total reward amount: 133374323
-// [EXPECTED] Reward to user: 39731368
+// [EXPECTED] Total reward amount: 133374324
+// [EXPECTED] Reward to user: 39731369
 // [EXPECTED] Reward penalty: 93642955
 //
 // [SCENARIO] 14. Check staking info after reward collection


### PR DESCRIPTION
## Summary

Two independent write-reduction fixes for the staker realm's append-only trees, which the gas report identified as growing without bound (no prune path) and driving the gradual increase in gas usage over time (issue 3).

## Changes

### 1. Skip redundant staked-liquidity tree writes
`modifyDeposit` appended a `StakedLiquidity` entry on every call. It now writes only when the value actually changes. A zero-net-delta update (e.g. a balanced tick cross) is a no-op for readers, which resolve the value via `CurrentStakedLiquidity` (latest entry ≤ t) with no dependency on the entry's timestamp.

The global reward ratio accumulation write is deliberately **not** guarded the same way: each of its entries doubles as a *time checkpoint* that `calculateGlobalRewardRatioAccumulation` uses to derive `timeDiff`. Suppressing a same-valued write there would fail to advance the checkpoint and make a later non-zero-liquidity interval over-accumulate across the skipped zero-liquidity span.

### 2. Stop redundant global-accumulation writes in `cacheInternalReward`
`cacheInternalReward` wrote a global reward ratio accumulation checkpoint on every call. Because it runs on every position reward calculation (via `cacheRewardForPool`) and every emission distribution across all tiered pools, it appended an entry on nearly every staker interaction — a dominant driver of the unbounded growth.

The write is redundant: the global accumulation is a function of staked liquidity only (emission is applied later, per-warmup), and staked liquidity changes exclusively through `modifyDeposit`, which already checkpoints the accumulation (with pre-change liquidity) at every change. Between changes the accumulation for any timestamp is derived on demand as `lastCheckpoint + (t - lastCheckpointTime) * q128 / liquidity`.

## Reward rounding behavior (precision change)

Removing the per-call global-accumulation write from the reward path changes the rounding of collected rewards by small amounts (observed ±1, up to a few units in cumulative sums). This is a precision change, not an accounting error. Details below.

### What changed numerically

Scenario filetests under `gno.land/r/gnoswap/scenario/staker` show `CollectReward` outputs shifting slightly upward, with the matching refund shifting down, e.g.:

```
creator receives all remaining reward token: 1512000003 -> 1512000002   (+1 distributed to stakers)
frequent collections total (10 blocks):      40132690    -> 40132693     (closer to the single-collect 40132695)
```

The direction is consistent: slightly **more** is distributed and **less** dust is left behind.

### Why

The global reward ratio accumulation is built as a sum of floored terms in `calculateGlobalRewardRatioAccumulation`:

```
acc(t) = oldAcc + MulDiv(timeDiff, q128, stakedLiquidity)   // MulDiv floors
```

Previously an accumulation checkpoint was written on nearly every interaction (every position reward calculation / emission distribution), so the interval was split into many small pieces and `MulDiv` floored many times. The accumulation is now checkpointed only when staked liquidity actually changes (in `modifyDeposit`), so the same span is covered by fewer, larger `MulDiv` steps and is floored fewer times. The value is therefore slightly higher and closer to the mathematical value.

Invariant that holds in both cases: every term is floored, so `acc <= true value` regardless of checkpoint density. This change only reduces the undercount; it never makes `acc` exceed the true value.

### Conservation across multiple positions

For in-range positions the per-position inside-accumulation deltas telescope:

```
Σ (insideAccDelta_i · liquidity_i) = globalAccDelta · stakedLiquidity
```

so, with `rewardPerWarmup` computing `floor(insideAccDelta · liquidity · rewardPerSecond / q128)` per position:

```
Σ reward ≤ (rewardPerSecond / q128) · globalAccDelta · stakedLiquidity
         ≤ rewardPerSecond · Δt = emission
```

because `globalAccDelta ≤ true`. The total distributed can therefore never exceed the emission (internal) or the incentive budget (external), so no realm balance can be drained. This is confirmed by `end_external_incentive_reward_amount_invariant_filetest`, which passes.

### Ledger safety

- **Internal (emission):** staker balance = minted − collected ≥ 0, since collected ≤ emission = minted.
- **External incentives:** `CollectReward` already guards each transfer with the incentive's remaining `RewardAmount`, and the end-of-incentive refund stays ≥ 0 (`1512000002 > 0`).
- **Collection-order independence:** the accumulation now depends only on liquidity-changing events (`modifyDeposit`), not on when/who collects. Previously each collect wrote a checkpoint, so the accumulation — and its rounding — depended on collection timing/order. Rewards are now deterministic with respect to liquidity events alone.
