### PR TITLE
perf(staker): cache rewards only for staked pool

### DIFF
--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier.gno
@@ -302,8 +302,8 @@ func (self *PoolTier) cacheRewardForPool(currentTimestamp int64, pools *Pools, p
 	poolResolver := NewPoolResolver(pool)
 
 	if len(halvingTimestamps) == 0 {
-		// No emission change within the range => use current emission.
-		self.applyCacheToPool(poolResolver, tierNum, currentTimestamp, self.currentEmission)
+		// No emission change within the range => use the live emission.
+		self.applyCacheToPool(poolResolver, tierNum, currentTimestamp, self.getEmission())
 		return
 	}
 

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier_test.gno
@@ -72,6 +72,104 @@ func TestCacheReward(cur realm, t *testing.T) {
 	}
 }
 
+func TestCacheRewardForPoolUsesLatestHalvingEmission(t *testing.T) {
+	poolPath := pl.GetPoolPath("gno.land/r/test/token1", "gno.land/r/test/token2", 3000)
+
+	t.Run("halving in range updates cached emission", func(t *testing.T) {
+		pools := NewPools()
+		pool := sr.NewPool(poolPath, 1000)
+		pools.set(poolPath, pool)
+
+		poolTier := NewPoolTierBy(
+			sr.NewBPTreeN(16),
+			sr.NewTierRatio(100, 0, 0),
+			[AllTierCount]uint64{0, 1, 0, 0},
+			1000,
+			1000,
+			func() int64 { return 500 },
+			func(start, end int64) ([]int64, []int64) {
+				if start < 1010 && end > 1010 {
+					return []int64{1010}, []int64{500}
+				}
+				return nil, nil
+			},
+		)
+		poolTier.membership.Set(poolPath, uint64(1))
+
+		poolTier.cacheRewardForPool(1020, pools, poolPath)
+
+		uassert.Equal(t, int64(500), NewPoolResolver(pool).CurrentReward(1020))
+	})
+
+	t.Run("post-halving range uses latest emission", func(t *testing.T) {
+		pools := NewPools()
+		pool := sr.NewPool(poolPath, 1000)
+		pool.RewardCache().Set(1020, int64(500))
+		pools.set(poolPath, pool)
+
+		poolTier := NewPoolTierBy(
+			sr.NewBPTreeN(16),
+			sr.NewTierRatio(100, 0, 0),
+			[AllTierCount]uint64{0, 1, 0, 0},
+			1000,
+			1000,
+			func() int64 { return 500 },
+			func(start, end int64) ([]int64, []int64) { return nil, nil },
+		)
+		poolTier.membership.Set(poolPath, uint64(1))
+
+		poolTier.cacheRewardForPool(1030, pools, poolPath)
+
+		uassert.Equal(t, int64(500), NewPoolResolver(pool).CurrentReward(1030))
+	})
+}
+
+func TestCacheRewardStopsAtEmissionEndBoundary(t *testing.T) {
+	poolPath := pl.GetPoolPath("gno.land/r/test/token1", "gno.land/r/test/token2", 3000)
+
+	newPoolTier := func() (*Pools, *sr.Pool, *PoolTier) {
+		pools := NewPools()
+		pool := sr.NewPool(poolPath, 1000)
+		pool.SetRewardCacheAt(1000, 1000)
+		pools.set(poolPath, pool)
+
+		poolTier := NewPoolTierBy(
+			sr.NewBPTreeN(16),
+			sr.NewTierRatio(100, 0, 0),
+			[AllTierCount]uint64{0, 1, 0, 0},
+			1000,
+			1000,
+			func() int64 { return 0 },
+			func(start, end int64) ([]int64, []int64) {
+				if start <= 1020 && 1020 < end {
+					return []int64{1021}, []int64{0}
+				}
+				return nil, nil
+			},
+		)
+		poolTier.membership.Set(poolPath, uint64(1))
+		return pools, pool, poolTier
+	}
+
+	t.Run("global tier cache writes zero at emission end boundary", func(t *testing.T) {
+		pools, pool, poolTier := newPoolTier()
+
+		poolTier.cacheReward(1030, pools)
+
+		uassert.Equal(t, true, pool.RewardCache().Has(1021))
+		uassert.Equal(t, int64(0), NewPoolResolver(pool).CurrentReward(1030))
+	})
+
+	t.Run("lazy pool cache writes zero at emission end boundary", func(t *testing.T) {
+		pools, pool, poolTier := newPoolTier()
+
+		poolTier.cacheRewardForPool(1030, pools, poolPath)
+
+		uassert.Equal(t, true, pool.RewardCache().Has(1021))
+		uassert.Equal(t, int64(0), NewPoolResolver(pool).CurrentReward(1030))
+	})
+}
+
 var test_gnousdc = pl.GetPoolPath("gno.land/r/gnoland/wugnot.wugnot", "gno.land/r/gnoswap/gns.GNS", 3000)
 
 func SetupPoolTier(t *testing.T) *PoolTier {

--- a/contract/r/gnoswap/staker/v1/staker.gno
+++ b/contract/r/gnoswap/staker/v1/staker.gno
@@ -295,8 +295,7 @@ func (s *stakerV1) StakeToken(_ int, rlm realm, positionId uint64, referrer stri
 	pn.SetPositionOperator(cross(rlm), positionId, caller)
 
 	poolTier := s.getPoolTier()
-	poolTier.cacheReward(currentTime, pools)
-	s.updatePoolTier(0, rlm, poolTier)
+	poolTier.cacheRewardForPool(currentTime, pools, poolPath)
 
 	signedLiquidity := i256.FromUint256(liquidity)
 	currentTick := s.poolAccessor.GetSlot0Tick(poolPath)

--- a/contract/r/scenario/staker/stake_updates_only_target_pool_reward_cache_filetest.gno
+++ b/contract/r/scenario/staker/stake_updates_only_target_pool_reward_cache_filetest.gno
@@ -1,0 +1,118 @@
+// PKGPATH: gno.land/r/gnoswap/v1/main
+
+package main
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"gno.land/p/demo/tokens/grc721"
+	"gno.land/p/gnoswap/gnsmath"
+	prbac "gno.land/p/gnoswap/rbac"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/emission"
+	"gno.land/r/gnoswap/gnft"
+	pl "gno.land/r/gnoswap/pool"
+	pn "gno.land/r/gnoswap/position"
+	"gno.land/r/gnoswap/scenarioutils"
+	sr "gno.land/r/gnoswap/staker"
+
+	_ "gno.land/r/gnoswap/pool/v1"
+	_ "gno.land/r/gnoswap/position/v1"
+	_ "gno.land/r/gnoswap/rbac"
+	_ "gno.land/r/gnoswap/staker/v1"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/baz"
+	_ "gno.land/r/onbloc/foo"
+	_ "gno.land/r/onbloc/qux"
+)
+
+const (
+	targetPoolPath    = "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/baz.BAZ:3000"
+	unrelatedPoolPath = "gno.land/r/onbloc/foo.FOO:gno.land/r/onbloc/qux.QUX:3000"
+	maxTimeout  int64 = 9999999999
+	maxInt64    int64 = 9223372036854775807
+)
+
+var (
+	adminAddr, _  = access.GetAddress(prbac.ROLE_ADMIN.String())
+	adminRealm    = testing.NewUserRealm(adminAddr)
+	poolAddr, _   = access.GetAddress(prbac.ROLE_POOL.String())
+	stakerAddr, _ = access.GetAddress(prbac.ROLE_STAKER.String())
+)
+
+func main(cur realm) {
+	println("[SCENARIO] initialize and tier two internal pools")
+	setupPools(cur)
+	println("[EXPECTED] both pools are tiered for internal rewards")
+	println()
+
+	println("[SCENARIO] stake a position in pool A")
+	stakeTargetPoolPosition(cur)
+	println("[EXPECTED] position staked successfully")
+	println("[EXPECTED] only pool A reward-cache count increased")
+}
+
+func setupPools(cur realm) {
+	testing.SetRealm(adminRealm)
+	scenarioutils.EnsureCanonicalDefaultPool(cross(cur))
+	emission.SetDistributionStartTime(cross(cur), time.Now().Unix()+1)
+	emission.ChangeDistributionPct(cross(cur), 7500, 2500, 0, 0)
+	sr.SetUnStakingFee(cross(cur), 0)
+	pl.SetPoolCreationFee(cross(cur), 0)
+
+	initialPrice := gnsmath.TickMathGetSqrtRatioAtTick(0).ToString()
+	pl.CreatePool(cross(cur), "gno.land/r/onbloc/bar.BAR", "gno.land/r/onbloc/baz.BAZ", 3000, initialPrice)
+	pl.CreatePool(cross(cur), "gno.land/r/onbloc/foo.FOO", "gno.land/r/onbloc/qux.QUX", 3000, initialPrice)
+	sr.SetPoolTier(cross(cur), targetPoolPath, 1)
+	sr.SetPoolTier(cross(cur), unrelatedPoolPath, 2)
+}
+
+func stakeTargetPoolPosition(cur realm) {
+	testing.SetRealm(adminRealm)
+	bar.Approve(cross(cur), poolAddr, maxInt64)
+	baz.Approve(cross(cur), poolAddr, maxInt64)
+
+	poolACacheCountBefore := sr.GetPoolRewardCacheCount(targetPoolPath)
+	poolBCacheCountBefore := sr.GetPoolRewardCacheCount(unrelatedPoolPath)
+	positionID, _, _, _ := pn.Mint(
+		cross(cur),
+		"gno.land/r/onbloc/bar.BAR",
+		"gno.land/r/onbloc/baz.BAZ",
+		3000,
+		int32(-1020),
+		int32(1020),
+		"1000000",
+		"1000000",
+		"1",
+		"1",
+		maxTimeout,
+		adminAddr,
+		"",
+	)
+
+	gnft.Approve(cross(cur), stakerAddr, grc721.TokenID(strconv.Itoa(int(positionID))))
+	testing.SkipHeights(1)
+	sr.StakeToken(cross(cur), positionID, "")
+
+	if owner := gnft.MustOwnerOf(grc721.TokenID(strconv.Itoa(int(positionID)))); owner != stakerAddr {
+		panic("position was not staked")
+	}
+	if got := sr.GetPoolRewardCacheCount(targetPoolPath); got != poolACacheCountBefore+1 {
+		panic("pool A reward-cache count did not increase")
+	}
+	if got := sr.GetPoolRewardCacheCount(unrelatedPoolPath); got != poolBCacheCountBefore {
+		panic("pool B reward-cache count changed")
+	}
+}
+
+// Output:
+// [SCENARIO] initialize and tier two internal pools
+// [EXPECTED] both pools are tiered for internal rewards
+//
+// [SCENARIO] stake a position in pool A
+// [EXPECTED] position staked successfully
+// [EXPECTED] only pool A reward-cache count increased

--- a/contract/r/scenario/staker/staker_halving_lazy_pool_cache_filetest.gno
+++ b/contract/r/scenario/staker/staker_halving_lazy_pool_cache_filetest.gno
@@ -1,0 +1,212 @@
+// PKGPATH: gno.land/r/gnoswap/v1/main
+
+package main
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"gno.land/p/demo/tokens/grc721"
+	prbac "gno.land/p/gnoswap/rbac"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/emission"
+	"gno.land/r/gnoswap/gnft"
+	"gno.land/r/gnoswap/gns"
+	pl "gno.land/r/gnoswap/pool"
+	pn "gno.land/r/gnoswap/position"
+	"gno.land/r/gnoswap/scenarioutils"
+	sr "gno.land/r/gnoswap/staker"
+
+	_ "gno.land/r/gnoswap/pool/v1"
+	_ "gno.land/r/gnoswap/position/v1"
+	_ "gno.land/r/gnoswap/rbac"
+	_ "gno.land/r/gnoswap/staker/v1"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/baz"
+)
+
+const (
+	halvingCacheBlockTime int64  = 5
+	halvingCachePoolPath  string = "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/baz.BAZ:3000"
+)
+
+var (
+	halvingCacheAdminAddr, _ = access.GetAddress(prbac.ROLE_ADMIN.String())
+	halvingCacheAdminRealm   = testing.NewUserRealm(halvingCacheAdminAddr)
+	halvingCacheStakerAddr, _ = access.GetAddress(prbac.ROLE_STAKER.String())
+	halvingCachePoolAddr, _   = access.GetAddress(prbac.ROLE_POOL.String())
+
+	halvingCacheMaxTimeout int64 = 9999999999
+	halvingCacheMaxInt64   int64 = 9223372036854775807
+)
+
+func main(cur realm) {
+	println("[SCENARIO] 1. Initialize emission and pool")
+	initHalvingCacheScenario(cur)
+	println("[EXPECTED] initialized staker halving cache scenario")
+	println()
+
+	println("[SCENARIO] 2. Stake position and cache pre-halving reward")
+	stakeHalvingCachePosition(cur)
+	preHalvingReward := cacheBeforeHalving(cur)
+	println("[EXPECTED] pre-halving pool reward cache uses year 1 pool reward")
+	println()
+
+	println("[SCENARIO] 3. Cross first halving boundary and collect once")
+	skipToFirstHalving(cur)
+	firstPostHalvingReward := collectAndAssertLatestCache(cur, "first post-halving")
+	assertHalvingReducedPoolReward(preHalvingReward, firstPostHalvingReward)
+	println("[EXPECTED] first post-halving collect persisted the reduced pool reward")
+	println()
+
+	println("[SCENARIO] 4. Collect again after halving")
+	testing.SkipHeights(1)
+	secondPostHalvingReward := collectAndAssertLatestCache(cur, "second post-halving")
+	if secondPostHalvingReward != firstPostHalvingReward {
+		panic("post-halving pool reward changed without another halving")
+	}
+	println("[EXPECTED] second post-halving collect persisted the reduced pool reward")
+}
+
+func initHalvingCacheScenario(cur realm) {
+	testing.SetRealm(halvingCacheAdminRealm)
+	scenarioutils.EnsureCanonicalDefaultPool(cross(cur))
+	emission.SetDistributionStartTime(cross(cur), time.Now().Unix()+1)
+	emission.ChangeDistributionPct(cross(cur), 7500, 2500, 0, 0)
+	sr.SetUnStakingFee(cross(cur), 0)
+	pl.SetPoolCreationFee(cross(cur), 0)
+
+	testing.SkipHeights(1)
+	emission.MintAndDistributeGns(cross(cur))
+
+	pl.CreatePool(cross(cur), "gno.land/r/onbloc/bar.BAR", "gno.land/r/onbloc/baz.BAZ", 3000, "79228162514264337593543950337")
+	sr.SetPoolTier(cross(cur), halvingCachePoolPath, 1)
+}
+
+func stakeHalvingCachePosition(cur realm) {
+	testing.SetRealm(halvingCacheAdminRealm)
+	bar.Approve(cross(cur), halvingCachePoolAddr, halvingCacheMaxInt64)
+	baz.Approve(cross(cur), halvingCachePoolAddr, halvingCacheMaxInt64)
+
+	positionId, _, _, _ := pn.Mint(
+		cross(cur),
+		"gno.land/r/onbloc/bar.BAR",
+		"gno.land/r/onbloc/baz.BAZ",
+		3000,
+		int32(-1020),
+		int32(1020),
+		"1000000",
+		"1000000",
+		"1",
+		"1",
+		halvingCacheMaxTimeout,
+		halvingCacheAdminAddr,
+		"",
+	)
+	if positionId != 1 {
+		panic("unexpected position id")
+	}
+
+	gnft.Approve(cross(cur), halvingCacheStakerAddr, halvingCachePositionIdFrom(positionId))
+	sr.StakeToken(cross(cur), positionId, "")
+}
+
+func cacheBeforeHalving(cur realm) int64 {
+	testing.SetRealm(halvingCacheAdminRealm)
+	testing.SkipHeights(10)
+	sr.CollectReward(cross(cur), 1)
+
+	if gns.GetCurrentYear() != 1 {
+		panic("expected pre-halving year 1")
+	}
+	return assertLatestPoolRewardCacheMatchesCurrentPoolReward("pre-halving")
+}
+
+func skipToFirstHalving(cur realm) {
+	testing.SetRealm(halvingCacheAdminRealm)
+	year3Start := gns.GetHalvingYearStartTimestamp(3)
+	now := time.Now().Unix()
+	if now >= year3Start {
+		panic("test setup already passed first halving")
+	}
+
+	blocksToYear3 := (year3Start-now)/halvingCacheBlockTime + 2
+	testing.SkipHeights(blocksToYear3)
+
+	if gns.GetCurrentYear() != 3 {
+		panic("expected first halving to enter year 3")
+	}
+	println("[INFO] crossed to halving year:", gns.GetCurrentYear())
+}
+
+func collectAndAssertLatestCache(cur realm, label string) int64 {
+	sr.CollectReward(cross(cur), 1)
+	return assertLatestPoolRewardCacheMatchesCurrentPoolReward(label)
+}
+
+func assertLatestPoolRewardCacheMatchesCurrentPoolReward(label string) int64 {
+	latestCache := latestPoolRewardCache()
+	currentPoolReward := sr.GetPoolReward(1)
+	println("[INFO]", label, "pool reward cache:", latestCache)
+	println("[INFO]", label, "current pool reward:", currentPoolReward)
+	if latestCache != currentPoolReward {
+		panic("pool reward cache did not use the latest halving pool reward")
+	}
+	return latestCache
+}
+
+func assertHalvingReducedPoolReward(before, after int64) {
+	if after >= before {
+		panic("halving did not reduce the pool reward")
+	}
+	println("[INFO] halving reduced pool reward from", before, "to", after)
+}
+
+func latestPoolRewardCache() int64 {
+	count := int(sr.GetPoolRewardCacheCount(halvingCachePoolPath))
+	if count == 0 {
+		panic("pool reward cache is empty")
+	}
+
+	ids := sr.GetPoolRewardCacheIDs(halvingCachePoolPath, 0, count)
+	if len(ids) == 0 {
+		panic("pool reward cache ids not found")
+	}
+
+	latestId := ids[0]
+	for _, id := range ids {
+		if id > latestId {
+			latestId = id
+		}
+	}
+
+	return sr.GetPoolRewardCache(halvingCachePoolPath, uint64(latestId))
+}
+
+func halvingCachePositionIdFrom(positionId uint64) grc721.TokenID {
+	return grc721.TokenID(strconv.Itoa(int(positionId)))
+}
+
+// Output:
+// [SCENARIO] 1. Initialize emission and pool
+// [EXPECTED] initialized staker halving cache scenario
+//
+// [SCENARIO] 2. Stake position and cache pre-halving reward
+// [INFO] pre-halving pool reward cache: 2675513
+// [INFO] pre-halving current pool reward: 2675513
+// [EXPECTED] pre-halving pool reward cache uses year 1 pool reward
+//
+// [SCENARIO] 3. Cross first halving boundary and collect once
+// [INFO] crossed to halving year: 3
+// [INFO] first post-halving pool reward cache: 1337756
+// [INFO] first post-halving current pool reward: 1337756
+// [INFO] halving reduced pool reward from 2675513 to 1337756
+// [EXPECTED] first post-halving collect persisted the reduced pool reward
+//
+// [SCENARIO] 4. Collect again after halving
+// [INFO] second post-halving pool reward cache: 1337756
+// [INFO] second post-halving current pool reward: 1337756
+// [EXPECTED] second post-halving collect persisted the reduced pool reward


### PR DESCRIPTION
## Summary
- Cache rewards only for the pool being staked, avoiding a full tier-membership scan on public `StakeToken`.
- Keep lazy per-pool reward caches aligned with the latest emission across halving and emission-end boundaries.
- Add unit and scenario coverage for lazy cache behavior and target-only cache updates.

## Testing
- `make test WORKDIR=unit-review-tmp PKG=gno.land/r/gnoswap/staker/v1`
- `make test WORKDIR=unit-review-tmp PKG=gno.land/r/gnoswap/scenario/staker`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reward calculations when emission rates change or reach their end.
  * Staking now updates rewards only for the affected pool, helping ensure accurate reward balances and more efficient processing.
* **Tests**
  * Added coverage for halving transitions, emission-end boundaries, and pool-specific reward caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->