### PR TITLE
refactor(tokens): source the user teller from the token's own ledger [draft, upstream-gated]

### DIFF
--- a/contract/r/gnoswap/gns/_helper_test.gno
+++ b/contract/r/gnoswap/gns/_helper_test.gno
@@ -27,7 +27,7 @@ func resetGnsTokenObject(cur realm, t *testing.T) {
 	t.Helper()
 
 	token, privateLedger = grc20.NewToken("Gnoswap", "GNS", 6, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(adminAddr, INITIAL_MINT_AMOUNT)
 }

--- a/contract/r/gnoswap/gns/gns.gno
+++ b/contract/r/gnoswap/gns/gns.gno
@@ -36,7 +36,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("Gnoswap", "GNS", 6, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	adminAddr := access.MustGetAddress(prabc.ROLE_ADMIN.String())
 	err := privateLedger.Mint(adminAddr, INITIAL_MINT_AMOUNT)

--- a/contract/r/gnoswap/test_token/bar/bar.gno
+++ b/contract/r/gnoswap/test_token/bar/bar.gno
@@ -22,7 +22,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("Bar", "BAR", 6, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(owner.Owner(), 100_000_000_000_000)
 	grc20reg.Register(cross(cur), token, "")

--- a/contract/r/gnoswap/test_token/baz/baz.gno
+++ b/contract/r/gnoswap/test_token/baz/baz.gno
@@ -22,7 +22,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("Baz", "BAZ", 6, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(owner.Owner(), 100_000_000_000_000)
 	grc20reg.Register(cross(cur), token, "")

--- a/contract/r/gnoswap/test_token/foo/foo.gno
+++ b/contract/r/gnoswap/test_token/foo/foo.gno
@@ -22,7 +22,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("Foo", "FOO", 6, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(owner.Owner(), 100_000_000_000_000)
 	grc20reg.Register(cross(cur), token, "")

--- a/contract/r/gnoswap/test_token/obl/obl.gno
+++ b/contract/r/gnoswap/test_token/obl/obl.gno
@@ -22,7 +22,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("Obl", "OBL", 6, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(owner.Owner(), 100_000_000_000_000)
 	grc20reg.Register(cross(cur), token, "")

--- a/contract/r/gnoswap/test_token/qux/qux.gno
+++ b/contract/r/gnoswap/test_token/qux/qux.gno
@@ -22,7 +22,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("Qux", "QUX", 6, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(owner.Owner(), 100_000_000_000_000)
 	grc20reg.Register(cross(cur), token, "")

--- a/contract/r/gnoswap/test_token/test_atom/atom.gno
+++ b/contract/r/gnoswap/test_token/test_atom/atom.gno
@@ -22,7 +22,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("Cosmos", "ATOM", 6, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(owner.Owner(), 300_000_000_000_000)
 	grc20reg.Register(cross(cur), token, "")

--- a/contract/r/gnoswap/test_token/test_atone/atone.gno
+++ b/contract/r/gnoswap/test_token/test_atone/atone.gno
@@ -22,7 +22,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("AtomOne", "ATONE", 6, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(owner.Owner(), 140_000_000_000_000)
 	grc20reg.Register(cross(cur), token, "")

--- a/contract/r/gnoswap/test_token/test_btc/btc.gno
+++ b/contract/r/gnoswap/test_token/test_btc/btc.gno
@@ -22,7 +22,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("Bitcoin", "BTC", 8, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(owner.Owner(), 2_100_000_000_000_000)
 	grc20reg.Register(cross(cur), token, "")

--- a/contract/r/gnoswap/test_token/test_dai/dai.gno
+++ b/contract/r/gnoswap/test_token/test_dai/dai.gno
@@ -22,7 +22,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("Dai", "DAI", 6, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(owner.Owner(), 5_000_000_000_000_000)
 	grc20reg.Register(cross(cur), token, "")

--- a/contract/r/gnoswap/test_token/test_eth/eth.gno
+++ b/contract/r/gnoswap/test_token/test_eth/eth.gno
@@ -22,7 +22,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("Ethereum", "ETH", 6, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(owner.Owner(), 120_000_000_000_000)
 	grc20reg.Register(cross(cur), token, "")

--- a/contract/r/gnoswap/test_token/test_photon/photon.gno
+++ b/contract/r/gnoswap/test_token/test_photon/photon.gno
@@ -22,7 +22,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("Photon", "PHOTON", 6, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(owner.Owner(), 10_000_000_000_000)
 	grc20reg.Register(cross(cur), token, "")

--- a/contract/r/gnoswap/test_token/test_sol/sol.gno
+++ b/contract/r/gnoswap/test_token/test_sol/sol.gno
@@ -22,7 +22,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("Solana", "SOL", 9, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(owner.Owner(), 600_000_000_000_000_000)
 	grc20reg.Register(cross(cur), token, "")

--- a/contract/r/gnoswap/test_token/test_trx/trx.gno
+++ b/contract/r/gnoswap/test_token/test_trx/trx.gno
@@ -22,7 +22,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("Tron", "TRX", 6, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(owner.Owner(), 100_000_000_000_000_000)
 	grc20reg.Register(cross(cur), token, "")

--- a/contract/r/gnoswap/test_token/test_usdc/usdc.gno
+++ b/contract/r/gnoswap/test_token/test_usdc/usdc.gno
@@ -22,7 +22,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("Usd Coin", "USDC", 6, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(owner.Owner(), 70_000_000_000_000_000)
 	grc20reg.Register(cross(cur), token, "")

--- a/contract/r/gnoswap/test_token/test_usdt/usdt.gno
+++ b/contract/r/gnoswap/test_token/test_usdt/usdt.gno
@@ -22,7 +22,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("Tether", "USDT", 6, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(owner.Owner(), 200_000_000_000_000_000)
 	grc20reg.Register(cross(cur), token, "")

--- a/docs/token-movement-migration.md
+++ b/docs/token-movement-migration.md
@@ -1,0 +1,72 @@
+# Token-movement layout: where this is heading
+
+gnoswap moves tokens two ways today, and only one of them is expressible without
+a generic frame-relative deputy.
+
+## Today
+
+`common/grc20reg_helper.go` exposes `GetTokenTeller(path)`, which returns
+`GetToken(path).CallerTeller()`. The contract of that teller is *"debit whoever
+crossed into `common`"* — resolved late, from the invoking frame. Every
+`common.Transfer` / `Approve` / `TransferFrom` / `SafeGRC20*` call rides it.
+
+That is a generic pass-through: one helper acts on behalf of an arbitrary
+upstream caller, for an arbitrary registered token. It works, but it means the
+identity that gets debited is decided by the call graph rather than named at the
+call site — and it cannot be reproduced with any eagerly-bound teller.
+`RealmTeller(0, cur)` inside `common` freezes the actor to **`common`'s own
+address**, so the hub would move its own funds rather than its caller's.
+
+## Measured surface
+
+Counted against `main`, and worth stating precisely because the figure has been
+overstated repeatedly in discussion:
+
+| | count |
+|---|---|
+| `.CallerTeller()` call sites | **17** — 16 in token-owning realms (`test_token/*` ×15, `gns`), 1 in `common` |
+| `common.*` token-movement sites, **product** | **31**, across 18 files |
+| same, scenario filetests | 139 |
+| same, `_test.gno` | 75 |
+
+The 31 product sites are the real migration. Earlier counts of 170 and 263 swept
+in `contract/r/scenario/**` filetests and downstream test surface.
+
+### The 31, by module
+
+| module | sites |
+|---|---|
+| `pool/v1` | 9 (`pool.gno` 4, `protocol_fee.gno` 3, `transfer.gno` 2) |
+| `staker/v1` | 5 (`external_incentive.gno` 3, `staker.gno` 1, `protocol_fee_unstaking.gno` 1) |
+| `router/v1` | 5 (`swap_callback.gno` 2, `exact_in` / `exact_out` / `protocol_fee_swap` 1 each) |
+| `launchpad/v1` | 5 (`launchpad_withdraw.gno` 2, `launchpad_project.gno` 2, `launchpad_reward.gno` 1) |
+| `protocol_fee/v1` | 3 |
+| `position/v1` | 2 (`burn.gno`) |
+| `gov/staker/v1` | 1 |
+| `community_pool` | 1 |
+
+## Where each site lands
+
+Two intents, and they separate cleanly:
+
+1. **Module-owned funds** — reward payouts, refunds, protocol-fee sweeps. The
+   module holds a per-module `RealmTeller`, built in its own frame, and calls
+   the token directly. No allowance involved.
+2. **User funds** — swap input, liquidity provision. The user `Approve`s the
+   module on the token, and the module spends that allowance with its own
+   `RealmTeller().TransferFrom`. This is already how real swaps work, which is
+   why the core DEX is unaffected by the accessor change itself.
+
+`common`'s read helpers (`BalanceOf`, `Allowance`, `TotalSupply`,
+`IsRegistered`, `MustRegistered`) are untouched by any of this.
+
+## Sequencing
+
+1. This PR — the 17 accessor sites. Mechanical, one line each.
+2. Test-side groundwork — already open as #1367: test mocks stop paying through
+   the generic hub and use each token's own realm, matching production.
+3. The 31 product sites — the actual work, per the table above.
+4. Retire `GetTokenTeller`.
+
+Steps 1 and 3 are independent; 3 can start today, since `RealmTeller` and
+`Approve`/`TransferFrom` already exist.


### PR DESCRIPTION
## Status: draft, gated on upstream

`p/demo/tokens/grc20` is being reshaped upstream so that a token's frame-relative teller is sourced differently. This PR is one of two candidate adaptations — see the sibling PR for the other. **Neither compiles until the corresponding upstream change lands**, which is why both are drafts: they exist so the downstream cost of each shape can be compared with real diffs rather than estimated.

Opening both rather than picking one, because the choice is not gnoswap's to make.

## Why a teller should not be a generic pass-through

`common.GetTokenTeller(path)` returns a teller whose contract is *"debit whoever crossed into `common`"* — the actor is resolved late, from the invoking frame. Every `common.Transfer` / `Approve` / `TransferFrom` / `SafeGRC20*` rides it, so the identity being debited is decided by the call graph rather than named at the call site.

That pattern cannot be reproduced with an eagerly-bound teller: `RealmTeller(0, cur)` inside `common` freezes the actor to **`common`'s own address**, so the hub would move its own funds rather than its caller's. Whichever upstream shape lands, `GetTokenTeller` has to go.

## Measured surface — the numbers have been overstated

| | count |
|---|---|
| `.CallerTeller()` call sites | **17** — 16 in token-owning realms (`test_token/*` ×15, `gns`), 1 in `common` |
| `common.*` token-movement, **product** | **31**, across 18 files |
| same, `scenario/**` filetests | 139 |
| same, `_test.gno` | 75 |

Figures of 170 and 263 have circulated; both sweep in `contract/r/scenario/**` filetests and downstream test surface. The real product migration is **31 sites**, itemized by module in `docs/token-movement-migration.md`.

## What is in this PR

Only the 17 accessor sites — one line each, fully mechanical. **The 31 product sites are not here**; they are independent of the accessor choice and can start today, since `RealmTeller` and `Approve`/`TransferFrom` already exist.

Sequencing: (1) this PR, (2) test-side groundwork already open as #1367, (3) the 31 product sites, (4) retire `GetTokenTeller`.

## This variant

`userTeller = privateLedger.CallerTeller()` — the accessor moves onto the private ledger, which each token realm already holds and never exports. A realm that does not own the token cannot obtain the accessor at all, so `common` fails to **compile** rather than failing at runtime.

Verified: the 17 sites compile against a gno tree carrying that shape.