### PR TITLE
test(pool): restore the collect balance invariant and correct cap naming

### DIFF
--- a/contract/r/gnoswap/pool/v1/pool.gno
+++ b/contract/r/gnoswap/pool/v1/pool.gno
@@ -196,6 +196,11 @@ func (i *poolV1) Burn(
 //   - amount0: Token0 amount transferred (before any withdrawal fees)
 //   - amount1: Token1 amount transferred (before any withdrawal fees)
 //
+// The collected amount is capped by the position's tokensOwed. It is NOT
+// capped by the pool's internal balance: a balance short of the owed amount
+// means the internal ledger has drifted, so Collect reverts rather than
+// silently paying out less.
+//
 // Note: Withdrawal fees are applied by the position contract, not here.
 // Only callable by position contract.
 func (i *poolV1) Collect(

--- a/contract/r/gnoswap/pool/v1/pool_test.gno
+++ b/contract/r/gnoswap/pool/v1/pool_test.gno
@@ -1122,8 +1122,8 @@ func TestCollect(cur realm, t *testing.T) {
 			uassert.Equal(t, tt.expectedOwed1After, utils.FormatInt(positionAfter.TokensOwed1()),
 				"TokensOwed1 should decrease by collected amount")
 
-			// Verify Collect never stores negative pool balances.
-			validateCollectInvariant(t, pool)
+			// Verify pool balance >= tokensOwed invariant
+			validateCollectInvariant(t, pool, WIDE_RANGE_LOWER, WIDE_RANGE_UPPER)
 
 			t.Logf("✓ Collected %s/%s (requested %s/%s, before owed %s/%s, after owed %s/%s)",
 				amount0, amount1,
@@ -1175,8 +1175,7 @@ func TestCollect(cur realm, t *testing.T) {
 		positionAfter := mustGetPositionByPool(pool, positionKey)
 		uassert.Equal(t, utils.FormatInt(owed0Before), utils.FormatInt(positionAfter.TokensOwed0()),
 			"TokensOwed0 must stay unchanged after revert")
-		uassert.True(t, pool.BalanceToken0() >= 0,
-			"Pool balance0 must never become negative")
+		validateNonNegativeBalances(t, pool)
 		uassert.Equal(t, int64(1), pool.BalanceToken0(),
 			"Pool balance0 must stay at the forced value after revert")
 
@@ -1184,8 +1183,25 @@ func TestCollect(cur realm, t *testing.T) {
 	})
 }
 
-// validateCollectInvariant validates collect never stores negative pool balances.
-func validateCollectInvariant(t *testing.T, pool *pl.Pool) {
+// validateCollectInvariant validates the normal-path invariant that the pool's
+// internal balance covers the position's outstanding owed amounts.
+func validateCollectInvariant(t *testing.T, pool *pl.Pool, tickLower, tickUpper int32) {
+	t.Helper()
+	positionKey := getPositionKey(tickLower, tickUpper)
+	position := mustGetPositionByPool(pool, positionKey)
+
+	uassert.True(t, pool.BalanceToken0() >= position.TokensOwed0(),
+		ufmt.Sprintf("Pool balance0 (%s) must be >= tokensOwed0 (%s)",
+			utils.FormatInt(pool.BalanceToken0()), utils.FormatInt(position.TokensOwed0())))
+	uassert.True(t, pool.BalanceToken1() >= position.TokensOwed1(),
+		ufmt.Sprintf("Pool balance1 (%s) must be >= tokensOwed1 (%s)",
+			utils.FormatInt(pool.BalanceToken1()), utils.FormatInt(position.TokensOwed1())))
+}
+
+// validateNonNegativeBalances validates only that Collect never stores a
+// negative balance. Used by the forced-desync case, where the setup
+// deliberately violates the stronger invariant above.
+func validateNonNegativeBalances(t *testing.T, pool *pl.Pool) {
 	t.Helper()
 
 	uassert.True(t, pool.BalanceToken0() >= 0,

--- a/contract/r/scenario/position/position_collect_balance_revert_filetest.gno
+++ b/contract/r/scenario/position/position_collect_balance_revert_filetest.gno
@@ -1,4 +1,4 @@
-// position collect balance cap
+// position collect reverts on insufficient internal balance
 
 // PKGPATH: gno.land/r/demo/main
 
@@ -15,7 +15,7 @@ import (
 	"gno.land/r/gnoswap/access"
 	"gno.land/r/gnoswap/common"
 	"gno.land/r/gnoswap/pool"
-	_ "gno.land/r/gnoswap/pool/collect_balance_cap"
+	_ "gno.land/r/gnoswap/pool/collect_balance_revert"
 	_ "gno.land/r/gnoswap/pool/v1"
 	"gno.land/r/gnoswap/position"
 	_ "gno.land/r/gnoswap/position/v1"
@@ -32,7 +32,7 @@ const (
 	MIN_PRICE string = "4295128740"
 
 	poolV1Path             = "gno.land/r/gnoswap/pool/v1"
-	poolCollectCapTestPath = "gno.land/r/gnoswap/pool/collect_balance_cap"
+	poolCollectRevertTestPath = "gno.land/r/gnoswap/pool/collect_balance_revert"
 )
 
 var (
@@ -59,7 +59,7 @@ func main(cur realm) {
 	executeSwap(cur)
 	println()
 
-	ufmt.Println("[SCENARIO] 4. Upgrade to balance-cap test implementation")
+	ufmt.Println("[SCENARIO] 4. Upgrade to balance-revert test implementation")
 	upgradePool(cur)
 	println()
 
@@ -138,7 +138,7 @@ func executeSwap(cur realm) {
 
 func upgradePool(cur realm) {
 	testing.SetRealm(adminRealm)
-	pool.UpgradeImpl(cross(cur), poolCollectCapTestPath)
+	pool.UpgradeImpl(cross(cur), poolCollectRevertTestPath)
 	ufmt.Printf("[EXPECTED] Pool implementation should be %s\n", pool.GetImplementationPackagePath())
 }
 
@@ -216,8 +216,8 @@ func mockSwapCallback(cur realm, amount0Delta int64, amount1Delta int64) error {
 // [SCENARIO] 3. Swap to move price
 // [EXPECTED] Swap should succeed
 //
-// [SCENARIO] 4. Upgrade to balance-cap test implementation
-// [EXPECTED] Pool implementation should be gno.land/r/gnoswap/pool/collect_balance_cap
+// [SCENARIO] 4. Upgrade to balance-revert test implementation
+// [EXPECTED] Pool implementation should be gno.land/r/gnoswap/pool/collect_balance_revert
 //
 // [SCENARIO] 5. Decrease liquidity with reverting Collect
 // [INFO] DecreaseLiquidity aborted: [GNOSWAP-POOL-021] balance update failed. cannot decrease, token0(1) - amount(29999)

--- a/contract/r/scenario/upgrade/implements/collect_balance_cap/pool/gnomod.toml
+++ b/contract/r/scenario/upgrade/implements/collect_balance_cap/pool/gnomod.toml
@@ -1,2 +1,0 @@
-module = "gno.land/r/gnoswap/pool/collect_balance_cap"
-gno = "0.9"

--- a/contract/r/scenario/upgrade/implements/collect_balance_revert/pool/gnomod.toml
+++ b/contract/r/scenario/upgrade/implements/collect_balance_revert/pool/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/r/gnoswap/pool/collect_balance_revert"
+gno = "0.9"

--- a/contract/r/scenario/upgrade/implements/collect_balance_revert/pool/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/collect_balance_revert/pool/test_impl.gno
@@ -1,4 +1,4 @@
-package collect_balance_cap
+package collect_balance_revert
 
 import (
 	pool "gno.land/r/gnoswap/pool"


### PR DESCRIPTION
## Review follow-up

Addresses two of the three review items raised on #1361.

| Review item | Disposition |
| --- | --- |
| Commit and PR title say "cap by internal balance" but the implementation reverts | Fixed — doc comment, filetest, and test realm renamed |
| Test invariant weakened from `balance >= tokensOwed` to `balance >= 0` | Fixed — strong invariant restored on the normal path |
| A real desync blocks full collect until an upgrade; consider emitting an event or an admin recovery path | Deferred to separate work — see "Not in scope" below |

## Summary

Follow-ups on the collect internal balance guard: restore the invariant the new test case weakened, and correct the naming that says "cap" where the code reverts.

## Changes

**Restore the normal-path invariant.** Adding a forced-desync case weakened the shared assertion from `balance >= tokensOwed` down to `balance >= 0` for every collect case. That dropped the only check that would surface an internal ledger drift before it blocks withdrawals. The helpers are now split: `validateCollectInvariant` keeps the strong invariant for the normal path, `validateNonNegativeBalances` covers the desync case, where the setup deliberately violates it.

**Correct the naming.** `Collect` does not cap the collected amount by the pool's internal balance; it caps by the position's `tokensOwed` and reverts when the balance is short, keeping the internal ledger authoritative. The doc comment, the scenario filetest, and the test implementation realm all still said "cap", which reads as a silent partial payout:

- `Collect` doc now states the revert behaviour explicitly
- `position_collect_balance_cap_filetest.gno` → `position_collect_balance_revert_filetest.gno`
- `r/gnoswap/pool/collect_balance_cap` → `r/gnoswap/pool/collect_balance_revert`

## Tests

`gno test ./gno.land/r/gnoswap/pool/v1 ./gno.land/r/gnoswap/scenario/position` passes, including the renamed filetest and its golden output.

## Not in scope

Once the internal balance is short, `Collect` reverts for every position in that pool. The position contract always requests the full owed or burned amount — `CollectFee` passes `tokensOwed0/1` and `DecreaseLiquidity` passes the burned amounts — so there is no caller-side lever to request less and withdrawals stop pool-wide until the ledger is reconciled.

That is the correct trade against silently storing a negative balance, which is what happened before the guard. But it leaves no recovery path, and the failure currently surfaces as the generic `errBalanceUpdateFailed`, indistinguishable from an invalid-input rejection. A dedicated error code and a recovery path are being handled separately.
