### PR TITLE
perf(gov/staker): avoid protocol-fee work for tokens with no new fees

### DIFF
--- a/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_accumulation_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_accumulation_test.gno
@@ -1,0 +1,231 @@
+package staker
+
+import (
+	"testing"
+
+	uassert "gno.land/p/nt/uassert/v0"
+
+	"gno.land/r/gnoswap/gov/staker"
+)
+
+// updateAccumulatedProtocolFeeX128PerStake must persist only the tokens whose value actually changed,
+// while always advancing the accumulated timestamp (gas report issue 1 / §1.2).
+func TestUpdateAccumulatedProtocolFee(cur realm, t *testing.T) {
+	type round struct {
+		amounts map[string]int64
+		at      int64
+	}
+	tests := []struct {
+		name          string
+		stake         int64
+		rounds        []round
+		wantAmounts   map[string]int64
+		wantTimestamp int64
+	}{
+		{
+			name:  "single round establishes all tokens",
+			stake: 1000,
+			rounds: []round{
+				{amounts: map[string]int64{"token1": 1000, "token2": 2000}, at: 20},
+			},
+			wantAmounts:   map[string]int64{"token1": 1000, "token2": 2000},
+			wantTimestamp: 20,
+		},
+		{
+			name:  "second round updates only the changed token",
+			stake: 1000,
+			rounds: []round{
+				{amounts: map[string]int64{"token1": 1000, "token2": 2000}, at: 20},
+				{amounts: map[string]int64{"token1": 1000, "token2": 5000}, at: 30},
+			},
+			wantAmounts:   map[string]int64{"token1": 1000, "token2": 5000},
+			wantTimestamp: 30,
+		},
+		{
+			name:  "round with no new fees still advances the timestamp",
+			stake: 1000,
+			rounds: []round{
+				{amounts: map[string]int64{"token1": 1000}, at: 20},
+				{amounts: map[string]int64{"token1": 1000}, at: 30},
+			},
+			wantAmounts:   map[string]int64{"token1": 1000},
+			wantTimestamp: 30,
+		},
+		{
+			name:  "new token discovered in a later round",
+			stake: 1000,
+			rounds: []round{
+				{amounts: map[string]int64{"token1": 1000}, at: 20},
+				{amounts: map[string]int64{"token1": 1000, "token2": 500}, at: 30},
+			},
+			wantAmounts:   map[string]int64{"token1": 1000, "token2": 500},
+			wantTimestamp: 30,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
+			manager := staker.NewProtocolFeeRewardManager()
+			resolver := NewProtocolFeeRewardManagerResolver(manager)
+			resolver.addStake("user1", tt.stake, 10)
+
+			for _, r := range tt.rounds {
+				err := resolver.updateAccumulatedProtocolFeeX128PerStake(r.amounts, r.at)
+				uassert.NoError(t, err)
+			}
+
+			storedAmounts := manager.GetProtocolFeeAmounts()
+			for token, want := range tt.wantAmounts {
+				uassert.Equal(t, want, storedAmounts[token])
+			}
+			uassert.Equal(t, tt.wantTimestamp, manager.GetAccumulatedTimestamp())
+		})
+	}
+}
+
+// A token that receives no new fees in a round must keep its exact accumulator object (not be re-written),
+// while a token with new fees advances. This is the core of the write-reduction optimization.
+func TestUpdateAccumulatedProtocolFee_UnchangedTokenNotRewritten(cur realm, t *testing.T) {
+	manager := staker.NewProtocolFeeRewardManager()
+	resolver := NewProtocolFeeRewardManagerResolver(manager)
+	resolver.addStake("user1", 1000, 10)
+
+	err := resolver.updateAccumulatedProtocolFeeX128PerStake(map[string]int64{"token1": 1000, "token2": 2000}, 20)
+	uassert.NoError(t, err)
+
+	token1Before := manager.GetAccumulatedProtocolFeeX128PerStake("token1")
+	token2Before := manager.GetAccumulatedProtocolFeeX128PerStake("token2")
+	uassert.NotEqual(t, "0", token1Before.ToString())
+	uassert.NotEqual(t, "0", token2Before.ToString())
+
+	// Only token2 receives new fees.
+	err = resolver.updateAccumulatedProtocolFeeX128PerStake(map[string]int64{"token1": 1000, "token2": 5000}, 30)
+	uassert.NoError(t, err)
+
+	token1After := manager.GetAccumulatedProtocolFeeX128PerStake("token1")
+	token2After := manager.GetAccumulatedProtocolFeeX128PerStake("token2")
+
+	// token1 was not re-written: same object instance and value preserved.
+	if token1Before != token1After {
+		t.Errorf("token1 accumulator was rewritten despite no new fees")
+	}
+	uassert.Equal(t, token1Before.ToString(), token1After.ToString())
+
+	// token2 advanced.
+	uassert.True(t, token2After.Gt(token2Before))
+	uassert.Equal(t, int64(5000), manager.GetProtocolFeeAmounts()["token2"])
+}
+
+// updateAccumulatedProtocolFeeX128PerStake must be a no-op when called with a past timestamp.
+func TestUpdateAccumulatedProtocolFee_PastTimestampNoOp(cur realm, t *testing.T) {
+	manager := staker.NewProtocolFeeRewardManager()
+	resolver := NewProtocolFeeRewardManagerResolver(manager)
+	resolver.addStake("user1", 1000, 10)
+
+	err := resolver.updateAccumulatedProtocolFeeX128PerStake(map[string]int64{"token1": 1000}, 20)
+	uassert.NoError(t, err)
+	token1Before := manager.GetAccumulatedProtocolFeeX128PerStake("token1")
+
+	// Past timestamp: nothing changes.
+	err = resolver.updateAccumulatedProtocolFeeX128PerStake(map[string]int64{"token1": 9999}, 10)
+	uassert.NoError(t, err)
+
+	uassert.Equal(t, token1Before.ToString(), manager.GetAccumulatedProtocolFeeX128PerStake("token1").ToString())
+	uassert.Equal(t, int64(1000), manager.GetProtocolFeeAmounts()["token1"])
+	uassert.Equal(t, int64(20), manager.GetAccumulatedTimestamp())
+}
+
+// addStake / removeStake reject invalid amounts.
+func TestProtocolFeeStake_AmountErrors(cur realm, t *testing.T) {
+	tests := []struct {
+		name      string
+		op        string // "add" | "remove"
+		amount    int64
+		wantError bool
+	}{
+		{name: "addStake rejects zero", op: "add", amount: 0, wantError: true},
+		{name: "addStake rejects negative", op: "add", amount: -1, wantError: true},
+		{name: "addStake accepts positive", op: "add", amount: 100, wantError: false},
+		{name: "removeStake rejects negative", op: "remove", amount: -1, wantError: true},
+		{name: "removeStake accepts zero", op: "remove", amount: 0, wantError: false},
+		{name: "removeStake accepts positive", op: "remove", amount: 100, wantError: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
+			manager := staker.NewProtocolFeeRewardManager()
+			resolver := NewProtocolFeeRewardManagerResolver(manager)
+			// Seed a stake so removeStake has something to operate on.
+			resolver.addStake("user1", 1000, 10)
+
+			var err error
+			switch tt.op {
+			case "add":
+				err = resolver.addStake("user1", tt.amount, 20)
+			case "remove":
+				err = resolver.removeStake("user1", tt.amount, 20)
+			}
+
+			if tt.wantError {
+				uassert.Error(t, err)
+			} else {
+				uassert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// Claiming must skip tokens with no newly distributed fees (zero per-staker delta) without affecting
+// correctness: a round with no new fees yields nothing, and only tokens that actually accrued fees are
+// claimed (gas report issue 1 / §1.2). Rounds are applied sequentially to a single staker.
+func TestProtocolFeeReward_ClaimSkipsZeroDeltaTokens(cur realm, t *testing.T) {
+	type round struct {
+		name     string
+		amounts  map[string]int64 // cumulative distributed protocol-fee amounts by token
+		updateAt int64
+		claimAt  int64
+		want     map[string]int64 // expected claimed amounts (absent key == 0)
+	}
+	rounds := []round{
+		{
+			name:     "first round: both tokens accrue and are claimed",
+			amounts:  map[string]int64{"token1": 1000, "token2": 2000},
+			updateAt: 20,
+			claimAt:  30,
+			want:     map[string]int64{"token1": 1000, "token2": 2000},
+		},
+		{
+			name:     "no new fees: nothing to claim for any token",
+			amounts:  map[string]int64{"token1": 1000, "token2": 2000},
+			updateAt: 40,
+			claimAt:  50,
+			want:     map[string]int64{"token1": 0, "token2": 0},
+		},
+		{
+			name:     "only token1 accrues: token2 (zero delta) is skipped",
+			amounts:  map[string]int64{"token1": 3000, "token2": 2000},
+			updateAt: 60,
+			claimAt:  70,
+			want:     map[string]int64{"token1": 2000, "token2": 0},
+		},
+	}
+
+	manager := staker.NewProtocolFeeRewardManager()
+	resolver := NewProtocolFeeRewardManagerResolver(manager)
+	resolver.addStake("user1", 1000, 10)
+
+	for _, r := range rounds {
+		t.Run(r.name, func(cur realm, t *testing.T) {
+			err := resolver.updateAccumulatedProtocolFeeX128PerStake(r.amounts, r.updateAt)
+			uassert.NoError(t, err)
+
+			claimed, err := resolver.claimRewards("user1", r.claimAt)
+			uassert.NoError(t, err)
+
+			// claimed[token] returns 0 for absent keys, so zero-delta tokens compare equal.
+			for token, want := range r.want {
+				uassert.Equal(t, want, claimed[token])
+			}
+		})
+	}
+}

--- a/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_manager.gno
+++ b/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_manager.gno
@@ -143,8 +143,27 @@ func (self *ProtocolFeeRewardManagerResolver) updateAccumulatedProtocolFeeX128Pe
 		return err
 	}
 
-	self.SetAccumulatedProtocolFeeX128PerStake(accumulatedProtocolFeeX128PerStake)
-	self.SetProtocolFeeAmounts(changedProtocolFeeAmounts)
+	// Persist only the tokens whose value actually changed instead of replacing the whole map.
+	// calculateAccumulatedRewardX128PerStake returns the previous (identical) accumulator and amount for
+	// tokens that received no new fees this round, so the full-map setters would deep-copy and re-persist
+	// every registered token on every add/remove/claim, growing storage and gas linearly in the number of
+	// registered tokens regardless of how many actually earned fees (gas report issue 1 / §1.2).
+	//
+	// Registered protocol-fee tokens are monotonic (never removed) and distributedAmounts always covers the
+	// full registered set, so the stored token set never shrinks; skipping unchanged entries therefore yields
+	// the same persisted state as the previous full-replace, only without the redundant re-writes.
+	for token, newAcc := range accumulatedProtocolFeeX128PerStake {
+		existing := self.GetAccumulatedProtocolFeeX128PerStake(token)
+		if existing == nil || !existing.Eq(newAcc) {
+			self.SetAccumulatedProtocolFeeX128PerStakeForToken(token, newAcc)
+		}
+	}
+	for token, amount := range changedProtocolFeeAmounts {
+		if self.GetProtocolFeeAmount(token) != amount {
+			self.SetProtocolFeeAmountForToken(token, amount)
+		}
+	}
+
 	self.SetAccumulatedTimestamp(currentTimestamp)
 
 	return nil

--- a/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_state.gno
+++ b/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_state.gno
@@ -99,6 +99,15 @@ func (p *ProtocolFeeRewardStateResolver) calculateClaimableRewards(
 			rewardDebtX128,
 		)
 
+		// Skip the 256-bit MulDiv for tokens with no newly distributed fees for this staker: the per-stake
+		// accumulator is unchanged since the staker's reward debt, so the reward is exactly zero. The zero
+		// is still recorded so the result map is unchanged; only the expensive computation is avoided,
+		// keeping cost proportional to the tokens that actually received fees (gas report issue 1 / §1.2).
+		if rewardDebtDeltaX128.IsZero() {
+			rewardAmounts[token] = 0
+			continue
+		}
+
 		// Multiply by staked amount to get total reward for this staker and token
 		rewardAmount := u256.MulDiv(
 			rewardDebtDeltaX128,


### PR DESCRIPTION
## Summary

Addresses the gas report's issue 1: per-transaction protocol-fee processing cost scaled with the number of *registered* tokens rather than the number that actually received fees ("even zero-reward tokens are fully iterated"). This change stops doing work for tokens whose newly distributed amount is zero.

## Changes

- `updateAccumulatedProtocolFeeX128PerStake` persists only the tokens whose accumulator/amount actually changed, instead of deep-copying and re-persisting the whole per-token maps on every add/remove/claim.
- `calculateClaimableRewards` skips the 256-bit `MulDiv` for tokens whose per-stake accumulator is unchanged since the staker's reward debt (zero newly accrued): the reward is exactly zero, so only the expensive computation is avoided while the result is preserved (the zero is still recorded).

Both are behavior-preserving: unchanged tokens keep identical values, registered protocol-fee tokens are monotonic (never removed), and `distributedAmounts` always covers the full set.

## Testing

- New table-driven tests (incl. error handling): `TestUpdateAccumulatedProtocolFee`, `TestUpdateAccumulatedProtocolFee_UnchangedTokenNotRewritten`, `TestUpdateAccumulatedProtocolFee_PastTimestampNoOp`, `TestProtocolFeeStake_AmountErrors`, `TestProtocolFeeReward_ClaimSkipsZeroDeltaTokens`.
- The full `gov/staker/v1` suite passes.
