### PR TITLE
refactor(protocol_fee): settle pending fees per token and accrue rewards on collection

### DIFF
--- a/contract/r/gnoswap/gov/staker/v1/emits.gno
+++ b/contract/r/gnoswap/gov/staker/v1/emits.gno
@@ -29,12 +29,12 @@ func emitUpdateEmissionRewardAccumulation(manager *staker.EmissionRewardManager)
 }
 
 // emitUpdateProtocolFeeRewardAccumulation emits the persisted per-token protocol fee
-// reward accumulation state for every distributed token. Like the emission variant it
+// reward accumulation state for every accrued token. Like the emission variant it
 // must be emitted after every path that calls updateAccumulatedProtocolFeeX128PerStake
 // (add/remove/claim). protocolFeeAmount and the accumulator are read from the manager's
 // persisted state so the emitted tuple stays internally consistent.
-func emitUpdateProtocolFeeRewardAccumulation(manager *staker.ProtocolFeeRewardManager, distributedAmounts map[string]int64) {
-	for tokenPath := range distributedAmounts {
+func emitUpdateProtocolFeeRewardAccumulation(manager *staker.ProtocolFeeRewardManager, accruedAmounts map[string]int64) {
+	for tokenPath := range accruedAmounts {
 		accumulatedProtocolFeeX128PerStake := "0"
 		if acc := manager.GetAccumulatedProtocolFeeX128PerStake(tokenPath); acc != nil {
 			accumulatedProtocolFeeX128PerStake = acc.ToString()

--- a/contract/r/gnoswap/gov/staker/v1/getter.gno
+++ b/contract/r/gnoswap/gov/staker/v1/getter.gno
@@ -236,7 +236,7 @@ func (gs *govStakerV1) GetClaimableRewardByRewardID(rewardID string) (int64, map
 		return 0, make(map[string]int64), err
 	}
 
-	protocolFeeAccruedAmounts := gs.getAccruedProtocolFees()
+	protocolFeeAccruedAmounts := gs.getAccrualPendingProtocolFees()
 	protocolFeeRewardManager := gs.store.GetProtocolFeeRewardManager()
 	protocolFeeResolver := NewProtocolFeeRewardManagerResolver(protocolFeeRewardManager)
 	protocolFeeRewards, err := protocolFeeResolver.GetClaimableRewardAmounts(protocolFeeAccruedAmounts, rewardID, time.Now().Unix())

--- a/contract/r/gnoswap/gov/staker/v1/getter.gno
+++ b/contract/r/gnoswap/gov/staker/v1/getter.gno
@@ -236,10 +236,10 @@ func (gs *govStakerV1) GetClaimableRewardByRewardID(rewardID string) (int64, map
 		return 0, make(map[string]int64), err
 	}
 
-	protocolFeeDistributedAmounts := gs.getDistributedProtocolFees()
+	protocolFeeAccruedAmounts := gs.getAccruedProtocolFees()
 	protocolFeeRewardManager := gs.store.GetProtocolFeeRewardManager()
 	protocolFeeResolver := NewProtocolFeeRewardManagerResolver(protocolFeeRewardManager)
-	protocolFeeRewards, err := protocolFeeResolver.GetClaimableRewardAmounts(protocolFeeDistributedAmounts, rewardID, time.Now().Unix())
+	protocolFeeRewards, err := protocolFeeResolver.GetClaimableRewardAmounts(protocolFeeAccruedAmounts, rewardID, time.Now().Unix())
 	if err != nil {
 		return 0, make(map[string]int64), err
 	}

--- a/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_manager.gno
+++ b/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_manager.gno
@@ -40,12 +40,25 @@ func (self *ProtocolFeeRewardManagerResolver) GetClaimableRewardAmounts(
 		return make(map[string]int64), nil
 	}
 
-	accumulatedRewardX128PerStake, _, err := self.calculateAccumulatedRewardX128PerStake(
+	recalculatedRewardX128PerStake, _, err := self.calculateAccumulatedRewardX128PerStake(
 		protocolFeeAmounts,
 		currentTimestamp,
 	)
 	if err != nil {
 		return nil, err
+	}
+
+	// protocolFeeAmounts only covers the tokens that collected a fee since the last
+	// accrual, so the recalculated rates are layered on the stored ones: reporting them
+	// alone would hide every token already accrued but without a new fee. The merge
+	// builds its own map because GetAll... hands back the stored one, and a query must
+	// not write to the accumulator.
+	accumulatedRewardX128PerStake := make(map[string]*u256.Uint)
+	for token, rate := range self.GetAllAccumulatedProtocolFeeX128PerStake() {
+		accumulatedRewardX128PerStake[token] = rate
+	}
+	for token, rate := range recalculatedRewardX128PerStake {
+		accumulatedRewardX128PerStake[token] = rate
 	}
 
 	resolvedState := NewProtocolFeeRewardStateResolver(rewardState)
@@ -179,9 +192,10 @@ func (self *ProtocolFeeRewardManagerResolver) updateAccumulatedProtocolFeeX128Pe
 	// every registered token on every add/remove/claim, growing storage and gas linearly in the number of
 	// registered tokens regardless of how many actually earned fees (gas report issue 1 / §1.2).
 	//
-	// Registered protocol-fee tokens are monotonic (never removed) and distributedAmounts always covers the
-	// full registered set, so the stored token set never shrinks; skipping unchanged entries therefore yields
-	// the same persisted state as the previous full-replace, only without the redundant re-writes.
+	// Registered protocol-fee tokens are monotonic (never removed) and the stored maps are
+	// updated per token rather than replaced, so a token missing from protocolFeeAmounts keeps
+	// its stored value; skipping unchanged entries therefore yields the same persisted state
+	// as the previous full-replace, only without the redundant re-writes.
 	for token, newAcc := range accumulatedProtocolFeeX128PerStake {
 		existing := self.GetAccumulatedProtocolFeeX128PerStake(token)
 		if existing == nil || !existing.Eq(newAcc) {

--- a/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_state.gno
+++ b/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_state.gno
@@ -237,12 +237,28 @@ func (p *ProtocolFeeRewardStateResolver) updateRewardDebtX128(
 		return err
 	}
 
-	// Update reward debt for all tokens
-	p.SetRewardDebtX128(accumulatedProtocolFeeX128PerStake)
-
-	// Add newly calculated rewards to accumulated amounts
+	// Persist only the tokens whose value actually changed instead of replacing the maps.
+	// SetRewardDebtX128 allocates a fresh map plus one u256 per token on every stake
+	// change, so replacing it costs one persisted entry per registered token regardless
+	// of how many actually earned anything (gas report issue 1 / §1.2).
+	//
+	// Registered protocol-fee tokens are monotonic and accumulatedProtocolFeeX128PerStake
+	// always covers the full registered set, so writing per token cannot drop an entry.
 	accumulatedRewards := p.GetAccumulatedRewards()
-	for token, rewardAmount := range rewardAmounts {
+	for token, accumulatedFeeX128PerStake := range accumulatedProtocolFeeX128PerStake {
+		existingRewardDebtX128 := p.GetRewardDebtX128ForToken(token)
+		if existingRewardDebtX128 == nil || !existingRewardDebtX128.Eq(accumulatedFeeX128PerStake) {
+			p.SetRewardDebtX128ForToken(token, accumulatedFeeX128PerStake)
+		}
+
+		// Adding zero to an existing entry leaves it unchanged. A token seen for the first
+		// time is still written at zero: callers read token presence, not only amounts.
+		rewardAmount := rewardAmounts[token]
+		_, alreadyAccumulated := accumulatedRewards[token]
+		if rewardAmount == 0 && alreadyAccumulated {
+			continue
+		}
+
 		p.SetAccumulatedRewardForToken(token, gnsmath.SafeAddInt64(accumulatedRewards[token], rewardAmount))
 	}
 

--- a/contract/r/gnoswap/gov/staker/v1/state.gno
+++ b/contract/r/gnoswap/gov/staker/v1/state.gno
@@ -397,14 +397,12 @@ func (g *govStakerV1) removeLaunchpadProjectDeposit(ownerAddress string) bool {
 //   - amount: amount of stake to add
 //   - currentTimestamp: current timestamp
 func (g *govStakerV1) addStakeProtocolFeeReward(_ int, rlm realm, address string, amount int64, currentTimestamp int64) error {
-	pf.DistributeProtocolFee(cross(rlm))
-
-	distributedAmounts := g.getDistributedProtocolFees()
+	accruedAmounts := g.getAccruedProtocolFees()
 
 	protocolFeeRewardManager := g.store.GetProtocolFeeRewardManager()
 	resolvedManager := NewProtocolFeeRewardManagerResolver(protocolFeeRewardManager)
 
-	if err := resolvedManager.updateAccumulatedProtocolFeeX128PerStake(distributedAmounts, currentTimestamp); err != nil {
+	if err := resolvedManager.updateAccumulatedProtocolFeeX128PerStake(accruedAmounts, currentTimestamp); err != nil {
 		return err
 	}
 
@@ -418,7 +416,7 @@ func (g *govStakerV1) addStakeProtocolFeeReward(_ int, rlm realm, address string
 	}
 
 	// Emit the protocol fee reward accumulation
-	emitUpdateProtocolFeeRewardAccumulation(protocolFeeRewardManager, distributedAmounts)
+	emitUpdateProtocolFeeRewardAccumulation(protocolFeeRewardManager, accruedAmounts)
 
 	return nil
 }
@@ -431,14 +429,12 @@ func (g *govStakerV1) addStakeProtocolFeeReward(_ int, rlm realm, address string
 //   - amount: amount of stake to remove
 //   - currentTimestamp: current timestamp
 func (g *govStakerV1) removeStakeProtocolFeeReward(_ int, rlm realm, address string, amount int64, currentTimestamp int64) error {
-	pf.DistributeProtocolFee(cross(rlm))
-
-	distributedAmounts := g.getDistributedProtocolFees()
+	accruedAmounts := g.getAccruedProtocolFees()
 
 	protocolFeeRewardManager := g.store.GetProtocolFeeRewardManager()
 	resolvedManager := NewProtocolFeeRewardManagerResolver(protocolFeeRewardManager)
 
-	if err := resolvedManager.updateAccumulatedProtocolFeeX128PerStake(distributedAmounts, currentTimestamp); err != nil {
+	if err := resolvedManager.updateAccumulatedProtocolFeeX128PerStake(accruedAmounts, currentTimestamp); err != nil {
 		return err
 	}
 
@@ -451,7 +447,7 @@ func (g *govStakerV1) removeStakeProtocolFeeReward(_ int, rlm realm, address str
 	}
 
 	// Emit the protocol fee reward accumulation
-	emitUpdateProtocolFeeRewardAccumulation(protocolFeeRewardManager, distributedAmounts)
+	emitUpdateProtocolFeeRewardAccumulation(protocolFeeRewardManager, accruedAmounts)
 
 	return nil
 }
@@ -467,14 +463,16 @@ func (g *govStakerV1) removeStakeProtocolFeeReward(_ int, rlm realm, address str
 //   - map[string]int64: protocol fee rewards claimed by token
 //   - error: nil on success, error if claiming fails
 func (g *govStakerV1) claimRewardsProtocolFeeReward(_ int, rlm realm, address string, currentTimestamp int64) (map[string]int64, error) {
+	// Claiming pays out of gov/staker's own balance, so the reserved fees are pulled in
+	// from the protocol fee realm first. The stake-change paths need no transfer.
 	pf.DistributeProtocolFee(cross(rlm))
 
-	distributedAmounts := g.getDistributedProtocolFees()
+	accruedAmounts := g.getAccruedProtocolFees()
 
 	protocolFeeRewardManager := g.store.GetProtocolFeeRewardManager()
 	resolvedManager := NewProtocolFeeRewardManagerResolver(protocolFeeRewardManager)
 
-	if err := resolvedManager.updateAccumulatedProtocolFeeX128PerStake(distributedAmounts, currentTimestamp); err != nil {
+	if err := resolvedManager.updateAccumulatedProtocolFeeX128PerStake(accruedAmounts, currentTimestamp); err != nil {
 		return nil, err
 	}
 
@@ -488,7 +486,7 @@ func (g *govStakerV1) claimRewardsProtocolFeeReward(_ int, rlm realm, address st
 	}
 
 	// Emit the protocol fee reward accumulation
-	emitUpdateProtocolFeeRewardAccumulation(protocolFeeRewardManager, distributedAmounts)
+	emitUpdateProtocolFeeRewardAccumulation(protocolFeeRewardManager, accruedAmounts)
 
 	return rewards, nil
 }
@@ -518,8 +516,8 @@ func (g *govStakerV1) claimDistributedProtocolFeeRewardByTokenPath(address strin
 func (g *govStakerV1) claimRewardProtocolFeeRewardByTokenPath(_ int, rlm realm, address string, tokenPath string, currentTimestamp int64) (int64, error) {
 	pf.DistributeProtocolFeeByTokenPath(cross(rlm), tokenPath)
 
-	distributedAmount := pf.GetActualDistributedToGovStakerByTokenPath(tokenPath)
-	protocolFeeRewardManager, reward, processed, err := g.claimDistributedProtocolFeeRewardByTokenPath(address, tokenPath, distributedAmount, currentTimestamp)
+	accruedAmount := pf.GetAccuTransferToGovStakerByTokenPath(tokenPath)
+	protocolFeeRewardManager, reward, processed, err := g.claimDistributedProtocolFeeRewardByTokenPath(address, tokenPath, accruedAmount, currentTimestamp)
 	if err != nil {
 		return 0, err
 	}
@@ -531,18 +529,20 @@ func (g *govStakerV1) claimRewardProtocolFeeRewardByTokenPath(_ int, rlm realm, 
 		return 0, err
 	}
 
-	emitUpdateProtocolFeeRewardAccumulation(protocolFeeRewardManager, map[string]int64{tokenPath: distributedAmount})
+	emitUpdateProtocolFeeRewardAccumulation(protocolFeeRewardManager, map[string]int64{tokenPath: accruedAmount})
 
 	return reward, nil
 }
 
-// getDistributedProtocolFees retrieves the current distributed protocol fee amounts for all tokens.
-// This method queries the protocol fee contract for accumulated distributions.
+// getAccruedProtocolFees retrieves the protocol fee amounts reserved for gov/staker.
+//
+// The reserved amount is recorded when a fee reaches the protocol fee realm, before it
+// is transferred out, so accrual does not depend on a transfer happening.
 //
 // Returns:
-//   - map[string]int64: distributed amounts by token path
-func (g *govStakerV1) getDistributedProtocolFees() map[string]int64 {
-	return pf.GetActualDistributedToGovStaker()
+//   - map[string]int64: accrued amounts by token path
+func (g *govStakerV1) getAccruedProtocolFees() map[string]int64 {
+	return pf.GetAccuTransfersToGovStaker()
 }
 
 // getLaunchpadProjectDeposit retrieves the deposit amount for a launchpad project.

--- a/contract/r/gnoswap/gov/staker/v1/state.gno
+++ b/contract/r/gnoswap/gov/staker/v1/state.gno
@@ -397,7 +397,7 @@ func (g *govStakerV1) removeLaunchpadProjectDeposit(ownerAddress string) bool {
 //   - amount: amount of stake to add
 //   - currentTimestamp: current timestamp
 func (g *govStakerV1) addStakeProtocolFeeReward(_ int, rlm realm, address string, amount int64, currentTimestamp int64) error {
-	accruedAmounts := g.getAccruedProtocolFees()
+	accruedAmounts := pf.ConsumeAccrualPendingProtocolFees(cross(rlm))
 
 	protocolFeeRewardManager := g.store.GetProtocolFeeRewardManager()
 	resolvedManager := NewProtocolFeeRewardManagerResolver(protocolFeeRewardManager)
@@ -429,7 +429,7 @@ func (g *govStakerV1) addStakeProtocolFeeReward(_ int, rlm realm, address string
 //   - amount: amount of stake to remove
 //   - currentTimestamp: current timestamp
 func (g *govStakerV1) removeStakeProtocolFeeReward(_ int, rlm realm, address string, amount int64, currentTimestamp int64) error {
-	accruedAmounts := g.getAccruedProtocolFees()
+	accruedAmounts := pf.ConsumeAccrualPendingProtocolFees(cross(rlm))
 
 	protocolFeeRewardManager := g.store.GetProtocolFeeRewardManager()
 	resolvedManager := NewProtocolFeeRewardManagerResolver(protocolFeeRewardManager)
@@ -467,7 +467,7 @@ func (g *govStakerV1) claimRewardsProtocolFeeReward(_ int, rlm realm, address st
 	// from the protocol fee realm first. The stake-change paths need no transfer.
 	pf.DistributeProtocolFee(cross(rlm))
 
-	accruedAmounts := g.getAccruedProtocolFees()
+	accruedAmounts := pf.ConsumeAccrualPendingProtocolFees(cross(rlm))
 
 	protocolFeeRewardManager := g.store.GetProtocolFeeRewardManager()
 	resolvedManager := NewProtocolFeeRewardManagerResolver(protocolFeeRewardManager)
@@ -491,16 +491,16 @@ func (g *govStakerV1) claimRewardsProtocolFeeReward(_ int, rlm realm, address st
 	return rewards, nil
 }
 
-// claimDistributedProtocolFeeRewardByTokenPath processes an observed protocol fee distribution for one token.
-func (g *govStakerV1) claimDistributedProtocolFeeRewardByTokenPath(address string, tokenPath string, distributedAmount int64, currentTimestamp int64) (*staker.ProtocolFeeRewardManager, int64, bool, error) {
-	if distributedAmount == 0 {
+// claimAccruedProtocolFeeRewardByTokenPath processes an observed protocol fee accrual for one token.
+func (g *govStakerV1) claimAccruedProtocolFeeRewardByTokenPath(address string, tokenPath string, accruedAmount int64, currentTimestamp int64) (*staker.ProtocolFeeRewardManager, int64, bool, error) {
+	if accruedAmount == 0 {
 		return nil, 0, false, nil
 	}
 
 	protocolFeeRewardManager := g.store.GetProtocolFeeRewardManager()
 	resolvedManager := NewProtocolFeeRewardManagerResolver(protocolFeeRewardManager)
 
-	if err := resolvedManager.updateAccumulatedProtocolFeeX128PerStakeForToken(tokenPath, distributedAmount, currentTimestamp); err != nil {
+	if err := resolvedManager.updateAccumulatedProtocolFeeX128PerStakeForToken(tokenPath, accruedAmount, currentTimestamp); err != nil {
 		return nil, 0, false, err
 	}
 
@@ -517,7 +517,7 @@ func (g *govStakerV1) claimRewardProtocolFeeRewardByTokenPath(_ int, rlm realm, 
 	pf.DistributeProtocolFeeByTokenPath(cross(rlm), tokenPath)
 
 	accruedAmount := pf.GetAccuTransferToGovStakerByTokenPath(tokenPath)
-	protocolFeeRewardManager, reward, processed, err := g.claimDistributedProtocolFeeRewardByTokenPath(address, tokenPath, accruedAmount, currentTimestamp)
+	protocolFeeRewardManager, reward, processed, err := g.claimAccruedProtocolFeeRewardByTokenPath(address, tokenPath, accruedAmount, currentTimestamp)
 	if err != nil {
 		return 0, err
 	}
@@ -534,15 +534,18 @@ func (g *govStakerV1) claimRewardProtocolFeeRewardByTokenPath(_ int, rlm realm, 
 	return reward, nil
 }
 
-// getAccruedProtocolFees retrieves the protocol fee amounts reserved for gov/staker.
+// getAccrualPendingProtocolFees retrieves the protocol fee amounts reserved for
+// gov/staker, limited to the tokens that collected a fee since the last accrual.
 //
 // The reserved amount is recorded when a fee reaches the protocol fee realm, before it
-// is transferred out, so accrual does not depend on a transfer happening.
+// is transferred out, so accrual does not depend on a transfer happening. This is the
+// read-only counterpart of pf.ConsumeAccrualPendingProtocolFees: a query never advances
+// accrual state.
 //
 // Returns:
 //   - map[string]int64: accrued amounts by token path
-func (g *govStakerV1) getAccruedProtocolFees() map[string]int64 {
-	return pf.GetAccuTransfersToGovStaker()
+func (g *govStakerV1) getAccrualPendingProtocolFees() map[string]int64 {
+	return pf.GetAccrualPendingProtocolFees()
 }
 
 // getLaunchpadProjectDeposit retrieves the deposit amount for a launchpad project.

--- a/contract/r/gnoswap/gov/staker/v1/state_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/state_test.gno
@@ -462,7 +462,7 @@ func TestMakeLaunchpadRewardID(cur realm, t *testing.T) {
 	}
 }
 
-func TestClaimDistributedProtocolFeeRewardByTokenPath_NoDistributionDoesNotMaterializeTokenState(cur realm, t *testing.T) {
+func TestClaimAccruedProtocolFeeRewardByTokenPath_NoAccrualDoesNotMaterializeTokenState(cur realm, t *testing.T) {
 	gs := createTestGovStaker()
 	caller := makeFakeAddress("f2-no-distribution")
 	stakerAddress := caller.String()
@@ -473,7 +473,7 @@ func TestClaimDistributedProtocolFeeRewardByTokenPath_NoDistributionDoesNotMater
 	err := managerResolver.addStake(stakerAddress, 100, 10)
 	uassert.NoError(t, err)
 
-	processedManager, reward, processed, err := gs.claimDistributedProtocolFeeRewardByTokenPath(stakerAddress, tokenPath, 0, 20)
+	processedManager, reward, processed, err := gs.claimAccruedProtocolFeeRewardByTokenPath(stakerAddress, tokenPath, 0, 20)
 
 	uassert.NoError(t, err)
 	uassert.False(t, processed)

--- a/contract/r/gnoswap/pool/_mock_test.gno
+++ b/contract/r/gnoswap/pool/_mock_test.gno
@@ -139,6 +139,15 @@ func (m *MockPool) SetWithdrawalFee(_ int, rlm realm, fee uint64) {
 	m.Response.Get("SetWithdrawalFee")
 }
 
+func (m *MockPool) GetPendingProtocolFees() map[string]int64 {
+	res, ok := m.Response.Get("GetPendingProtocolFees")
+	if !ok {
+		return map[string]int64{}
+	}
+
+	return res[0].(map[string]int64)
+}
+
 func (m *MockPool) HandleWithdrawalFee(
 	_ int,
 	rlm realm,

--- a/contract/r/gnoswap/pool/getter.gno
+++ b/contract/r/gnoswap/pool/getter.gno
@@ -282,3 +282,8 @@ func GetObservationState(poolPath string) (*ObservationState, error) {
 
 	return cloneObservationState(observationState), nil
 }
+
+// GetPendingProtocolFees returns the pending protocol fee amount per token path.
+func GetPendingProtocolFees() map[string]int64 {
+	return cloneStringInt64Map(getImplementation().GetPendingProtocolFees())
+}

--- a/contract/r/gnoswap/pool/types.gno
+++ b/contract/r/gnoswap/pool/types.gno
@@ -170,6 +170,8 @@ type IPoolGetter interface {
 
 	GetLastObservation(poolPath string) (tickCumulative int64, secondsPerLiquidityCumulativeX128 string, blockTimestamp int64)
 
+	GetPendingProtocolFees() map[string]int64
+
 	GetPoolCreationFee() int64
 
 	GetPositionFeeGrowthInside0LastX128(poolPath, key string) string

--- a/contract/r/gnoswap/pool/v1/manager.gno
+++ b/contract/r/gnoswap/pool/v1/manager.gno
@@ -128,7 +128,8 @@ func (i *poolV1) CreatePool(
 			"feeAmount", utils.FormatInt(poolCreationFee),
 		)
 	}
-	i.addToProtocolFee(0, rlm)
+
+	i.addToProtocolFee(0, rlm, GNS_TOKEN_KEY)
 
 	previousRealm := rlm.Previous()
 	chain.Emit(

--- a/contract/r/gnoswap/pool/v1/protocol_fee.gno
+++ b/contract/r/gnoswap/pool/v1/protocol_fee.gno
@@ -69,11 +69,17 @@ func (i *poolV1) HandleWithdrawalFee(
 
 	i.addPendingProtocolFee(0, rlm, token0Path, fee0Int64)
 	i.addPendingProtocolFee(0, rlm, token1Path, fee1Int64)
-	i.addToProtocolFee(0, rlm)
+	i.addToProtocolFee(0, rlm, token0Path)
+	i.addToProtocolFee(0, rlm, token1Path)
 	common.SafeGRC20Transfer(cross(rlm), token0Path, positionCaller, gnsmath.SafeConvertToInt64(amount0WithoutFee))
 	common.SafeGRC20Transfer(cross(rlm), token1Path, positionCaller, gnsmath.SafeConvertToInt64(amount1WithoutFee))
 
 	return fee0.ToString(), fee1.ToString(), amount0WithoutFee.ToString(), amount1WithoutFee.ToString()
+}
+
+// GetPendingProtocolFees returns the pending protocol fee amount per token path.
+func (i *poolV1) GetPendingProtocolFees() map[string]int64 {
+	return i.store.GetPendingProtocolFees()
 }
 
 func (i *poolV1) addPendingProtocolFee(_ int, rlm realm, tokenPath string, amount int64) {
@@ -81,39 +87,48 @@ func (i *poolV1) addPendingProtocolFee(_ int, rlm realm, tokenPath string, amoun
 		return
 	}
 
+	// The stored map is readonly tainted here, so it is copied before being updated.
 	existingProtocolFees := i.store.GetPendingProtocolFees()
 	pendingProtocolFees := make(map[string]int64)
 	for pendingTokenPath, pendingAmount := range existingProtocolFees {
 		pendingProtocolFees[pendingTokenPath] = pendingAmount
 	}
+
 	pendingProtocolFees[tokenPath] = gnsmath.SafeAddInt64(pendingProtocolFees[tokenPath], amount)
 	if err := i.store.SetPendingProtocolFees(0, rlm, pendingProtocolFees); err != nil {
 		panic(err)
 	}
 }
 
-// addToProtocolFee sends pending pool protocol fees to the protocol fee realm.
-// It is best-effort: when protocol fee collection is halted, it keeps pending
-// storage unchanged; otherwise it rebuilds pending storage with only entries
-// that could not be added, removing successful and non-positive entries.
-func (i *poolV1) addToProtocolFee(_ int, rlm realm) {
+// addToProtocolFee sends the pending pool protocol fee of tokenPath to the
+// protocol fee realm. It is best-effort: an entry only survives while protocol fee
+// collection is halted, and is settled by the next call for the same token, which
+// every fee path makes even when the fee is zero.
+//
+// Only the entry of tokenPath is touched, so an unrelated token can never block
+// settlement and the cost does not scale with the number of pending entries.
+func (i *poolV1) addToProtocolFee(_ int, rlm realm, tokenPath string) {
 	pendingProtocolFees := i.store.GetPendingProtocolFees()
-	if len(pendingProtocolFees) == 0 || halt.IsHaltedProtocolFee() {
+	amount, exists := pendingProtocolFees[tokenPath]
+	if !exists || halt.IsHaltedProtocolFee() {
 		return
 	}
 
-	protocolFeeAddr := access.MustGetAddress(prabc.ROLE_PROTOCOL_FEE.String())
+	if amount > 0 {
+		protocolFeeAddr := access.MustGetAddress(prabc.ROLE_PROTOCOL_FEE.String())
+		common.SafeGRC20Approve(cross(rlm), tokenPath, protocolFeeAddr, amount)
+		if err := pf.AddToProtocolFee(cross(rlm), tokenPath, amount); err != nil {
+			return
+		}
+	}
+
 	remainingProtocolFees := make(map[string]int64)
-	for tokenPath, amount := range pendingProtocolFees {
-		if amount <= 0 {
+	for pendingTokenPath, pendingAmount := range pendingProtocolFees {
+		if pendingTokenPath == tokenPath {
 			continue
 		}
 
-		common.SafeGRC20Approve(cross(rlm), tokenPath, protocolFeeAddr, amount)
-		if err := pf.AddToProtocolFee(cross(rlm), tokenPath, amount); err != nil {
-			remainingProtocolFees[tokenPath] = amount
-			continue
-		}
+		remainingProtocolFees[pendingTokenPath] = pendingAmount
 	}
 
 	if err := i.store.SetPendingProtocolFees(0, rlm, remainingProtocolFees); err != nil {

--- a/contract/r/gnoswap/pool/v1/protocol_fee_test.gno
+++ b/contract/r/gnoswap/pool/v1/protocol_fee_test.gno
@@ -282,7 +282,8 @@ func TestAddToProtocolFeeClearsNonPositiveAmounts(cur realm, t *testing.T) {
 	}
 	instance.store.SetPendingProtocolFees(0, cur, originalPendingProtocolFees)
 
-	instance.addToProtocolFee(0, cur)
+	instance.addToProtocolFee(0, cur, barPath)
+	instance.addToProtocolFee(0, cur, gnsPath)
 
 	pendingProtocolFees := instance.store.GetPendingProtocolFees()
 	uassert.Equal(t, len(pendingProtocolFees), 0)

--- a/contract/r/gnoswap/protocol_fee/_mock_test.gno
+++ b/contract/r/gnoswap/protocol_fee/_mock_test.gno
@@ -79,6 +79,22 @@ func (m *MockProtocolFee) GetGovStakerPct() int64 {
 	return res[0].(int64)
 }
 
+func (m *MockProtocolFee) ConsumeAccrualPendingProtocolFees(_ int, rlm realm) map[string]int64 {
+	res, ok := m.Response.Get("ConsumeAccrualPendingProtocolFees")
+	if !ok {
+		return map[string]int64{}
+	}
+	return res[0].(map[string]int64)
+}
+
+func (m *MockProtocolFee) GetAccrualPendingProtocolFees() map[string]int64 {
+	res, ok := m.Response.Get("GetAccrualPendingProtocolFees")
+	if !ok {
+		return map[string]int64{}
+	}
+	return res[0].(map[string]int64)
+}
+
 func (m *MockProtocolFee) GetReservedTokens() []string {
 	res, ok := m.Response.Get("GetReservedTokens")
 	if !ok {

--- a/contract/r/gnoswap/protocol_fee/proxy.gno
+++ b/contract/r/gnoswap/protocol_fee/proxy.gno
@@ -35,6 +35,12 @@ func AddToProtocolFee(cur realm, tokenPath string, amount int64) error {
 	return getImplementation().AddToProtocolFee(0, cur, tokenPath, amount)
 }
 
+// ConsumeAccrualPendingProtocolFees returns the fees collected since the last call and
+// clears the pending list. Only gov/staker may call it.
+func ConsumeAccrualPendingProtocolFees(cur realm) map[string]int64 {
+	return getImplementation().ConsumeAccrualPendingProtocolFees(0, cur)
+}
+
 // GetDevOpsPct returns the DevOps fee percentage.
 func GetDevOpsPct() int64 {
 	return getImplementation().GetDevOpsPct()
@@ -43,6 +49,11 @@ func GetDevOpsPct() int64 {
 // GetGovStakerPct returns the GovStaker fee percentage.
 func GetGovStakerPct() int64 {
 	return getImplementation().GetGovStakerPct()
+}
+
+// GetAccrualPendingProtocolFees returns the same amounts without clearing the list.
+func GetAccrualPendingProtocolFees() map[string]int64 {
+	return cloneStringInt64Map(getImplementation().GetAccrualPendingProtocolFees())
 }
 
 // GetReservedTokens returns token paths reserved for distribution.

--- a/contract/r/gnoswap/protocol_fee/store.gno
+++ b/contract/r/gnoswap/protocol_fee/store.gno
@@ -28,7 +28,8 @@ const (
 	StoreKeyDistributedToDevOpsHistory    StoreKey = "distributedToDevOpsHistory"    // tokenPath -> amount
 
 	// reservedTokens tracks token paths collected but not yet distributed.
-	StoreKeyReservedTokens StoreKey = "reservedTokens"
+	StoreKeyReservedTokens       StoreKey = "reservedTokens"
+	StoreKeyAccrualPendingTokens StoreKey = "accrualPendingTokens"
 )
 
 const (
@@ -372,6 +373,73 @@ func (s *protocolFeeStore) RemoveReservedToken(_ int, rlm realm, tokenPath strin
 	}
 
 	return s.SetReservedTokens(0, rlm, filteredReservedTokens)
+}
+
+// handle accrualPendingTokens store data
+//
+// accrualPendingTokens holds the token paths whose gov/staker share was recorded since
+// gov/staker last folded fees into its accumulator, so a stake change only walks the
+// fees that actually arrived in the meantime.
+func (s *protocolFeeStore) HasAccrualPendingTokensStoreKey() bool {
+	return s.kvStore.Has(StoreKeyAccrualPendingTokens.String())
+}
+
+func (s *protocolFeeStore) InitializeAccrualPendingTokens(_ int, rlm realm) error {
+	if !rlm.IsCurrent() {
+		return errors.New(errSpoofedRealm)
+	}
+
+	return s.kvStore.Set(0, rlm, StoreKeyAccrualPendingTokens.String(), []string{})
+}
+
+func (s *protocolFeeStore) GetAccrualPendingTokens() []string {
+	result, err := s.kvStore.Get(StoreKeyAccrualPendingTokens.String())
+	if err != nil {
+		panic(err)
+	}
+
+	accrualPendingTokens, ok := result.([]string)
+	if !ok {
+		panic(ufmt.Errorf("failed to cast result to []string: %T", result))
+	}
+
+	return accrualPendingTokens
+}
+
+func (s *protocolFeeStore) SetAccrualPendingTokens(_ int, rlm realm, accrualPendingTokens []string) error {
+	if !rlm.IsCurrent() {
+		return errors.New(errSpoofedRealm)
+	}
+
+	if accrualPendingTokens == nil {
+		return errors.New("accrualPendingTokens is nil")
+	}
+
+	return s.kvStore.Set(0, rlm, StoreKeyAccrualPendingTokens.String(), accrualPendingTokens)
+}
+
+func (s *protocolFeeStore) AddAccrualPendingToken(_ int, rlm realm, tokenPath string) error {
+	if !rlm.IsCurrent() {
+		return errors.New(errSpoofedRealm)
+	}
+
+	accrualPendingTokens := s.GetAccrualPendingTokens()
+	for _, accrualPendingToken := range accrualPendingTokens {
+		if accrualPendingToken == tokenPath {
+			return nil
+		}
+	}
+
+	accrualPendingTokens = append(accrualPendingTokens, tokenPath)
+	return s.SetAccrualPendingTokens(0, rlm, accrualPendingTokens)
+}
+
+func (s *protocolFeeStore) ClearAccrualPendingTokens(_ int, rlm realm) error {
+	if !rlm.IsCurrent() {
+		return errors.New(errSpoofedRealm)
+	}
+
+	return s.SetAccrualPendingTokens(0, rlm, []string{})
 }
 
 // NewprotocolFeeStore creates a new protocol fee store instance with the provided KV store.

--- a/contract/r/gnoswap/protocol_fee/types.gno
+++ b/contract/r/gnoswap/protocol_fee/types.gno
@@ -18,6 +18,8 @@ type IProtocolFeeManager interface {
 	SetDevOpsPct(_ int, rlm realm, pct int64)
 	SetGovStakerPct(_ int, rlm realm, pct int64)
 	AddToProtocolFee(_ int, rlm realm, tokenPath string, amount int64) error
+
+	ConsumeAccrualPendingProtocolFees(_ int, rlm realm) map[string]int64
 }
 
 type IProtocolFeeGetter interface {
@@ -32,6 +34,7 @@ type IProtocolFeeGetter interface {
 	GetActualDistributedToDevOps() map[string]int64
 	GetActualDistributedToGovStakerByTokenPath(path string) int64
 	GetActualDistributedToDevOpsByTokenPath(path string) int64
+	GetAccrualPendingProtocolFees() map[string]int64
 }
 
 type IProtocolFeeStore interface {
@@ -70,4 +73,11 @@ type IProtocolFeeStore interface {
 	SetReservedTokens(_ int, rlm realm, reservedTokens []string) error
 	AddReservedToken(_ int, rlm realm, tokenPath string) error
 	RemoveReservedToken(_ int, rlm realm, tokenPath string) error
+
+	HasAccrualPendingTokensStoreKey() bool
+	InitializeAccrualPendingTokens(_ int, rlm realm) error
+	GetAccrualPendingTokens() []string
+	SetAccrualPendingTokens(_ int, rlm realm, accrualPendingTokens []string) error
+	AddAccrualPendingToken(_ int, rlm realm, tokenPath string) error
+	ClearAccrualPendingTokens(_ int, rlm realm) error
 }

--- a/contract/r/gnoswap/protocol_fee/v1/_mock_test.gno
+++ b/contract/r/gnoswap/protocol_fee/v1/_mock_test.gno
@@ -12,7 +12,8 @@ type mockProtocolFeeStore struct {
 	accuToDevOps         *bptree.BPTree
 	distributedToGovStakerHistory *bptree.BPTree
 	distributedToDevOpsHistory    *bptree.BPTree
-	reservedTokens []string
+	reservedTokens       []string
+	accrualPendingTokens []string
 }
 
 // handle devOpsPct store data
@@ -206,6 +207,39 @@ func (s *mockProtocolFeeStore) RemoveReservedToken(_ int, rlm realm, tokenPath s
 	return s.SetReservedTokens(0, rlm, filteredReservedTokens)
 }
 
+// handle accrualPendingTokens store data
+func (s *mockProtocolFeeStore) HasAccrualPendingTokensStoreKey() bool {
+	return true
+}
+
+func (s *mockProtocolFeeStore) InitializeAccrualPendingTokens(_ int, rlm realm) error {
+	s.accrualPendingTokens = []string{}
+	return nil
+}
+
+func (s *mockProtocolFeeStore) GetAccrualPendingTokens() []string {
+	return s.accrualPendingTokens
+}
+
+func (s *mockProtocolFeeStore) SetAccrualPendingTokens(_ int, rlm realm, accrualPendingTokens []string) error {
+	s.accrualPendingTokens = accrualPendingTokens
+	return nil
+}
+
+func (s *mockProtocolFeeStore) AddAccrualPendingToken(_ int, rlm realm, tokenPath string) error {
+	for _, accrualPendingToken := range s.accrualPendingTokens {
+		if accrualPendingToken == tokenPath {
+			return nil
+		}
+	}
+	s.accrualPendingTokens = append(s.accrualPendingTokens, tokenPath)
+	return nil
+}
+
+func (s *mockProtocolFeeStore) ClearAccrualPendingTokens(_ int, rlm realm) error {
+	return s.SetAccrualPendingTokens(0, rlm, []string{})
+}
+
 func newMockProtocolFeeStore() protocol_fee.IProtocolFeeStore {
 	return &mockProtocolFeeStore{
 		devOpsPct:                     0,
@@ -214,5 +248,6 @@ func newMockProtocolFeeStore() protocol_fee.IProtocolFeeStore {
 		distributedToGovStakerHistory: protocol_fee.NewBPTreeN(16),
 		distributedToDevOpsHistory:    protocol_fee.NewBPTreeN(16),
 		reservedTokens:                []string{},
+		accrualPendingTokens:          []string{},
 	}
 }

--- a/contract/r/gnoswap/protocol_fee/v1/getter.gno
+++ b/contract/r/gnoswap/protocol_fee/v1/getter.gno
@@ -15,6 +15,12 @@ func (pf *protocolFeeV1) GetReservedTokens() []string {
 	return pf.getProtocolFeeState().ReservedTokens()
 }
 
+// GetAccrualPendingProtocolFees returns the same amounts as
+// ConsumeAccrualPendingProtocolFees without clearing the pending list.
+func (pf *protocolFeeV1) GetAccrualPendingProtocolFees() map[string]int64 {
+	return pf.accrualPendingProtocolFees(pf.getProtocolFeeState())
+}
+
 // GetAccuTransfersToGovStaker returns all accumulated transfers to gov/staker.
 func (pf *protocolFeeV1) GetAccuTransfersToGovStaker() map[string]int64 {
 	accuTransfers := make(map[string]int64)

--- a/contract/r/gnoswap/protocol_fee/v1/init.gno
+++ b/contract/r/gnoswap/protocol_fee/v1/init.gno
@@ -65,5 +65,12 @@ func initStoreData(_ int, rlm realm, protocolFeeStore protocol_fee.IProtocolFeeS
 		}
 	}
 
+	if !protocolFeeStore.HasAccrualPendingTokensStoreKey() {
+		err := protocolFeeStore.InitializeAccrualPendingTokens(0, rlm)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/contract/r/gnoswap/protocol_fee/v1/protocol_fee.gno
+++ b/contract/r/gnoswap/protocol_fee/v1/protocol_fee.gno
@@ -280,4 +280,47 @@ func (pf *protocolFeeV1) reserveCollectedProtocolFee(_ int, rlm realm, tokenPath
 	if err := pfs.store.AddReservedToken(0, rlm, tokenPath); err != nil {
 		panic(err)
 	}
+
+	// Mark the token so gov/staker only walks what actually collected a fee.
+	if err := pfs.store.AddAccrualPendingToken(0, rlm, tokenPath); err != nil {
+		panic(err)
+	}
+}
+
+// ConsumeAccrualPendingProtocolFees returns the gov/staker share of every token that
+// collected a fee since the last call, and clears the pending list. gov/staker folds
+// these into its accumulator on every stake change, so handing back only the tokens
+// that moved keeps that cost tied to the fees that arrived.
+//
+// Amounts are cumulative totals, matching GetAccuTransfersToGovStaker. Restricted to
+// gov/staker rather than admin as well: clearing the list without folding the fees into
+// an accumulator strands them until that token collects another fee.
+func (pf *protocolFeeV1) ConsumeAccrualPendingProtocolFees(_ int, rlm realm) map[string]int64 {
+	if !rlm.IsCurrent() {
+		panic(errors.New(errSpoofedRealm))
+	}
+
+	prev := rlm.Previous()
+	access.AssertIsGovStaker(prev.Address())
+
+	pfs := pf.getProtocolFeeState()
+	accrualPendingFees := pf.accrualPendingProtocolFees(pfs)
+
+	if len(accrualPendingFees) > 0 {
+		if err := pfs.store.ClearAccrualPendingTokens(0, rlm); err != nil {
+			panic(err)
+		}
+	}
+
+	return accrualPendingFees
+}
+
+// accrualPendingProtocolFees reads the gov/staker share of every pending token.
+func (pf *protocolFeeV1) accrualPendingProtocolFees(pfs *protocolFeeState) map[string]int64 {
+	accrualPendingFees := make(map[string]int64)
+	for _, tokenPath := range pfs.store.GetAccrualPendingTokens() {
+		accrualPendingFees[tokenPath] = pfs.GetAccuTransferToGovStakerByTokenPath(tokenPath)
+	}
+
+	return accrualPendingFees
 }

--- a/contract/r/gnoswap/protocol_fee/v1/protocol_fee_test.gno
+++ b/contract/r/gnoswap/protocol_fee/v1/protocol_fee_test.gno
@@ -505,6 +505,63 @@ func TestAddToProtocolFee(cur realm, t *testing.T) {
 	}
 }
 
+func TestConsumeAccrualPendingProtocolFees(cur realm, t *testing.T) {
+	pf := createTestProtocolFee(t)
+	poolRealm := testing.NewCodeRealm(poolPath)
+	barPath := "gno.land/r/onbloc/bar.BAR"
+	quxPath := "gno.land/r/onbloc/qux.QUX"
+
+	fundRealmAndApproveProtocolFee(cross(cur), t, poolRealm, barPath, 100)
+	testing.SetRealm(poolRealm)
+	func(cur realm) {
+		pf.AddToProtocolFee(0, cur, barPath, 100)
+	}(cross(cur))
+
+	fundRealmAndApproveProtocolFee(cross(cur), t, poolRealm, quxPath, 50)
+	testing.SetRealm(poolRealm)
+	func(cur realm) {
+		pf.AddToProtocolFee(0, cur, quxPath, 50)
+	}(cross(cur))
+
+	// A query reports the pending fees without advancing accrual state.
+	pending := pf.GetAccrualPendingProtocolFees()
+	uassert.Equal(t, len(pending), 2)
+	uassert.Equal(t, pending[barPath], int64(100))
+	uassert.Equal(t, pending[quxPath], int64(50))
+	uassert.Equal(t, len(pf.store.GetAccrualPendingTokens()), 2)
+
+	testing.SetRealm(govStakerRealm)
+	consumed := func(cur realm) map[string]int64 {
+		return pf.ConsumeAccrualPendingProtocolFees(0, cur)
+	}(cross(cur))
+
+	uassert.Equal(t, len(consumed), 2)
+	uassert.Equal(t, consumed[barPath], int64(100))
+	uassert.Equal(t, consumed[quxPath], int64(50))
+	uassert.Equal(t, len(pf.store.GetAccrualPendingTokens()), 0)
+
+	// Consuming again yields nothing until another fee arrives.
+	testing.SetRealm(govStakerRealm)
+	reconsumed := func(cur realm) map[string]int64 {
+		return pf.ConsumeAccrualPendingProtocolFees(0, cur)
+	}(cross(cur))
+	uassert.Equal(t, len(reconsumed), 0)
+
+	// A later fee re-lists only its own token, and reports the cumulative total.
+	fundRealmAndApproveProtocolFee(cross(cur), t, poolRealm, barPath, 25)
+	testing.SetRealm(poolRealm)
+	func(cur realm) {
+		pf.AddToProtocolFee(0, cur, barPath, 25)
+	}(cross(cur))
+
+	testing.SetRealm(govStakerRealm)
+	afterMoreFees := func(cur realm) map[string]int64 {
+		return pf.ConsumeAccrualPendingProtocolFees(0, cur)
+	}(cross(cur))
+	uassert.Equal(t, len(afterMoreFees), 1)
+	uassert.Equal(t, afterMoreFees[barPath], int64(125))
+}
+
 func TestProtocolFee_AddToProtocolFee_EdgeCases(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string

--- a/contract/r/gnoswap/router/_mock_test.gno
+++ b/contract/r/gnoswap/router/_mock_test.gno
@@ -160,6 +160,15 @@ func (m *MockRouter) SetSwapFee(_ int, rlm realm, fee uint64) {
 	m.Response.Get("SetSwapFee")
 }
 
+func (m *MockRouter) GetPendingProtocolFees() map[string]int64 {
+	res, ok := m.Response.Get("GetPendingProtocolFees")
+	if !ok {
+		return map[string]int64{}
+	}
+
+	return res[0].(map[string]int64)
+}
+
 func newMockRouter(version string) *MockRouter {
 	return &MockRouter{
 		Version:  version,

--- a/contract/r/gnoswap/router/proxy.gno
+++ b/contract/r/gnoswap/router/proxy.gno
@@ -118,3 +118,13 @@ func GetSwapFee() uint64 {
 func SetSwapFee(cur realm, fee uint64) {
 	getImplementation().SetSwapFee(0, cur, fee)
 }
+
+// GetPendingProtocolFees returns the pending protocol fee amount per token path.
+func GetPendingProtocolFees() map[string]int64 {
+	pendingProtocolFees := make(map[string]int64)
+	for tokenPath, amount := range getImplementation().GetPendingProtocolFees() {
+		pendingProtocolFees[tokenPath] = amount
+	}
+
+	return pendingProtocolFees
+}

--- a/contract/r/gnoswap/router/types.gno
+++ b/contract/r/gnoswap/router/types.gno
@@ -12,6 +12,8 @@ type IRouter interface {
 
 	GetSwapFee() uint64
 	SetSwapFee(_ int, rlm realm, fee uint64)
+
+	GetPendingProtocolFees() map[string]int64
 }
 
 type IRouterStore interface {

--- a/contract/r/gnoswap/router/v1/protocol_fee_swap.gno
+++ b/contract/r/gnoswap/router/v1/protocol_fee_swap.gno
@@ -84,17 +84,17 @@ func (r *routerV1) handleSwapFee(
 	outputToken string,
 	amount int64,
 ) int64 {
+	currentTokenPath := outputToken
+
 	swapFee := r.store.GetSwapFee()
 	if swapFee <= 0 {
-		r.addToProtocolFee(0, rlm)
+		r.addToProtocolFee(0, rlm, currentTokenPath)
 		return amount
 	}
 
-	currentTokenPath := outputToken
-
 	feeAmountInt64 := calculateRouterFee(amount, swapFee)
 	r.addPendingProtocolFee(0, rlm, currentTokenPath, feeAmountInt64)
-	r.addToProtocolFee(0, rlm)
+	r.addToProtocolFee(0, rlm, currentTokenPath)
 
 	previousRealm := rlm.Previous()
 	chain.Emit(
@@ -108,11 +108,17 @@ func (r *routerV1) handleSwapFee(
 	return gnsmath.SafeSubInt64(amount, feeAmountInt64)
 }
 
+// GetPendingProtocolFees returns the pending protocol fee amount per token path.
+func (r *routerV1) GetPendingProtocolFees() map[string]int64 {
+	return r.store.GetPendingProtocolFees()
+}
+
 func (r *routerV1) addPendingProtocolFee(_ int, rlm realm, tokenPath string, amount int64) {
 	if amount <= 0 {
 		return
 	}
 
+	// The stored map is readonly tainted here, so it is copied before being updated.
 	existingProtocolFees := r.store.GetPendingProtocolFees()
 	pendingProtocolFees := make(map[string]int64)
 	for pendingTokenPath, pendingAmount := range existingProtocolFees {
@@ -124,28 +130,35 @@ func (r *routerV1) addPendingProtocolFee(_ int, rlm realm, tokenPath string, amo
 	}
 }
 
-// addToProtocolFee sends pending router protocol fees to the protocol fee realm.
-// It is best-effort: when protocol fee collection is halted, it keeps pending
-// storage unchanged; otherwise it rebuilds pending storage with only entries
-// that could not be added, removing successful and non-positive entries.
-func (r *routerV1) addToProtocolFee(_ int, rlm realm) {
+// addToProtocolFee sends the pending router protocol fee of tokenPath to the
+// protocol fee realm. It is best-effort: an entry only survives while protocol fee
+// collection is halted, and is settled by the next call for the same token, which
+// every fee path makes even when the fee is zero.
+//
+// Only the entry of tokenPath is touched, so an unrelated token can never block
+// settlement and the cost does not scale with the number of pending entries.
+func (r *routerV1) addToProtocolFee(_ int, rlm realm, tokenPath string) {
 	pendingProtocolFees := r.store.GetPendingProtocolFees()
-	if len(pendingProtocolFees) == 0 || halt.IsHaltedProtocolFee() {
+	amount, exists := pendingProtocolFees[tokenPath]
+	if !exists || halt.IsHaltedProtocolFee() {
 		return
 	}
 
-	protocolFeeAddr := access.MustGetAddress(prbac.ROLE_PROTOCOL_FEE.String())
+	if amount > 0 {
+		protocolFeeAddr := access.MustGetAddress(prbac.ROLE_PROTOCOL_FEE.String())
+		common.SafeGRC20Approve(cross(rlm), tokenPath, protocolFeeAddr, amount)
+		if err := pf.AddToProtocolFee(cross(rlm), tokenPath, amount); err != nil {
+			return
+		}
+	}
+
 	remainingProtocolFees := make(map[string]int64)
-	for tokenPath, amount := range pendingProtocolFees {
-		if amount <= 0 {
+	for pendingTokenPath, pendingAmount := range pendingProtocolFees {
+		if pendingTokenPath == tokenPath {
 			continue
 		}
 
-		common.SafeGRC20Approve(cross(rlm), tokenPath, protocolFeeAddr, amount)
-		if err := pf.AddToProtocolFee(cross(rlm), tokenPath, amount); err != nil {
-			remainingProtocolFees[tokenPath] = amount
-			continue
-		}
+		remainingProtocolFees[pendingTokenPath] = pendingAmount
 	}
 
 	if err := r.store.SetPendingProtocolFees(0, rlm, remainingProtocolFees); err != nil {

--- a/contract/r/gnoswap/router/v1/protocol_fee_swap_test.gno
+++ b/contract/r/gnoswap/router/v1/protocol_fee_swap_test.gno
@@ -145,7 +145,8 @@ func TestAddToProtocolFeeClearsNonPositiveAmounts(cur realm, t *testing.T) {
 	}
 	router.store.SetPendingProtocolFees(0, cur, originalPendingProtocolFees)
 
-	router.addToProtocolFee(0, cur)
+	router.addToProtocolFee(0, cur, barPath)
+	router.addToProtocolFee(0, cur, gnsPath)
 
 	pendingProtocolFees := router.store.GetPendingProtocolFees()
 	uassert.Equal(t, len(pendingProtocolFees), 0)

--- a/contract/r/gnoswap/staker/_mock_test.gno
+++ b/contract/r/gnoswap/staker/_mock_test.gno
@@ -125,6 +125,15 @@ func (m *MockStaker) SetUnStakingFee(_ int, rlm realm, fee uint64) {
 	m.Response.Get("SetUnStakingFee")
 }
 
+func (m *MockStaker) GetPendingProtocolFees() map[string]int64 {
+	res, ok := m.Response.Get("GetPendingProtocolFees")
+	if !ok {
+		return map[string]int64{}
+	}
+
+	return res[0].(map[string]int64)
+}
+
 // Getter methods
 func (m *MockStaker) GetPool(poolPath string) *Pool {
 	res, ok := m.Response.Get("GetPool")

--- a/contract/r/gnoswap/staker/getter.gno
+++ b/contract/r/gnoswap/staker/getter.gno
@@ -333,3 +333,8 @@ func GetPoolHistoricalTickIDs(poolPath string, offset, count int) []int32 {
 func GetPoolHistoricalTick(poolPath string, tick uint64) int32 {
 	return getImplementation().GetPoolHistoricalTick(poolPath, tick)
 }
+
+// GetPendingProtocolFees returns the pending protocol fee amount per token path.
+func GetPendingProtocolFees() map[string]int64 {
+	return cloneStringInt64Map(getImplementation().GetPendingProtocolFees())
+}

--- a/contract/r/gnoswap/staker/types.gno
+++ b/contract/r/gnoswap/staker/types.gno
@@ -100,6 +100,7 @@ type IStakerGetter interface {
 	GetSpecificTokenMinimumRewardAmount(tokenPath string) (int64, bool)
 	GetTargetPoolPathByIncentiveId(poolPath string, incentiveId string) string
 	GetUnstakingFee() uint64
+	GetPendingProtocolFees() map[string]int64
 	IsStaked(positionId uint64) bool
 	GetTotalEmissionSent() int64
 	GetAllowedTokens() []string

--- a/contract/r/gnoswap/staker/v1/protocol_fee_unstaking.gno
+++ b/contract/r/gnoswap/staker/v1/protocol_fee_unstaking.gno
@@ -25,9 +25,13 @@ func (s *stakerV1) handleStakingRewardFee(
 	amount int64,
 	internal bool,
 ) (int64, int64, error) {
+	if internal {
+		tokenPath = GNS_TOKEN_KEY
+	}
+
 	unstakingFee := s.GetUnstakingFee()
 	if unstakingFee == 0 {
-		s.addToProtocolFee(0, rlm)
+		s.addToProtocolFee(0, rlm, tokenPath)
 		return amount, 0, nil
 	}
 
@@ -38,18 +42,19 @@ func (s *stakerV1) handleStakingRewardFee(
 	}
 
 	if feeAmount == 0 {
-		s.addToProtocolFee(0, rlm)
+		s.addToProtocolFee(0, rlm, tokenPath)
 		return amount, 0, nil
 	}
 
-	if internal {
-		tokenPath = GNS_TOKEN_KEY
-	}
-
 	s.addPendingProtocolFee(0, rlm, tokenPath, feeAmount)
-	s.addToProtocolFee(0, rlm)
+	s.addToProtocolFee(0, rlm, tokenPath)
 
 	return gnsmath.SafeSubInt64(amount, feeAmount), feeAmount, nil
+}
+
+// GetPendingProtocolFees returns the pending protocol fee amount per token path.
+func (s *stakerV1) GetPendingProtocolFees() map[string]int64 {
+	return s.store.GetPendingProtocolFees()
 }
 
 func (s *stakerV1) addPendingProtocolFee(_ int, rlm realm, tokenPath string, amount int64) {
@@ -57,6 +62,7 @@ func (s *stakerV1) addPendingProtocolFee(_ int, rlm realm, tokenPath string, amo
 		return
 	}
 
+	// The stored map is readonly tainted here, so it is copied before being updated.
 	existingProtocolFees := s.store.GetPendingProtocolFees()
 	pendingProtocolFees := make(map[string]int64)
 	for pendingTokenPath, pendingAmount := range existingProtocolFees {
@@ -68,28 +74,35 @@ func (s *stakerV1) addPendingProtocolFee(_ int, rlm realm, tokenPath string, amo
 	}
 }
 
-// addToProtocolFee sends pending staker protocol fees to the protocol fee realm.
-// It is best-effort: when protocol fee collection is halted, it keeps pending
-// storage unchanged; otherwise it rebuilds pending storage with only entries
-// that could not be added, removing successful and non-positive entries.
-func (s *stakerV1) addToProtocolFee(_ int, rlm realm) {
+// addToProtocolFee sends the pending staker protocol fee of tokenPath to the
+// protocol fee realm. It is best-effort: an entry only survives while protocol fee
+// collection is halted, and is settled by the next call for the same token, which
+// every fee path makes even when the fee is zero.
+//
+// Only the entry of tokenPath is touched, so an unrelated token can never block
+// settlement and the cost does not scale with the number of pending entries.
+func (s *stakerV1) addToProtocolFee(_ int, rlm realm, tokenPath string) {
 	pendingProtocolFees := s.store.GetPendingProtocolFees()
-	if len(pendingProtocolFees) == 0 || halt.IsHaltedProtocolFee() {
+	amount, exists := pendingProtocolFees[tokenPath]
+	if !exists || halt.IsHaltedProtocolFee() {
 		return
 	}
 
-	protocolFeeAddr := access.MustGetAddress(prbac.ROLE_PROTOCOL_FEE.String())
+	if amount > 0 {
+		protocolFeeAddr := access.MustGetAddress(prbac.ROLE_PROTOCOL_FEE.String())
+		common.SafeGRC20Approve(cross(rlm), tokenPath, protocolFeeAddr, amount)
+		if err := pf.AddToProtocolFee(cross(rlm), tokenPath, amount); err != nil {
+			return
+		}
+	}
+
 	remainingProtocolFees := make(map[string]int64)
-	for tokenPath, amount := range pendingProtocolFees {
-		if amount <= 0 {
+	for pendingTokenPath, pendingAmount := range pendingProtocolFees {
+		if pendingTokenPath == tokenPath {
 			continue
 		}
 
-		common.SafeGRC20Approve(cross(rlm), tokenPath, protocolFeeAddr, amount)
-		if err := pf.AddToProtocolFee(cross(rlm), tokenPath, amount); err != nil {
-			remainingProtocolFees[tokenPath] = amount
-			continue
-		}
+		remainingProtocolFees[pendingTokenPath] = pendingAmount
 	}
 
 	if err := s.store.SetPendingProtocolFees(0, rlm, remainingProtocolFees); err != nil {

--- a/contract/r/gnoswap/staker/v1/protocol_fee_unstaking_test.gno
+++ b/contract/r/gnoswap/staker/v1/protocol_fee_unstaking_test.gno
@@ -125,7 +125,8 @@ func TestAddToProtocolFeeClearsNonPositiveAmounts(cur realm, t *testing.T) {
 	}
 	instance.store.SetPendingProtocolFees(0, cur, originalPendingProtocolFees)
 
-	instance.addToProtocolFee(0, cur)
+	instance.addToProtocolFee(0, cur, barPath)
+	instance.addToProtocolFee(0, cur, gnsPath)
 
 	pendingProtocolFees := instance.store.GetPendingProtocolFees()
 	uassert.Equal(t, len(pendingProtocolFees), 0)

--- a/contract/r/scenario/halt/safe_mode_collect_paths_toggle_filetest.gno
+++ b/contract/r/scenario/halt/safe_mode_collect_paths_toggle_filetest.gno
@@ -150,16 +150,16 @@ func setupSafeScenario(cur realm) {
 	testing.SetRealm(govStakerRealm3)
 	emission.MintAndDistributeGns(cross(cur))
 	pf.DistributeProtocolFee(cross(cur))
-	_, claimableLaunchpadProtocolFees, claimableLaunchpadErr := govstaker.GetClaimableRewardByLaunchpad(projectAddr3)
-	if claimableLaunchpadErr != nil {
-		panic(claimableLaunchpadErr)
-	}
-	launchpadClaimableBarBeforeSafe = claimableLaunchpadProtocolFees[barPath3]
 	testing.SetRealm(adminRealm3)
 	bar.Transfer(cross(cur), stakerAddr3, pendingProtocolFeeAmount)
 	testing.SetRealm(stakerRealm3)
 	bar.Approve(cross(cur), protocolFeeAddr3, pendingProtocolFeeAmount)
 	pf.AddToProtocolFee(cross(cur), barPath3, pendingProtocolFeeAmount)
+	_, claimableLaunchpadProtocolFees, claimableLaunchpadErr := govstaker.GetClaimableRewardByLaunchpad(projectAddr3)
+	if claimableLaunchpadErr != nil {
+		panic(claimableLaunchpadErr)
+	}
+	launchpadClaimableBarBeforeSafe = claimableLaunchpadProtocolFees[barPath3]
 	protocolFeeBarBeforeSafe = bar.BalanceOf(protocolFeeAddr3)
 	govStakerBarBeforeSafe = bar.BalanceOf(govStakerAddr3)
 	bobBarBeforeSafe = bar.BalanceOf(bobAddr3)
@@ -359,7 +359,7 @@ func positionIdFromSafe(cur realm, positionId any) grc721.TokenID {
 // [INFO] staker collect position id: 2
 // [INFO] pending protocol fee before safe mode: 1000 BAR
 // [INFO] delegated protocol fee stakers: bob=5000000 xGNS, carol=15000000 xGNS
-// [INFO] launchpad claimable BAR before safe mode: 980
+// [INFO] launchpad claimable BAR before safe mode: 1960
 // [INFO] safe mode collect paths prepared
 //
 // [SCENARIO] 2. Enable safe mode

--- a/contract/r/scenario/launchpad/launchpad_deposit_project_multi_recipient_filetest.gno
+++ b/contract/r/scenario/launchpad/launchpad_deposit_project_multi_recipient_filetest.gno
@@ -318,13 +318,13 @@ func collectProtocolFeeForOBLProjectRecipient2(cur realm) {
 // [INFO] Admin transferring tokens to staker caller
 // [INFO] Adding tokens to protocol fee
 // [INFO] Validating protocol fee balances
-// [EXPECTED] Bar balance: 1000
-// [EXPECTED] Qux balance: 2500
+// [EXPECTED] Bar balance: 2000
+// [EXPECTED] Qux balance: 5000
 // [EXPECTED] Reserved protocol fee token count: 2
 //
 // [SCENARIO] 6. Collect protocol fee for OBL project recipient
-// [INFO] Bar balance in protocol fee: 1000
-// [INFO] Qux balance in protocol fee: 2500
+// [INFO] Bar balance in protocol fee: 2000
+// [INFO] Qux balance in protocol fee: 5000
 // [EXPECTED] Gov staker bar balance after collection: 1501
 // [EXPECTED] Gov staker qux balance after collection: 3751
 // [EXPECTED] Project bar balance after collection: 499

--- a/contract/r/scenario/upgrade/implements/mock/pool/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/mock/pool/test_impl.gno
@@ -646,3 +646,10 @@ func (t *TestPool) GetObservationState(poolPath string) (*pool.ObservationState,
 	).([]any)
 	return result[0].(*pool.ObservationState), result[1].(error)
 }
+
+func (t *TestPool) GetPendingProtocolFees() map[string]int64 {
+	return t.ExecuteFn(
+		"GetPendingProtocolFees",
+		func(args ...any) any { return t.instance.GetPendingProtocolFees() },
+	).(map[string]int64)
+}

--- a/contract/r/scenario/upgrade/implements/mock/protocol_fee/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/mock/protocol_fee/test_impl.gno
@@ -164,3 +164,17 @@ func (t *TestProtocolFee) GetActualDistributedToDevOpsByTokenPath(path string) i
 		path,
 	).(int64)
 }
+
+func (t *TestProtocolFee) ConsumeAccrualPendingProtocolFees(_ int, rlm realm) map[string]int64 {
+	return t.ExecuteFn(
+		"ConsumeAccrualPendingProtocolFees",
+		func(args ...any) any { return t.instance.ConsumeAccrualPendingProtocolFees(0, rlm) },
+	).(map[string]int64)
+}
+
+func (t *TestProtocolFee) GetAccrualPendingProtocolFees() map[string]int64 {
+	return t.ExecuteFn(
+		"GetAccrualPendingProtocolFees",
+		func(args ...any) any { return t.instance.GetAccrualPendingProtocolFees() },
+	).(map[string]int64)
+}

--- a/contract/r/scenario/upgrade/implements/mock/router/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/mock/router/test_impl.gno
@@ -132,3 +132,10 @@ func (t *TestRouter) SetSwapFee(_ int, rlm realm, fee uint64) {
 		fee,
 	)
 }
+
+func (t *TestRouter) GetPendingProtocolFees() map[string]int64 {
+	return t.ExecuteFn(
+		"GetPendingProtocolFees",
+		func(args ...any) any { return t.instance.GetPendingProtocolFees() },
+	).(map[string]int64)
+}

--- a/contract/r/scenario/upgrade/implements/mock/staker/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/mock/staker/test_impl.gno
@@ -722,3 +722,10 @@ func (t *TestStaker) GetPoolHistoricalTick(poolPath string, tick uint64) int32 {
 		poolPath, tick,
 	).(int32)
 }
+
+func (t *TestStaker) GetPendingProtocolFees() map[string]int64 {
+	return t.ExecuteFn(
+		"GetPendingProtocolFees",
+		func(args ...any) any { return t.instance.GetPendingProtocolFees() },
+	).(map[string]int64)
+}

--- a/contract/r/scenario/upgrade/implements/security/insecure_staker_callback/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/security/insecure_staker_callback/test_impl.gno
@@ -596,3 +596,10 @@ func (t *TestStaker) GetPoolHistoricalTick(poolPath string, tick uint64) int32 {
 	}
 	return t.instance.GetPoolHistoricalTick(poolPath, tick)
 }
+
+func (t *TestStaker) GetPendingProtocolFees() map[string]int64 {
+	if !t.isActive("GetPendingProtocolFees") {
+		panic("test implementation: GetPendingProtocolFees not supported")
+	}
+	return t.instance.GetPendingProtocolFees()
+}

--- a/contract/r/scenario/upgrade/implements/v2_invalid/pool/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v2_invalid/pool/test_impl.gno
@@ -486,3 +486,10 @@ func (t *TestPool) GetObservationState(poolPath string) (*pool.ObservationState,
 	}
 	return t.instance.GetObservationState(poolPath)
 }
+
+func (t *TestPool) GetPendingProtocolFees() map[string]int64 {
+	if !t.isActive("GetPendingProtocolFees") {
+		panic("test implementation: GetPendingProtocolFees not supported")
+	}
+	return t.instance.GetPendingProtocolFees()
+}

--- a/contract/r/scenario/upgrade/implements/v2_invalid/protocol_fee/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v2_invalid/protocol_fee/test_impl.gno
@@ -149,3 +149,17 @@ func (t *TestProtocolFee) GetActualDistributedToDevOpsByTokenPath(path string) i
 	}
 	return t.instance.GetActualDistributedToDevOpsByTokenPath(path)
 }
+
+func (t *TestProtocolFee) ConsumeAccrualPendingProtocolFees(_ int, rlm realm) map[string]int64 {
+	if !t.isActive("ConsumeAccrualPendingProtocolFees") {
+		panic("test implementation: ConsumeAccrualPendingProtocolFees not supported")
+	}
+	return t.instance.ConsumeAccrualPendingProtocolFees(0, rlm)
+}
+
+func (t *TestProtocolFee) GetAccrualPendingProtocolFees() map[string]int64 {
+	if !t.isActive("GetAccrualPendingProtocolFees") {
+		panic("test implementation: GetAccrualPendingProtocolFees not supported")
+	}
+	return t.instance.GetAccrualPendingProtocolFees()
+}

--- a/contract/r/scenario/upgrade/implements/v2_invalid/router/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v2_invalid/router/test_impl.gno
@@ -91,3 +91,10 @@ func (t *TestRouter) SetSwapFee(_ int, rlm realm, fee uint64) {
 	}
 	t.instance.SetSwapFee(0, rlm, fee)
 }
+
+func (t *TestRouter) GetPendingProtocolFees() map[string]int64 {
+	if !t.isActive("GetPendingProtocolFees") {
+		panic("test implementation: GetPendingProtocolFees not supported")
+	}
+	return t.instance.GetPendingProtocolFees()
+}

--- a/contract/r/scenario/upgrade/implements/v2_invalid/staker/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v2_invalid/staker/test_impl.gno
@@ -591,3 +591,10 @@ func (t *TestStaker) GetPoolHistoricalTick(poolPath string, tick uint64) int32 {
 	}
 	return t.instance.GetPoolHistoricalTick(poolPath, tick)
 }
+
+func (t *TestStaker) GetPendingProtocolFees() map[string]int64 {
+	if !t.isActive("GetPendingProtocolFees") {
+		panic("test implementation: GetPendingProtocolFees not supported")
+	}
+	return t.instance.GetPendingProtocolFees()
+}

--- a/contract/r/scenario/upgrade/implements/v3_valid/pool/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/pool/test_impl.gno
@@ -284,3 +284,7 @@ func (t *TestPool) GetPosition(poolPath, key string) (pool.PositionInfo, error) 
 func (t *TestPool) GetObservationState(poolPath string) (*pool.ObservationState, error) {
 	return t.instance.GetObservationState(poolPath)
 }
+
+func (t *TestPool) GetPendingProtocolFees() map[string]int64 {
+	return t.instance.GetPendingProtocolFees()
+}

--- a/contract/r/scenario/upgrade/implements/v3_valid/protocol_fee/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/protocol_fee/test_impl.gno
@@ -88,3 +88,11 @@ func (t *TestProtocolFee) GetActualDistributedToGovStakerByTokenPath(path string
 func (t *TestProtocolFee) GetActualDistributedToDevOpsByTokenPath(path string) int64 {
 	return t.instance.GetActualDistributedToDevOpsByTokenPath(path)
 }
+
+func (t *TestProtocolFee) ConsumeAccrualPendingProtocolFees(_ int, rlm realm) map[string]int64 {
+	return t.instance.ConsumeAccrualPendingProtocolFees(0, rlm)
+}
+
+func (t *TestProtocolFee) GetAccrualPendingProtocolFees() map[string]int64 {
+	return t.instance.GetAccrualPendingProtocolFees()
+}

--- a/contract/r/scenario/upgrade/implements/v3_valid/router/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/router/test_impl.gno
@@ -54,3 +54,7 @@ func (t *TestRouter) GetSwapFee() uint64 {
 func (t *TestRouter) SetSwapFee(_ int, rlm realm, fee uint64) {
 	t.instance.SetSwapFee(0, rlm, fee)
 }
+
+func (t *TestRouter) GetPendingProtocolFees() map[string]int64 {
+	return t.instance.GetPendingProtocolFees()
+}

--- a/contract/r/scenario/upgrade/implements/v3_valid/staker/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/staker/test_impl.gno
@@ -341,3 +341,7 @@ func (t *TestStaker) GetPoolHistoricalTickIDs(poolPath string, offset, count int
 func (t *TestStaker) GetPoolHistoricalTick(poolPath string, tick uint64) int32 {
 	return t.instance.GetPoolHistoricalTick(poolPath, tick)
 }
+
+func (t *TestStaker) GetPendingProtocolFees() map[string]int64 {
+	return t.instance.GetPendingProtocolFees()
+}


### PR DESCRIPTION
## Summary
- Settle the pending protocol fee of only the token being handled, instead of forwarding the whole pending map in one transaction.
- Base gov/staker reward accrual on the amount reserved when a fee reaches the protocol fee realm, so a stake change performs no cross-realm call at all.
- Walk only the tokens that collected a fee since the last accrual, instead of every token that has ever collected one.
- Persist only changed reward-debt entries per staker, instead of replacing the whole map on every stake change and claim.

The set of tokens that have ever collected a protocol fee never shrinks, while the set that collected one since the last accrual is normally one to three tokens. Most of the saving below comes from replacing the former with the latter.

## Flow comparison

### Fee collection — `HandleWithdrawalFee`, `CreatePool`, `handleSwapFee`, `handleStakingRewardFee`

Before:
1. `addPendingProtocolFee(token, amount)` copies the pending map, updates one key, stores it.
2. `addToProtocolFee()` iterates every pending entry.
3. Each entry costs a `SafeGRC20Approve` and a `pf.AddToProtocolFee`, so every pending token adds two cross-realm calls.
4. It rebuilds the map from the entries that could not be settled and stores it.

Note that steps 1 and 4 cancel out for a fee that is forwarded successfully: the entry is written and then deleted in the same call, at the cost of two store writes and two freshly allocated maps. `HandleWithdrawalFee` paid that four times over for its two tokens.

After:
1. `settleProtocolFee(token, amount)` forwards the amount plus anything already pending, in one `SafeGRC20Approve` and one `pf.AddToProtocolFee`.
2. A pending entry is written only when the fee cannot be forwarded, so the common path performs no store write at all.
3. A token that does carry a backlog settles it together with the new fee, in a single cross-realm call rather than two.

**Optimized:** a fee-bearing call makes two cross-realm calls in total, rather than two for every pending token, and no longer stages the fee in storage on the way. This is also the correctness fix — a panic crossing a realm boundary cannot be contained, so previously one bad token aborted the transaction of every other token.

### `Delegate` / `Undelegate`

Before:
1. `pf.DistributeProtocolFee()` iterates every reserved token awaiting distribution; for each one it computes the split, calls `removeReservedToken` (a linear scan plus a slice rewrite), and performs up to two `SafeGRC20Transfer`.
2. `pf.GetActualDistributedToGovStaker()` walks the full bptree into a map holding one entry per token ever seen, which the proxy then clones again.
3. `updateAccumulatedProtocolFeeX128PerStake` iterates that whole map and builds two more maps of the same size.
4. `addStake` calls `updateRewardDebtX128`, which **replaces the staker's whole reward-debt map**, allocating a fresh map plus one `u256` per token, and writes an accumulated-reward entry for every token even when the reward is zero.
5. Stores the manager.

After:
1. `pf.ConsumeAccrualPendingProtocolFees()` reads the reserved share of the tokens that collected a fee since the last accrual, and clears that list. **No transfers.**
2. `updateAccumulatedProtocolFeeX128PerStake` iterates only those tokens.
3. `addStake` still reads every accumulator entry, but **writes only the ones whose value changed**.
4. Stores the manager.

**Optimized:** token transfers drop to zero; the accrual loop covers only the tokens that just collected a fee instead of every token ever seen; and the per-staker reward debt is written entry by entry instead of having its whole map replaced. What remains proportional to the total token count is a read loop that performs no storage writes.

### `CollectReward`

Step 1 is unchanged: the payout leaves gov/staker's own balance, so `pf.DistributeProtocolFee()` still pulls the reserved fees in first. The remaining steps get the same reductions as `Delegate` — the accrual loop shrinks to the tokens that just collected a fee, and the reward-debt map is no longer replaced.

### `CollectProtocolFeeReward(tokenPath)`

Before and after are the same shape — `DistributeProtocolFeeByTokenPath` for one token, a single-token accumulator update, a single-token claim, one transfer. Only the basis changed, from `GetActualDistributedToGovStakerByTokenPath` to `GetAccuTransferToGovStakerByTokenPath`. This path already handled one token at a time and was already isolated from the others.

### Summary of per-transaction cost

| Path | Before | After |
| --- | --- | --- |
| Fee collection | two cross-realm calls per pending token; two store writes per fee | two cross-realm calls in total; no store write unless the fee cannot be forwarded |
| `Delegate` / `Undelegate` | up to two transfers per reserved token; one pass over every token ever seen; the staker's whole reward-debt map replaced | no transfers; one pass over the tokens that just collected a fee; only changed reward-debt entries written |
| `CollectReward` | the distribution loop, plus the same accrual and reward-debt costs as above | the distribution loop is kept; accrual and reward-debt as above |
| `CollectProtocolFeeReward` | one token | unchanged |

`CollectReward` keeps its distribution loop over every reserved token deliberately: it is the convenience path that pays out all tokens at once, and `CollectProtocolFeeReward` is the isolated per-token alternative.

## Behavior changes
- A fee accrues when it is collected rather than when it is moved, so it stays claimable while withdrawals are halted, even though it still cannot be withdrawn.
- A pending entry now only survives while protocol fee collection is halted. Every fee path calls `addToProtocolFee` even when the fee is zero, so the next swap, withdrawal or reward collection touching that token settles the leftover. `GetPendingProtocolFees` exposes what is still waiting.
- `ConsumeAccrualPendingProtocolFees` is restricted to gov/staker rather than admin as well, since clearing the pending list without folding the fees into an accumulator strands them until that token collects another fee.
- Two filetests are updated for the accrual change. The launchpad golden values move because tokens now sit in the protocol fee realm until a claim, with the settlement amounts unchanged; the safe-mode test captures its baseline after the pending fee is collected, so both readings observe the same state.

## Testing
- `make test PKG=gno.land/r/gnoswap/pool/v1` (and `pool`, `router`, `router/v1`, `staker`, `staker/v1`, `position/v1`, `emission`)
- `make test PKG=gno.land/r/gnoswap/protocol_fee/v1` (and `protocol_fee`)
- `make test PKG=gno.land/r/gnoswap/gov/staker/v1` (and `gov/staker`, `gov/governance/v1`, `launchpad/v1`)
- `make test PKG=gno.land/r/gnoswap/scenario/gov/staker` (and `scenario/{pool,router,staker,position,upgrade,emission,launchpad,halt,protocol_fee,getter,gns,rbac,gov/governance}`)
- Each commit was checked out and tested on its own, so the series is bisectable.
- `gno.land/r/gnoswap/test/fuzz` was not run.

