### PR TITLE
fix(pool): distinguish pre-epoch oracle lookback from stale observations

### DIFF
--- a/contract/r/gnoswap/pool/v1/errors.gno
+++ b/contract/r/gnoswap/pool/v1/errors.gno
@@ -32,6 +32,7 @@ const (
 	errNotInitializedObservation = "[GNOSWAP-POOL-024] not initialized observation"
 	errObservationTooOld         = "[GNOSWAP-POOL-025] target timestamp before oldest observation"
 	errSpoofedRealm              = "[GNOSWAP-POOL-026] rlm does not match the current crossing frame"
+	errObservationBeforeEpoch    = "[GNOSWAP-POOL-027] lookback window starts before unix epoch"
 )
 
 // newErrorWithDetail adds detail to an error message.

--- a/contract/r/gnoswap/pool/v1/oracle.gno
+++ b/contract/r/gnoswap/pool/v1/oracle.gno
@@ -175,10 +175,6 @@ func grow(os *pl.ObservationState, currentCardinality, nextCardinality uint16) (
 	return nextCardinality, nil
 }
 
-func lte(a, b int64) bool {
-	return a <= b
-}
-
 func writeObservation(
 	os *pl.ObservationState,
 	currentTime int64,
@@ -338,8 +334,10 @@ func getSurroundingObservations(
 		return nil, nil, err
 	}
 
+	// Timestamps are int64, so natural ordering applies. Uniswap V3 needs a
+	// wraparound-aware comparison here only because it stores them as uint32.
 	// If the target is chronologically at or after the newest observation, we can early return
-	if lte(beforeOrAt.BlockTimestamp(), target) {
+	if beforeOrAt.BlockTimestamp() <= target {
 		if beforeOrAt.BlockTimestamp() == target {
 			// If newest observation equals target, we're in the same block, so we can ignore atOrAfter
 			return beforeOrAt, nil, nil
@@ -363,7 +361,7 @@ func getSurroundingObservations(
 	}
 
 	// Ensure that the target is chronologically at or after the oldest observation
-	if !lte(beforeOrAt.BlockTimestamp(), target) {
+	if beforeOrAt.BlockTimestamp() > target {
 		return nil, nil, errors.New(errObservationTooOld)
 	}
 
@@ -400,10 +398,10 @@ func binarySearch(
 			return nil, nil, err
 		}
 
-		targetAtOrAfter := lte(beforeOrAt.BlockTimestamp(), target)
+		targetAtOrAfter := beforeOrAt.BlockTimestamp() <= target
 
 		// check if we've found the answer!
-		if targetAtOrAfter && lte(target, atOrAfter.BlockTimestamp()) {
+		if targetAtOrAfter && target <= atOrAfter.BlockTimestamp() {
 			break
 		}
 

--- a/contract/r/gnoswap/pool/v1/oracle.gno
+++ b/contract/r/gnoswap/pool/v1/oracle.gno
@@ -267,8 +267,9 @@ func observeSingle(
 		return last.TickCumulative(), last.SecondsPerLiquidityCumulativeX128(), nil
 	}
 
+	// A lookback longer than the chain's own age would place the target before unix epoch.
 	if int64(secondsAgo) > currentTime {
-		return 0, "", errors.New(errObservationTooOld)
+		return 0, "", errors.New(errObservationBeforeEpoch)
 	}
 
 	target := currentTime - int64(secondsAgo)

--- a/contract/r/gnoswap/pool/v1/oracle_spec_test.gno
+++ b/contract/r/gnoswap/pool/v1/oracle_spec_test.gno
@@ -1,6 +1,7 @@
 package pool
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -378,7 +379,26 @@ func testObserveFailsIfSecondsAgoExceedsCurrentTime(t *testing.T) {
 	os := pl.NewObservationState(0)
 
 	_, _, err := observeSingle(os, 10, 11, 2, 0, u256.NewUint(4), 1)
-	uassert.ErrorContains(t, err, "[GNOSWAP-POOL-025]")
+	uassert.ErrorContains(t, err, "[GNOSWAP-POOL-027]")
+}
+
+// TestOracleLookbackErrorsAreDistinct pins the two rejection reasons to separate error codes.
+func TestOracleLookbackErrorsAreDistinct(cur realm, t *testing.T) {
+	// Retention failure: oldest observation (t=100) is newer than target (t=99).
+	tooOld := pl.NewObservationState(100)
+	_, _, errTooOld := observeSingle(tooOld, 150, 51, 12, 0, u256.NewUint(4), 1)
+	uassert.ErrorContains(t, errTooOld, "[GNOSWAP-POOL-025]")
+	if errTooOld != nil && strings.Contains(errTooOld.Error(), "[GNOSWAP-POOL-027]") {
+		t.Error("too-old lookback must not report the pre-epoch error code")
+	}
+
+	// Malformed request: secondsAgo exceeds the chain's own age.
+	beforeEpoch := pl.NewObservationState(0)
+	_, _, errEpoch := observeSingle(beforeEpoch, 10, 11, 12, 0, u256.NewUint(4), 1)
+	uassert.ErrorContains(t, errEpoch, "[GNOSWAP-POOL-027]")
+	if errEpoch != nil && strings.Contains(errEpoch.Error(), "[GNOSWAP-POOL-025]") {
+		t.Error("pre-epoch lookback must not report the too-old error code")
+	}
 }
 
 func testObserveInterpolatesMaxLiquidity(t *testing.T) {

--- a/contract/r/gnoswap/pool/v1/oracle_spec_test.gno
+++ b/contract/r/gnoswap/pool/v1/oracle_spec_test.gno
@@ -326,15 +326,6 @@ func testAccumulatesLiquidity(t *testing.T) {
 	}
 }
 
-// TestOracleLTE verifies int64 timestamp comparisons use natural ordering.
-func TestOracleLTE(cur realm, t *testing.T) {
-	uassert.True(t, lte(90, 100), "timestamps should use natural ordering")
-	uassert.True(t, lte(100, 100), "equal timestamps should compare as lte")
-	uassert.True(t, lte(-1, 0), "signed timestamps should preserve natural ordering")
-	uassert.False(t, lte(100, 90), "newer timestamps should not sort before older timestamps")
-	uassert.False(t, lte(int64(1<<32)-2, 2), "int64 timestamps must not apply uint32 wrap ordering")
-}
-
 func TestOracleObserve(cur realm, t *testing.T) {
 	tests := []struct {
 		name string

--- a/contract/r/gnoswap/pool/v1/twap_consistency_test.gno
+++ b/contract/r/gnoswap/pool/v1/twap_consistency_test.gno
@@ -138,6 +138,32 @@ func TestOracle_TWAPConsistencyCases(cur realm, t *testing.T) {
 			wantErr: "[GNOSWAP-POOL-027]",
 		},
 		{
+			// Timestamps are int64. A uint32-based comparison would sort
+			// 2^32-100 after 2^32+100 and pick the wrong bracket.
+			name:        "observations spanning the uint32 boundary keep natural ordering",
+			currentTime: 1<<32 + 100,
+			secondsAgo:  200,
+			currentTick: 25,
+			observations: []twapConsistencyObservation{
+				{timestamp: 1<<32 - 300, tickCumulative: 0},
+				{timestamp: 1<<32 - 100, tickCumulative: 1000},
+				{timestamp: 1<<32 + 100, tickCumulative: 6000},
+			},
+			wantTick: 25,
+		},
+		{
+			name:        "interpolation across the uint32 boundary keeps natural ordering",
+			currentTime: 1<<32 + 200,
+			secondsAgo:  250,
+			currentTick: 20,
+			observations: []twapConsistencyObservation{
+				{timestamp: 1<<32 - 300, tickCumulative: 0},
+				{timestamp: 1<<32 - 100, tickCumulative: 1000},
+				{timestamp: 1<<32 + 200, tickCumulative: 7000},
+			},
+			wantTick: 20,
+		},
+		{
 			name:        "multi interval weighted average",
 			currentTime: 400,
 			secondsAgo:  200,

--- a/contract/r/gnoswap/pool/v1/twap_consistency_test.gno
+++ b/contract/r/gnoswap/pool/v1/twap_consistency_test.gno
@@ -127,7 +127,7 @@ func TestOracle_TWAPConsistencyCases(cur realm, t *testing.T) {
 			wantErr: "[GNOSWAP-POOL-025]",
 		},
 		{
-			name:        "window before unix epoch returns oracle error",
+			name:        "window before unix epoch returns pre-epoch error",
 			currentTime: 10,
 			secondsAgo:  11,
 			currentTick: 12,
@@ -135,7 +135,7 @@ func TestOracle_TWAPConsistencyCases(cur realm, t *testing.T) {
 				{timestamp: 0, tickCumulative: 0},
 				{timestamp: 10, tickCumulative: 120},
 			},
-			wantErr: "[GNOSWAP-POOL-025]",
+			wantErr: "[GNOSWAP-POOL-027]",
 		},
 		{
 			name:        "multi interval weighted average",


### PR DESCRIPTION
## Review follow-up

Addresses both review items raised on #1357.

| Review item | Disposition |
| --- | --- |
| Pre-epoch lookback reuses `errObservationTooOld`; a dedicated error would ease diagnosis | Fixed — `GNOSWAP-POOL-027` |
| `lte(a, b)` is now a plain `<=` alias; inline it or clean up the name | Fixed — inlined at its four call sites |

## Summary

Two follow-ups on the oracle lookback guard.

`observeSingle` rejects a `secondsAgo` larger than the chain's own age, but reported `errObservationTooOld` — the same code raised when the target predates the oldest stored observation. The two failures call for different responses: a stale-observation window is fixed by growing the observation cardinality, a pre-epoch window never can be. Sharing one code also meant the existing tests passed on either path, so neither actually pinned the guard it was written for.

Separately, `lte` had been reduced to a plain `<=` alias once observation timestamps moved to `int64`. Uniswap V3 needs a wraparound-aware comparison there because it stores timestamps as `uint32`; GnoSwap does not, and the surviving indirection suggested otherwise.

## Changes

- Add `errObservationBeforeEpoch` (`GNOSWAP-POOL-027`) and raise it from the pre-epoch guard in `observeSingle`.
- Inline `lte` at its four call sites in `getSurroundingObservations` and `binarySearch`, with a note on why the Uniswap wraparound logic does not apply here.

## Tests

- `TestOracleLookbackErrorsAreDistinct` asserts both directions: a stale-observation window reports `POOL-025` and not `POOL-027`, and a pre-epoch window the reverse.
- The pre-epoch expectations in `TestOracleObserve` and `TestOracle_TWAPConsistencyCases` move from `POOL-025` to `POOL-027`.
- The alias-level `TestOracleLTE` is replaced with TWAP consistency cases whose observations straddle `2^32`. Reintroducing a `uint32`-based ordering makes the boundary case fail, and makes `binarySearch` loop forever on the interpolation case.

Each test was checked by reverting the corresponding source change and confirming it fails.

`gno test ./gno.land/r/gnoswap/pool/v1` passes.

## Note for consumers

Off-chain code matching `[GNOSWAP-POOL-025]` for a lookback longer than the chain's age will now see `[GNOSWAP-POOL-027]`.
