### PR TITLE
fix(staker): guard batched tick crosses against pruned ticks

### DIFF
--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool.gno
@@ -126,6 +126,10 @@ func (self *PoolResolver) CurrentStakedLiquidity(currentTime int64) (liquidity *
 }
 
 // GetOrNewTick returns the existing tick or a new zero-valued tick.
+//
+// Substituting a zero-valued tick on a read is safe because ticks are pruned
+// only when their staked gross liquidity reaches zero, in the same call that
+// removes the last deposit referencing them.
 func (self *PoolResolver) GetOrNewTick(tickId int32) *sr.Tick {
 	tick := self.Ticks().Get(tickId)
 	if tick == nil {

--- a/contract/r/gnoswap/staker/v1/reward_calculation_tick.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_tick.gno
@@ -239,6 +239,12 @@ func (s *stakerV1) processBatchedTickCrosses(_ int, rlm realm) error {
 
 	for _, tickCross := range batch.Crosses() {
 		tick := batch.Pool().Ticks().Get(tickCross.TickID())
+		if tick == nil {
+			// Pruned after the cross was accumulated, so its staked gross
+			// liquidity is zero and it carries no reward weight.
+			continue
+		}
+
 		tickResolver := NewTickResolver(tick)
 		tickResolver.updateCurrentOutsideAccumulation(timestamp, newAcc)
 

--- a/contract/r/gnoswap/staker/v1/reward_calculation_tick_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_tick_test.gno
@@ -580,3 +580,58 @@ func TestRewardAfterUnstakeRestakeSameRange(cur realm, t *testing.T) {
 	uassert.False(t, overflow, "out-of-range accumulation must not underflow")
 	uassert.True(t, outOfRangeDelta.IsZero(), "an out-of-range deposit must not accrue")
 }
+
+// TestTickStateReturnsToEmptyOverStakeCycle asserts a full stake, swap, read,
+// unstake cycle leaves no tick behind. Reads used to insert a tick on lookup
+// and unstake never removed one, so the tree grew with every swap.
+func TestTickStateReturnsToEmptyOverStakeCycle(cur realm, t *testing.T) {
+	initStakerTest(cur, t)
+
+	instance := getMockInstance()
+	poolPath := "tick-growth-pool"
+	liquidity := i256.NewInt(1000)
+
+	pool := sr.NewPool(poolPath, 1000)
+	poolResolver := NewPoolResolver(pool)
+	instance.getPools().set(poolPath, pool)
+
+	modifyRange := func(at int64, delta *i256.Int) {
+		lower := poolResolver.GetOrNewTick(-10)
+		NewTickResolver(lower).modifyDepositLower(at, delta)
+		pool.Ticks().SetTick(-10, lower)
+
+		upper := poolResolver.GetOrNewTick(10)
+		NewTickResolver(upper).modifyDepositUpper(at, delta)
+		pool.Ticks().SetTick(10, upper)
+	}
+
+	uassert.Equal(t, 0, pool.Ticks().Tree().Size())
+
+	poolResolver.modifyDeposit(liquidity, 1000, 0)
+	modifyRange(1000, liquidity)
+	uassert.Equal(t, 2, pool.Ticks().Tree().Size())
+
+	// A swap crossing ticks nobody staked must not insert them.
+	instance.swapStartHook(0, cur, poolPath, 1100)
+	instance.tickCrossHook(0, cur, poolPath, 500, false, 1100)
+	instance.tickCrossHook(0, cur, poolPath, -500, true, 1100)
+	uassert.False(t, pool.Ticks().Has(500))
+	uassert.False(t, pool.Ticks().Has(-500))
+	uassert.Equal(t, 2, pool.Ticks().Tree().Size())
+	uassert.NoError(t, instance.swapEndHook(0, cur, poolPath))
+
+	// Reading rewards for a range with unstaked boundaries must not insert them.
+	deposit := sr.NewDeposit(
+		testutils.TestAddress("owner"), poolPath,
+		u256.NewUint(1000), 1000, -60, 60, nil,
+	)
+	poolResolver.CalculateRawRewardForPosition(1100, 0, deposit)
+	uassert.False(t, pool.Ticks().Has(-60))
+	uassert.False(t, pool.Ticks().Has(60))
+	uassert.Equal(t, 2, pool.Ticks().Tree().Size())
+
+	// Unstaking releases both boundaries.
+	poolResolver.modifyDeposit(i256.Zero().Neg(liquidity), 1200, 0)
+	modifyRange(1200, i256.Zero().Neg(liquidity))
+	uassert.Equal(t, 0, pool.Ticks().Tree().Size())
+}

--- a/contract/r/gnoswap/staker/v1/reward_calculation_tick_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_tick_test.gno
@@ -6,6 +6,7 @@ import (
 	i256 "gno.land/p/gnoswap/int256"
 	u256 "gno.land/p/gnoswap/uint256"
 
+	testutils "gno.land/p/nt/testutils/v0"
 	uassert "gno.land/p/nt/uassert/v0"
 	sr "gno.land/r/gnoswap/staker"
 )
@@ -502,4 +503,80 @@ func TestBoundaryTicksOutliveTheirDeposits(cur realm, t *testing.T) {
 	uassert.False(t, pool.Ticks().Has(-10))
 	uassert.False(t, pool.Ticks().Has(10))
 	uassert.Equal(t, 0, pool.Ticks().Tree().Size())
+}
+
+// TestRewardAfterUnstakeRestakeSameRange covers a deposit restaked into the
+// same range after its boundary ticks were pruned. The first deposit crosses a
+// boundary, so the pruned ticks carried outside accumulation; the restaked
+// deposit must still earn exactly the global accumulation growth over the time
+// it is in range, and nothing while out of range.
+func TestRewardAfterUnstakeRestakeSameRange(cur realm, t *testing.T) {
+	initStakerTest(cur, t)
+
+	liquidity := i256.NewInt(1_000_000)
+	pool := sr.NewPool("restake-pool", 0)
+	poolResolver := NewPoolResolver(pool)
+
+	modifyRange := func(at int64, delta *i256.Int, currentTick int32) {
+		poolResolver.modifyDeposit(delta, at, currentTick)
+
+		lower := poolResolver.GetOrNewTick(-10)
+		NewTickResolver(lower).modifyDepositLower(at, delta)
+		pool.Ticks().SetTick(-10, lower)
+
+		upper := poolResolver.GetOrNewTick(10)
+		NewTickResolver(upper).modifyDepositUpper(at, delta)
+		pool.Ticks().SetTick(10, upper)
+	}
+
+	crossTick := func(at int64, tickId int32, zeroForOne bool) {
+		tick := pool.Ticks().Get(tickId)
+		delta := tick.StakedLiquidityDelta()
+		nextTick := tickId
+		if zeroForOne {
+			delta = i256.Zero().Neg(delta)
+			nextTick--
+		}
+		newAcc := poolResolver.modifyDeposit(delta, at, nextTick)
+		NewTickResolver(tick).updateCurrentOutsideAccumulation(at, newAcc)
+	}
+
+	globalAcc := func(at int64) *u256.Uint {
+		return poolResolver.calculateGlobalRewardRatioAccumulation(at, poolResolver.CurrentStakedLiquidity(at))
+	}
+
+	// First deposit: staked at 100, crosses the upper boundary out at 200 and
+	// back in at 250 so the boundary tick accumulates outside values, then
+	// unstaked at 300 while in range.
+	modifyRange(100, liquidity, 0)
+	crossTick(200, 10, false)
+	uassert.False(t, NewTickResolver(pool.Ticks().Get(10)).CurrentOutsideAccumulation(200).IsZero(),
+		"the upper boundary must carry outside accumulation before pruning")
+	crossTick(250, 10, true)
+	modifyRange(300, i256.Zero().Neg(liquidity), 0)
+	uassert.Equal(t, 0, pool.Ticks().Tree().Size(), "both boundaries must be pruned")
+
+	// Restake the same range at 500, back in range.
+	modifyRange(500, liquidity, 0)
+	deposit := sr.NewDeposit(
+		testutils.TestAddress("owner"), "restake-pool",
+		u256.NewUint(1_000_000), 500, -10, 10, nil,
+	)
+
+	// In range for [500, 900]: earns exactly the global accumulation growth.
+	inRangeStart := poolResolver.CalculateRawRewardForPosition(500, 0, deposit)
+	inRangeEnd := poolResolver.CalculateRawRewardForPosition(900, 0, deposit)
+	inRangeDelta, overflow := u256.Zero().SubOverflow(inRangeEnd, inRangeStart)
+	uassert.False(t, overflow, "in-range accumulation must not underflow after a restake")
+	uassert.Equal(t,
+		u256.Zero().Sub(globalAcc(900), globalAcc(500)).ToString(),
+		inRangeDelta.ToString(),
+	)
+
+	// Cross out of range at 900; nothing accrues afterwards.
+	crossTick(900, 10, false)
+	outOfRangeEnd := poolResolver.CalculateRawRewardForPosition(1300, 20, deposit)
+	outOfRangeDelta, overflow := u256.Zero().SubOverflow(outOfRangeEnd, inRangeEnd)
+	uassert.False(t, overflow, "out-of-range accumulation must not underflow")
+	uassert.True(t, outOfRangeDelta.IsZero(), "an out-of-range deposit must not accrue")
 }

--- a/contract/r/gnoswap/staker/v1/reward_calculation_tick_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_tick_test.gno
@@ -458,3 +458,48 @@ func TestProcessBatchedTickCrosses_SkipsPrunedTick(cur realm, t *testing.T) {
 	})
 	uassert.NoError(t, hookErr)
 }
+
+// TestBoundaryTicksOutliveTheirDeposits asserts a tick is pruned only once no
+// deposit references it. Reward reads substitute a zero-valued tick when one is
+// missing, so a live deposit whose boundary tick was pruned early would have
+// its accumulated reward silently shifted.
+func TestBoundaryTicksOutliveTheirDeposits(cur realm, t *testing.T) {
+	initStakerTest(cur, t)
+
+	startTime := int64(1000)
+	liquidity := i256.NewInt(1000)
+	pool := sr.NewPool("boundary-tick-pool", startTime)
+	poolResolver := NewPoolResolver(pool)
+
+	stake := func(tickLower, tickUpper int32, delta *i256.Int) {
+		lower := poolResolver.GetOrNewTick(tickLower)
+		NewTickResolver(lower).modifyDepositLower(startTime, delta)
+		pool.Ticks().SetTick(tickLower, lower)
+
+		upper := poolResolver.GetOrNewTick(tickUpper)
+		NewTickResolver(upper).modifyDepositUpper(startTime, delta)
+		pool.Ticks().SetTick(tickUpper, upper)
+	}
+
+	// Two deposits sharing the -10 boundary; unstaking one must keep it alive.
+	stake(-10, 10, liquidity)
+	stake(-10, 20, liquidity)
+	uassert.True(t, pool.Ticks().Has(-10))
+
+	stake(-10, 20, i256.Zero().Neg(liquidity))
+	uassert.True(t, pool.Ticks().Has(-10), "shared boundary must survive a partial unstake")
+	uassert.False(t, pool.Ticks().Has(20), "an unreferenced boundary must be pruned")
+	uassert.NotNil(t, pool.Ticks().Get(-10))
+	uassert.NotNil(t, pool.Ticks().Get(10))
+
+	// One deposit's upper boundary is another's lower boundary.
+	stake(10, 30, liquidity)
+	stake(10, 30, i256.Zero().Neg(liquidity))
+	uassert.True(t, pool.Ticks().Has(10), "boundary shared across roles must survive")
+
+	// The last deposit leaves and both of its boundaries go.
+	stake(-10, 10, i256.Zero().Neg(liquidity))
+	uassert.False(t, pool.Ticks().Has(-10))
+	uassert.False(t, pool.Ticks().Has(10))
+	uassert.Equal(t, 0, pool.Ticks().Tree().Size())
+}

--- a/contract/r/gnoswap/staker/v1/reward_calculation_tick_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_tick_test.gno
@@ -415,3 +415,46 @@ func TestSwapStartHook_SkipsBatchForPoolWithoutStakedTicks(cur realm, t *testing
 		t.Fatal("swapStartHook must not create a swap batch for a pool without staked ticks")
 	}
 }
+
+// TestProcessBatchedTickCrosses_SkipsPrunedTick verifies batch processing
+// tolerates a tick removed between cross accumulation and batch processing.
+// A pruned tick has zero staked gross liquidity and no reward weight, so it
+// must be skipped rather than dereferenced.
+func TestProcessBatchedTickCrosses_SkipsPrunedTick(cur realm, t *testing.T) {
+	initStakerTest(cur, t)
+
+	instance := getMockInstance()
+	poolPath := "test_pool"
+	startTime := int64(1000)
+	batchTime := int64(1010)
+	liquidity := i256.NewInt(1000)
+
+	pool := sr.NewPool(poolPath, startTime)
+	poolResolver := NewPoolResolver(pool)
+	poolResolver.modifyDeposit(liquidity, startTime, 5)
+
+	tick := poolResolver.GetOrNewTick(10)
+	tickResolver := NewTickResolver(tick)
+	tickResolver.modifyDepositUpper(startTime, liquidity)
+	tickResolver.modifyDepositLower(startTime, liquidity)
+	pool.Ticks().SetTick(10, tick)
+
+	instance.getPools().set(poolPath, pool)
+	instance.swapStartHook(0, cur, poolPath, batchTime)
+	instance.tickCrossHook(0, cur, poolPath, 10, false, batchTime)
+
+	batch := instance.store.GetCurrentSwapBatch()
+	if crosses := batch.Crosses(); len(crosses) != 1 {
+		t.Fatalf("batch crosses length = %d, want 1", len(crosses))
+	}
+
+	// Prune the tick after its cross was already accumulated.
+	pool.Ticks().SetTick(10, sr.NewTick(10))
+	uassert.False(t, pool.Ticks().Has(10))
+
+	var hookErr error
+	uassert.NotAborts(t, cur, func() {
+		hookErr = instance.swapEndHook(0, cur, poolPath)
+	})
+	uassert.NoError(t, hookErr)
+}


### PR DESCRIPTION
## Review follow-up

Addresses all four review items raised on #1374.

| Review item | Disposition |
| --- | --- |
| `processBatchedTickCrosses` uses `Ticks().Get` without a nil check | Fixed — guard added |
| No regression test for unstake → restake same range → tick cross reward accuracy | Test added |
| Tick outside-accumulation initialisation timing could let wrapped raw values abort `SubOverflow`, blocking `CollectReward` / `UnStakeToken` | Does not hold — the two initialisation schemes differ by a time-invariant constant that cancels in the reward delta (derivation below). The invariant the argument does depend on is pinned by tests instead |
| Empty `gross == 0` ticks accumulated before this change are not reclaimed on upgrade | Not applicable — this deploys fresh, with no accumulated ticks to sweep. Covered by a no-growth cycle test so the growth cannot reappear |

## Summary

Follow-ups on the staker tick state changes: one guard, and the invariants that the new pruning behaviour relies on but nothing asserted.

## Changes

**Skip pruned ticks when processing a swap batch.** Ticks are now dropped from the tree once their staked gross liquidity reaches zero, and `Ticks().Get` returns nil for a missing tick. `processBatchedTickCrosses` dereferenced that result directly, so a tick pruned between cross accumulation and swap end would abort the swap. Reaching it requires staker state to change mid-swap, which the pool lock currently prevents — but the batch should not depend on that non-local invariant.

The rest of this PR is test coverage. `GetOrNewTick` also picks up a comment recording why substituting a zero-valued tick on a read is safe.

## Tests

**`TestProcessBatchedTickCrosses_SkipsPrunedTick`** — prunes a tick after its cross was accumulated and asserts the swap end hook completes. Without the guard this aborts with a nil pointer dereference.

**`TestBoundaryTicksOutliveTheirDeposits`** — reward reads substitute a zero-valued tick when a boundary tick is missing, which is only safe because a tick is pruned exactly when the last deposit referencing it goes away. Covers the cases where the two could diverge: a boundary shared by two deposits, a boundary that is one deposit's upper and another's lower, and the last deposit leaving.

**`TestRewardAfterUnstakeRestakeSameRange`** — unstaking now prunes boundary ticks, discarding their outside accumulation history; restaking the same range rebuilds them from scratch. The first deposit crosses a boundary so the pruned ticks carry accumulation, and the restaked deposit must earn exactly the global accumulation growth while in range and nothing while out of range.

**`TestTickStateReturnsToEmptyOverStakeCycle`** — tick state is bounded by two rules with nothing tying them together: reads never insert a tick, and unstaking prunes a boundary once no deposit holds it. Regressing either grows the tree on every swap. Asserts the whole cycle: stake, cross unstaked ticks during a swap, read rewards for a range whose boundaries were never staked, unstake, tree empty again.

Each test was checked by reverting the behaviour it targets and confirming it fails — restoring auto-insert on `Ticks().Get` breaks the cycle test, and pruning on delta instead of gross breaks the boundary test.

`gno test ./gno.land/r/gnoswap/staker/v1` passes.

## On the outside-accumulation initialisation concern

A separate concern was raised that boundary ticks start with a zero outside accumulation instead of Uniswap's `outside = global` for a tick at or below the current tick, and that the resulting wrapped values could make `SubOverflow` abort `CollectReward` permanently.

This does not hold. The difference between the two schemes is a time-invariant constant. Let `d_T` be what Uniswap adds at initialisation. Each cross flips a tick's outside via `out' = G - out`, so after `k` crosses `out_uniswap = out_current + (-1)^k * d_T`. A tick's cross parity is fixed by which side of it the current tick is on, so evaluating the three branches of `CalculateRawRewardForPosition` gives `raw_uniswap - raw_current = d_upper - d_lower` in every branch. The offset cancels in `endRaw - startRaw`, so reward deltas are identical under both schemes and the initialisation difference cannot by itself produce an underflow.

What the argument does depend on is that a tick is never pruned and recreated during a deposit's lifetime, that every cross flips the outside exactly once, and that `HistoricalTick` agrees with cross parity. `TestBoundaryTicksOutliveTheirDeposits` and `TestRewardAfterUnstakeRestakeSameRange` pin the first of those, which is the one the new pruning behaviour touches.
