### PR TITLE
test(scenario): full cross-function upgrade scenario and data-validating upgrade filetests

### DIFF
--- a/contract/r/gnoswap/position/proxy.gno
+++ b/contract/r/gnoswap/position/proxy.gno
@@ -79,11 +79,11 @@ func IncreaseLiquidity(
 // Returns:
 //   - uint64: position ID
 //   - string: removed liquidity amount
-//   - string: amount of token0 removed
-//   - string: amount of token1 removed
+//   - string: collected fee amount of token0 (after the withdrawal fee)
+//   - string: collected fee amount of token1 (after the withdrawal fee)
+//   - string: amount of token0 returned to the caller
+//   - string: amount of token1 returned to the caller
 //   - string: pool path
-//   - string: net amount of token0 after fees
-//   - string: net amount of token1 after fees
 func DecreaseLiquidity(
 	cur realm,
 	positionId uint64,

--- a/contract/r/gnoswap/position/proxy.gno
+++ b/contract/r/gnoswap/position/proxy.gno
@@ -76,13 +76,16 @@ func IncreaseLiquidity(
 //   - amount1MinStr: minimum amount of token1
 //   - deadline: transaction deadline
 //
+// The accrued swap fees are collected first, so the returned fee amounts are
+// net of the withdrawal fee while the returned principal is not subject to it.
+//
 // Returns:
 //   - uint64: position ID
 //   - string: removed liquidity amount
-//   - string: collected fee amount of token0 (after the withdrawal fee)
-//   - string: collected fee amount of token1 (after the withdrawal fee)
-//   - string: amount of token0 returned to the caller
-//   - string: amount of token1 returned to the caller
+//   - string: token0 fees collected, net of the withdrawal fee
+//   - string: token1 fees collected, net of the withdrawal fee
+//   - string: principal amount of token0 returned to the caller
+//   - string: principal amount of token1 returned to the caller
 //   - string: pool path
 func DecreaseLiquidity(
 	cur realm,
@@ -135,11 +138,11 @@ func Reposition(
 //
 // Returns:
 //   - uint64: position ID
-//   - string: amount of token0 collected
-//   - string: amount of token1 collected
+//   - string: token0 fees paid out, net of the withdrawal fee
+//   - string: token1 fees paid out, net of the withdrawal fee
 //   - string: pool path
-//   - string: token0 path
-//   - string: token1 path
+//   - string: token0 fees collected, before the withdrawal fee
+//   - string: token1 fees collected, before the withdrawal fee
 func CollectFee(
 	cur realm,
 	positionId uint64,

--- a/contract/r/scenario/upgrade/full_lifecycle_v2_valid_upgrade_filetest.gno
+++ b/contract/r/scenario/upgrade/full_lifecycle_v2_valid_upgrade_filetest.gno
@@ -211,11 +211,13 @@ type upgradeSnapshot struct {
 	stakerUnstakingFee uint64
 	stakerDepositGns   int64
 	stakerAllowedToken int
+	stakerAllowedList  []string
 	depositLiquidity   string
 	depositStakeTime   int64
 	depositTickLower   int32
 	depositTickUpper   int32
 	depositWarmupCount int
+	depositWarmups     []staker.Warmup
 	depositCollected   int64
 	totalEmissionSent  int64
 	incentiveTotal     int64
@@ -1139,11 +1141,13 @@ func captureSnapshot() upgradeSnapshot {
 		stakerUnstakingFee: staker.GetUnstakingFee(),
 		stakerDepositGns:   staker.GetDepositGnsAmount(),
 		stakerAllowedToken: len(staker.GetAllowedTokens()),
+		stakerAllowedList:  staker.GetAllowedTokens(),
 		depositLiquidity:   staker.GetDepositLiquidityAsString(1),
 		depositStakeTime:   staker.GetDepositStakeTime(1),
 		depositTickLower:   staker.GetDepositTickLower(1),
 		depositTickUpper:   staker.GetDepositTickUpper(1),
 		depositWarmupCount: len(staker.GetDepositWarmUp(1)),
+		depositWarmups:     staker.GetDepositWarmUp(1),
 		depositCollected:   staker.GetDepositCollectedInternalReward(1),
 		totalEmissionSent:  staker.GetTotalEmissionSent(),
 		incentiveTotal:     staker.GetIncentiveTotalRewardAmount(barFoo500PoolPath, externalIncentiveId),
@@ -1199,6 +1203,13 @@ func printSnapshot(s upgradeSnapshot) {
 	println("[EXPECTED] proposal ids:", len(s.proposalIDs), "delegation ids:", len(s.delegationIDs))
 	println("[EXPECTED] param proposal yea / nay / status:", s.paramProposalYea, s.paramProposalNay, s.paramProposalState)
 	println("[EXPECTED] launchpad project active:", s.projectActive)
+	for _, tokenPath := range s.stakerAllowedList {
+		println("[EXPECTED] staker allowed token:", tokenPath)
+	}
+	for i, warmup := range s.depositWarmups {
+		println("[EXPECTED] deposit warmup", i, "duration / nextWarmupTime / ratio:",
+			warmup.TimeDuration, warmup.NextWarmupTime, warmup.WarmupRatio)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -1314,6 +1325,18 @@ func validateSnapshotUnchanged() {
 	uassert.Equal(t, len(snap.proposalIDs), len(after.proposalIDs))
 	for i, id := range snap.proposalIDs {
 		uassert.Equal(t, id, after.proposalIDs[i])
+	}
+	uassert.Equal(t, len(snap.stakerAllowedList), len(after.stakerAllowedList))
+	for i, tokenPath := range snap.stakerAllowedList {
+		uassert.Equal(t, tokenPath, after.stakerAllowedList[i])
+	}
+	// warm-up records carry the reward ratio schedule, so every field of every
+	// tier is compared, not just how many tiers there are
+	uassert.Equal(t, len(snap.depositWarmups), len(after.depositWarmups))
+	for i, warmup := range snap.depositWarmups {
+		uassert.Equal(t, warmup.TimeDuration, after.depositWarmups[i].TimeDuration)
+		uassert.Equal(t, warmup.NextWarmupTime, after.depositWarmups[i].NextWarmupTime)
+		uassert.Equal(t, warmup.WarmupRatio, after.depositWarmups[i].WarmupRatio)
 	}
 
 	println("[EXPECTED] every snapshot field is identical after the upgrade")
@@ -1679,6 +1702,13 @@ func finalInvariants(cur realm) {
 // [EXPECTED] proposal ids: 3 delegation ids: 3
 // [EXPECTED] param proposal yea / nay / status: 6500000000 0 executed
 // [EXPECTED] launchpad project active: true
+// [EXPECTED] staker allowed token: gno.land/r/gnoswap/gns.GNS
+// [EXPECTED] staker allowed token: gno.land/r/gnoland/wugnot.wugnot
+// [EXPECTED] staker allowed token: gno.land/r/onbloc/bar.BAR
+// [EXPECTED] deposit warmup 0 duration / nextWarmupTime / ratio: 432000 1234999970 30
+// [EXPECTED] deposit warmup 1 duration / nextWarmupTime / ratio: 864000 1235863970 50
+// [EXPECTED] deposit warmup 2 duration / nextWarmupTime / ratio: 2592000 1238455970 70
+// [EXPECTED] deposit warmup 3 duration / nextWarmupTime / ratio: 9223372036854775807 9223372036854775807 100
 //
 // [SCENARIO] 16. Upgrade all eight implementations to v2_valid
 // [EXPECTED] pool impl: gno.land/r/gnoswap/pool/v2_valid

--- a/contract/r/scenario/upgrade/full_lifecycle_v2_valid_upgrade_filetest.gno
+++ b/contract/r/scenario/upgrade/full_lifecycle_v2_valid_upgrade_filetest.gno
@@ -197,20 +197,57 @@ type upgradeSnapshot struct {
 	positionTickLower  int32
 	positionTickUpper  int32
 	positionOwner      address
+	positionOperator   address
+	positionFeeGrowth0 string
+	positionFeeGrowth1 string
+	positionOwed0      int64
+	positionOwed1      int64
+	positionUnclaimed0 string
+	positionUnclaimed1 string
+	positionBurned     bool
+	positionInRange    bool
 	stakerPoolTier     uint64
+	stakerPoolTierRat  uint64
 	stakerUnstakingFee uint64
 	stakerDepositGns   int64
+	stakerAllowedToken int
 	depositLiquidity   string
+	depositStakeTime   int64
+	depositTickLower   int32
+	depositTickUpper   int32
+	depositWarmupCount int
+	depositCollected   int64
+	totalEmissionSent  int64
+	incentiveTotal     int64
+	incentiveDistrib   int64
+	incentiveRefunded  bool
 	devOpsPct          int64
 	govStakerPct       int64
 	accuGovStakerBar   int64
+	accuDevOpsBar      int64
+	reservedTokens     []string
 	totalDelegated     int64
 	totalXGnsSupply    int64
+	totalLocked        int64
 	delegationCount    int
+	delegationIDs      []int64
 	proposalCount      int
+	proposalIDs        []int64
+	paramProposalYea   int64
+	paramProposalNay   int64
+	paramProposalState string
+	spendProposalState string
+	textProposalState  string
+	adminVoteWeight    int64
 	configVersion      int64
+	configVotingPeriod int64
 	projectCount       int
+	projectActive      bool
+	projectRecipient   address
+	projectTier30Total int64
 	launchpadDeposits  int64
+	launchpadDepositID int64
+	depositAmount      int64
 }
 
 func main(cur realm) {
@@ -999,6 +1036,19 @@ func launchpadLifecycle(cur realm) {
 func captureSnapshot() upgradeSnapshot {
 	feeGrowth0, feeGrowth1 := pool.GetFeeGrowthGlobalX128(barFoo500PoolPath)
 	protocolFee0, protocolFee1 := pool.GetProtocolFeesTokens(barFoo500PoolPath)
+	positionFeeGrowth0, positionFeeGrowth1 := position.GetPositionFeeGrowthInsideLastX128(1)
+	positionOwed0, positionOwed1 := position.GetPositionTokensOwed(1)
+	positionUnclaimed0, positionUnclaimed1 := position.GetUnclaimedFee(1)
+	paramStatus, _ := govGovernance.GetProposalStatusByProposalId(paramProposalId)
+	spendStatus, _ := govGovernance.GetProposalStatusByProposalId(spendProposalId)
+	textStatus, _ := govGovernance.GetProposalStatusByProposalId(textProposalId)
+	paramYea, _ := govGovernance.GetYeaByProposalId(paramProposalId)
+	paramNay, _ := govGovernance.GetNayByProposalId(paramProposalId)
+	adminVoteWeight, _ := govGovernance.GetVoteWeight(paramProposalId, adminAddr)
+	projectActive, _ := launchpad.GetProjectActiveStatus(launchpadProjectId)
+	projectRecipient, _ := launchpad.GetProjectRecipient(launchpadProjectId)
+	projectTier30Total, _ := launchpad.GetProjectTierTotalDistributeAmount(launchpadProjectId, 30)
+	launchpadDepositAmount, _ := launchpad.GetDepositAmount(launchpadDepositId)
 
 	return upgradeSnapshot{
 		poolLiquidity:      pool.GetLiquidity(barFoo500PoolPath),
@@ -1016,20 +1066,57 @@ func captureSnapshot() upgradeSnapshot {
 		positionTickLower:  position.GetPositionTickLower(1),
 		positionTickUpper:  position.GetPositionTickUpper(1),
 		positionOwner:      position.GetPositionOwner(1),
+		positionOperator:   position.GetPositionOperator(1),
+		positionFeeGrowth0: positionFeeGrowth0,
+		positionFeeGrowth1: positionFeeGrowth1,
+		positionOwed0:      positionOwed0,
+		positionOwed1:      positionOwed1,
+		positionUnclaimed0: positionUnclaimed0,
+		positionUnclaimed1: positionUnclaimed1,
+		positionBurned:     position.IsBurned(1),
+		positionInRange:    position.IsInRange(1),
 		stakerPoolTier:     staker.GetPoolTier(barFoo500PoolPath),
+		stakerPoolTierRat:  staker.GetPoolTierRatio(barFoo500PoolPath),
 		stakerUnstakingFee: staker.GetUnstakingFee(),
 		stakerDepositGns:   staker.GetDepositGnsAmount(),
+		stakerAllowedToken: len(staker.GetAllowedTokens()),
 		depositLiquidity:   staker.GetDepositLiquidityAsString(1),
+		depositStakeTime:   staker.GetDepositStakeTime(1),
+		depositTickLower:   staker.GetDepositTickLower(1),
+		depositTickUpper:   staker.GetDepositTickUpper(1),
+		depositWarmupCount: len(staker.GetDepositWarmUp(1)),
+		depositCollected:   staker.GetDepositCollectedInternalReward(1),
+		totalEmissionSent:  staker.GetTotalEmissionSent(),
+		incentiveTotal:     staker.GetIncentiveTotalRewardAmount(barFoo500PoolPath, externalIncentiveId),
+		incentiveDistrib:   staker.GetIncentiveDistributedRewardAmount(barFoo500PoolPath, externalIncentiveId),
+		incentiveRefunded:  staker.GetIncentiveRefunded(barFoo500PoolPath, externalIncentiveId),
 		devOpsPct:          protocolFee.GetDevOpsPct(),
 		govStakerPct:       protocolFee.GetGovStakerPct(),
 		accuGovStakerBar:   protocolFee.GetAccuTransferToGovStakerByTokenPath(barPath),
+		accuDevOpsBar:      protocolFee.GetAccuTransferToDevOpsByTokenPath(barPath),
+		reservedTokens:     protocolFee.GetReservedTokens(),
 		totalDelegated:     govStaker.GetTotalDelegated(),
 		totalXGnsSupply:    govStaker.GetTotalxGnsSupply(),
+		totalLocked:        govStaker.GetTotalLockedAmount(),
 		delegationCount:    govStaker.GetDelegationCount(),
+		delegationIDs:      govStaker.GetDelegationIDs(0, 10),
 		proposalCount:      govGovernance.GetProposalCount(),
+		proposalIDs:        govGovernance.GetProposalIDs(0, 10),
+		paramProposalYea:   paramYea,
+		paramProposalNay:   paramNay,
+		paramProposalState: paramStatus,
+		spendProposalState: spendStatus,
+		textProposalState:  textStatus,
+		adminVoteWeight:    adminVoteWeight,
 		configVersion:      govGovernance.GetLatestConfigVersion(),
+		configVotingPeriod: govGovernance.GetLatestConfig().VotingPeriod,
 		projectCount:       launchpad.GetProjectCount(),
+		projectActive:      projectActive,
+		projectRecipient:   projectRecipient,
+		projectTier30Total: projectTier30Total,
 		launchpadDeposits:  launchpad.GetTotalGNSStakedAmount(),
+		launchpadDepositID: launchpad.GetCurrentDepositId(),
+		depositAmount:      launchpadDepositAmount,
 	}
 }
 
@@ -1045,6 +1132,14 @@ func printSnapshot(s upgradeSnapshot) {
 	println("[EXPECTED] proposal count:", s.proposalCount)
 	println("[EXPECTED] project count:", s.projectCount)
 	println("[EXPECTED] launchpad deposits:", s.launchpadDeposits)
+	println("[EXPECTED] position fee growth inside last:", s.positionFeeGrowth0, s.positionFeeGrowth1)
+	println("[EXPECTED] position unclaimed fee:", s.positionUnclaimed0, s.positionUnclaimed1)
+	println("[EXPECTED] staker collected internal reward:", s.depositCollected)
+	println("[EXPECTED] total emission sent:", s.totalEmissionSent)
+	println("[EXPECTED] external incentive total / distributed:", s.incentiveTotal, s.incentiveDistrib)
+	println("[EXPECTED] proposal ids:", len(s.proposalIDs), "delegation ids:", len(s.delegationIDs))
+	println("[EXPECTED] param proposal yea / nay / status:", s.paramProposalYea, s.paramProposalNay, s.paramProposalState)
+	println("[EXPECTED] launchpad project active:", s.projectActive)
 }
 
 // ---------------------------------------------------------------------------
@@ -1098,20 +1193,69 @@ func validateSnapshotUnchanged() {
 	uassert.Equal(t, snap.positionTickLower, after.positionTickLower)
 	uassert.Equal(t, snap.positionTickUpper, after.positionTickUpper)
 	uassert.Equal(t, snap.positionOwner, after.positionOwner)
+	uassert.Equal(t, snap.positionOperator, after.positionOperator)
+	uassert.Equal(t, snap.positionFeeGrowth0, after.positionFeeGrowth0)
+	uassert.Equal(t, snap.positionFeeGrowth1, after.positionFeeGrowth1)
+	uassert.Equal(t, snap.positionOwed0, after.positionOwed0)
+	uassert.Equal(t, snap.positionOwed1, after.positionOwed1)
+	uassert.Equal(t, snap.positionUnclaimed0, after.positionUnclaimed0)
+	uassert.Equal(t, snap.positionUnclaimed1, after.positionUnclaimed1)
+	uassert.Equal(t, snap.positionBurned, after.positionBurned)
+	uassert.Equal(t, snap.positionInRange, after.positionInRange)
 	uassert.Equal(t, snap.stakerPoolTier, after.stakerPoolTier)
+	uassert.Equal(t, snap.stakerPoolTierRat, after.stakerPoolTierRat)
 	uassert.Equal(t, snap.stakerUnstakingFee, after.stakerUnstakingFee)
 	uassert.Equal(t, snap.stakerDepositGns, after.stakerDepositGns)
+	uassert.Equal(t, snap.stakerAllowedToken, after.stakerAllowedToken)
 	uassert.Equal(t, snap.depositLiquidity, after.depositLiquidity)
+	uassert.Equal(t, snap.depositStakeTime, after.depositStakeTime)
+	uassert.Equal(t, snap.depositTickLower, after.depositTickLower)
+	uassert.Equal(t, snap.depositTickUpper, after.depositTickUpper)
+	uassert.Equal(t, snap.depositWarmupCount, after.depositWarmupCount)
+	uassert.Equal(t, snap.depositCollected, after.depositCollected)
+	uassert.Equal(t, snap.totalEmissionSent, after.totalEmissionSent)
+	uassert.Equal(t, snap.incentiveTotal, after.incentiveTotal)
+	uassert.Equal(t, snap.incentiveDistrib, after.incentiveDistrib)
+	uassert.Equal(t, snap.incentiveRefunded, after.incentiveRefunded)
 	uassert.Equal(t, snap.devOpsPct, after.devOpsPct)
 	uassert.Equal(t, snap.govStakerPct, after.govStakerPct)
 	uassert.Equal(t, snap.accuGovStakerBar, after.accuGovStakerBar)
+	uassert.Equal(t, snap.accuDevOpsBar, after.accuDevOpsBar)
 	uassert.Equal(t, snap.totalDelegated, after.totalDelegated)
 	uassert.Equal(t, snap.totalXGnsSupply, after.totalXGnsSupply)
+	uassert.Equal(t, snap.totalLocked, after.totalLocked)
 	uassert.Equal(t, snap.delegationCount, after.delegationCount)
 	uassert.Equal(t, snap.proposalCount, after.proposalCount)
+	uassert.Equal(t, snap.paramProposalYea, after.paramProposalYea)
+	uassert.Equal(t, snap.paramProposalNay, after.paramProposalNay)
+	uassert.Equal(t, snap.paramProposalState, after.paramProposalState)
+	uassert.Equal(t, snap.spendProposalState, after.spendProposalState)
+	uassert.Equal(t, snap.textProposalState, after.textProposalState)
+	uassert.Equal(t, snap.adminVoteWeight, after.adminVoteWeight)
 	uassert.Equal(t, snap.configVersion, after.configVersion)
+	uassert.Equal(t, snap.configVotingPeriod, after.configVotingPeriod)
 	uassert.Equal(t, snap.projectCount, after.projectCount)
+	uassert.Equal(t, snap.projectActive, after.projectActive)
+	uassert.Equal(t, snap.projectRecipient, after.projectRecipient)
+	uassert.Equal(t, snap.projectTier30Total, after.projectTier30Total)
 	uassert.Equal(t, snap.launchpadDeposits, after.launchpadDeposits)
+	uassert.Equal(t, snap.launchpadDepositID, after.launchpadDepositID)
+	uassert.Equal(t, snap.depositAmount, after.depositAmount)
+
+	// list-valued getters are compared element by element: a list of the same
+	// length holding different ids would otherwise pass
+	uassert.Equal(t, len(snap.reservedTokens), len(after.reservedTokens))
+	for i, tokenPath := range snap.reservedTokens {
+		uassert.Equal(t, tokenPath, after.reservedTokens[i])
+	}
+	uassert.Equal(t, len(snap.delegationIDs), len(after.delegationIDs))
+	for i, id := range snap.delegationIDs {
+		uassert.Equal(t, id, after.delegationIDs[i])
+	}
+	uassert.Equal(t, len(snap.proposalIDs), len(after.proposalIDs))
+	for i, id := range snap.proposalIDs {
+		uassert.Equal(t, id, after.proposalIDs[i])
+	}
 
 	println("[EXPECTED] every snapshot field is identical after the upgrade")
 }
@@ -1463,6 +1607,14 @@ func finalInvariants(cur realm) {
 // [EXPECTED] proposal count: 3
 // [EXPECTED] project count: 1
 // [EXPECTED] launchpad deposits: 1000000
+// [EXPECTED] position fee growth inside last: 198985911547938715431204752120259 200040607192185740424656367414182
+// [EXPECTED] position unclaimed fee: 0 0
+// [EXPECTED] staker collected internal reward: 2311656609564
+// [EXPECTED] total emission sent: 2302423347314
+// [EXPECTED] external incentive total / distributed: 1500000000 66572240
+// [EXPECTED] proposal ids: 3 delegation ids: 3
+// [EXPECTED] param proposal yea / nay / status: 6500000000 0 executed
+// [EXPECTED] launchpad project active: true
 //
 // [SCENARIO] 16. Upgrade all eight implementations to v2_valid
 // [EXPECTED] pool impl: gno.land/r/gnoswap/pool/v2_valid

--- a/contract/r/scenario/upgrade/full_lifecycle_v2_valid_upgrade_filetest.gno
+++ b/contract/r/scenario/upgrade/full_lifecycle_v2_valid_upgrade_filetest.gno
@@ -527,10 +527,22 @@ func positionLifecycle(cur realm) {
 	println("[EXPECTED] increased liquidity:", increasedLiquidity, "amount0:", increased0, "amount1:", increased1)
 	println("[EXPECTED] position liquidity now:", position.GetPositionLiquidity(positionId))
 
+	// Trade both ways so the position actually accrues swap fees. Without this
+	// the DecreaseLiquidity below would collect a zero fee and the withdrawal
+	// fee it charges would be invisible.
+	swapBothWays(cur)
+
+	// DecreaseLiquidity collects the accrued fees first, so the gross fee is
+	// what the position holds right before the call.
+	grossFee0, grossFee1 := position.GetUnclaimedFee(positionId)
+	println("[EXPECTED] fees accrued before decrease (gross):", grossFee0, grossFee1)
+
 	// decrease half of the liquidity; the withdrawal fee is routed to protocol fee
 	decreaseAmount := position.GetPositionLiquidity(positionId)
 	beforeBarAccu := protocolFee.GetAccuTransferToGovStakerByTokenPath(barPath) +
 		protocolFee.GetAccuTransferToDevOpsByTokenPath(barPath)
+	beforeFooAccu := protocolFee.GetAccuTransferToGovStakerByTokenPath(fooPath) +
+		protocolFee.GetAccuTransferToDevOpsByTokenPath(fooPath)
 
 	// returns: positionId, liquidity, fee0, fee1, amount0, amount1, poolPath
 	_, removedLiquidity, fee0, fee1, removed0, removed1, removedPoolPath := position.DecreaseLiquidity(
@@ -540,13 +552,31 @@ func positionLifecycle(cur realm) {
 
 	afterBarAccu := protocolFee.GetAccuTransferToGovStakerByTokenPath(barPath) +
 		protocolFee.GetAccuTransferToDevOpsByTokenPath(barPath)
+	afterFooAccu := protocolFee.GetAccuTransferToGovStakerByTokenPath(fooPath) +
+		protocolFee.GetAccuTransferToDevOpsByTokenPath(fooPath)
+
+	withdrawalFee0 := afterBarAccu - beforeBarAccu
+	withdrawalFee1 := afterFooAccu - beforeFooAccu
 
 	println("[EXPECTED] removed liquidity:", removedLiquidity, "from pool:", removedPoolPath)
 	println("[EXPECTED] principal returned:", removed0, removed1)
-	println("[EXPECTED] fees returned with the principal:", fee0, fee1)
-	println("[EXPECTED] withdrawal fee accrued (BAR):", afterBarAccu-beforeBarAccu)
+	println("[EXPECTED] fees returned with the principal (net):", fee0, fee1)
+	println("[EXPECTED] withdrawal fee accrued (BAR / FOO):", withdrawalFee0, withdrawalFee1)
 	println("[EXPECTED] position liquidity after decrease:", position.GetPositionLiquidity(positionId))
 	println("[EXPECTED] position count:", position.GetPositionCount())
+
+	// withdrawal fee is withdrawalFeeBPS of the gross fee, and the caller keeps
+	// the rest; the principal is not charged
+	expectedWithdrawalFee0 := parseInt64(grossFee0) * int64(pool.GetWithdrawalFee()) / 10000
+	expectedWithdrawalFee1 := parseInt64(grossFee1) * int64(pool.GetWithdrawalFee()) / 10000
+	println("[EXPECTED] withdrawal fee expected from the gross fee:", expectedWithdrawalFee0, expectedWithdrawalFee1)
+
+	uassert.True(t, parseInt64(grossFee0) > 0)
+	uassert.True(t, parseInt64(grossFee1) > 0)
+	uassert.Equal(t, expectedWithdrawalFee0, withdrawalFee0)
+	uassert.Equal(t, expectedWithdrawalFee1, withdrawalFee1)
+	uassert.Equal(t, parseInt64(grossFee0)-expectedWithdrawalFee0, parseInt64(fee0))
+	uassert.Equal(t, parseInt64(grossFee1)-expectedWithdrawalFee1, parseInt64(fee1))
 
 	uassert.Equal(t, adminAddr, position.GetPositionOwner(positionId))
 	uassert.Equal(t, barFoo500PoolPath, position.GetPositionPoolKey(positionId))
@@ -555,14 +585,43 @@ func positionLifecycle(cur realm) {
 	uassert.Equal(t, 2, position.GetPositionCount())
 }
 
-// halfOf divides a decimal string by two. The liquidity values used here always
-// fit into int64, so a plain parse is enough.
-func halfOf(value string) string {
+// swapBothWays trades a small amount in each direction so both sides of the
+// position accrue swap fees while the price ends up back inside the range.
+func swapBothWays(cur realm) {
+	testing.SetRealm(adminRealm)
+	bar.Approve(cross(cur), routerAddr, math.MaxInt64)
+	foo.Approve(cross(cur), routerAddr, math.MaxInt64)
+	bar.Approve(cross(cur), poolAddr, math.MaxInt64)
+	foo.Approve(cross(cur), poolAddr, math.MaxInt64)
+
+	inBar, outFoo := router.ExactInSingleSwapRoute(
+		cross(cur), barPath, fooPath, "2000000", barFooRoute, "1", "0", time.Now().Unix()+3600, "",
+	)
+	testing.SkipHeights(1)
+	inFoo, outBar := router.ExactInSingleSwapRoute(
+		cross(cur), fooPath, barPath, "2000000", fooBarRoute, "1", "0", time.Now().Unix()+3600, "",
+	)
+	testing.SkipHeights(1)
+
+	println("[EXPECTED] fee-accrual swap bar->foo in/out:", inBar, outFoo)
+	println("[EXPECTED] fee-accrual swap foo->bar in/out:", inFoo, outBar)
+	println("[EXPECTED] pool tick after the fee-accrual swaps:", pool.GetSlot0Tick(barFoo500PoolPath))
+}
+
+// parseInt64 parses a decimal amount string; every value it is used on is
+// produced by the contracts themselves and fits into int64.
+func parseInt64(value string) int64 {
 	parsed, err := strconv.ParseInt(value, 10, 64)
 	if err != nil {
 		panic(err)
 	}
-	return strconv.FormatInt(parsed/2, 10)
+	return parsed
+}
+
+// halfOf divides a decimal string by two. The liquidity values used here always
+// fit into int64, so a plain parse is enough.
+func halfOf(value string) string {
+	return strconv.FormatInt(parseInt64(value)/2, 10)
 }
 
 // ---------------------------------------------------------------------------
@@ -1477,41 +1536,46 @@ func finalInvariants(cur realm) {
 // [EXPECTED] minted position: 2 liquidity: 327755575
 // [EXPECTED] increased liquidity: 213383746 amount0: 10000000 amount1: 10000000
 // [EXPECTED] position liquidity now: 1280302477
+// [EXPECTED] fee-accrual swap bar->foo in/out: 2000000 -1976553
+// [EXPECTED] fee-accrual swap foo->bar in/out: 2000000 -1981465
+// [EXPECTED] pool tick after the fee-accrual swaps: 0
+// [EXPECTED] fees accrued before decrease (gross): 597 597
 // [EXPECTED] removed liquidity: 640151238 from pool: gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:500
-// [EXPECTED] principal returned: 29999999 29999999
-// [EXPECTED] fees returned with the principal: 0 0
-// [EXPECTED] withdrawal fee accrued (BAR): 0
+// [EXPECTED] principal returned: 29999012 30000987
+// [EXPECTED] fees returned with the principal (net): 592 592
+// [EXPECTED] withdrawal fee accrued (BAR / FOO): 5 5
 // [EXPECTED] position liquidity after decrease: 640151239
 // [EXPECTED] position count: 2
+// [EXPECTED] withdrawal fee expected from the gross fee: 5 5
 //
 // [SCENARIO] 6. Router: exact-in / exact-out, single and multi-hop
-// [EXPECTED] exact-in-single in/out: 1000000 -988484
-// [EXPECTED] exact-in in/out: 1000000 -990523
-// [EXPECTED] exact-out-single in/out: 505568 -500000
-// [EXPECTED] exact-out in/out: 505043 -500000
+// [EXPECTED] exact-in-single in/out: 1000000 -988486
+// [EXPECTED] exact-in in/out: 1000000 -990520
+// [EXPECTED] exact-out-single in/out: 505567 -500000
+// [EXPECTED] exact-out in/out: 505045 -500000
 // [EXPECTED] pool tick after swaps: 0
 // [EXPECTED] pool liquidity: 967906814
-// [EXPECTED] fee growth global: 198985911547938715431204752120259 200040607192185740424656367414182
-// [EXPECTED] pool protocol fees: 188 186
-// [EXPECTED] router fee accrued (FOO): 15034
+// [EXPECTED] fee growth global: 358045537627336065200174822438606 358257148375155596322091915147789
+// [EXPECTED] pool protocol fees: 438 438
+// [EXPECTED] router fee accrued (FOO): 35004
 //
 // [SCENARIO] 7. Collect position fees generated by the swaps
-// [EXPECTED] unclaimed fee before collect: 374 376
-// [EXPECTED] collected fee: 371 373 pool: gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:500
-// [EXPECTED] fee tokens: 374 376
+// [EXPECTED] unclaimed fee before collect: 375 375
+// [EXPECTED] collected fee: 372 372 pool: gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:500
+// [EXPECTED] fee tokens: 375 375
 // [EXPECTED] unclaimed fee after collect: 0 0
 //
 // [SCENARIO] 8. Reposition the second position into a new tick range
 // [EXPECTED] liquidity before reposition: 0
-// [EXPECTED] repositioned liquidity: 676731855 ticks: -600 600
-// [EXPECTED] amounts used: 19998928 20000000
+// [EXPECTED] repositioned liquidity: 676696536 ticks: -600 600
+// [EXPECTED] amounts used: 19996841 20000000
 // [EXPECTED] position ticks from getter: -600 600
 //
 // [SCENARIO] 9. Staker: tier setup, external incentive, stake position 1
 // [EXPECTED] pool tier after SetPoolTier: 2
 // [EXPECTED] pool tier after ChangePoolTier: 1
 // [EXPECTED] tier1 pool count: 2
-// [EXPECTED] incentive id: g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5:1234567955:1
+// [EXPECTED] incentive id: g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5:1234567965:1
 // [EXPECTED] incentive reward token: gno.land/r/gnoswap/gns.GNS
 // [EXPECTED] incentive total reward: 1500000000
 // [EXPECTED] incentive creator: g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5
@@ -1526,20 +1590,20 @@ func finalInvariants(cur realm) {
 //
 // [SCENARIO] 10. Accumulate 10 days of rewards and collect them
 // [EXPECTED] collectable emission reward: 924663981581
-// [EXPECTED] collectable external reward: 66572240
+// [EXPECTED] collectable external reward: 66572819
 // [EXPECTED] internal reward to user: 915417341766 penalty: 1386992627983
-// [EXPECTED] external reward to user: gno.land/r/gnoswap/gns.GNS 66572240
-// [EXPECTED] external reward penalty: gno.land/r/gnoswap/gns.GNS 99779032
+// [EXPECTED] external reward to user: gno.land/r/gnoswap/gns.GNS 66572819
+// [EXPECTED] external reward penalty: gno.land/r/gnoswap/gns.GNS 99780382
 // [EXPECTED] collected internal reward total: 2311656609564
 // [EXPECTED] total emission sent: 2302423347314
 //
 // [SCENARIO] 11. Protocol fee distribution to devops / gov staker
-// [EXPECTED] accumulated BAR (gov staker / devops): 9036 6023
-// [EXPECTED] distributed BAR to gov staker: 9036
-// [EXPECTED] distributed BAR to devops: 6023
+// [EXPECTED] accumulated BAR (gov staker / devops): 21049 14031
+// [EXPECTED] distributed BAR to gov staker: 21049
+// [EXPECTED] distributed BAR to devops: 14031
 // [EXPECTED] reserved token count: 0
-// [EXPECTED] distributed FOO to gov staker: 9024
-// [EXPECTED] distributed GNS to gov staker: 5608383323
+// [EXPECTED] distributed FOO to gov staker: 21007
+// [EXPECTED] distributed GNS to gov staker: 5608383326
 //
 // [SCENARIO] 12. Gov staker: delegate, redelegate, undelegate, collect
 // [EXPECTED] alice delegated amount: 2000000000
@@ -1556,7 +1620,7 @@ func finalInvariants(cur realm) {
 // [EXPECTED] alice claimable emission reward: 0
 // [EXPECTED] alice claimable protocol fee token count: 3
 // [EXPECTED] emission distributed amount: 0
-// [EXPECTED] protocol fee amount (BAR): 9036
+// [EXPECTED] protocol fee amount (BAR): 21049
 // [EXPECTED] delegation snapshots present: true
 //
 // [SCENARIO] 13. Governance: propose, vote, execute, cancel, reconfigure
@@ -1582,7 +1646,7 @@ func finalInvariants(cur realm) {
 // [EXPECTED] governance config version after reconfigure: 2
 //
 // [SCENARIO] 14. Launchpad: project, deposit, reward collection
-// [EXPECTED] project id: gno.land/r/onbloc/obl.OBL:518577
+// [EXPECTED] project id: gno.land/r/onbloc/obl.OBL:518579
 // [EXPECTED] project count: 1
 // [EXPECTED] project name: OBL launchpad project
 // [EXPECTED] project recipient is project owner: true
@@ -1596,9 +1660,9 @@ func finalInvariants(cur realm) {
 // [EXPECTED] project recipient collected launchpad rewards
 //
 // [SCENARIO] 15. Capture the pre-upgrade snapshot through the getters
-// [EXPECTED] pool liquidity: 1316883094
+// [EXPECTED] pool liquidity: 1316847775
 // [EXPECTED] pool tick: 0
-// [EXPECTED] pool protocol fees: 188 186
+// [EXPECTED] pool protocol fees: 438 438
 // [EXPECTED] position 1 liquidity: 640151239
 // [EXPECTED] staker pool tier: 1
 // [EXPECTED] staked deposit liquidity: 640151239
@@ -1607,11 +1671,11 @@ func finalInvariants(cur realm) {
 // [EXPECTED] proposal count: 3
 // [EXPECTED] project count: 1
 // [EXPECTED] launchpad deposits: 1000000
-// [EXPECTED] position fee growth inside last: 198985911547938715431204752120259 200040607192185740424656367414182
+// [EXPECTED] position fee growth inside last: 358045537627336065200174822438606 358257148375155596322091915147789
 // [EXPECTED] position unclaimed fee: 0 0
 // [EXPECTED] staker collected internal reward: 2311656609564
 // [EXPECTED] total emission sent: 2302423347314
-// [EXPECTED] external incentive total / distributed: 1500000000 66572240
+// [EXPECTED] external incentive total / distributed: 1500000000 66572819
 // [EXPECTED] proposal ids: 3 delegation ids: 3
 // [EXPECTED] param proposal yea / nay / status: 6500000000 0 executed
 // [EXPECTED] launchpad project active: true
@@ -1630,11 +1694,11 @@ func finalInvariants(cur realm) {
 // [EXPECTED] every snapshot field is identical after the upgrade
 //
 // [SCENARIO] 18. Re-run the same operations through v2_valid
-// [EXPECTED] v2_valid minted position: 3 liquidity: 1066900695
-// [EXPECTED] v2_valid mint amounts: 49998310 50000000
-// [EXPECTED] v2_valid swap in/out: 1000000 -989090
-// [EXPECTED] v2_valid staking reward to user/penalty: 42692890284 101133750250
-// [EXPECTED] v2_valid distributed FOO to gov staker: 15018
+// [EXPECTED] v2_valid minted position: 3 liquidity: 1066865580
+// [EXPECTED] v2_valid mint amounts: 49995019 50000000
+// [EXPECTED] v2_valid swap in/out: 1000000 -989093
+// [EXPECTED] v2_valid staking reward to user/penalty: 42692363335 101132501977
+// [EXPECTED] v2_valid distributed FOO to gov staker: 27001
 // [EXPECTED] v2_valid delegated amount: 1000000000
 // [EXPECTED] v2_valid delegation count: 4
 // [EXPECTED] v2_valid total delegated: 7800000000
@@ -1644,15 +1708,15 @@ func finalInvariants(cur realm) {
 //
 // [SCENARIO] 19. Wind down: end incentive, unstake, remove tier
 // [EXPECTED] incentive refunded: true
-// [EXPECTED] incentive distributed: 69697221
-// [EXPECTED] collected incentive penalty: 107070652
+// [EXPECTED] incentive distributed: 69697761
+// [EXPECTED] collected incentive penalty: 107071913
 // [EXPECTED] position 1 staked after unstake: false
 // [EXPECTED] position 1 owner after unstake: g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5
 // [EXPECTED] position 1 operator cleared: true
 // [EXPECTED] allowed token count after removal: 2
 // [EXPECTED] pool tier after removal: 0
-// [EXPECTED] pool protocol fees before: 313 186
-// [EXPECTED] collected protocol fees: 313 186
+// [EXPECTED] pool protocol fees before: 562 438
+// [EXPECTED] collected protocol fees: 562 438
 // [EXPECTED] pool protocol fees after: 0 0
 // [EXPECTED] launchpad project ended: true
 // [EXPECTED] launchpad leftover transferred: 900000001
@@ -1660,11 +1724,11 @@ func finalInvariants(cur realm) {
 // [SCENARIO] 20. Final invariants
 // [EXPECTED] pool count: 2
 // [EXPECTED] position count: 3
-// [EXPECTED] total emission sent: 19960011592312
+// [EXPECTED] total emission sent: 19960224142687
 // [EXPECTED] gov staker total delegated: 7800000000
 // [EXPECTED] governance proposal count: 4
 // [EXPECTED] launchpad project count: 1
-// [EXPECTED] incentive total/distributed/remaining/penalty: 1500000000 713588362 500166223 179174763
+// [EXPECTED] incentive total/distributed/remaining/penalty: 1500000000 713594326 500158844 179174917
 // [EXPECTED] pool impl: gno.land/r/gnoswap/pool/v2_valid
 // [EXPECTED] position impl: gno.land/r/gnoswap/position/v2_valid
 // [EXPECTED] router impl: gno.land/r/gnoswap/router/v2_valid

--- a/contract/r/scenario/upgrade/full_lifecycle_v2_valid_upgrade_filetest.gno
+++ b/contract/r/scenario/upgrade/full_lifecycle_v2_valid_upgrade_filetest.gno
@@ -1,0 +1,1523 @@
+// PKGPATH: gno.land/r/gnoswap/v1/main
+
+// Full-lifecycle upgrade scenario across every upgradeable GnoSwap contract.
+//
+// Goal: drive every cross (crossing) entry point of the eight upgradeable
+// contracts through a realistic, time-advancing transaction sequence, verify
+// the observable state with the public getters after each step, upgrade all
+// eight implementations to v2_valid, prove the v1-created data survives the
+// upgrade byte-for-byte, and then re-run the same operations through v2_valid
+// to prove the behaviour is unchanged.
+//
+// Upgradeable contracts (proxy -> implementation):
+//
+//	pool, position, router, staker, launchpad, protocol_fee,
+//	gov/governance, gov/staker
+//
+// Entry points reached directly:
+//
+//	pool:          CreatePool, IncreaseObservationCardinalityNext, CollectProtocol,
+//	               SetPoolCreationFee, SetWithdrawalFee, SetFeeProtocol, UpgradeImpl
+//	position:      Mint, IncreaseLiquidity, DecreaseLiquidity, CollectFee,
+//	               Reposition, UpgradeImpl
+//	router:        ExactInSwapRoute, ExactInSingleSwapRoute, ExactOutSwapRoute,
+//	               ExactOutSingleSwapRoute, SetSwapFee, UpgradeImpl
+//	staker:        SetPoolTier, ChangePoolTier, RemovePoolTier, AddToken,
+//	               RemoveToken, SetWarmUp, SetDepositGnsAmount,
+//	               SetMinimumRewardAmount, SetTokenMinimumRewardAmount,
+//	               SetUnStakingFee, CreateExternalIncentive, StakeToken,
+//	               CollectReward, UnStakeToken, EndExternalIncentive,
+//	               CollectExternalIncentivePenalty, UpgradeImpl
+//	launchpad:     CreateProject, DepositGns, CollectRewardByDepositId,
+//	               CollectDepositGns, CollectProtocolFee, CollectEmissionReward,
+//	               CollectProtocolFeeReward, TransferLeftFromProjectByAdmin,
+//	               UpgradeImpl
+//	protocol_fee:  SetDevOpsPct, SetGovStakerPct, DistributeProtocolFeeByTokenPath,
+//	               DistributeProtocolFee, UpgradeImpl
+//	gov/governance ProposeText, ProposeCommunityPoolSpend, ProposeParameterChange,
+//	               Vote, Execute, Cancel, Reconfigure, UpgradeImpl
+//	gov/staker:    Delegate, Redelegate, Undelegate, CollectUndelegatedGns,
+//	               CollectReward, CollectEmissionReward, CollectProtocolFeeReward,
+//	               CleanStakerDelegationSnapshotByAdmin,
+//	               SetUnDelegationLockupPeriodByAdmin, UpgradeImpl
+//
+// Entry points reached indirectly (they are role-gated and unreachable from an
+// EOA, so they are covered through their only legitimate caller):
+//
+//	pool.Mint / Burn / Collect / HandleWithdrawalFee   <- position
+//	pool.Swap                                          <- router
+//	pool.SetSwapStartHook / SetSwapEndHook /
+//	    SetTickCrossHook                               <- staker initializer
+//	router.SwapCallback                                <- pool
+//	position.SetPositionOperator                       <- staker (StakeToken)
+//	protocol_fee.AddToProtocolFee                      <- pool / position / router / staker
+//	gov/staker.SetAmountByProjectWallet                <- launchpad (DepositGns)
+//	gov/staker.CollectRewardFromLaunchPad /
+//	    CollectEmissionRewardFromLaunchPad /
+//	    CollectProtocolFeeRewardFromLaunchPad          <- launchpad (project recipient)
+//	*.RegisterInitializer                              <- each version's init()
+package main
+
+import (
+	"math"
+	"strconv"
+	"testing"
+	"time"
+
+	"gno.land/p/demo/tokens/grc721"
+	"gno.land/p/gnoswap/gnsmath"
+	prbac "gno.land/p/gnoswap/rbac"
+	testutils "gno.land/p/nt/testutils/v0"
+	uassert "gno.land/p/nt/uassert/v0"
+	ufmt "gno.land/p/nt/ufmt/v0"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/emission"
+	"gno.land/r/gnoswap/gnft"
+	"gno.land/r/gnoswap/gns"
+	govGovernance "gno.land/r/gnoswap/gov/governance"
+	govStaker "gno.land/r/gnoswap/gov/staker"
+	"gno.land/r/gnoswap/launchpad"
+	"gno.land/r/gnoswap/pool"
+	"gno.land/r/gnoswap/position"
+	protocolFee "gno.land/r/gnoswap/protocol_fee"
+	"gno.land/r/gnoswap/router"
+	"gno.land/r/gnoswap/scenarioutils"
+	"gno.land/r/gnoswap/staker"
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/foo"
+	"gno.land/r/onbloc/obl"
+
+	_ "gno.land/r/gnoswap/rbac"
+
+	_ "gno.land/r/gnoswap/gov/governance/v1"
+	_ "gno.land/r/gnoswap/gov/staker/v1"
+	_ "gno.land/r/gnoswap/launchpad/v1"
+	_ "gno.land/r/gnoswap/pool/v1"
+	_ "gno.land/r/gnoswap/position/v1"
+	_ "gno.land/r/gnoswap/protocol_fee/v1"
+	_ "gno.land/r/gnoswap/router/v1"
+	_ "gno.land/r/gnoswap/staker/v1"
+
+	_ "gno.land/r/gnoswap/gov/governance/v2_valid"
+	_ "gno.land/r/gnoswap/gov/staker/v2_valid"
+	_ "gno.land/r/gnoswap/launchpad/v2_valid"
+	_ "gno.land/r/gnoswap/pool/v2_valid"
+	_ "gno.land/r/gnoswap/position/v2_valid"
+	_ "gno.land/r/gnoswap/protocol_fee/v2_valid"
+	_ "gno.land/r/gnoswap/router/v2_valid"
+	_ "gno.land/r/gnoswap/staker/v2_valid"
+)
+
+var t *testing.T
+
+const (
+	poolV1Path          = "gno.land/r/gnoswap/pool/v1"
+	positionV1Path      = "gno.land/r/gnoswap/position/v1"
+	routerV1Path        = "gno.land/r/gnoswap/router/v1"
+	stakerV1Path        = "gno.land/r/gnoswap/staker/v1"
+	launchpadV1Path     = "gno.land/r/gnoswap/launchpad/v1"
+	protocolFeeV1Path   = "gno.land/r/gnoswap/protocol_fee/v1"
+	governanceV1Path    = "gno.land/r/gnoswap/gov/governance/v1"
+	govStakerV1Path     = "gno.land/r/gnoswap/gov/staker/v1"
+	poolV2Path          = "gno.land/r/gnoswap/pool/v2_valid"
+	positionV2Path      = "gno.land/r/gnoswap/position/v2_valid"
+	routerV2Path        = "gno.land/r/gnoswap/router/v2_valid"
+	stakerV2Path        = "gno.land/r/gnoswap/staker/v2_valid"
+	launchpadV2Path     = "gno.land/r/gnoswap/launchpad/v2_valid"
+	protocolFeeV2Path   = "gno.land/r/gnoswap/protocol_fee/v2_valid"
+	governanceV2Path    = "gno.land/r/gnoswap/gov/governance/v2_valid"
+	govStakerV2Path     = "gno.land/r/gnoswap/gov/staker/v2_valid"
+	blockTimeSeconds    = int64(5)
+	secondsPerDay       = int64(86400)
+	incentiveDuration   = 90 * secondsPerDay
+	incentiveReward     = int64(1_500_000_000)
+	launchpadTierWaitID = int64(30)
+)
+
+var (
+	adminAddr  = access.MustGetAddress(prbac.ROLE_ADMIN.String())
+	adminRealm = testing.NewUserRealm(adminAddr)
+
+	poolAddr      = access.MustGetAddress(prbac.ROLE_POOL.String())
+	routerAddr    = access.MustGetAddress(prbac.ROLE_ROUTER.String())
+	stakerAddr    = access.MustGetAddress(prbac.ROLE_STAKER.String())
+	govStakerAddr = access.MustGetAddress(prbac.ROLE_GOV_STAKER.String())
+	launchpadAddr = access.MustGetAddress(prbac.ROLE_LAUNCHPAD.String())
+
+	aliceAddr  = testutils.TestAddress("alice")
+	aliceRealm = testing.NewUserRealm(aliceAddr)
+
+	projectAddr  = testutils.TestAddress("project-owner")
+	projectRealm = testing.NewUserRealm(projectAddr)
+
+	barPath = "gno.land/r/onbloc/bar.BAR"
+	fooPath = "gno.land/r/onbloc/foo.FOO"
+	gnsPath = "gno.land/r/gnoswap/gns.GNS"
+	oblPath = "gno.land/r/onbloc/obl.OBL"
+
+	fee500 = uint32(500)
+
+	zeroAddress = address("")
+
+	barFoo500PoolPath = "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:500"
+	barFooRoute       = "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:500"
+	fooBarRoute       = "gno.land/r/onbloc/foo.FOO:gno.land/r/onbloc/bar.BAR:500"
+
+	externalIncentiveId  string
+	launchpadProjectId   string
+	launchpadTier30Id    string
+	launchpadDepositId   string
+	textProposalId       int64
+	spendProposalId      int64
+	paramProposalId      int64
+	aliceDelegatedAmount int64
+
+	// snapshot captured right before the v2_valid upgrade
+	snap upgradeSnapshot
+)
+
+// upgradeSnapshot holds the state observed through the public getters right
+// before the upgrade. Every field must be identical after the upgrade: the KV
+// store is shared across implementations, so a data-layout regression in the
+// new implementation shows up here.
+type upgradeSnapshot struct {
+	poolLiquidity      string
+	poolSqrtPriceX96   string
+	poolTick           int32
+	poolFeeGrowth0     string
+	poolFeeGrowth1     string
+	poolProtocolFee0   int64
+	poolProtocolFee1   int64
+	poolCreationFee    int64
+	withdrawalFee      uint64
+	swapFee            uint64
+	positionCount      int
+	positionLiquidity  string
+	positionTickLower  int32
+	positionTickUpper  int32
+	positionOwner      address
+	stakerPoolTier     uint64
+	stakerUnstakingFee uint64
+	stakerDepositGns   int64
+	depositLiquidity   string
+	devOpsPct          int64
+	govStakerPct       int64
+	accuGovStakerBar   int64
+	totalDelegated     int64
+	totalXGnsSupply    int64
+	delegationCount    int
+	proposalCount      int
+	configVersion      int64
+	projectCount       int
+	launchpadDeposits  int64
+}
+
+func main(cur realm) {
+	println("[SCENARIO] 1. Activate v1 implementations for every upgradeable contract")
+	activateV1Implementations(cur)
+	println()
+
+	println("[SCENARIO] 2. Bootstrap emission and the canonical GNS/WUGNOT pool")
+	bootstrapEmission(cur)
+	println()
+
+	println("[SCENARIO] 3. Configure protocol parameters through the admin setters")
+	configureProtocolParameters(cur)
+	println()
+
+	println("[SCENARIO] 4. Create the BAR/FOO pool and grow its observation cardinality")
+	createTargetPool(cur)
+	println()
+
+	println("[SCENARIO] 5. Position lifecycle: mint, increase, decrease, collect fee")
+	positionLifecycle(cur)
+	println()
+
+	println("[SCENARIO] 6. Router: exact-in / exact-out, single and multi-hop")
+	routerSwaps(cur)
+	println()
+
+	println("[SCENARIO] 7. Collect position fees generated by the swaps")
+	collectPositionFee(cur, 1)
+	println()
+
+	println("[SCENARIO] 8. Reposition the second position into a new tick range")
+	repositionPosition(cur, 2)
+	println()
+
+	println("[SCENARIO] 9. Staker: tier setup, external incentive, stake position 1")
+	stakerSetup(cur)
+	println()
+
+	println("[SCENARIO] 10. Accumulate 10 days of rewards and collect them")
+	accumulateAndCollectStakingReward(cur)
+	println()
+
+	println("[SCENARIO] 11. Protocol fee distribution to devops / gov staker")
+	distributeProtocolFee(cur)
+	println()
+
+	println("[SCENARIO] 12. Gov staker: delegate, redelegate, undelegate, collect")
+	govStakerLifecycle(cur)
+	println()
+
+	println("[SCENARIO] 13. Governance: propose, vote, execute, cancel, reconfigure")
+	governanceLifecycle(cur)
+	println()
+
+	println("[SCENARIO] 14. Launchpad: project, deposit, reward collection")
+	launchpadLifecycle(cur)
+	println()
+
+	println("[SCENARIO] 15. Capture the pre-upgrade snapshot through the getters")
+	snap = captureSnapshot()
+	printSnapshot(snap)
+	println()
+
+	println("[SCENARIO] 16. Upgrade all eight implementations to v2_valid")
+	upgradeAllToV2Valid(cur)
+	println()
+
+	println("[SCENARIO] 17. Validate that every v1 value survived the upgrade")
+	validateSnapshotUnchanged()
+	println()
+
+	println("[SCENARIO] 18. Re-run the same operations through v2_valid")
+	rerunAfterUpgrade(cur)
+	println()
+
+	println("[SCENARIO] 19. Wind down: end incentive, unstake, remove tier")
+	windDown(cur)
+	println()
+
+	println("[SCENARIO] 20. Final invariants")
+	finalInvariants(cur)
+	println()
+}
+
+// ---------------------------------------------------------------------------
+// 1. implementation activation
+// ---------------------------------------------------------------------------
+
+func activateV1Implementations(cur realm) {
+	testing.SetRealm(adminRealm)
+
+	protocolFee.UpgradeImpl(cross(cur), protocolFeeV1Path)
+	pool.UpgradeImpl(cross(cur), poolV1Path)
+	position.UpgradeImpl(cross(cur), positionV1Path)
+	router.UpgradeImpl(cross(cur), routerV1Path)
+	staker.UpgradeImpl(cross(cur), stakerV1Path)
+	launchpad.UpgradeImpl(cross(cur), launchpadV1Path)
+	govStaker.UpgradeImpl(cross(cur), govStakerV1Path)
+	govGovernance.UpgradeImpl(cross(cur), governanceV1Path)
+
+	printImplementations()
+
+	uassert.Equal(t, poolV1Path, pool.GetImplementationPackagePath())
+	uassert.Equal(t, positionV1Path, position.GetImplementationPackagePath())
+	uassert.Equal(t, routerV1Path, router.GetImplementationPackagePath())
+	uassert.Equal(t, stakerV1Path, staker.GetImplementationPackagePath())
+	uassert.Equal(t, launchpadV1Path, launchpad.GetImplementationPackagePath())
+	uassert.Equal(t, protocolFeeV1Path, protocolFee.GetImplementationPackagePath())
+	uassert.Equal(t, governanceV1Path, govGovernance.GetImplementationPackagePath())
+	uassert.Equal(t, govStakerV1Path, govStaker.GetImplementationPackagePath())
+}
+
+func printImplementations() {
+	println("[EXPECTED] pool impl:", pool.GetImplementationPackagePath())
+	println("[EXPECTED] position impl:", position.GetImplementationPackagePath())
+	println("[EXPECTED] router impl:", router.GetImplementationPackagePath())
+	println("[EXPECTED] staker impl:", staker.GetImplementationPackagePath())
+	println("[EXPECTED] launchpad impl:", launchpad.GetImplementationPackagePath())
+	println("[EXPECTED] protocol_fee impl:", protocolFee.GetImplementationPackagePath())
+	println("[EXPECTED] governance impl:", govGovernance.GetImplementationPackagePath())
+	println("[EXPECTED] gov staker impl:", govStaker.GetImplementationPackagePath())
+}
+
+// ---------------------------------------------------------------------------
+// 2. emission bootstrap
+// ---------------------------------------------------------------------------
+
+func bootstrapEmission(cur realm) {
+	testing.SetRealm(adminRealm)
+	pool.SetPoolCreationFee(cross(cur), 0)
+	scenarioutils.EnsureCanonicalDefaultPool(cross(cur))
+
+	testing.SetRealm(adminRealm)
+	emission.SetDistributionStartTime(cross(cur), time.Now().Unix()+blockTimeSeconds)
+	testing.SkipHeights(1)
+
+	println("[EXPECTED] canonical pool exists:", pool.ExistsPoolPath("gno.land/r/gnoland/wugnot.wugnot:gno.land/r/gnoswap/gns.GNS:3000"))
+	println("[EXPECTED] pool count:", pool.GetPoolCount())
+}
+
+// ---------------------------------------------------------------------------
+// 3. protocol parameters
+// ---------------------------------------------------------------------------
+
+func configureProtocolParameters(cur realm) {
+	testing.SetRealm(adminRealm)
+
+	// pool
+	pool.SetPoolCreationFee(cross(cur), 100_000_000)
+	pool.SetWithdrawalFee(cross(cur), 100) // 1%
+	println("[EXPECTED] pool creation fee:", pool.GetPoolCreationFee())
+	println("[EXPECTED] withdrawal fee bps:", pool.GetWithdrawalFee())
+
+	// router
+	router.SetSwapFee(cross(cur), 100) // 1%
+	println("[EXPECTED] router swap fee bps:", router.GetSwapFee())
+
+	// protocol fee split
+	protocolFee.SetDevOpsPct(cross(cur), 4000) // 40%
+	protocolFee.SetGovStakerPct(cross(cur), 6000)
+	println("[EXPECTED] devops pct:", protocolFee.GetDevOpsPct())
+	println("[EXPECTED] gov staker pct:", protocolFee.GetGovStakerPct())
+
+	// staker
+	staker.SetUnStakingFee(cross(cur), 100) // 1%
+	staker.SetDepositGnsAmount(cross(cur), 1_000_000_000)
+	staker.SetMinimumRewardAmount(cross(cur), 1_000_000_000)
+	staker.SetTokenMinimumRewardAmount(cross(cur), ufmt.Sprintf("%s:%d", barPath, int64(1_000_000)))
+	staker.AddToken(cross(cur), barPath)
+	println("[EXPECTED] unstaking fee bps:", staker.GetUnstakingFee())
+	println("[EXPECTED] deposit gns amount:", staker.GetDepositGnsAmount())
+	println("[EXPECTED] minimum reward amount:", staker.GetMinimumRewardAmount())
+	barMinimum, barMinimumFound := staker.GetSpecificTokenMinimumRewardAmount(barPath)
+	println("[EXPECTED] bar minimum reward amount:", barMinimum, "found:", barMinimumFound)
+	println("[EXPECTED] allowed token count:", len(staker.GetAllowedTokens()))
+	println("[EXPECTED] warmup tiers:", len(staker.GetWarmupTemplate()))
+
+	// gov staker
+	govStaker.SetUnDelegationLockupPeriodByAdmin(cross(cur), 100)
+	println("[EXPECTED] undelegation lockup period:", govStaker.GetUnDelegationLockupPeriod())
+
+	uassert.Equal(t, int64(100_000_000), pool.GetPoolCreationFee())
+	uassert.Equal(t, uint64(100), pool.GetWithdrawalFee())
+	uassert.Equal(t, uint64(100), router.GetSwapFee())
+	uassert.Equal(t, int64(4000), protocolFee.GetDevOpsPct())
+	uassert.Equal(t, int64(6000), protocolFee.GetGovStakerPct())
+	uassert.Equal(t, uint64(100), staker.GetUnstakingFee())
+	uassert.Equal(t, int64(100), govStaker.GetUnDelegationLockupPeriod())
+}
+
+// ---------------------------------------------------------------------------
+// 4. pool creation
+// ---------------------------------------------------------------------------
+
+func createTargetPool(cur realm) {
+	testing.SetRealm(adminRealm)
+
+	// The 100 GNS creation fee is routed to the protocol fee contract, which
+	// exercises protocol_fee.AddToProtocolFee through the pool implementation.
+	beforeGnsAccu := protocolFee.GetAccuTransferToGovStakerByTokenPath(gnsPath) +
+		protocolFee.GetAccuTransferToDevOpsByTokenPath(gnsPath)
+
+	gns.Approve(cross(cur), poolAddr, math.MaxInt64)
+	pool.CreatePool(cross(cur), barPath, fooPath, fee500, gnsmath.TickMathGetSqrtRatioAtTick(0).ToString())
+	testing.SkipHeights(1)
+
+	afterGnsAccu := protocolFee.GetAccuTransferToGovStakerByTokenPath(gnsPath) +
+		protocolFee.GetAccuTransferToDevOpsByTokenPath(gnsPath)
+
+	println("[EXPECTED] created pool:", pool.GetPoolPath(barPath, fooPath, fee500))
+	println("[EXPECTED] pool exists:", pool.ExistsPoolPath(barFoo500PoolPath))
+	println("[EXPECTED] token0:", pool.GetToken0Path(barFoo500PoolPath))
+	println("[EXPECTED] token1:", pool.GetToken1Path(barFoo500PoolPath))
+	println("[EXPECTED] fee:", pool.GetFee(barFoo500PoolPath))
+	println("[EXPECTED] tick spacing:", pool.GetTickSpacing(barFoo500PoolPath))
+	println("[EXPECTED] slot0 tick:", pool.GetSlot0Tick(barFoo500PoolPath))
+	println("[EXPECTED] slot0 sqrtPriceX96:", pool.GetSlot0SqrtPriceX96(barFoo500PoolPath))
+	println("[EXPECTED] slot0 unlocked:", pool.GetSlot0Unlocked(barFoo500PoolPath))
+	println("[EXPECTED] creation fee accrued to protocol fee:", afterGnsAccu-beforeGnsAccu)
+
+	// protocol fee split for token0/token1 is exercised by the swaps below.
+	testing.SetRealm(adminRealm)
+	pool.SetFeeProtocol(cross(cur), 4, 4)
+	println("[EXPECTED] slot0 fee protocol:", pool.GetSlot0FeeProtocol(barFoo500PoolPath))
+
+	pool.IncreaseObservationCardinalityNext(cross(cur), barPath, fooPath, fee500, 10)
+	observation, err := pool.GetObservationState(barFoo500PoolPath)
+	if err != nil {
+		panic(err)
+	}
+	println("[EXPECTED] observation cardinality next:", observation.CardinalityNext())
+
+	uassert.Equal(t, int64(100_000_000), afterGnsAccu-beforeGnsAccu)
+	uassert.Equal(t, uint8(68), pool.GetSlot0FeeProtocol(barFoo500PoolPath)) // 4 + 4<<4
+	uassert.True(t, pool.ExistsPoolPath(barFoo500PoolPath))
+
+	// keep the remaining pools free to create
+	testing.SetRealm(adminRealm)
+	pool.SetPoolCreationFee(cross(cur), 0)
+}
+
+// ---------------------------------------------------------------------------
+// 5. position lifecycle
+// ---------------------------------------------------------------------------
+
+func positionLifecycle(cur realm) {
+	testing.SetRealm(adminRealm)
+	bar.Approve(cross(cur), poolAddr, math.MaxInt64)
+	foo.Approve(cross(cur), poolAddr, math.MaxInt64)
+
+	positionId, liquidity, amount0, amount1 := position.Mint(
+		cross(cur), barPath, fooPath, fee500, -960, 960,
+		"50000000", "50000000", "0", "0", time.Now().Unix()+3600, adminAddr, "",
+	)
+	testing.SkipHeights(1)
+	println("[EXPECTED] minted position:", positionId, "liquidity:", liquidity, "amount0:", amount0, "amount1:", amount1)
+	println("[EXPECTED] position owner:", position.GetPositionOwner(positionId))
+	println("[EXPECTED] position pool key:", position.GetPositionPoolKey(positionId))
+	println("[EXPECTED] position ticks:", position.GetPositionTickLower(positionId), position.GetPositionTickUpper(positionId))
+	println("[EXPECTED] position in range:", position.IsInRange(positionId))
+	println("[EXPECTED] position burned:", position.IsBurned(positionId))
+
+	// second position with a wider range, used for Reposition later
+	secondId, secondLiquidity, _, _ := position.Mint(
+		cross(cur), barPath, fooPath, fee500, -1920, 1920,
+		"30000000", "30000000", "0", "0", time.Now().Unix()+3600, adminAddr, "",
+	)
+	testing.SkipHeights(1)
+	println("[EXPECTED] minted position:", secondId, "liquidity:", secondLiquidity)
+
+	// increase liquidity on position 1
+	_, increasedLiquidity, increased0, increased1, _ := position.IncreaseLiquidity(
+		cross(cur), positionId, "10000000", "10000000", "0", "0", time.Now().Unix()+3600,
+	)
+	testing.SkipHeights(1)
+	println("[EXPECTED] increased liquidity:", increasedLiquidity, "amount0:", increased0, "amount1:", increased1)
+	println("[EXPECTED] position liquidity now:", position.GetPositionLiquidity(positionId))
+
+	// decrease half of the liquidity; the withdrawal fee is routed to protocol fee
+	decreaseAmount := position.GetPositionLiquidity(positionId)
+	beforeBarAccu := protocolFee.GetAccuTransferToGovStakerByTokenPath(barPath) +
+		protocolFee.GetAccuTransferToDevOpsByTokenPath(barPath)
+
+	// returns: positionId, liquidity, fee0, fee1, amount0, amount1, poolPath
+	_, removedLiquidity, fee0, fee1, removed0, removed1, removedPoolPath := position.DecreaseLiquidity(
+		cross(cur), positionId, halfOf(decreaseAmount), "0", "0", time.Now().Unix()+3600,
+	)
+	testing.SkipHeights(1)
+
+	afterBarAccu := protocolFee.GetAccuTransferToGovStakerByTokenPath(barPath) +
+		protocolFee.GetAccuTransferToDevOpsByTokenPath(barPath)
+
+	println("[EXPECTED] removed liquidity:", removedLiquidity, "from pool:", removedPoolPath)
+	println("[EXPECTED] principal returned:", removed0, removed1)
+	println("[EXPECTED] fees returned with the principal:", fee0, fee1)
+	println("[EXPECTED] withdrawal fee accrued (BAR):", afterBarAccu-beforeBarAccu)
+	println("[EXPECTED] position liquidity after decrease:", position.GetPositionLiquidity(positionId))
+	println("[EXPECTED] position count:", position.GetPositionCount())
+
+	uassert.Equal(t, adminAddr, position.GetPositionOwner(positionId))
+	uassert.Equal(t, barFoo500PoolPath, position.GetPositionPoolKey(positionId))
+	uassert.True(t, position.IsInRange(positionId))
+	uassert.False(t, position.IsBurned(positionId))
+	uassert.Equal(t, 2, position.GetPositionCount())
+}
+
+// halfOf divides a decimal string by two. The liquidity values used here always
+// fit into int64, so a plain parse is enough.
+func halfOf(value string) string {
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		panic(err)
+	}
+	return strconv.FormatInt(parsed/2, 10)
+}
+
+// ---------------------------------------------------------------------------
+// 6. router swaps
+// ---------------------------------------------------------------------------
+
+func routerSwaps(cur realm) {
+	testing.SetRealm(adminRealm)
+	bar.Approve(cross(cur), routerAddr, math.MaxInt64)
+	foo.Approve(cross(cur), routerAddr, math.MaxInt64)
+	bar.Approve(cross(cur), poolAddr, math.MaxInt64)
+	foo.Approve(cross(cur), poolAddr, math.MaxInt64)
+
+	in1, out1 := router.ExactInSingleSwapRoute(
+		cross(cur), barPath, fooPath, "1000000", barFooRoute, "1", "0", time.Now().Unix()+3600, "",
+	)
+	testing.SkipHeights(1)
+	println("[EXPECTED] exact-in-single in/out:", in1, out1)
+
+	in2, out2 := router.ExactInSwapRoute(
+		cross(cur), fooPath, barPath, "1000000", fooBarRoute, "100", "1", time.Now().Unix()+3600, "",
+	)
+	testing.SkipHeights(1)
+	println("[EXPECTED] exact-in in/out:", in2, out2)
+
+	in3, out3 := router.ExactOutSingleSwapRoute(
+		cross(cur), barPath, fooPath, "500000", barFooRoute, "10000000", "0", time.Now().Unix()+3600, "",
+	)
+	testing.SkipHeights(1)
+	println("[EXPECTED] exact-out-single in/out:", in3, out3)
+
+	in4, out4 := router.ExactOutSwapRoute(
+		cross(cur), fooPath, barPath, "500000", fooBarRoute, "100", "10000000", time.Now().Unix()+3600, "",
+	)
+	testing.SkipHeights(1)
+	println("[EXPECTED] exact-out in/out:", in4, out4)
+
+	println("[EXPECTED] pool tick after swaps:", pool.GetSlot0Tick(barFoo500PoolPath))
+	println("[EXPECTED] pool liquidity:", pool.GetLiquidity(barFoo500PoolPath))
+	feeGrowth0, feeGrowth1 := pool.GetFeeGrowthGlobalX128(barFoo500PoolPath)
+	println("[EXPECTED] fee growth global:", feeGrowth0, feeGrowth1)
+	protocolFee0, protocolFee1 := pool.GetProtocolFeesTokens(barFoo500PoolPath)
+	println("[EXPECTED] pool protocol fees:", protocolFee0, protocolFee1)
+	println("[EXPECTED] router fee accrued (FOO):", protocolFee.GetAccuTransferToGovStakerByTokenPath(fooPath)+
+		protocolFee.GetAccuTransferToDevOpsByTokenPath(fooPath))
+
+	uassert.True(t, protocolFee0 > 0)
+	uassert.True(t, protocolFee1 > 0)
+}
+
+// ---------------------------------------------------------------------------
+// 7-8. fee collection and reposition
+// ---------------------------------------------------------------------------
+
+func collectPositionFee(cur realm, positionId uint64) {
+	testing.SetRealm(adminRealm)
+
+	unclaimed0, unclaimed1 := position.GetUnclaimedFee(positionId)
+	println("[EXPECTED] unclaimed fee before collect:", unclaimed0, unclaimed1)
+
+	_, collected0, collected1, poolPath, token0, token1 := position.CollectFee(cross(cur), positionId)
+	testing.SkipHeights(1)
+	println("[EXPECTED] collected fee:", collected0, collected1, "pool:", poolPath)
+	println("[EXPECTED] fee tokens:", token0, token1)
+
+	after0, after1 := position.GetUnclaimedFee(positionId)
+	println("[EXPECTED] unclaimed fee after collect:", after0, after1)
+
+	uassert.Equal(t, barFoo500PoolPath, poolPath)
+}
+
+func repositionPosition(cur realm, positionId uint64) {
+	testing.SetRealm(adminRealm)
+
+	liquidity := position.GetPositionLiquidity(positionId)
+	_, _, _, _, _, _, _ = position.DecreaseLiquidity(
+		cross(cur), positionId, liquidity, "0", "0", time.Now().Unix()+3600,
+	)
+	testing.SkipHeights(1)
+	println("[EXPECTED] liquidity before reposition:", position.GetPositionLiquidity(positionId))
+
+	_, newLiquidity, tickLower, tickUpper, used0, used1 := position.Reposition(
+		cross(cur), positionId, -600, 600, "20000000", "20000000", "0", "0", time.Now().Unix()+3600,
+	)
+	testing.SkipHeights(1)
+	println("[EXPECTED] repositioned liquidity:", newLiquidity, "ticks:", tickLower, tickUpper)
+	println("[EXPECTED] amounts used:", used0, used1)
+	println("[EXPECTED] position ticks from getter:", position.GetPositionTickLower(positionId), position.GetPositionTickUpper(positionId))
+
+	uassert.Equal(t, int32(-600), position.GetPositionTickLower(positionId))
+	uassert.Equal(t, int32(600), position.GetPositionTickUpper(positionId))
+}
+
+// ---------------------------------------------------------------------------
+// 9-10. staker
+// ---------------------------------------------------------------------------
+
+func stakerSetup(cur realm) {
+	testing.SetRealm(adminRealm)
+
+	staker.SetPoolTier(cross(cur), barFoo500PoolPath, 2)
+	println("[EXPECTED] pool tier after SetPoolTier:", staker.GetPoolTier(barFoo500PoolPath))
+	staker.ChangePoolTier(cross(cur), barFoo500PoolPath, 1)
+	println("[EXPECTED] pool tier after ChangePoolTier:", staker.GetPoolTier(barFoo500PoolPath))
+	println("[EXPECTED] tier1 pool count:", staker.GetPoolTierCount(1))
+
+	// external incentive funded with GNS
+	gns.Approve(cross(cur), stakerAddr, math.MaxInt64)
+	createTimestamp := time.Now().Unix()
+	startTime := ((createTimestamp / secondsPerDay) + 1) * secondsPerDay
+	endTime := startTime + incentiveDuration
+	externalIncentiveId = ufmt.Sprintf("%s:%d:%d", adminAddr.String(), createTimestamp, 1)
+
+	staker.CreateExternalIncentive(cross(cur), barFoo500PoolPath, gnsPath, incentiveReward, startTime, endTime)
+	testing.SkipHeights(1)
+
+	println("[EXPECTED] incentive id:", externalIncentiveId)
+	println("[EXPECTED] incentive reward token:", staker.GetIncentiveRewardToken(barFoo500PoolPath, externalIncentiveId))
+	println("[EXPECTED] incentive total reward:", staker.GetIncentiveTotalRewardAmount(barFoo500PoolPath, externalIncentiveId))
+	println("[EXPECTED] incentive creator:", staker.GetIncentiveCreator(barFoo500PoolPath, externalIncentiveId))
+	println("[EXPECTED] incentive deposit gns:", staker.GetIncentiveDepositGnsAmount(barFoo500PoolPath, externalIncentiveId))
+
+	// stake position 1; staker takes NFT custody and becomes the position operator
+	gnft.Approve(cross(cur), stakerAddr, grc721.TokenID("1"))
+	lpTokenId := staker.StakeToken(cross(cur), 1, "")
+	testing.SkipHeights(1)
+
+	println("[EXPECTED] staked position 1 into:", lpTokenId)
+	println("[EXPECTED] is staked:", staker.IsStaked(1))
+	println("[EXPECTED] deposit owner:", staker.GetDepositOwner(1))
+	println("[EXPECTED] deposit liquidity:", staker.GetDepositLiquidityAsString(1))
+	println("[EXPECTED] deposit target pool:", staker.GetDepositTargetPoolPath(1))
+	// StakeToken routes position.SetPositionOperator (staker-only entry point)
+	// and records the staking caller as the position operator.
+	println("[EXPECTED] position operator after stake is the staker caller:", position.GetPositionOperator(1) == adminAddr)
+	println("[EXPECTED] pool staked liquidity:", staker.GetPoolStakedLiquidity(barFoo500PoolPath))
+
+	uassert.Equal(t, uint64(1), staker.GetPoolTier(barFoo500PoolPath))
+	uassert.True(t, staker.IsStaked(1))
+	uassert.Equal(t, adminAddr, staker.GetDepositOwner(1))
+	uassert.Equal(t, adminAddr, position.GetPositionOperator(1))
+	uassert.Equal(t, incentiveReward, staker.GetIncentiveTotalRewardAmount(barFoo500PoolPath, externalIncentiveId))
+}
+
+func accumulateAndCollectStakingReward(cur realm) {
+	// 10 days: the first warm-up tier ends after 5 days, so the collected
+	// amount reflects two different warm-up ratios.
+	testing.SkipHeights(10 * secondsPerDay / blockTimeSeconds)
+
+	collectableEmission := staker.CollectableEmissionReward(1)
+	collectableExternal := staker.CollectableExternalIncentiveReward(1, externalIncentiveId)
+	println("[EXPECTED] collectable emission reward:", collectableEmission)
+	println("[EXPECTED] collectable external reward:", collectableExternal)
+
+	testing.SetRealm(adminRealm)
+	rewardToUser, rewardPenalty, externalToUser, externalPenalty := staker.CollectReward(cross(cur), 1)
+	testing.SkipHeights(1)
+
+	println("[EXPECTED] internal reward to user:", rewardToUser, "penalty:", rewardPenalty)
+	for tokenPath, amount := range externalToUser {
+		println("[EXPECTED] external reward to user:", tokenPath, amount)
+	}
+	for tokenPath, amount := range externalPenalty {
+		println("[EXPECTED] external reward penalty:", tokenPath, amount)
+	}
+	println("[EXPECTED] collected internal reward total:", staker.GetDepositCollectedInternalReward(1))
+	println("[EXPECTED] total emission sent:", staker.GetTotalEmissionSent())
+
+	toUser, _ := strconv.ParseInt(rewardToUser, 10, 64)
+	penalty, _ := strconv.ParseInt(rewardPenalty, 10, 64)
+	uassert.True(t, toUser > 0)
+	uassert.True(t, penalty > 0)
+	// the collected-reward ledger also accounts for the penalty share and for
+	// the block mined between the getter read and the collect transaction
+	uassert.True(t, staker.GetDepositCollectedInternalReward(1) >= toUser)
+}
+
+// ---------------------------------------------------------------------------
+// 11. protocol fee
+// ---------------------------------------------------------------------------
+
+func distributeProtocolFee(cur realm) {
+	testing.SetRealm(adminRealm)
+
+	accuGovStakerBar := protocolFee.GetAccuTransferToGovStakerByTokenPath(barPath)
+	accuDevOpsBar := protocolFee.GetAccuTransferToDevOpsByTokenPath(barPath)
+	println("[EXPECTED] accumulated BAR (gov staker / devops):", accuGovStakerBar, accuDevOpsBar)
+
+	protocolFee.DistributeProtocolFeeByTokenPath(cross(cur), barPath)
+	testing.SkipHeights(1)
+	println("[EXPECTED] distributed BAR to gov staker:", protocolFee.GetActualDistributedToGovStakerByTokenPath(barPath))
+	println("[EXPECTED] distributed BAR to devops:", protocolFee.GetActualDistributedToDevOpsByTokenPath(barPath))
+
+	protocolFee.DistributeProtocolFee(cross(cur))
+	testing.SkipHeights(1)
+	println("[EXPECTED] reserved token count:", len(protocolFee.GetReservedTokens()))
+	println("[EXPECTED] distributed FOO to gov staker:", protocolFee.GetActualDistributedToGovStakerByTokenPath(fooPath))
+	println("[EXPECTED] distributed GNS to gov staker:", protocolFee.GetActualDistributedToGovStakerByTokenPath(gnsPath))
+
+	// 40 / 60 split must hold for every distributed token
+	distributedGovStaker := protocolFee.GetActualDistributedToGovStakerByTokenPath(barPath)
+	distributedDevOps := protocolFee.GetActualDistributedToDevOpsByTokenPath(barPath)
+	uassert.Equal(t, accuGovStakerBar, distributedGovStaker)
+	uassert.Equal(t, accuDevOpsBar, distributedDevOps)
+}
+
+// ---------------------------------------------------------------------------
+// 12. gov staker
+// ---------------------------------------------------------------------------
+
+func govStakerLifecycle(cur realm) {
+	// alice delegates to admin
+	testing.SetRealm(adminRealm)
+	gns.Transfer(cross(cur), aliceAddr, 5_000_000_000)
+
+	testing.SetRealm(aliceRealm)
+	gns.Approve(cross(cur), govStakerAddr, 5_000_000_000)
+	// Delegate returns the delegated amount, not a delegation id
+	aliceDelegatedAmount = govStaker.Delegate(cross(cur), adminAddr, 2_000_000_000, "")
+	testing.SkipHeights(1)
+	println("[EXPECTED] alice delegated amount:", aliceDelegatedAmount)
+	println("[EXPECTED] total delegated:", govStaker.GetTotalDelegated())
+	println("[EXPECTED] total xGNS supply:", govStaker.GetTotalxGnsSupply())
+	println("[EXPECTED] delegation count:", govStaker.GetDelegationCount())
+
+	// admin delegates to itself; needed later to pass the proposal threshold
+	testing.SetRealm(adminRealm)
+	gns.Approve(cross(cur), govStakerAddr, 5_000_000_000)
+	adminDelegatedAmount := govStaker.Delegate(cross(cur), adminAddr, 5_000_000_000, "")
+	testing.SkipHeights(1)
+	println("[EXPECTED] admin delegated amount:", adminDelegatedAmount)
+	println("[EXPECTED] total delegated after admin:", govStaker.GetTotalDelegated())
+
+	// redelegate part of alice's stake to herself
+	testing.SetRealm(aliceRealm)
+	redelegated := govStaker.Redelegate(cross(cur), adminAddr, aliceAddr, 500_000_000)
+	testing.SkipHeights(1)
+	println("[EXPECTED] redelegated:", redelegated)
+	println("[EXPECTED] alice->alice delegation count:", govStaker.GetUserDelegationCount(aliceAddr, aliceAddr))
+
+	// undelegate and collect after the lockup period
+	govStaker.Undelegate(cross(cur), aliceAddr, 200_000_000)
+	testing.SkipHeights(1)
+	println("[EXPECTED] total locked amount:", govStaker.GetTotalLockedAmount())
+
+	testing.SkipHeights(100 / blockTimeSeconds)
+	collected := govStaker.CollectUndelegatedGns(cross(cur))
+	testing.SkipHeights(1)
+	println("[EXPECTED] collected undelegated gns:", collected)
+	println("[EXPECTED] total locked amount after collect:", govStaker.GetTotalLockedAmount())
+
+	// rewards accrue from emission and from the distributed protocol fee
+	testing.SkipHeights(secondsPerDay / blockTimeSeconds)
+	emissionReward, protocolFeeRewards, err := govStaker.GetClaimableRewardByAddress(aliceAddr)
+	if err != nil {
+		panic(err)
+	}
+	println("[EXPECTED] alice claimable emission reward:", emissionReward)
+	println("[EXPECTED] alice claimable protocol fee token count:", len(protocolFeeRewards))
+
+	testing.SetRealm(aliceRealm)
+	govStaker.CollectEmissionReward(cross(cur))
+	govStaker.CollectProtocolFeeReward(cross(cur), barPath)
+	govStaker.CollectReward(cross(cur))
+	testing.SkipHeights(1)
+	println("[EXPECTED] emission distributed amount:", govStaker.GetEmissionDistributedAmount())
+	println("[EXPECTED] protocol fee amount (BAR):", govStaker.GetProtocolFeeAmount(barPath))
+
+	// snapshot cleanup keeps the delegation history bounded
+	testing.SetRealm(adminRealm)
+	// snapshots may only be pruned once they are older than the maximum
+	// smoothing period (30 days)
+	govStaker.CleanStakerDelegationSnapshotByAdmin(cross(cur), time.Now().Unix()-31*secondsPerDay, aliceAddr)
+	testing.SkipHeights(1)
+	println("[EXPECTED] delegation snapshots present:", govStaker.HasDelegationSnapshotsKey())
+
+	uassert.Equal(t, int64(6_800_000_000), govStaker.GetTotalDelegated())
+	uassert.Equal(t, int64(6_800_000_000), govStaker.GetTotalLockedAmount())
+	uassert.Equal(t, int64(2_000_000_000), aliceDelegatedAmount)
+}
+
+// ---------------------------------------------------------------------------
+// 13. governance
+// ---------------------------------------------------------------------------
+
+func governanceLifecycle(cur realm) {
+	config := govGovernance.GetLatestConfig()
+	println("[EXPECTED] governance config version:", govGovernance.GetLatestConfigVersion())
+	println("[EXPECTED] voting period:", config.VotingPeriod, "quorum:", config.Quorum)
+
+	// voting weight is averaged over the smoothing duration, so the delegation
+	// made in the previous scenario must age before a proposal can be created
+	testing.SkipHeights(config.VotingWeightSmoothingDuration / blockTimeSeconds)
+
+	// A proposer may only hold one active proposal at a time, so each proposal
+	// is driven to a terminal state before the next one is created.
+
+	// --- text proposal: created, then canceled ---
+	testing.SetRealm(adminRealm)
+	textProposalId = govGovernance.ProposeText(cross(cur), "text proposal", "signal only")
+	testing.SkipHeights(1)
+	println("[EXPECTED] text proposal id:", textProposalId)
+	textTitle, _ := govGovernance.GetTitleByProposalId(textProposalId)
+	println("[EXPECTED] text proposal title:", textTitle)
+	textProposer, _ := govGovernance.GetProposerByProposalId(textProposalId)
+	println("[EXPECTED] text proposal proposer is admin:", textProposer == adminAddr)
+
+	canceledId := govGovernance.Cancel(cross(cur), textProposalId)
+	testing.SkipHeights(1)
+	canceledStatus, _ := govGovernance.GetProposalStatusByProposalId(canceledId)
+	println("[EXPECTED] text proposal status after cancel:", canceledStatus)
+
+	// --- community pool spend proposal: voted and executed ---
+	testing.SetRealm(adminRealm)
+	spendProposalId = govGovernance.ProposeCommunityPoolSpend(
+		cross(cur), "community pool spend", "spend 1000 GNS", aliceAddr, gnsPath, 1_000,
+	)
+	testing.SkipHeights(1)
+	println("[EXPECTED] spend proposal id:", spendProposalId)
+	spendType, _ := govGovernance.GetProposalTypeByProposalId(spendProposalId)
+	println("[EXPECTED] spend proposal type:", spendType.String())
+
+	aliceGnsBefore := gns.BalanceOf(aliceAddr)
+	voteAndExecute(cur, config, spendProposalId)
+	aliceGnsAfter := gns.BalanceOf(aliceAddr)
+	spendStatus, _ := govGovernance.GetProposalStatusByProposalId(spendProposalId)
+	println("[EXPECTED] spend proposal status after execute:", spendStatus)
+	println("[EXPECTED] community pool spend received by alice:", aliceGnsAfter-aliceGnsBefore)
+
+	// --- parameter change proposal: governance drives the staker setter ---
+	testing.SetRealm(adminRealm)
+	paramProposalId = govGovernance.ProposeParameterChange(
+		cross(cur), "parameter change", "raise the unstaking fee", 1,
+		"gno.land/r/gnoswap/staker*EXE*SetUnStakingFee*EXE*150",
+	)
+	testing.SkipHeights(1)
+	println("[EXPECTED] param proposal id:", paramProposalId)
+	println("[EXPECTED] proposal count:", govGovernance.GetProposalCount())
+
+	unstakingFeeBefore := staker.GetUnstakingFee()
+	voteAndExecute(cur, config, paramProposalId)
+	println("[EXPECTED] unstaking fee before/after governance execution:", unstakingFeeBefore, staker.GetUnstakingFee())
+
+	// --- reconfigure produces a new config version ---
+	testing.SetRealm(adminRealm)
+	newVersion := govGovernance.Reconfigure(
+		cross(cur),
+		config.VotingStartDelay,
+		config.VotingPeriod,
+		config.VotingWeightSmoothingDuration,
+		config.Quorum,
+		config.ProposalCreationThreshold,
+		config.ExecutionDelay,
+		config.ExecutionWindow,
+	)
+	testing.SkipHeights(1)
+	println("[EXPECTED] governance config version after reconfigure:", newVersion)
+
+	uassert.Equal(t, uint64(150), staker.GetUnstakingFee())
+	uassert.Equal(t, int64(2), newVersion)
+	uassert.Equal(t, 3, govGovernance.GetProposalCount())
+	uassert.Equal(t, int64(1_000), aliceGnsAfter-aliceGnsBefore)
+}
+
+// voteAndExecute drives a proposal through the full voting schedule:
+// votingStartDelay -> Vote -> votingPeriod + executionDelay -> Execute.
+func voteAndExecute(cur realm, config govGovernance.Config, proposalId int64) {
+	testing.SkipHeights(config.VotingStartDelay / blockTimeSeconds)
+
+	testing.SetRealm(adminRealm)
+	govGovernance.Vote(cross(cur), proposalId, true)
+	testing.SkipHeights(1)
+
+	yea, _ := govGovernance.GetYeaByProposalId(proposalId)
+	nay, _ := govGovernance.GetNayByProposalId(proposalId)
+	println("[EXPECTED] proposal", proposalId, "yea/nay:", yea, nay)
+	voteWeight, _ := govGovernance.GetVoteWeight(proposalId, adminAddr)
+	println("[EXPECTED] admin vote weight:", voteWeight)
+	quorum, maxVotingWeight, yesWeight, noWeight, _ := govGovernance.GetVoteStatus(proposalId)
+	println("[EXPECTED] vote status quorum/max/yes/no:", quorum, maxVotingWeight, yesWeight, noWeight)
+
+	testing.SkipHeights((config.VotingPeriod + config.ExecutionDelay) / blockTimeSeconds)
+	testing.SetRealm(adminRealm)
+	govGovernance.Execute(cross(cur), proposalId)
+	testing.SkipHeights(1)
+}
+
+// ---------------------------------------------------------------------------
+// 14. launchpad
+// ---------------------------------------------------------------------------
+
+func launchpadLifecycle(cur realm) {
+	testing.SetRealm(adminRealm)
+
+	rewardAmount := int64(1_000_000_000)
+	startTime := time.Now().Unix() + 7*secondsPerDay
+
+	obl.Approve(cross(cur), launchpadAddr, rewardAmount)
+	launchpadProjectId = launchpad.CreateProject(
+		cross(cur),
+		"OBL launchpad project",
+		oblPath,
+		projectAddr,
+		rewardAmount,
+		"",
+		"",
+		10, // tier30 ratio
+		20, // tier90 ratio
+		70, // tier180 ratio
+		startTime,
+	)
+	testing.SkipHeights(1)
+	launchpadTier30Id = ufmt.Sprintf("%s:%d", launchpadProjectId, launchpadTierWaitID)
+
+	println("[EXPECTED] project id:", launchpadProjectId)
+	println("[EXPECTED] project count:", launchpad.GetProjectCount())
+	projectName, _ := launchpad.GetProjectName(launchpadProjectId)
+	println("[EXPECTED] project name:", projectName)
+	projectRecipient, _ := launchpad.GetProjectRecipient(launchpadProjectId)
+	println("[EXPECTED] project recipient is project owner:", projectRecipient == projectAddr)
+	tier30Total, _ := launchpad.GetProjectTierTotalDistributeAmount(launchpadProjectId, 30)
+	tier90Total, _ := launchpad.GetProjectTierTotalDistributeAmount(launchpadProjectId, 90)
+	tier180Total, _ := launchpad.GetProjectTierTotalDistributeAmount(launchpadProjectId, 180)
+	println("[EXPECTED] tier distribute amounts:", tier30Total, tier90Total, tier180Total)
+
+	// wait for the tier to open, then deposit GNS
+	testing.SkipHeights(7 * secondsPerDay / blockTimeSeconds)
+
+	testing.SetRealm(adminRealm)
+	gns.Transfer(cross(cur), aliceAddr, 1_000_000)
+
+	testing.SetRealm(aliceRealm)
+	gns.Approve(cross(cur), launchpadAddr, 1_000_000)
+	launchpadDepositId = launchpad.DepositGns(cross(cur), launchpadTier30Id, 1_000_000, "")
+	testing.SkipHeights(1)
+
+	println("[EXPECTED] deposit id:", launchpadDepositId)
+	println("[EXPECTED] deposit count:", launchpad.GetDepositCount())
+	println("[EXPECTED] total GNS staked in launchpad:", launchpad.GetTotalGNSStakedAmount())
+	depositAmount, _ := launchpad.GetDepositAmount(launchpadDepositId)
+	println("[EXPECTED] deposit amount:", depositAmount)
+	projectWalletAmount, projectWalletFound := govStaker.GetLaunchpadProjectDeposit(projectAddr.String())
+	println("[EXPECTED] launchpad project wallet xGNS:", projectWalletAmount, "found:", projectWalletFound)
+
+	// reward becomes claimable after the tier's collect-wait duration (3 days)
+	testing.SkipHeights(4 * secondsPerDay / blockTimeSeconds)
+
+	testing.SetRealm(aliceRealm)
+	claimed := launchpad.CollectRewardByDepositId(cross(cur), launchpadDepositId)
+	testing.SkipHeights(1)
+	println("[EXPECTED] launchpad reward claimed:", claimed)
+
+	// the project recipient collects the gov-staker side rewards
+	testing.SetRealm(projectRealm)
+	launchpad.CollectEmissionReward(cross(cur))
+	launchpad.CollectProtocolFeeReward(cross(cur), barPath)
+	launchpad.CollectProtocolFee(cross(cur))
+	testing.SkipHeights(1)
+	println("[EXPECTED] project recipient collected launchpad rewards")
+
+	uassert.Equal(t, 1, launchpad.GetProjectCount())
+	uassert.Equal(t, int64(1_000_000), depositAmount)
+	uassert.True(t, projectWalletFound)
+	uassert.True(t, claimed > 0)
+}
+
+// ---------------------------------------------------------------------------
+// 15. snapshot
+// ---------------------------------------------------------------------------
+
+func captureSnapshot() upgradeSnapshot {
+	feeGrowth0, feeGrowth1 := pool.GetFeeGrowthGlobalX128(barFoo500PoolPath)
+	protocolFee0, protocolFee1 := pool.GetProtocolFeesTokens(barFoo500PoolPath)
+
+	return upgradeSnapshot{
+		poolLiquidity:      pool.GetLiquidity(barFoo500PoolPath),
+		poolSqrtPriceX96:   pool.GetSlot0SqrtPriceX96(barFoo500PoolPath),
+		poolTick:           pool.GetSlot0Tick(barFoo500PoolPath),
+		poolFeeGrowth0:     feeGrowth0,
+		poolFeeGrowth1:     feeGrowth1,
+		poolProtocolFee0:   protocolFee0,
+		poolProtocolFee1:   protocolFee1,
+		poolCreationFee:    pool.GetPoolCreationFee(),
+		withdrawalFee:      pool.GetWithdrawalFee(),
+		swapFee:            router.GetSwapFee(),
+		positionCount:      position.GetPositionCount(),
+		positionLiquidity:  position.GetPositionLiquidity(1),
+		positionTickLower:  position.GetPositionTickLower(1),
+		positionTickUpper:  position.GetPositionTickUpper(1),
+		positionOwner:      position.GetPositionOwner(1),
+		stakerPoolTier:     staker.GetPoolTier(barFoo500PoolPath),
+		stakerUnstakingFee: staker.GetUnstakingFee(),
+		stakerDepositGns:   staker.GetDepositGnsAmount(),
+		depositLiquidity:   staker.GetDepositLiquidityAsString(1),
+		devOpsPct:          protocolFee.GetDevOpsPct(),
+		govStakerPct:       protocolFee.GetGovStakerPct(),
+		accuGovStakerBar:   protocolFee.GetAccuTransferToGovStakerByTokenPath(barPath),
+		totalDelegated:     govStaker.GetTotalDelegated(),
+		totalXGnsSupply:    govStaker.GetTotalxGnsSupply(),
+		delegationCount:    govStaker.GetDelegationCount(),
+		proposalCount:      govGovernance.GetProposalCount(),
+		configVersion:      govGovernance.GetLatestConfigVersion(),
+		projectCount:       launchpad.GetProjectCount(),
+		launchpadDeposits:  launchpad.GetTotalGNSStakedAmount(),
+	}
+}
+
+func printSnapshot(s upgradeSnapshot) {
+	println("[EXPECTED] pool liquidity:", s.poolLiquidity)
+	println("[EXPECTED] pool tick:", s.poolTick)
+	println("[EXPECTED] pool protocol fees:", s.poolProtocolFee0, s.poolProtocolFee1)
+	println("[EXPECTED] position 1 liquidity:", s.positionLiquidity)
+	println("[EXPECTED] staker pool tier:", s.stakerPoolTier)
+	println("[EXPECTED] staked deposit liquidity:", s.depositLiquidity)
+	println("[EXPECTED] protocol fee split:", s.devOpsPct, s.govStakerPct)
+	println("[EXPECTED] total delegated:", s.totalDelegated)
+	println("[EXPECTED] proposal count:", s.proposalCount)
+	println("[EXPECTED] project count:", s.projectCount)
+	println("[EXPECTED] launchpad deposits:", s.launchpadDeposits)
+}
+
+// ---------------------------------------------------------------------------
+// 16-17. upgrade and validation
+// ---------------------------------------------------------------------------
+
+func upgradeAllToV2Valid(cur realm) {
+	testing.SetRealm(adminRealm)
+
+	protocolFee.UpgradeImpl(cross(cur), protocolFeeV2Path)
+	pool.UpgradeImpl(cross(cur), poolV2Path)
+	position.UpgradeImpl(cross(cur), positionV2Path)
+	router.UpgradeImpl(cross(cur), routerV2Path)
+	// The staker upgrade re-registers the pool swap hooks
+	// (SetSwapStartHook / SetSwapEndHook / SetTickCrossHook) from the new
+	// implementation, which is what keeps tick-cross reward accounting alive
+	// after a pool upgrade.
+	staker.UpgradeImpl(cross(cur), stakerV2Path)
+	launchpad.UpgradeImpl(cross(cur), launchpadV2Path)
+	govStaker.UpgradeImpl(cross(cur), govStakerV2Path)
+	govGovernance.UpgradeImpl(cross(cur), governanceV2Path)
+	testing.SkipHeights(1)
+
+	printImplementations()
+
+	uassert.Equal(t, poolV2Path, pool.GetImplementationPackagePath())
+	uassert.Equal(t, positionV2Path, position.GetImplementationPackagePath())
+	uassert.Equal(t, routerV2Path, router.GetImplementationPackagePath())
+	uassert.Equal(t, stakerV2Path, staker.GetImplementationPackagePath())
+	uassert.Equal(t, launchpadV2Path, launchpad.GetImplementationPackagePath())
+	uassert.Equal(t, protocolFeeV2Path, protocolFee.GetImplementationPackagePath())
+	uassert.Equal(t, governanceV2Path, govGovernance.GetImplementationPackagePath())
+	uassert.Equal(t, govStakerV2Path, govStaker.GetImplementationPackagePath())
+}
+
+func validateSnapshotUnchanged() {
+	after := captureSnapshot()
+
+	uassert.Equal(t, snap.poolLiquidity, after.poolLiquidity)
+	uassert.Equal(t, snap.poolSqrtPriceX96, after.poolSqrtPriceX96)
+	uassert.Equal(t, snap.poolTick, after.poolTick)
+	uassert.Equal(t, snap.poolFeeGrowth0, after.poolFeeGrowth0)
+	uassert.Equal(t, snap.poolFeeGrowth1, after.poolFeeGrowth1)
+	uassert.Equal(t, snap.poolProtocolFee0, after.poolProtocolFee0)
+	uassert.Equal(t, snap.poolProtocolFee1, after.poolProtocolFee1)
+	uassert.Equal(t, snap.poolCreationFee, after.poolCreationFee)
+	uassert.Equal(t, snap.withdrawalFee, after.withdrawalFee)
+	uassert.Equal(t, snap.swapFee, after.swapFee)
+	uassert.Equal(t, snap.positionCount, after.positionCount)
+	uassert.Equal(t, snap.positionLiquidity, after.positionLiquidity)
+	uassert.Equal(t, snap.positionTickLower, after.positionTickLower)
+	uassert.Equal(t, snap.positionTickUpper, after.positionTickUpper)
+	uassert.Equal(t, snap.positionOwner, after.positionOwner)
+	uassert.Equal(t, snap.stakerPoolTier, after.stakerPoolTier)
+	uassert.Equal(t, snap.stakerUnstakingFee, after.stakerUnstakingFee)
+	uassert.Equal(t, snap.stakerDepositGns, after.stakerDepositGns)
+	uassert.Equal(t, snap.depositLiquidity, after.depositLiquidity)
+	uassert.Equal(t, snap.devOpsPct, after.devOpsPct)
+	uassert.Equal(t, snap.govStakerPct, after.govStakerPct)
+	uassert.Equal(t, snap.accuGovStakerBar, after.accuGovStakerBar)
+	uassert.Equal(t, snap.totalDelegated, after.totalDelegated)
+	uassert.Equal(t, snap.totalXGnsSupply, after.totalXGnsSupply)
+	uassert.Equal(t, snap.delegationCount, after.delegationCount)
+	uassert.Equal(t, snap.proposalCount, after.proposalCount)
+	uassert.Equal(t, snap.configVersion, after.configVersion)
+	uassert.Equal(t, snap.projectCount, after.projectCount)
+	uassert.Equal(t, snap.launchpadDeposits, after.launchpadDeposits)
+
+	println("[EXPECTED] every snapshot field is identical after the upgrade")
+}
+
+// ---------------------------------------------------------------------------
+// 18. post-upgrade rerun
+// ---------------------------------------------------------------------------
+
+func rerunAfterUpgrade(cur realm) {
+	testing.SetRealm(adminRealm)
+
+	// pool + position through v2_valid
+	bar.Approve(cross(cur), poolAddr, math.MaxInt64)
+	foo.Approve(cross(cur), poolAddr, math.MaxInt64)
+	positionId, liquidity, amount0, amount1 := position.Mint(
+		cross(cur), barPath, fooPath, fee500, -960, 960,
+		"50000000", "50000000", "0", "0", time.Now().Unix()+3600, adminAddr, "",
+	)
+	testing.SkipHeights(1)
+	println("[EXPECTED] v2_valid minted position:", positionId, "liquidity:", liquidity)
+	println("[EXPECTED] v2_valid mint amounts:", amount0, amount1)
+
+	// router through v2_valid
+	bar.Approve(cross(cur), routerAddr, math.MaxInt64)
+	foo.Approve(cross(cur), routerAddr, math.MaxInt64)
+	in, out := router.ExactInSingleSwapRoute(
+		cross(cur), barPath, fooPath, "1000000", barFooRoute, "1", "0", time.Now().Unix()+3600, "",
+	)
+	testing.SkipHeights(1)
+	println("[EXPECTED] v2_valid swap in/out:", in, out)
+
+	// staker through v2_valid: stake the freshly minted position
+	gnft.Approve(cross(cur), stakerAddr, grc721.TokenID(strconv.FormatUint(positionId, 10)))
+	staker.StakeToken(cross(cur), positionId, "")
+	testing.SkipHeights(secondsPerDay / blockTimeSeconds)
+	rewardToUser, rewardPenalty, _, _ := staker.CollectReward(cross(cur), positionId)
+	testing.SkipHeights(1)
+	println("[EXPECTED] v2_valid staking reward to user/penalty:", rewardToUser, rewardPenalty)
+
+	// protocol fee through v2_valid
+	testing.SetRealm(adminRealm)
+	protocolFee.DistributeProtocolFee(cross(cur))
+	testing.SkipHeights(1)
+	println("[EXPECTED] v2_valid distributed FOO to gov staker:", protocolFee.GetActualDistributedToGovStakerByTokenPath(fooPath))
+
+	// gov staker through v2_valid
+	testing.SetRealm(aliceRealm)
+	gns.Approve(cross(cur), govStakerAddr, 1_000_000_000)
+	delegationCountBefore := govStaker.GetDelegationCount()
+	newDelegatedAmount := govStaker.Delegate(cross(cur), adminAddr, 1_000_000_000, "")
+	testing.SkipHeights(1)
+	println("[EXPECTED] v2_valid delegated amount:", newDelegatedAmount)
+	println("[EXPECTED] v2_valid delegation count:", govStaker.GetDelegationCount())
+	println("[EXPECTED] v2_valid total delegated:", govStaker.GetTotalDelegated())
+
+	// launchpad through v2_valid: collect the remaining deposit principal
+	testing.SkipHeights(30 * secondsPerDay / blockTimeSeconds)
+	testing.SetRealm(aliceRealm)
+	principal, err := launchpad.CollectDepositGns(cross(cur), launchpadDepositId)
+	if err != nil {
+		panic(err)
+	}
+	testing.SkipHeights(1)
+	println("[EXPECTED] v2_valid collected deposit principal:", principal)
+
+	// governance through v2_valid
+	testing.SetRealm(adminRealm)
+	newProposalId := govGovernance.ProposeText(cross(cur), "post upgrade text", "created through v2_valid")
+	testing.SkipHeights(1)
+	println("[EXPECTED] v2_valid proposal id:", newProposalId)
+	println("[EXPECTED] v2_valid proposal count:", govGovernance.GetProposalCount())
+
+	uassert.Equal(t, int64(1_000_000), principal)
+	uassert.Equal(t, 4, govGovernance.GetProposalCount())
+	uassert.Equal(t, int64(1_000_000_000), newDelegatedAmount)
+	uassert.Equal(t, delegationCountBefore+1, govStaker.GetDelegationCount())
+}
+
+// ---------------------------------------------------------------------------
+// 19. wind down
+// ---------------------------------------------------------------------------
+
+func windDown(cur realm) {
+	// jump past the 90-day incentive window plus one day of buffer
+	testing.SkipHeights((incentiveDuration + secondsPerDay) / blockTimeSeconds)
+
+	testing.SetRealm(adminRealm)
+	staker.EndExternalIncentive(cross(cur), barFoo500PoolPath, externalIncentiveId, adminAddr)
+	testing.SkipHeights(1)
+	println("[EXPECTED] incentive refunded:", staker.GetIncentiveRefunded(barFoo500PoolPath, externalIncentiveId))
+	println("[EXPECTED] incentive distributed:", staker.GetIncentiveDistributedRewardAmount(barFoo500PoolPath, externalIncentiveId))
+
+	penalty := staker.CollectExternalIncentivePenalty(cross(cur), barFoo500PoolPath, externalIncentiveId, adminAddr)
+	testing.SkipHeights(1)
+	println("[EXPECTED] collected incentive penalty:", penalty)
+
+	staker.UnStakeToken(cross(cur), 1)
+	testing.SkipHeights(1)
+	println("[EXPECTED] position 1 staked after unstake:", staker.IsStaked(1))
+	println("[EXPECTED] position 1 owner after unstake:", position.GetPositionOwner(1))
+	println("[EXPECTED] position 1 operator cleared:", position.GetPositionOperator(1) == zeroAddress)
+
+	staker.RemoveToken(cross(cur), barPath)
+	println("[EXPECTED] allowed token count after removal:", len(staker.GetAllowedTokens()))
+
+	staker.RemovePoolTier(cross(cur), barFoo500PoolPath)
+	println("[EXPECTED] pool tier after removal:", staker.GetPoolTier(barFoo500PoolPath))
+
+	// admin sweeps the pool protocol fees
+	before0, before1 := pool.GetProtocolFeesTokens(barFoo500PoolPath)
+	collected0, collected1 := pool.CollectProtocol(
+		cross(cur), barPath, fooPath, fee500, adminAddr, "1000000000", "1000000000",
+	)
+	testing.SkipHeights(1)
+	after0, after1 := pool.GetProtocolFeesTokens(barFoo500PoolPath)
+	println("[EXPECTED] pool protocol fees before:", before0, before1)
+	println("[EXPECTED] collected protocol fees:", collected0, collected1)
+	println("[EXPECTED] pool protocol fees after:", after0, after1)
+
+	// the admin may only reclaim the leftovers once the last tier has ended
+	tier180End, err := launchpad.GetProjectTierEndTime(launchpadProjectId, 180)
+	if err != nil {
+		panic(err)
+	}
+	if remaining := tier180End - time.Now().Unix(); remaining > 0 {
+		testing.SkipHeights(remaining/blockTimeSeconds + 1)
+	}
+	println("[EXPECTED] launchpad project ended:", time.Now().Unix() >= tier180End)
+
+	left := launchpad.TransferLeftFromProjectByAdmin(cross(cur), launchpadProjectId, projectAddr)
+	testing.SkipHeights(1)
+	println("[EXPECTED] launchpad leftover transferred:", left)
+
+	uassert.False(t, staker.IsStaked(1))
+	uassert.Equal(t, adminAddr, position.GetPositionOwner(1))
+	uassert.Equal(t, uint64(0), staker.GetPoolTier(barFoo500PoolPath))
+	uassert.Equal(t, int64(0), after0)
+	uassert.Equal(t, int64(0), after1)
+}
+
+// ---------------------------------------------------------------------------
+// 20. final invariants
+// ---------------------------------------------------------------------------
+
+func finalInvariants(cur realm) {
+	println("[EXPECTED] pool count:", pool.GetPoolCount())
+	println("[EXPECTED] position count:", position.GetPositionCount())
+	println("[EXPECTED] total emission sent:", staker.GetTotalEmissionSent())
+	println("[EXPECTED] gov staker total delegated:", govStaker.GetTotalDelegated())
+	println("[EXPECTED] governance proposal count:", govGovernance.GetProposalCount())
+	println("[EXPECTED] launchpad project count:", launchpad.GetProjectCount())
+
+	// external incentive ledger: the amount handed out (rewards + the refund
+	// booked at EndExternalIncentive) can never exceed the funded total, and
+	// the incentive must be marked refunded once it has been ended.
+	total := staker.GetIncentiveTotalRewardAmount(barFoo500PoolPath, externalIncentiveId)
+	distributed := staker.GetIncentiveDistributedRewardAmount(barFoo500PoolPath, externalIncentiveId)
+	remaining := staker.GetIncentiveRemainingRewardAmount(barFoo500PoolPath, externalIncentiveId)
+	penalty := staker.GetIncentiveAccumulatedPenaltyAmount(barFoo500PoolPath, externalIncentiveId)
+	println("[EXPECTED] incentive total/distributed/remaining/penalty:", total, distributed, remaining, penalty)
+	uassert.True(t, distributed > 0)
+	uassert.True(t, distributed <= total)
+	uassert.True(t, staker.GetIncentiveRefunded(barFoo500PoolPath, externalIncentiveId))
+	uassert.False(t, staker.IsIncentiveActive(barFoo500PoolPath, externalIncentiveId))
+
+	printImplementations()
+}
+
+// Output:
+// [SCENARIO] 1. Activate v1 implementations for every upgradeable contract
+// [EXPECTED] pool impl: gno.land/r/gnoswap/pool/v1
+// [EXPECTED] position impl: gno.land/r/gnoswap/position/v1
+// [EXPECTED] router impl: gno.land/r/gnoswap/router/v1
+// [EXPECTED] staker impl: gno.land/r/gnoswap/staker/v1
+// [EXPECTED] launchpad impl: gno.land/r/gnoswap/launchpad/v1
+// [EXPECTED] protocol_fee impl: gno.land/r/gnoswap/protocol_fee/v1
+// [EXPECTED] governance impl: gno.land/r/gnoswap/gov/governance/v1
+// [EXPECTED] gov staker impl: gno.land/r/gnoswap/gov/staker/v1
+//
+// [SCENARIO] 2. Bootstrap emission and the canonical GNS/WUGNOT pool
+// [EXPECTED] canonical pool exists: true
+// [EXPECTED] pool count: 1
+//
+// [SCENARIO] 3. Configure protocol parameters through the admin setters
+// [EXPECTED] pool creation fee: 100000000
+// [EXPECTED] withdrawal fee bps: 100
+// [EXPECTED] router swap fee bps: 100
+// [EXPECTED] devops pct: 4000
+// [EXPECTED] gov staker pct: 6000
+// [EXPECTED] unstaking fee bps: 100
+// [EXPECTED] deposit gns amount: 1000000000
+// [EXPECTED] minimum reward amount: 1000000000
+// [EXPECTED] bar minimum reward amount: 1000000 found: true
+// [EXPECTED] allowed token count: 3
+// [EXPECTED] warmup tiers: 4
+// [EXPECTED] undelegation lockup period: 100
+//
+// [SCENARIO] 4. Create the BAR/FOO pool and grow its observation cardinality
+// [EXPECTED] created pool: gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:500
+// [EXPECTED] pool exists: true
+// [EXPECTED] token0: gno.land/r/onbloc/bar.BAR
+// [EXPECTED] token1: gno.land/r/onbloc/foo.FOO
+// [EXPECTED] fee: 500
+// [EXPECTED] tick spacing: 10
+// [EXPECTED] slot0 tick: 0
+// [EXPECTED] slot0 sqrtPriceX96: 79228162514264337593543950336
+// [EXPECTED] slot0 unlocked: true
+// [EXPECTED] creation fee accrued to protocol fee: 100000000
+// [EXPECTED] slot0 fee protocol: 68
+// [EXPECTED] observation cardinality next: 10
+//
+// [SCENARIO] 5. Position lifecycle: mint, increase, decrease, collect fee
+// [EXPECTED] minted position: 1 liquidity: 1066918731 amount0: 50000000 amount1: 50000000
+// [EXPECTED] position owner: g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5
+// [EXPECTED] position pool key: gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:500
+// [EXPECTED] position ticks: -960 960
+// [EXPECTED] position in range: true
+// [EXPECTED] position burned: false
+// [EXPECTED] minted position: 2 liquidity: 327755575
+// [EXPECTED] increased liquidity: 213383746 amount0: 10000000 amount1: 10000000
+// [EXPECTED] position liquidity now: 1280302477
+// [EXPECTED] removed liquidity: 640151238 from pool: gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:500
+// [EXPECTED] principal returned: 29999999 29999999
+// [EXPECTED] fees returned with the principal: 0 0
+// [EXPECTED] withdrawal fee accrued (BAR): 0
+// [EXPECTED] position liquidity after decrease: 640151239
+// [EXPECTED] position count: 2
+//
+// [SCENARIO] 6. Router: exact-in / exact-out, single and multi-hop
+// [EXPECTED] exact-in-single in/out: 1000000 -988484
+// [EXPECTED] exact-in in/out: 1000000 -990523
+// [EXPECTED] exact-out-single in/out: 505568 -500000
+// [EXPECTED] exact-out in/out: 505043 -500000
+// [EXPECTED] pool tick after swaps: 0
+// [EXPECTED] pool liquidity: 967906814
+// [EXPECTED] fee growth global: 198985911547938715431204752120259 200040607192185740424656367414182
+// [EXPECTED] pool protocol fees: 188 186
+// [EXPECTED] router fee accrued (FOO): 15034
+//
+// [SCENARIO] 7. Collect position fees generated by the swaps
+// [EXPECTED] unclaimed fee before collect: 374 376
+// [EXPECTED] collected fee: 371 373 pool: gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:500
+// [EXPECTED] fee tokens: 374 376
+// [EXPECTED] unclaimed fee after collect: 0 0
+//
+// [SCENARIO] 8. Reposition the second position into a new tick range
+// [EXPECTED] liquidity before reposition: 0
+// [EXPECTED] repositioned liquidity: 676731855 ticks: -600 600
+// [EXPECTED] amounts used: 19998928 20000000
+// [EXPECTED] position ticks from getter: -600 600
+//
+// [SCENARIO] 9. Staker: tier setup, external incentive, stake position 1
+// [EXPECTED] pool tier after SetPoolTier: 2
+// [EXPECTED] pool tier after ChangePoolTier: 1
+// [EXPECTED] tier1 pool count: 2
+// [EXPECTED] incentive id: g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5:1234567955:1
+// [EXPECTED] incentive reward token: gno.land/r/gnoswap/gns.GNS
+// [EXPECTED] incentive total reward: 1500000000
+// [EXPECTED] incentive creator: g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5
+// [EXPECTED] incentive deposit gns: 1000000000
+// [EXPECTED] staked position 1 into: gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:500
+// [EXPECTED] is staked: true
+// [EXPECTED] deposit owner: g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5
+// [EXPECTED] deposit liquidity: 640151239
+// [EXPECTED] deposit target pool: gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:500
+// [EXPECTED] position operator after stake is the staker caller: true
+// [EXPECTED] pool staked liquidity: 640151239
+//
+// [SCENARIO] 10. Accumulate 10 days of rewards and collect them
+// [EXPECTED] collectable emission reward: 924663981581
+// [EXPECTED] collectable external reward: 66572240
+// [EXPECTED] internal reward to user: 915417341766 penalty: 1386992627983
+// [EXPECTED] external reward to user: gno.land/r/gnoswap/gns.GNS 66572240
+// [EXPECTED] external reward penalty: gno.land/r/gnoswap/gns.GNS 99779032
+// [EXPECTED] collected internal reward total: 2311656609564
+// [EXPECTED] total emission sent: 2302423347314
+//
+// [SCENARIO] 11. Protocol fee distribution to devops / gov staker
+// [EXPECTED] accumulated BAR (gov staker / devops): 9036 6023
+// [EXPECTED] distributed BAR to gov staker: 9036
+// [EXPECTED] distributed BAR to devops: 6023
+// [EXPECTED] reserved token count: 0
+// [EXPECTED] distributed FOO to gov staker: 9024
+// [EXPECTED] distributed GNS to gov staker: 5608383323
+//
+// [SCENARIO] 12. Gov staker: delegate, redelegate, undelegate, collect
+// [EXPECTED] alice delegated amount: 2000000000
+// [EXPECTED] total delegated: 2000000000
+// [EXPECTED] total xGNS supply: 2000000000
+// [EXPECTED] delegation count: 1
+// [EXPECTED] admin delegated amount: 5000000000
+// [EXPECTED] total delegated after admin: 7000000000
+// [EXPECTED] redelegated: 500000000
+// [EXPECTED] alice->alice delegation count: 1
+// [EXPECTED] total locked amount: 7000000000
+// [EXPECTED] collected undelegated gns: 200000000
+// [EXPECTED] total locked amount after collect: 6800000000
+// [EXPECTED] alice claimable emission reward: 0
+// [EXPECTED] alice claimable protocol fee token count: 3
+// [EXPECTED] emission distributed amount: 0
+// [EXPECTED] protocol fee amount (BAR): 9036
+// [EXPECTED] delegation snapshots present: true
+//
+// [SCENARIO] 13. Governance: propose, vote, execute, cancel, reconfigure
+// [EXPECTED] governance config version: 1
+// [EXPECTED] voting period: 604800 quorum: 50
+// [EXPECTED] text proposal id: 1
+// [EXPECTED] text proposal title: text proposal
+// [EXPECTED] text proposal proposer is admin: true
+// [EXPECTED] text proposal status after cancel: canceled
+// [EXPECTED] spend proposal id: 2
+// [EXPECTED] spend proposal type: CommunityPoolSpend
+// [EXPECTED] proposal 2 yea/nay: 6500000000 0
+// [EXPECTED] admin vote weight: 6500000000
+// [EXPECTED] vote status quorum/max/yes/no: 3400000000 6800000000 6500000000 0
+// [EXPECTED] spend proposal status after execute: executed
+// [EXPECTED] community pool spend received by alice: 1000
+// [EXPECTED] param proposal id: 3
+// [EXPECTED] proposal count: 3
+// [EXPECTED] proposal 3 yea/nay: 6500000000 0
+// [EXPECTED] admin vote weight: 6500000000
+// [EXPECTED] vote status quorum/max/yes/no: 3400000000 6800000000 6500000000 0
+// [EXPECTED] unstaking fee before/after governance execution: 100 150
+// [EXPECTED] governance config version after reconfigure: 2
+//
+// [SCENARIO] 14. Launchpad: project, deposit, reward collection
+// [EXPECTED] project id: gno.land/r/onbloc/obl.OBL:518577
+// [EXPECTED] project count: 1
+// [EXPECTED] project name: OBL launchpad project
+// [EXPECTED] project recipient is project owner: true
+// [EXPECTED] tier distribute amounts: 100000000 200000000 700000000
+// [EXPECTED] deposit id: 1
+// [EXPECTED] deposit count: 1
+// [EXPECTED] total GNS staked in launchpad: 1000000
+// [EXPECTED] deposit amount: 1000000
+// [EXPECTED] launchpad project wallet xGNS: 1000000 found: true
+// [EXPECTED] launchpad reward claimed: 13333719
+// [EXPECTED] project recipient collected launchpad rewards
+//
+// [SCENARIO] 15. Capture the pre-upgrade snapshot through the getters
+// [EXPECTED] pool liquidity: 1316883094
+// [EXPECTED] pool tick: 0
+// [EXPECTED] pool protocol fees: 188 186
+// [EXPECTED] position 1 liquidity: 640151239
+// [EXPECTED] staker pool tier: 1
+// [EXPECTED] staked deposit liquidity: 640151239
+// [EXPECTED] protocol fee split: 4000 6000
+// [EXPECTED] total delegated: 6800000000
+// [EXPECTED] proposal count: 3
+// [EXPECTED] project count: 1
+// [EXPECTED] launchpad deposits: 1000000
+//
+// [SCENARIO] 16. Upgrade all eight implementations to v2_valid
+// [EXPECTED] pool impl: gno.land/r/gnoswap/pool/v2_valid
+// [EXPECTED] position impl: gno.land/r/gnoswap/position/v2_valid
+// [EXPECTED] router impl: gno.land/r/gnoswap/router/v2_valid
+// [EXPECTED] staker impl: gno.land/r/gnoswap/staker/v2_valid
+// [EXPECTED] launchpad impl: gno.land/r/gnoswap/launchpad/v2_valid
+// [EXPECTED] protocol_fee impl: gno.land/r/gnoswap/protocol_fee/v2_valid
+// [EXPECTED] governance impl: gno.land/r/gnoswap/gov/governance/v2_valid
+// [EXPECTED] gov staker impl: gno.land/r/gnoswap/gov/staker/v2_valid
+//
+// [SCENARIO] 17. Validate that every v1 value survived the upgrade
+// [EXPECTED] every snapshot field is identical after the upgrade
+//
+// [SCENARIO] 18. Re-run the same operations through v2_valid
+// [EXPECTED] v2_valid minted position: 3 liquidity: 1066900695
+// [EXPECTED] v2_valid mint amounts: 49998310 50000000
+// [EXPECTED] v2_valid swap in/out: 1000000 -989090
+// [EXPECTED] v2_valid staking reward to user/penalty: 42692890284 101133750250
+// [EXPECTED] v2_valid distributed FOO to gov staker: 15018
+// [EXPECTED] v2_valid delegated amount: 1000000000
+// [EXPECTED] v2_valid delegation count: 4
+// [EXPECTED] v2_valid total delegated: 7800000000
+// [EXPECTED] v2_valid collected deposit principal: 1000000
+// [EXPECTED] v2_valid proposal id: 4
+// [EXPECTED] v2_valid proposal count: 4
+//
+// [SCENARIO] 19. Wind down: end incentive, unstake, remove tier
+// [EXPECTED] incentive refunded: true
+// [EXPECTED] incentive distributed: 69697221
+// [EXPECTED] collected incentive penalty: 107070652
+// [EXPECTED] position 1 staked after unstake: false
+// [EXPECTED] position 1 owner after unstake: g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5
+// [EXPECTED] position 1 operator cleared: true
+// [EXPECTED] allowed token count after removal: 2
+// [EXPECTED] pool tier after removal: 0
+// [EXPECTED] pool protocol fees before: 313 186
+// [EXPECTED] collected protocol fees: 313 186
+// [EXPECTED] pool protocol fees after: 0 0
+// [EXPECTED] launchpad project ended: true
+// [EXPECTED] launchpad leftover transferred: 900000001
+//
+// [SCENARIO] 20. Final invariants
+// [EXPECTED] pool count: 2
+// [EXPECTED] position count: 3
+// [EXPECTED] total emission sent: 19960011592312
+// [EXPECTED] gov staker total delegated: 7800000000
+// [EXPECTED] governance proposal count: 4
+// [EXPECTED] launchpad project count: 1
+// [EXPECTED] incentive total/distributed/remaining/penalty: 1500000000 713588362 500166223 179174763
+// [EXPECTED] pool impl: gno.land/r/gnoswap/pool/v2_valid
+// [EXPECTED] position impl: gno.land/r/gnoswap/position/v2_valid
+// [EXPECTED] router impl: gno.land/r/gnoswap/router/v2_valid
+// [EXPECTED] staker impl: gno.land/r/gnoswap/staker/v2_valid
+// [EXPECTED] launchpad impl: gno.land/r/gnoswap/launchpad/v2_valid
+// [EXPECTED] protocol_fee impl: gno.land/r/gnoswap/protocol_fee/v2_valid
+// [EXPECTED] governance impl: gno.land/r/gnoswap/gov/governance/v2_valid
+// [EXPECTED] gov staker impl: gno.land/r/gnoswap/gov/staker/v2_valid

--- a/contract/r/scenario/upgrade/gov_governance_upgrade_with_validate_data_filetest.gno
+++ b/contract/r/scenario/upgrade/gov_governance_upgrade_with_validate_data_filetest.gno
@@ -235,6 +235,9 @@ func captureV1Snapshot() {
 
 	println("[EXPECTED] snapshot proposal count:", v1ProposalCount)
 	println("[EXPECTED] snapshot proposal ids:", len(v1ProposalIDs))
+	for _, id := range v1ProposalIDs {
+		println("[EXPECTED] snapshot proposal id:", id)
+	}
 	println("[EXPECTED] snapshot text proposal status:", v1TextStatus)
 	println("[EXPECTED] snapshot param proposal status:", v1ParamStatus)
 	println("[EXPECTED] snapshot param yea / nay:", v1ParamYea, v1ParamNay)
@@ -252,21 +255,42 @@ func upgradeTo(cur realm, packagePath string) {
 }
 
 func validateSnapshot() {
-	proposer, _ := govGovernance.GetProposerByProposalId(paramProposalId)
-	title, _ := govGovernance.GetTitleByProposalId(paramProposalId)
-	description, _ := govGovernance.GetDescriptionByProposalId(paramProposalId)
-	proposalType, _ := govGovernance.GetProposalTypeByProposalId(paramProposalId)
-	yea, _ := govGovernance.GetYeaByProposalId(paramProposalId)
-	nay, _ := govGovernance.GetNayByProposalId(paramProposalId)
-	quorumAmount, _ := govGovernance.GetQuorumAmountByProposalId(paramProposalId)
-	status, _ := govGovernance.GetProposalStatusByProposalId(paramProposalId)
-	configVer, _ := govGovernance.GetConfigVersionByProposalId(paramProposalId)
-	voteWeight, _ := govGovernance.GetVoteWeight(paramProposalId, adminAddr)
-	votedAt, _ := govGovernance.GetVotedAt(paramProposalId, adminAddr)
-	textStatus, _ := govGovernance.GetProposalStatusByProposalId(textProposalId)
+	// every getter error is asserted: a silent error would otherwise be turned
+	// into a zero value and could hide a missing or reshaped record
+	proposer, err := govGovernance.GetProposerByProposalId(paramProposalId)
+	uassert.NoError(t, err)
+	title, err := govGovernance.GetTitleByProposalId(paramProposalId)
+	uassert.NoError(t, err)
+	description, err := govGovernance.GetDescriptionByProposalId(paramProposalId)
+	uassert.NoError(t, err)
+	proposalType, err := govGovernance.GetProposalTypeByProposalId(paramProposalId)
+	uassert.NoError(t, err)
+	yea, err := govGovernance.GetYeaByProposalId(paramProposalId)
+	uassert.NoError(t, err)
+	nay, err := govGovernance.GetNayByProposalId(paramProposalId)
+	uassert.NoError(t, err)
+	quorumAmount, err := govGovernance.GetQuorumAmountByProposalId(paramProposalId)
+	uassert.NoError(t, err)
+	status, err := govGovernance.GetProposalStatusByProposalId(paramProposalId)
+	uassert.NoError(t, err)
+	configVer, err := govGovernance.GetConfigVersionByProposalId(paramProposalId)
+	uassert.NoError(t, err)
+	voteWeight, err := govGovernance.GetVoteWeight(paramProposalId, adminAddr)
+	uassert.NoError(t, err)
+	votedAt, err := govGovernance.GetVotedAt(paramProposalId, adminAddr)
+	uassert.NoError(t, err)
+	textStatus, err := govGovernance.GetProposalStatusByProposalId(textProposalId)
+	uassert.NoError(t, err)
+	_, err = govGovernance.GetConfig(v1LatestConfigVer)
+	uassert.NoError(t, err)
 
+	// compare the proposal ids themselves, not only how many there are
+	proposalIDs := govGovernance.GetProposalIDs(0, 10)
 	uassert.Equal(t, v1ProposalCount, govGovernance.GetProposalCount())
-	uassert.Equal(t, len(v1ProposalIDs), len(govGovernance.GetProposalIDs(0, 10)))
+	uassert.Equal(t, len(v1ProposalIDs), len(proposalIDs))
+	for i, id := range v1ProposalIDs {
+		uassert.Equal(t, id, proposalIDs[i])
+	}
 	uassert.Equal(t, v1TextStatus, textStatus)
 	uassert.Equal(t, v1ParamProposer, proposer)
 	uassert.Equal(t, v1ParamTitle, title)
@@ -287,6 +311,9 @@ func validateSnapshot() {
 	uassert.False(t, govGovernance.ExistsVotingInfo(paramProposalId, aliceAddr))
 
 	println("[EXPECTED] proposal count:", govGovernance.GetProposalCount())
+	for _, id := range proposalIDs {
+		println("[EXPECTED] proposal id after upgrade:", id)
+	}
 	println("[EXPECTED] param proposal title:", title)
 	println("[EXPECTED] param proposal yea / nay:", yea, nay)
 	println("[EXPECTED] admin vote weight:", voteWeight)
@@ -363,6 +390,8 @@ func assertAborts(cur realm, callback func(), logMessage string) {
 // [SCENARIO] 5. Snapshot v1 data through the getters
 // [EXPECTED] snapshot proposal count: 2
 // [EXPECTED] snapshot proposal ids: 2
+// [EXPECTED] snapshot proposal id: 1
+// [EXPECTED] snapshot proposal id: 2
 // [EXPECTED] snapshot text proposal status: canceled
 // [EXPECTED] snapshot param proposal status: active
 // [EXPECTED] snapshot param yea / nay: 5000000000 0
@@ -383,6 +412,8 @@ func assertAborts(cur realm, callback func(), logMessage string) {
 //
 // [SCENARIO] 9. Validate the v1 proposal data through v3_valid
 // [EXPECTED] proposal count: 2
+// [EXPECTED] proposal id after upgrade: 1
+// [EXPECTED] proposal id after upgrade: 2
 // [EXPECTED] param proposal title: raise the unstaking fee
 // [EXPECTED] param proposal yea / nay: 5000000000 0
 // [EXPECTED] admin vote weight: 5000000000

--- a/contract/r/scenario/upgrade/gov_governance_upgrade_with_validate_data_filetest.gno
+++ b/contract/r/scenario/upgrade/gov_governance_upgrade_with_validate_data_filetest.gno
@@ -1,0 +1,396 @@
+// PKGPATH: gno.land/r/gnoswap/v1/main
+
+// Gov/Governance contract upgrade scenario test with data validation.
+//
+// Proposals, their vote tallies and the config history live in the shared KV
+// store. This test creates a canceled proposal and a voted-on parameter-change
+// proposal with v1, snapshots what the public getters expose, walks the
+// implementation through v2_invalid (which must block the calls) up to
+// v3_valid, asserts the snapshot is unchanged, and then finishes the v1-created
+// proposal lifecycle (execute + reconfigure) through the new implementation.
+package main
+
+import (
+	"testing"
+
+	prbac "gno.land/p/gnoswap/rbac"
+	testutils "gno.land/p/nt/testutils/v0"
+	uassert "gno.land/p/nt/uassert/v0"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/gns"
+	govGovernance "gno.land/r/gnoswap/gov/governance"
+	govStaker "gno.land/r/gnoswap/gov/staker"
+	"gno.land/r/gnoswap/staker"
+
+	_ "gno.land/r/gnoswap/gov/governance/v1"
+	_ "gno.land/r/gnoswap/gov/governance/v2_invalid"
+	_ "gno.land/r/gnoswap/gov/governance/v3_valid"
+	_ "gno.land/r/gnoswap/gov/staker/v1"
+	_ "gno.land/r/gnoswap/pool/v1"
+	_ "gno.land/r/gnoswap/protocol_fee/v1"
+	_ "gno.land/r/gnoswap/rbac"
+	_ "gno.land/r/gnoswap/staker/v1"
+)
+
+var t *testing.T
+
+const (
+	governanceV1Path        = "gno.land/r/gnoswap/gov/governance/v1"
+	governanceV2InvalidPath = "gno.land/r/gnoswap/gov/governance/v2_invalid"
+	governanceV3ValidPath   = "gno.land/r/gnoswap/gov/governance/v3_valid"
+
+	blockTimeSeconds = int64(5)
+
+	delegateAmount     = int64(5_000_000_000)
+	newUnStakingFee    = uint64(150)
+	parameterChangeMsg = "gno.land/r/gnoswap/staker*EXE*SetUnStakingFee*EXE*150"
+)
+
+var (
+	adminAddr     = access.MustGetAddress(prbac.ROLE_ADMIN.String())
+	govStakerAddr = access.MustGetAddress(prbac.ROLE_GOV_STAKER.String())
+
+	adminRealm = testing.NewUserRealm(adminAddr)
+
+	aliceAddr = testutils.TestAddress("alice")
+
+	textProposalId  int64
+	paramProposalId int64
+
+	config govGovernance.Config
+
+	// snapshot of the v1-written state
+	v1ProposalCount     int
+	v1ProposalIDs       []int64
+	v1TextStatus        string
+	v1ParamProposer     address
+	v1ParamTitle        string
+	v1ParamDescription  string
+	v1ParamType         string
+	v1ParamYea          int64
+	v1ParamNay          int64
+	v1ParamQuorum       int64
+	v1ParamStatus       string
+	v1ParamConfigVer    int64
+	v1AdminVoteWeight   int64
+	v1AdminVotedAt      int64
+	v1UserProposalCount int
+	v1LatestConfigVer   int64
+	v1VotingPeriod      int64
+)
+
+func main(cur realm) {
+	println("[SCENARIO] 1. Initialize governance contract with v1")
+	initialize(cur)
+	println()
+
+	println("[SCENARIO] 2. Delegate GNS so the proposal threshold is met")
+	delegate(cur)
+	println()
+
+	println("[SCENARIO] 3. Create and cancel a text proposal with v1")
+	createAndCancelTextProposal(cur)
+	println()
+
+	println("[SCENARIO] 4. Create and vote on a parameter change proposal with v1")
+	createAndVoteParameterChangeProposal(cur)
+	println()
+
+	println("[SCENARIO] 5. Snapshot v1 data through the getters")
+	captureV1Snapshot()
+	println()
+
+	println("[SCENARIO] 6. Upgrade to v2_invalid")
+	upgradeTo(cur, governanceV2InvalidPath)
+	println()
+
+	println("[SCENARIO] 7. Mutating calls must be blocked by v2_invalid")
+	assertAborts(cur, func() {
+		testing.SetRealm(adminRealm)
+		govGovernance.ProposeText(cross(cur), "blocked", "blocked")
+	}, "[EXPECTED] ProposeText is blocked by v2_invalid")
+	assertAborts(cur, func() {
+		testing.SetRealm(adminRealm)
+		govGovernance.Execute(cross(cur), paramProposalId)
+	}, "[EXPECTED] Execute is blocked by v2_invalid")
+	println()
+
+	println("[SCENARIO] 8. Upgrade to v3_valid")
+	upgradeTo(cur, governanceV3ValidPath)
+	println()
+
+	println("[SCENARIO] 9. Validate the v1 proposal data through v3_valid")
+	validateSnapshot()
+	println()
+
+	println("[SCENARIO] 10. Finish the v1 proposal lifecycle with v3_valid")
+	executeAndReconfigure(cur)
+	println()
+}
+
+func initialize(cur realm) {
+	testing.SetRealm(adminRealm)
+	govGovernance.UpgradeImpl(cross(cur), governanceV1Path)
+	config = govGovernance.GetLatestConfig()
+
+	println("[EXPECTED] implementation:", govGovernance.GetImplementationPackagePath())
+	println("[EXPECTED] config version:", govGovernance.GetLatestConfigVersion())
+	println("[EXPECTED] voting period / quorum / threshold:",
+		config.VotingPeriod, config.Quorum, config.ProposalCreationThreshold)
+}
+
+func delegate(cur realm) {
+	testing.SetRealm(adminRealm)
+	gns.Approve(cross(cur), govStakerAddr, delegateAmount)
+	govStaker.Delegate(cross(cur), adminAddr, delegateAmount, "")
+	testing.SkipHeights(1)
+
+	// the voting weight is averaged over the smoothing duration
+	testing.SkipHeights(config.VotingWeightSmoothingDuration / blockTimeSeconds)
+
+	println("[EXPECTED] total delegated:", govStaker.GetTotalDelegated())
+	uassert.Equal(t, delegateAmount, govStaker.GetTotalDelegated())
+}
+
+func createAndCancelTextProposal(cur realm) {
+	testing.SetRealm(adminRealm)
+	textProposalId = govGovernance.ProposeText(cross(cur), "text proposal", "signal only")
+	testing.SkipHeights(1)
+
+	title, _ := govGovernance.GetTitleByProposalId(textProposalId)
+	proposer, _ := govGovernance.GetProposerByProposalId(textProposalId)
+	println("[EXPECTED] text proposal id:", textProposalId)
+	println("[EXPECTED] text proposal title:", title)
+	println("[EXPECTED] text proposal proposer is admin:", proposer == adminAddr)
+
+	// a proposer may only hold one active proposal, so the text proposal is
+	// canceled before the parameter change proposal is created
+	govGovernance.Cancel(cross(cur), textProposalId)
+	testing.SkipHeights(1)
+
+	status, _ := govGovernance.GetProposalStatusByProposalId(textProposalId)
+	println("[EXPECTED] text proposal status:", status)
+	uassert.Equal(t, "canceled", status)
+}
+
+func createAndVoteParameterChangeProposal(cur realm) {
+	testing.SetRealm(adminRealm)
+	paramProposalId = govGovernance.ProposeParameterChange(
+		cross(cur),
+		"raise the unstaking fee",
+		"routes staker.SetUnStakingFee through governance",
+		1,
+		parameterChangeMsg,
+	)
+	testing.SkipHeights(1)
+
+	proposalType, _ := govGovernance.GetProposalTypeByProposalId(paramProposalId)
+	println("[EXPECTED] param proposal id:", paramProposalId)
+	println("[EXPECTED] param proposal type:", proposalType.String())
+
+	// voting opens after the start delay
+	testing.SkipHeights(config.VotingStartDelay / blockTimeSeconds)
+	testing.SetRealm(adminRealm)
+	govGovernance.Vote(cross(cur), paramProposalId, true)
+	testing.SkipHeights(1)
+
+	yea, _ := govGovernance.GetYeaByProposalId(paramProposalId)
+	nay, _ := govGovernance.GetNayByProposalId(paramProposalId)
+	quorum, maxVotingWeight, yesWeight, noWeight, _ := govGovernance.GetVoteStatus(paramProposalId)
+	voteWeight, _ := govGovernance.GetVoteWeight(paramProposalId, adminAddr)
+
+	println("[EXPECTED] yea / nay:", yea, nay)
+	println("[EXPECTED] quorum / max / yes / no:", quorum, maxVotingWeight, yesWeight, noWeight)
+	println("[EXPECTED] admin vote weight:", voteWeight)
+	println("[EXPECTED] voting info count:", govGovernance.GetVotingInfoCount(paramProposalId))
+	println("[EXPECTED] admin has voted:", govGovernance.ExistsVotingInfo(paramProposalId, adminAddr))
+
+	// the whole delegated stake voted yes, so the quorum is met
+	uassert.Equal(t, delegateAmount, yea)
+	uassert.Equal(t, int64(0), nay)
+	uassert.Equal(t, delegateAmount, voteWeight)
+	uassert.True(t, yesWeight >= quorum)
+}
+
+func captureV1Snapshot() {
+	v1ProposalCount = govGovernance.GetProposalCount()
+	v1ProposalIDs = govGovernance.GetProposalIDs(0, 10)
+	v1TextStatus, _ = govGovernance.GetProposalStatusByProposalId(textProposalId)
+	v1ParamProposer, _ = govGovernance.GetProposerByProposalId(paramProposalId)
+	v1ParamTitle, _ = govGovernance.GetTitleByProposalId(paramProposalId)
+	v1ParamDescription, _ = govGovernance.GetDescriptionByProposalId(paramProposalId)
+	proposalType, _ := govGovernance.GetProposalTypeByProposalId(paramProposalId)
+	v1ParamType = proposalType.String()
+	v1ParamYea, _ = govGovernance.GetYeaByProposalId(paramProposalId)
+	v1ParamNay, _ = govGovernance.GetNayByProposalId(paramProposalId)
+	v1ParamQuorum, _ = govGovernance.GetQuorumAmountByProposalId(paramProposalId)
+	v1ParamStatus, _ = govGovernance.GetProposalStatusByProposalId(paramProposalId)
+	v1ParamConfigVer, _ = govGovernance.GetConfigVersionByProposalId(paramProposalId)
+	v1AdminVoteWeight, _ = govGovernance.GetVoteWeight(paramProposalId, adminAddr)
+	v1AdminVotedAt, _ = govGovernance.GetVotedAt(paramProposalId, adminAddr)
+	v1UserProposalCount = govGovernance.GetUserProposalCount(adminAddr)
+	v1LatestConfigVer = govGovernance.GetLatestConfigVersion()
+	v1VotingPeriod = govGovernance.GetLatestConfig().VotingPeriod
+
+	println("[EXPECTED] snapshot proposal count:", v1ProposalCount)
+	println("[EXPECTED] snapshot proposal ids:", len(v1ProposalIDs))
+	println("[EXPECTED] snapshot text proposal status:", v1TextStatus)
+	println("[EXPECTED] snapshot param proposal status:", v1ParamStatus)
+	println("[EXPECTED] snapshot param yea / nay:", v1ParamYea, v1ParamNay)
+	println("[EXPECTED] snapshot param quorum:", v1ParamQuorum)
+	println("[EXPECTED] snapshot admin vote weight:", v1AdminVoteWeight)
+	println("[EXPECTED] snapshot user proposal count:", v1UserProposalCount)
+	println("[EXPECTED] snapshot config version:", v1LatestConfigVer)
+}
+
+func upgradeTo(cur realm, packagePath string) {
+	testing.SetRealm(adminRealm)
+	govGovernance.UpgradeImpl(cross(cur), packagePath)
+	println("[EXPECTED] implementation:", govGovernance.GetImplementationPackagePath())
+	uassert.Equal(t, packagePath, govGovernance.GetImplementationPackagePath())
+}
+
+func validateSnapshot() {
+	proposer, _ := govGovernance.GetProposerByProposalId(paramProposalId)
+	title, _ := govGovernance.GetTitleByProposalId(paramProposalId)
+	description, _ := govGovernance.GetDescriptionByProposalId(paramProposalId)
+	proposalType, _ := govGovernance.GetProposalTypeByProposalId(paramProposalId)
+	yea, _ := govGovernance.GetYeaByProposalId(paramProposalId)
+	nay, _ := govGovernance.GetNayByProposalId(paramProposalId)
+	quorumAmount, _ := govGovernance.GetQuorumAmountByProposalId(paramProposalId)
+	status, _ := govGovernance.GetProposalStatusByProposalId(paramProposalId)
+	configVer, _ := govGovernance.GetConfigVersionByProposalId(paramProposalId)
+	voteWeight, _ := govGovernance.GetVoteWeight(paramProposalId, adminAddr)
+	votedAt, _ := govGovernance.GetVotedAt(paramProposalId, adminAddr)
+	textStatus, _ := govGovernance.GetProposalStatusByProposalId(textProposalId)
+
+	uassert.Equal(t, v1ProposalCount, govGovernance.GetProposalCount())
+	uassert.Equal(t, len(v1ProposalIDs), len(govGovernance.GetProposalIDs(0, 10)))
+	uassert.Equal(t, v1TextStatus, textStatus)
+	uassert.Equal(t, v1ParamProposer, proposer)
+	uassert.Equal(t, v1ParamTitle, title)
+	uassert.Equal(t, v1ParamDescription, description)
+	uassert.Equal(t, v1ParamType, proposalType.String())
+	uassert.Equal(t, v1ParamYea, yea)
+	uassert.Equal(t, v1ParamNay, nay)
+	uassert.Equal(t, v1ParamQuorum, quorumAmount)
+	uassert.Equal(t, v1ParamStatus, status)
+	uassert.Equal(t, v1ParamConfigVer, configVer)
+	uassert.Equal(t, v1AdminVoteWeight, voteWeight)
+	uassert.Equal(t, v1AdminVotedAt, votedAt)
+	uassert.Equal(t, v1UserProposalCount, govGovernance.GetUserProposalCount(adminAddr))
+	uassert.Equal(t, v1LatestConfigVer, govGovernance.GetLatestConfigVersion())
+	uassert.Equal(t, v1VotingPeriod, govGovernance.GetLatestConfig().VotingPeriod)
+	uassert.True(t, govGovernance.ExistsProposal(paramProposalId))
+	uassert.True(t, govGovernance.ExistsVotingInfo(paramProposalId, adminAddr))
+	uassert.False(t, govGovernance.ExistsVotingInfo(paramProposalId, aliceAddr))
+
+	println("[EXPECTED] proposal count:", govGovernance.GetProposalCount())
+	println("[EXPECTED] param proposal title:", title)
+	println("[EXPECTED] param proposal yea / nay:", yea, nay)
+	println("[EXPECTED] admin vote weight:", voteWeight)
+	println("[EXPECTED] every v1 proposal value survived the upgrade")
+}
+
+func executeAndReconfigure(cur realm) {
+	// the proposal becomes executable after the voting period plus the delay
+	testing.SkipHeights((config.VotingPeriod + config.ExecutionDelay) / blockTimeSeconds)
+
+	unStakingFeeBefore := staker.GetUnstakingFee()
+
+	testing.SetRealm(adminRealm)
+	executedId := govGovernance.Execute(cross(cur), paramProposalId)
+	testing.SkipHeights(1)
+
+	status, _ := govGovernance.GetProposalStatusByProposalId(paramProposalId)
+	println("[EXPECTED] executed proposal id:", executedId)
+	println("[EXPECTED] param proposal status after execute:", status)
+	println("[EXPECTED] staker unstaking fee before / after:", unStakingFeeBefore, staker.GetUnstakingFee())
+
+	// governance drove a setter on another upgradeable contract
+	uassert.Equal(t, newUnStakingFee, staker.GetUnstakingFee())
+	uassert.Equal(t, paramProposalId, executedId)
+
+	newVersion := govGovernance.Reconfigure(
+		cross(cur),
+		config.VotingStartDelay,
+		config.VotingPeriod,
+		config.VotingWeightSmoothingDuration,
+		config.Quorum,
+		config.ProposalCreationThreshold,
+		config.ExecutionDelay,
+		config.ExecutionWindow,
+	)
+	testing.SkipHeights(1)
+
+	println("[EXPECTED] config version after reconfigure:", newVersion)
+	println("[EXPECTED] latest config voting period:", govGovernance.GetLatestConfig().VotingPeriod)
+
+	uassert.Equal(t, v1LatestConfigVer+1, newVersion)
+	uassert.Equal(t, v1VotingPeriod, govGovernance.GetLatestConfig().VotingPeriod)
+}
+
+func assertAborts(cur realm, callback func(), logMessage string) {
+	uassert.AbortsContains(t, cur, "implementation", callback)
+	println(logMessage)
+}
+
+// Output:
+// [SCENARIO] 1. Initialize governance contract with v1
+// [EXPECTED] implementation: gno.land/r/gnoswap/gov/governance/v1
+// [EXPECTED] config version: 1
+// [EXPECTED] voting period / quorum / threshold: 604800 50 1000000000
+//
+// [SCENARIO] 2. Delegate GNS so the proposal threshold is met
+// [EXPECTED] total delegated: 5000000000
+//
+// [SCENARIO] 3. Create and cancel a text proposal with v1
+// [EXPECTED] text proposal id: 1
+// [EXPECTED] text proposal title: text proposal
+// [EXPECTED] text proposal proposer is admin: true
+// [EXPECTED] text proposal status: canceled
+//
+// [SCENARIO] 4. Create and vote on a parameter change proposal with v1
+// [EXPECTED] param proposal id: 2
+// [EXPECTED] param proposal type: ParameterChange
+// [EXPECTED] yea / nay: 5000000000 0
+// [EXPECTED] quorum / max / yes / no: 2500000000 5000000000 5000000000 0
+// [EXPECTED] admin vote weight: 5000000000
+// [EXPECTED] voting info count: 1
+// [EXPECTED] admin has voted: true
+//
+// [SCENARIO] 5. Snapshot v1 data through the getters
+// [EXPECTED] snapshot proposal count: 2
+// [EXPECTED] snapshot proposal ids: 2
+// [EXPECTED] snapshot text proposal status: canceled
+// [EXPECTED] snapshot param proposal status: active
+// [EXPECTED] snapshot param yea / nay: 5000000000 0
+// [EXPECTED] snapshot param quorum: 2500000000
+// [EXPECTED] snapshot admin vote weight: 5000000000
+// [EXPECTED] snapshot user proposal count: 1
+// [EXPECTED] snapshot config version: 1
+//
+// [SCENARIO] 6. Upgrade to v2_invalid
+// [EXPECTED] implementation: gno.land/r/gnoswap/gov/governance/v2_invalid
+//
+// [SCENARIO] 7. Mutating calls must be blocked by v2_invalid
+// [EXPECTED] ProposeText is blocked by v2_invalid
+// [EXPECTED] Execute is blocked by v2_invalid
+//
+// [SCENARIO] 8. Upgrade to v3_valid
+// [EXPECTED] implementation: gno.land/r/gnoswap/gov/governance/v3_valid
+//
+// [SCENARIO] 9. Validate the v1 proposal data through v3_valid
+// [EXPECTED] proposal count: 2
+// [EXPECTED] param proposal title: raise the unstaking fee
+// [EXPECTED] param proposal yea / nay: 5000000000 0
+// [EXPECTED] admin vote weight: 5000000000
+// [EXPECTED] every v1 proposal value survived the upgrade
+//
+// [SCENARIO] 10. Finish the v1 proposal lifecycle with v3_valid
+// [EXPECTED] executed proposal id: 2
+// [EXPECTED] param proposal status after execute: executed
+// [EXPECTED] staker unstaking fee before / after: 100 150
+// [EXPECTED] config version after reconfigure: 2
+// [EXPECTED] latest config voting period: 604800

--- a/contract/r/scenario/upgrade/gov_staker_upgrade_with_validate_data_filetest.gno
+++ b/contract/r/scenario/upgrade/gov_staker_upgrade_with_validate_data_filetest.gno
@@ -1,0 +1,355 @@
+// PKGPATH: gno.land/r/gnoswap/v1/main
+
+// Gov/Staker contract upgrade scenario test with data validation.
+//
+// Delegations, undelegation withdraw queues and the delegation snapshot history
+// live in the shared KV store, so an upgrade must leave every value untouched.
+// This test builds a delegation graph with v1, snapshots what the public getters
+// expose, walks the implementation through v2_invalid (which must block the
+// calls) up to v3_valid, asserts the snapshot is unchanged, and then keeps
+// operating on the v1-created delegations through the new implementation.
+package main
+
+import (
+	"testing"
+	"time"
+
+	prbac "gno.land/p/gnoswap/rbac"
+	testutils "gno.land/p/nt/testutils/v0"
+	uassert "gno.land/p/nt/uassert/v0"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/gns"
+	govStaker "gno.land/r/gnoswap/gov/staker"
+
+	_ "gno.land/r/gnoswap/gov/staker/v1"
+	_ "gno.land/r/gnoswap/gov/staker/v2_invalid"
+	_ "gno.land/r/gnoswap/gov/staker/v3_valid"
+	_ "gno.land/r/gnoswap/protocol_fee/v1"
+	_ "gno.land/r/gnoswap/rbac"
+)
+
+var t *testing.T
+
+const (
+	govStakerV1Path        = "gno.land/r/gnoswap/gov/staker/v1"
+	govStakerV2InvalidPath = "gno.land/r/gnoswap/gov/staker/v2_invalid"
+	govStakerV3ValidPath   = "gno.land/r/gnoswap/gov/staker/v3_valid"
+
+	blockTimeSeconds = int64(5)
+
+	lockupPeriod    = int64(100)
+	aliceDelegation = int64(2_000_000_000)
+	bobDelegation   = int64(1_000_000_000)
+	redelegateSize  = int64(500_000_000)
+	undelegateSize  = int64(200_000_000)
+)
+
+var (
+	adminAddr     = access.MustGetAddress(prbac.ROLE_ADMIN.String())
+	govStakerAddr = access.MustGetAddress(prbac.ROLE_GOV_STAKER.String())
+
+	adminRealm = testing.NewUserRealm(adminAddr)
+
+	aliceAddr  = testutils.TestAddress("alice")
+	aliceRealm = testing.NewUserRealm(aliceAddr)
+
+	bobAddr  = testutils.TestAddress("bob")
+	bobRealm = testing.NewUserRealm(bobAddr)
+
+	// snapshot of the v1-written state
+	v1TotalDelegated    int64
+	v1TotalXGnsSupply   int64
+	v1TotalLocked       int64
+	v1LockupPeriod      int64
+	v1DelegationCount   int
+	v1DelegationIDs     []int64
+	v1AliceToAdminCount int
+	v1AliceToAliceCount int
+	v1FirstDelegateFrom address
+	v1FirstDelegateTo   address
+	v1FirstDelegateAmt  int64
+	v1CollectableAlice  int64
+	v1WithdrawCount     int
+)
+
+func main(cur realm) {
+	println("[SCENARIO] 1. Initialize gov/staker contract with v1")
+	initialize(cur)
+	println()
+
+	println("[SCENARIO] 2. Build the delegation graph with v1")
+	delegateWithV1(cur)
+	println()
+
+	println("[SCENARIO] 3. Redelegate and undelegate with v1")
+	redelegateAndUndelegateWithV1(cur)
+	println()
+
+	println("[SCENARIO] 4. Snapshot v1 data through the getters")
+	captureV1Snapshot()
+	println()
+
+	println("[SCENARIO] 5. Upgrade to v2_invalid")
+	upgradeTo(cur, govStakerV2InvalidPath)
+	println()
+
+	println("[SCENARIO] 6. Mutating calls must be blocked by v2_invalid")
+	assertAborts(cur, func() {
+		testing.SetRealm(bobRealm)
+		gns.Approve(cross(cur), govStakerAddr, bobDelegation)
+		govStaker.Delegate(cross(cur), adminAddr, bobDelegation, "")
+	}, "[EXPECTED] Delegate is blocked by v2_invalid")
+	assertAborts(cur, func() {
+		testing.SetRealm(aliceRealm)
+		govStaker.CollectReward(cross(cur))
+	}, "[EXPECTED] CollectReward is blocked by v2_invalid")
+	println()
+
+	println("[SCENARIO] 7. Upgrade to v3_valid")
+	upgradeTo(cur, govStakerV3ValidPath)
+	println()
+
+	println("[SCENARIO] 8. Validate the v1 delegation data through v3_valid")
+	validateSnapshot()
+	println()
+
+	println("[SCENARIO] 9. Keep operating on the v1-created delegations")
+	operateWithV3Valid(cur)
+	println()
+}
+
+func initialize(cur realm) {
+	testing.SetRealm(adminRealm)
+	govStaker.UpgradeImpl(cross(cur), govStakerV1Path)
+	govStaker.SetUnDelegationLockupPeriodByAdmin(cross(cur), lockupPeriod)
+
+	println("[EXPECTED] implementation:", govStaker.GetImplementationPackagePath())
+	println("[EXPECTED] undelegation lockup period:", govStaker.GetUnDelegationLockupPeriod())
+	uassert.Equal(t, lockupPeriod, govStaker.GetUnDelegationLockupPeriod())
+}
+
+func delegateWithV1(cur realm) {
+	testing.SetRealm(adminRealm)
+	gns.Transfer(cross(cur), aliceAddr, aliceDelegation)
+	gns.Transfer(cross(cur), bobAddr, bobDelegation)
+
+	testing.SetRealm(aliceRealm)
+	gns.Approve(cross(cur), govStakerAddr, aliceDelegation)
+	aliceAmount := govStaker.Delegate(cross(cur), adminAddr, aliceDelegation, "")
+	testing.SkipHeights(1)
+
+	testing.SetRealm(bobRealm)
+	gns.Approve(cross(cur), govStakerAddr, bobDelegation)
+	bobAmount := govStaker.Delegate(cross(cur), bobAddr, bobDelegation, "")
+	testing.SkipHeights(1)
+
+	println("[EXPECTED] alice delegated amount:", aliceAmount)
+	println("[EXPECTED] bob delegated amount:", bobAmount)
+	println("[EXPECTED] delegation count:", govStaker.GetDelegationCount())
+	println("[EXPECTED] total delegated:", govStaker.GetTotalDelegated())
+	println("[EXPECTED] total xGNS supply:", govStaker.GetTotalxGnsSupply())
+	println("[EXPECTED] total locked amount:", govStaker.GetTotalLockedAmount())
+
+	// xGNS is minted 1:1 against the delegated GNS
+	uassert.Equal(t, aliceDelegation+bobDelegation, govStaker.GetTotalDelegated())
+	uassert.Equal(t, aliceDelegation+bobDelegation, govStaker.GetTotalxGnsSupply())
+	uassert.Equal(t, 2, govStaker.GetDelegationCount())
+}
+
+func redelegateAndUndelegateWithV1(cur realm) {
+	testing.SetRealm(aliceRealm)
+	redelegated := govStaker.Redelegate(cross(cur), adminAddr, aliceAddr, redelegateSize)
+	testing.SkipHeights(1)
+	println("[EXPECTED] redelegated:", redelegated)
+	println("[EXPECTED] alice->admin delegation count:", govStaker.GetUserDelegationCount(aliceAddr, adminAddr))
+	println("[EXPECTED] alice->alice delegation count:", govStaker.GetUserDelegationCount(aliceAddr, aliceAddr))
+	println("[EXPECTED] alice delegatee count:", govStaker.GetDelegatorDelegateeCount(aliceAddr))
+
+	undelegated := govStaker.Undelegate(cross(cur), aliceAddr, undelegateSize)
+	testing.SkipHeights(1)
+	println("[EXPECTED] undelegated:", undelegated)
+	println("[EXPECTED] total delegated after undelegate:", govStaker.GetTotalDelegated())
+	println("[EXPECTED] total xGNS supply after undelegate:", govStaker.GetTotalxGnsSupply())
+
+	// the redelegation must not change the totals, the undelegation must
+	uassert.Equal(t, redelegateSize, redelegated)
+	uassert.Equal(t, undelegateSize, undelegated)
+	uassert.Equal(t, aliceDelegation+bobDelegation-undelegateSize, govStaker.GetTotalDelegated())
+}
+
+func captureV1Snapshot() {
+	v1TotalDelegated = govStaker.GetTotalDelegated()
+	v1TotalXGnsSupply = govStaker.GetTotalxGnsSupply()
+	v1TotalLocked = govStaker.GetTotalLockedAmount()
+	v1LockupPeriod = govStaker.GetUnDelegationLockupPeriod()
+	v1DelegationCount = govStaker.GetDelegationCount()
+	v1DelegationIDs = govStaker.GetDelegationIDs(0, 10)
+	v1AliceToAdminCount = govStaker.GetUserDelegationCount(aliceAddr, adminAddr)
+	v1AliceToAliceCount = govStaker.GetUserDelegationCount(aliceAddr, aliceAddr)
+
+	firstDelegation, err := govStaker.GetDelegation(v1DelegationIDs[0])
+	if err != nil {
+		panic(err)
+	}
+	v1FirstDelegateFrom = firstDelegation.DelegateFrom()
+	v1FirstDelegateTo = firstDelegation.DelegateTo()
+	v1FirstDelegateAmt = firstDelegation.TotalDelegatedAmount()
+	v1WithdrawCount = govStaker.GetDelegationWithdrawCount(v1DelegationIDs[0])
+	v1CollectableAlice = govStaker.GetCollectableWithdrawAmount(v1DelegationIDs[0])
+
+	println("[EXPECTED] snapshot total delegated:", v1TotalDelegated)
+	println("[EXPECTED] snapshot total xGNS supply:", v1TotalXGnsSupply)
+	println("[EXPECTED] snapshot total locked:", v1TotalLocked)
+	println("[EXPECTED] snapshot delegation count:", v1DelegationCount)
+	println("[EXPECTED] snapshot delegation ids:", len(v1DelegationIDs))
+	println("[EXPECTED] snapshot first delegation amount:", v1FirstDelegateAmt)
+	println("[EXPECTED] snapshot withdraw count:", v1WithdrawCount)
+	println("[EXPECTED] snapshot collectable withdraw amount:", v1CollectableAlice)
+}
+
+func upgradeTo(cur realm, packagePath string) {
+	testing.SetRealm(adminRealm)
+	govStaker.UpgradeImpl(cross(cur), packagePath)
+	println("[EXPECTED] implementation:", govStaker.GetImplementationPackagePath())
+	uassert.Equal(t, packagePath, govStaker.GetImplementationPackagePath())
+}
+
+func validateSnapshot() {
+	firstDelegation, err := govStaker.GetDelegation(v1DelegationIDs[0])
+	if err != nil {
+		panic(err)
+	}
+
+	uassert.Equal(t, v1TotalDelegated, govStaker.GetTotalDelegated())
+	uassert.Equal(t, v1TotalXGnsSupply, govStaker.GetTotalxGnsSupply())
+	uassert.Equal(t, v1TotalLocked, govStaker.GetTotalLockedAmount())
+	uassert.Equal(t, v1LockupPeriod, govStaker.GetUnDelegationLockupPeriod())
+	uassert.Equal(t, v1DelegationCount, govStaker.GetDelegationCount())
+	uassert.Equal(t, len(v1DelegationIDs), len(govStaker.GetDelegationIDs(0, 10)))
+	uassert.Equal(t, v1AliceToAdminCount, govStaker.GetUserDelegationCount(aliceAddr, adminAddr))
+	uassert.Equal(t, v1AliceToAliceCount, govStaker.GetUserDelegationCount(aliceAddr, aliceAddr))
+	uassert.Equal(t, v1FirstDelegateFrom, firstDelegation.DelegateFrom())
+	uassert.Equal(t, v1FirstDelegateTo, firstDelegation.DelegateTo())
+	uassert.Equal(t, v1FirstDelegateAmt, firstDelegation.TotalDelegatedAmount())
+	uassert.Equal(t, v1WithdrawCount, govStaker.GetDelegationWithdrawCount(v1DelegationIDs[0]))
+	uassert.Equal(t, v1CollectableAlice, govStaker.GetCollectableWithdrawAmount(v1DelegationIDs[0]))
+	uassert.True(t, govStaker.ExistsDelegation(v1DelegationIDs[0]))
+
+	println("[EXPECTED] total delegated:", govStaker.GetTotalDelegated())
+	println("[EXPECTED] total xGNS supply:", govStaker.GetTotalxGnsSupply())
+	println("[EXPECTED] delegation count:", govStaker.GetDelegationCount())
+	println("[EXPECTED] first delegation from/to/amount:",
+		firstDelegation.DelegateFrom(), firstDelegation.DelegateTo(), firstDelegation.TotalDelegatedAmount())
+	println("[EXPECTED] every v1 delegation value survived the upgrade")
+}
+
+func operateWithV3Valid(cur realm) {
+	// the undelegated GNS is claimable once the lockup period has passed
+	testing.SkipHeights(lockupPeriod/blockTimeSeconds + 1)
+
+	testing.SetRealm(aliceRealm)
+	collected := govStaker.CollectUndelegatedGns(cross(cur))
+	testing.SkipHeights(1)
+	println("[EXPECTED] collected undelegated gns:", collected)
+	println("[EXPECTED] total locked amount:", govStaker.GetTotalLockedAmount())
+
+	// bob adds to the v1-created delegation tree through v3_valid
+	testing.SetRealm(adminRealm)
+	gns.Transfer(cross(cur), bobAddr, bobDelegation)
+
+	testing.SetRealm(bobRealm)
+	gns.Approve(cross(cur), govStakerAddr, bobDelegation)
+	bobAmount := govStaker.Delegate(cross(cur), bobAddr, bobDelegation, "")
+	testing.SkipHeights(1)
+	println("[EXPECTED] bob delegated again:", bobAmount)
+	println("[EXPECTED] delegation count:", govStaker.GetDelegationCount())
+	println("[EXPECTED] total delegated:", govStaker.GetTotalDelegated())
+
+	// reward collection through the new implementation
+	testing.SetRealm(aliceRealm)
+	govStaker.CollectReward(cross(cur))
+	testing.SkipHeights(1)
+	claimable, protocolFeeRewards, err := govStaker.GetClaimableRewardByAddress(aliceAddr)
+	if err != nil {
+		panic(err)
+	}
+	println("[EXPECTED] alice claimable emission reward after collect:", claimable)
+	println("[EXPECTED] alice claimable protocol fee token count:", len(protocolFeeRewards))
+	println("[EXPECTED] emission distributed amount:", govStaker.GetEmissionDistributedAmount())
+
+	// snapshot pruning is only allowed beyond the maximum smoothing period
+	testing.SetRealm(adminRealm)
+	govStaker.CleanStakerDelegationSnapshotByAdmin(cross(cur), time.Now().Unix()-31*86400, aliceAddr)
+	testing.SkipHeights(1)
+	println("[EXPECTED] delegation snapshots present:", govStaker.HasDelegationSnapshotsKey())
+
+	uassert.Equal(t, undelegateSize, collected)
+	uassert.Equal(t, v1DelegationCount+1, govStaker.GetDelegationCount())
+	uassert.Equal(t, v1TotalDelegated+bobDelegation, govStaker.GetTotalDelegated())
+}
+
+func assertAborts(cur realm, callback func(), logMessage string) {
+	uassert.AbortsContains(t, cur, "implementation", callback)
+	println(logMessage)
+}
+
+// Output:
+// [SCENARIO] 1. Initialize gov/staker contract with v1
+// [EXPECTED] implementation: gno.land/r/gnoswap/gov/staker/v1
+// [EXPECTED] undelegation lockup period: 100
+//
+// [SCENARIO] 2. Build the delegation graph with v1
+// [EXPECTED] alice delegated amount: 2000000000
+// [EXPECTED] bob delegated amount: 1000000000
+// [EXPECTED] delegation count: 2
+// [EXPECTED] total delegated: 3000000000
+// [EXPECTED] total xGNS supply: 3000000000
+// [EXPECTED] total locked amount: 3000000000
+//
+// [SCENARIO] 3. Redelegate and undelegate with v1
+// [EXPECTED] redelegated: 500000000
+// [EXPECTED] alice->admin delegation count: 1
+// [EXPECTED] alice->alice delegation count: 1
+// [EXPECTED] alice delegatee count: 2
+// [EXPECTED] undelegated: 200000000
+// [EXPECTED] total delegated after undelegate: 2800000000
+// [EXPECTED] total xGNS supply after undelegate: 3000000000
+//
+// [SCENARIO] 4. Snapshot v1 data through the getters
+// [EXPECTED] snapshot total delegated: 2800000000
+// [EXPECTED] snapshot total xGNS supply: 3000000000
+// [EXPECTED] snapshot total locked: 3000000000
+// [EXPECTED] snapshot delegation count: 3
+// [EXPECTED] snapshot delegation ids: 3
+// [EXPECTED] snapshot first delegation amount: 2000000000
+// [EXPECTED] snapshot withdraw count: 0
+// [EXPECTED] snapshot collectable withdraw amount: 0
+//
+// [SCENARIO] 5. Upgrade to v2_invalid
+// [EXPECTED] implementation: gno.land/r/gnoswap/gov/staker/v2_invalid
+//
+// [SCENARIO] 6. Mutating calls must be blocked by v2_invalid
+// [EXPECTED] Delegate is blocked by v2_invalid
+// [EXPECTED] CollectReward is blocked by v2_invalid
+//
+// [SCENARIO] 7. Upgrade to v3_valid
+// [EXPECTED] implementation: gno.land/r/gnoswap/gov/staker/v3_valid
+//
+// [SCENARIO] 8. Validate the v1 delegation data through v3_valid
+// [EXPECTED] total delegated: 2800000000
+// [EXPECTED] total xGNS supply: 3000000000
+// [EXPECTED] delegation count: 3
+// [EXPECTED] first delegation from/to/amount: g1v9kxjcm9ta047h6lta047h6lta047h6lzd40gh g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 2000000000
+// [EXPECTED] every v1 delegation value survived the upgrade
+//
+// [SCENARIO] 9. Keep operating on the v1-created delegations
+// [EXPECTED] collected undelegated gns: 200000000
+// [EXPECTED] total locked amount: 2800000000
+// [EXPECTED] bob delegated again: 1000000000
+// [EXPECTED] delegation count: 4
+// [EXPECTED] total delegated: 3800000000
+// [EXPECTED] alice claimable emission reward after collect: 0
+// [EXPECTED] alice claimable protocol fee token count: 0
+// [EXPECTED] emission distributed amount: 0
+// [EXPECTED] delegation snapshots present: true

--- a/contract/r/scenario/upgrade/implements/v2_invalid/launchpad/gnomod.toml
+++ b/contract/r/scenario/upgrade/implements/v2_invalid/launchpad/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/r/gnoswap/launchpad/v2_invalid"
+gno = "0.9"

--- a/contract/r/scenario/upgrade/implements/v2_invalid/launchpad/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v2_invalid/launchpad/test_impl.gno
@@ -1,0 +1,443 @@
+// Simplified test implementation for launchpad contract upgrade testing.
+//
+// Every method panics unless it has been explicitly activated, which is what
+// the upgrade filetests use to prove that switching the implementation really
+// does route traffic to the new version.
+package v2_invalid
+
+import (
+	u256 "gno.land/p/gnoswap/uint256"
+
+	"gno.land/r/gnoswap/launchpad"
+	v1 "gno.land/r/gnoswap/launchpad/v1"
+)
+
+func NewV2InvalidLaunchpad(store launchpad.ILaunchpadStore) launchpad.ILaunchpad {
+	return &TestLaunchpad{
+		instance:      v1.NewLaunchpadV1(store),
+		activeMethods: make(map[string]bool),
+	}
+}
+
+func init(cur realm) {
+	launchpad.RegisterInitializer(cross(cur), func(_ int, rlm realm, store launchpad.ILaunchpadStore) launchpad.ILaunchpad {
+		return NewV2InvalidLaunchpad(store)
+	})
+}
+
+// TestLaunchpad delegates to v1 only when the method has been activated.
+type TestLaunchpad struct {
+	instance      launchpad.ILaunchpad
+	activeMethods map[string]bool
+}
+
+func (t *TestLaunchpad) SetActiveMethod(fnName string, activated bool) {
+	t.activeMethods[fnName] = activated
+}
+
+func (t *TestLaunchpad) isActive(fnName string) bool {
+	active, ok := t.activeMethods[fnName]
+	return ok && active
+}
+
+// ILaunchpadProject interface
+func (t *TestLaunchpad) CreateProject(_ int, rlm realm, name string, tokenPath string, recipient address, depositAmount int64, conditionTokens string, conditionAmounts string, tier30Ratio int64, tier90Ratio int64, tier180Ratio int64, startTime int64) string {
+	if !t.isActive("CreateProject") {
+		panic("test implementation: CreateProject not supported")
+	}
+	return t.instance.CreateProject(0, rlm, name, tokenPath, recipient, depositAmount, conditionTokens, conditionAmounts, tier30Ratio, tier90Ratio, tier180Ratio, startTime)
+}
+
+func (t *TestLaunchpad) TransferLeftFromProjectByAdmin(_ int, rlm realm, projectID string, recipient address) int64 {
+	if !t.isActive("TransferLeftFromProjectByAdmin") {
+		panic("test implementation: TransferLeftFromProjectByAdmin not supported")
+	}
+	return t.instance.TransferLeftFromProjectByAdmin(0, rlm, projectID, recipient)
+}
+
+func (t *TestLaunchpad) CollectProtocolFee(_ int, rlm realm) {
+	if !t.isActive("CollectProtocolFee") {
+		panic("test implementation: CollectProtocolFee not supported")
+	}
+	t.instance.CollectProtocolFee(0, rlm)
+}
+
+func (t *TestLaunchpad) CollectEmissionReward(_ int, rlm realm) {
+	if !t.isActive("CollectEmissionReward") {
+		panic("test implementation: CollectEmissionReward not supported")
+	}
+	t.instance.CollectEmissionReward(0, rlm)
+}
+
+func (t *TestLaunchpad) CollectProtocolFeeReward(_ int, rlm realm, tokenPath string) {
+	if !t.isActive("CollectProtocolFeeReward") {
+		panic("test implementation: CollectProtocolFeeReward not supported")
+	}
+	t.instance.CollectProtocolFeeReward(0, rlm, tokenPath)
+}
+
+// ILaunchpadDeposit interface
+func (t *TestLaunchpad) DepositGns(_ int, rlm realm, targetProjectTierID string, depositAmount int64, referrer string) string {
+	if !t.isActive("DepositGns") {
+		panic("test implementation: DepositGns not supported")
+	}
+	return t.instance.DepositGns(0, rlm, targetProjectTierID, depositAmount, referrer)
+}
+
+func (t *TestLaunchpad) CollectDepositGns(_ int, rlm realm, depositID string) (int64, error) {
+	if !t.isActive("CollectDepositGns") {
+		panic("test implementation: CollectDepositGns not supported")
+	}
+	return t.instance.CollectDepositGns(0, rlm, depositID)
+}
+
+func (t *TestLaunchpad) CollectRewardByDepositId(_ int, rlm realm, depositID string) int64 {
+	if !t.isActive("CollectRewardByDepositId") {
+		panic("test implementation: CollectRewardByDepositId not supported")
+	}
+	return t.instance.CollectRewardByDepositId(0, rlm, depositID)
+}
+
+// ILaunchpadGetter interface
+func (t *TestLaunchpad) GetProjectCount() int {
+	if !t.isActive("GetProjectCount") {
+		panic("test implementation: GetProjectCount not supported")
+	}
+	return t.instance.GetProjectCount()
+}
+
+func (t *TestLaunchpad) GetProjectIDs(offset, count int) []string {
+	if !t.isActive("GetProjectIDs") {
+		panic("test implementation: GetProjectIDs not supported")
+	}
+	return t.instance.GetProjectIDs(offset, count)
+}
+
+func (t *TestLaunchpad) GetProject(projectId string) (*launchpad.Project, error) {
+	if !t.isActive("GetProject") {
+		panic("test implementation: GetProject not supported")
+	}
+	return t.instance.GetProject(projectId)
+}
+
+func (t *TestLaunchpad) GetProjectName(projectId string) (string, error) {
+	if !t.isActive("GetProjectName") {
+		panic("test implementation: GetProjectName not supported")
+	}
+	return t.instance.GetProjectName(projectId)
+}
+
+func (t *TestLaunchpad) GetProjectTokenPath(projectId string) (string, error) {
+	if !t.isActive("GetProjectTokenPath") {
+		panic("test implementation: GetProjectTokenPath not supported")
+	}
+	return t.instance.GetProjectTokenPath(projectId)
+}
+
+func (t *TestLaunchpad) GetProjectDepositAmount(projectId string) (int64, error) {
+	if !t.isActive("GetProjectDepositAmount") {
+		panic("test implementation: GetProjectDepositAmount not supported")
+	}
+	return t.instance.GetProjectDepositAmount(projectId)
+}
+
+func (t *TestLaunchpad) GetProjectRecipient(projectId string) (address, error) {
+	if !t.isActive("GetProjectRecipient") {
+		panic("test implementation: GetProjectRecipient not supported")
+	}
+	return t.instance.GetProjectRecipient(projectId)
+}
+
+func (t *TestLaunchpad) GetProjectCondition(projectId string, tokenPath string) (*launchpad.ProjectCondition, error) {
+	if !t.isActive("GetProjectCondition") {
+		panic("test implementation: GetProjectCondition not supported")
+	}
+	return t.instance.GetProjectCondition(projectId, tokenPath)
+}
+
+func (t *TestLaunchpad) GetProjectTiersRatios(projectId string) (map[int64]int64, error) {
+	if !t.isActive("GetProjectTiersRatios") {
+		panic("test implementation: GetProjectTiersRatios not supported")
+	}
+	return t.instance.GetProjectTiersRatios(projectId)
+}
+
+func (t *TestLaunchpad) GetProjectCreatedHeight(projectId string) (int64, error) {
+	if !t.isActive("GetProjectCreatedHeight") {
+		panic("test implementation: GetProjectCreatedHeight not supported")
+	}
+	return t.instance.GetProjectCreatedHeight(projectId)
+}
+
+func (t *TestLaunchpad) GetProjectCreatedAt(projectId string) (int64, error) {
+	if !t.isActive("GetProjectCreatedAt") {
+		panic("test implementation: GetProjectCreatedAt not supported")
+	}
+	return t.instance.GetProjectCreatedAt(projectId)
+}
+
+func (t *TestLaunchpad) GetProjectTier(projectId string, tier int64) (*launchpad.ProjectTier, error) {
+	if !t.isActive("GetProjectTier") {
+		panic("test implementation: GetProjectTier not supported")
+	}
+	return t.instance.GetProjectTier(projectId, tier)
+}
+
+func (t *TestLaunchpad) GetProjectTierDistributeAmountPerSecondX128(projectId string, tier int64) (*u256.Uint, error) {
+	if !t.isActive("GetProjectTierDistributeAmountPerSecondX128") {
+		panic("test implementation: GetProjectTierDistributeAmountPerSecondX128 not supported")
+	}
+	return t.instance.GetProjectTierDistributeAmountPerSecondX128(projectId, tier)
+}
+
+func (t *TestLaunchpad) GetProjectTierTotalDistributeAmount(projectId string, tier int64) (int64, error) {
+	if !t.isActive("GetProjectTierTotalDistributeAmount") {
+		panic("test implementation: GetProjectTierTotalDistributeAmount not supported")
+	}
+	return t.instance.GetProjectTierTotalDistributeAmount(projectId, tier)
+}
+
+func (t *TestLaunchpad) GetProjectTierTotalDepositAmount(projectId string, tier int64) (int64, error) {
+	if !t.isActive("GetProjectTierTotalDepositAmount") {
+		panic("test implementation: GetProjectTierTotalDepositAmount not supported")
+	}
+	return t.instance.GetProjectTierTotalDepositAmount(projectId, tier)
+}
+
+func (t *TestLaunchpad) GetProjectTierTotalWithdrawAmount(projectId string, tier int64) (int64, error) {
+	if !t.isActive("GetProjectTierTotalWithdrawAmount") {
+		panic("test implementation: GetProjectTierTotalWithdrawAmount not supported")
+	}
+	return t.instance.GetProjectTierTotalWithdrawAmount(projectId, tier)
+}
+
+func (t *TestLaunchpad) GetProjectTierTotalDepositCount(projectId string, tier int64) (int64, error) {
+	if !t.isActive("GetProjectTierTotalDepositCount") {
+		panic("test implementation: GetProjectTierTotalDepositCount not supported")
+	}
+	return t.instance.GetProjectTierTotalDepositCount(projectId, tier)
+}
+
+func (t *TestLaunchpad) GetProjectTierTotalWithdrawCount(projectId string, tier int64) (int64, error) {
+	if !t.isActive("GetProjectTierTotalWithdrawCount") {
+		panic("test implementation: GetProjectTierTotalWithdrawCount not supported")
+	}
+	return t.instance.GetProjectTierTotalWithdrawCount(projectId, tier)
+}
+
+func (t *TestLaunchpad) GetProjectTierTotalCollectedAmount(projectId string, tier int64) (int64, error) {
+	if !t.isActive("GetProjectTierTotalCollectedAmount") {
+		panic("test implementation: GetProjectTierTotalCollectedAmount not supported")
+	}
+	return t.instance.GetProjectTierTotalCollectedAmount(projectId, tier)
+}
+
+func (t *TestLaunchpad) GetProjectTierStartTime(projectId string, tier int64) (int64, error) {
+	if !t.isActive("GetProjectTierStartTime") {
+		panic("test implementation: GetProjectTierStartTime not supported")
+	}
+	return t.instance.GetProjectTierStartTime(projectId, tier)
+}
+
+func (t *TestLaunchpad) GetProjectTierEndTime(projectId string, tier int64) (int64, error) {
+	if !t.isActive("GetProjectTierEndTime") {
+		panic("test implementation: GetProjectTierEndTime not supported")
+	}
+	return t.instance.GetProjectTierEndTime(projectId, tier)
+}
+
+func (t *TestLaunchpad) GetDepositCount() int {
+	if !t.isActive("GetDepositCount") {
+		panic("test implementation: GetDepositCount not supported")
+	}
+	return t.instance.GetDepositCount()
+}
+
+func (t *TestLaunchpad) GetCurrentDepositId() int64 {
+	if !t.isActive("GetCurrentDepositId") {
+		panic("test implementation: GetCurrentDepositId not supported")
+	}
+	return t.instance.GetCurrentDepositId()
+}
+
+func (t *TestLaunchpad) GetProjectTierDepositCount(projectId string, tier int64) int {
+	if !t.isActive("GetProjectTierDepositCount") {
+		panic("test implementation: GetProjectTierDepositCount not supported")
+	}
+	return t.instance.GetProjectTierDepositCount(projectId, tier)
+}
+
+func (t *TestLaunchpad) GetProjectTierDepositIDs(projectId string, tier int64, offset, count int) []string {
+	if !t.isActive("GetProjectTierDepositIDs") {
+		panic("test implementation: GetProjectTierDepositIDs not supported")
+	}
+	return t.instance.GetProjectTierDepositIDs(projectId, tier, offset, count)
+}
+
+func (t *TestLaunchpad) GetDeposit(depositId string) (*launchpad.Deposit, error) {
+	if !t.isActive("GetDeposit") {
+		panic("test implementation: GetDeposit not supported")
+	}
+	return t.instance.GetDeposit(depositId)
+}
+
+func (t *TestLaunchpad) GetDepositProjectID(depositId string) (string, error) {
+	if !t.isActive("GetDepositProjectID") {
+		panic("test implementation: GetDepositProjectID not supported")
+	}
+	return t.instance.GetDepositProjectID(depositId)
+}
+
+func (t *TestLaunchpad) GetDepositTier(depositId string) (int64, error) {
+	if !t.isActive("GetDepositTier") {
+		panic("test implementation: GetDepositTier not supported")
+	}
+	return t.instance.GetDepositTier(depositId)
+}
+
+func (t *TestLaunchpad) GetDepositProjectTierID(depositId string) (string, error) {
+	if !t.isActive("GetDepositProjectTierID") {
+		panic("test implementation: GetDepositProjectTierID not supported")
+	}
+	return t.instance.GetDepositProjectTierID(depositId)
+}
+
+func (t *TestLaunchpad) GetDepositAmount(depositId string) (int64, error) {
+	if !t.isActive("GetDepositAmount") {
+		panic("test implementation: GetDepositAmount not supported")
+	}
+	return t.instance.GetDepositAmount(depositId)
+}
+
+func (t *TestLaunchpad) GetDepositWithdrawnHeight(depositId string) (int64, error) {
+	if !t.isActive("GetDepositWithdrawnHeight") {
+		panic("test implementation: GetDepositWithdrawnHeight not supported")
+	}
+	return t.instance.GetDepositWithdrawnHeight(depositId)
+}
+
+func (t *TestLaunchpad) GetDepositWithdrawnTime(depositId string) (int64, error) {
+	if !t.isActive("GetDepositWithdrawnTime") {
+		panic("test implementation: GetDepositWithdrawnTime not supported")
+	}
+	return t.instance.GetDepositWithdrawnTime(depositId)
+}
+
+func (t *TestLaunchpad) GetDepositCreatedHeight(depositId string) (int64, error) {
+	if !t.isActive("GetDepositCreatedHeight") {
+		panic("test implementation: GetDepositCreatedHeight not supported")
+	}
+	return t.instance.GetDepositCreatedHeight(depositId)
+}
+
+func (t *TestLaunchpad) GetDepositCreatedAt(depositId string) (int64, error) {
+	if !t.isActive("GetDepositCreatedAt") {
+		panic("test implementation: GetDepositCreatedAt not supported")
+	}
+	return t.instance.GetDepositCreatedAt(depositId)
+}
+
+func (t *TestLaunchpad) GetDepositEndTime(depositId string) (int64, error) {
+	if !t.isActive("GetDepositEndTime") {
+		panic("test implementation: GetDepositEndTime not supported")
+	}
+	return t.instance.GetDepositEndTime(depositId)
+}
+
+func (t *TestLaunchpad) GetTotalGNSStakedAmount() int64 {
+	if !t.isActive("GetTotalGNSStakedAmount") {
+		panic("test implementation: GetTotalGNSStakedAmount not supported")
+	}
+	return t.instance.GetTotalGNSStakedAmount()
+}
+
+func (t *TestLaunchpad) GetProjectTierRewardManagerCount() int {
+	if !t.isActive("GetProjectTierRewardManagerCount") {
+		panic("test implementation: GetProjectTierRewardManagerCount not supported")
+	}
+	return t.instance.GetProjectTierRewardManagerCount()
+}
+
+func (t *TestLaunchpad) GetProjectTierRewardManager(projectTierId string) (*launchpad.RewardManager, error) {
+	if !t.isActive("GetProjectTierRewardManager") {
+		panic("test implementation: GetProjectTierRewardManager not supported")
+	}
+	return t.instance.GetProjectTierRewardManager(projectTierId)
+}
+
+func (t *TestLaunchpad) GetProjectTierRewardDistributeAmountPerSecondX128(projectTierId string) (*u256.Uint, error) {
+	if !t.isActive("GetProjectTierRewardDistributeAmountPerSecondX128") {
+		panic("test implementation: GetProjectTierRewardDistributeAmountPerSecondX128 not supported")
+	}
+	return t.instance.GetProjectTierRewardDistributeAmountPerSecondX128(projectTierId)
+}
+
+func (t *TestLaunchpad) GetProjectTierRewardAccumulatedRewardPerDepositX128(projectTierId string) (*u256.Uint, error) {
+	if !t.isActive("GetProjectTierRewardAccumulatedRewardPerDepositX128") {
+		panic("test implementation: GetProjectTierRewardAccumulatedRewardPerDepositX128 not supported")
+	}
+	return t.instance.GetProjectTierRewardAccumulatedRewardPerDepositX128(projectTierId)
+}
+
+func (t *TestLaunchpad) GetProjectTierRewardTotalDistributeAmount(projectTierId string) (int64, error) {
+	if !t.isActive("GetProjectTierRewardTotalDistributeAmount") {
+		panic("test implementation: GetProjectTierRewardTotalDistributeAmount not supported")
+	}
+	return t.instance.GetProjectTierRewardTotalDistributeAmount(projectTierId)
+}
+
+func (t *TestLaunchpad) GetProjectTierRewardTotalClaimedAmount(projectTierId string) (int64, error) {
+	if !t.isActive("GetProjectTierRewardTotalClaimedAmount") {
+		panic("test implementation: GetProjectTierRewardTotalClaimedAmount not supported")
+	}
+	return t.instance.GetProjectTierRewardTotalClaimedAmount(projectTierId)
+}
+
+func (t *TestLaunchpad) GetProjectTierRewardDistributeStartTime(projectTierId string) (int64, error) {
+	if !t.isActive("GetProjectTierRewardDistributeStartTime") {
+		panic("test implementation: GetProjectTierRewardDistributeStartTime not supported")
+	}
+	return t.instance.GetProjectTierRewardDistributeStartTime(projectTierId)
+}
+
+func (t *TestLaunchpad) GetProjectTierRewardDistributeEndTime(projectTierId string) (int64, error) {
+	if !t.isActive("GetProjectTierRewardDistributeEndTime") {
+		panic("test implementation: GetProjectTierRewardDistributeEndTime not supported")
+	}
+	return t.instance.GetProjectTierRewardDistributeEndTime(projectTierId)
+}
+
+func (t *TestLaunchpad) GetProjectTierRewardAccumulatedDistributeAmount(projectTierId string) (int64, error) {
+	if !t.isActive("GetProjectTierRewardAccumulatedDistributeAmount") {
+		panic("test implementation: GetProjectTierRewardAccumulatedDistributeAmount not supported")
+	}
+	return t.instance.GetProjectTierRewardAccumulatedDistributeAmount(projectTierId)
+}
+
+func (t *TestLaunchpad) GetProjectTierRewardAccumulatedTime(projectTierId string) (int64, error) {
+	if !t.isActive("GetProjectTierRewardAccumulatedTime") {
+		panic("test implementation: GetProjectTierRewardAccumulatedTime not supported")
+	}
+	return t.instance.GetProjectTierRewardAccumulatedTime(projectTierId)
+}
+
+func (t *TestLaunchpad) GetProjectTierRewardClaimableDuration(projectTierId string) (int64, error) {
+	if !t.isActive("GetProjectTierRewardClaimableDuration") {
+		panic("test implementation: GetProjectTierRewardClaimableDuration not supported")
+	}
+	return t.instance.GetProjectTierRewardClaimableDuration(projectTierId)
+}
+
+func (t *TestLaunchpad) GetRewardState(projectTierId string, depositId string) (*launchpad.RewardState, error) {
+	if !t.isActive("GetRewardState") {
+		panic("test implementation: GetRewardState not supported")
+	}
+	return t.instance.GetRewardState(projectTierId, depositId)
+}
+
+func (t *TestLaunchpad) GetProjectActiveStatus(projectId string) (bool, error) {
+	if !t.isActive("GetProjectActiveStatus") {
+		panic("test implementation: GetProjectActiveStatus not supported")
+	}
+	return t.instance.GetProjectActiveStatus(projectId)
+}

--- a/contract/r/scenario/upgrade/launchpad_upgrade_with_validate_data_filetest.gno
+++ b/contract/r/scenario/upgrade/launchpad_upgrade_with_validate_data_filetest.gno
@@ -5,10 +5,10 @@
 // Projects, tiers, deposits and reward managers all live in the shared KV
 // store, so an upgrade must leave them untouched. This test creates a project
 // and a deposit with v1, snapshots everything the public getters expose,
-// upgrades v1 -> v2_valid, asserts the snapshot is unchanged, and keeps
-// operating on the v1-created data through the new implementation (second
-// deposit, reward collection, principal withdrawal and the admin leftover
-// sweep).
+// upgrades v1 -> v2_invalid (proving the calls are blocked) -> v2_valid,
+// asserts the snapshot is unchanged, and keeps operating on the v1-created data
+// through the new implementation (second deposit, reward collection, principal
+// withdrawal and the admin leftover sweep).
 //
 // v2_valid is a copy of the v1 sources under a v2_valid module path, so it must
 // behave identically. (launchpad/v3_valid is deliberately NOT used here: it is a
@@ -33,6 +33,7 @@ import (
 
 	_ "gno.land/r/gnoswap/gov/staker/v1"
 	_ "gno.land/r/gnoswap/launchpad/v1"
+	_ "gno.land/r/gnoswap/launchpad/v2_invalid"
 	_ "gno.land/r/gnoswap/launchpad/v2_valid"
 	_ "gno.land/r/gnoswap/protocol_fee/v1"
 	_ "gno.land/r/gnoswap/rbac"
@@ -41,8 +42,9 @@ import (
 var t *testing.T
 
 const (
-	launchpadV1Path      = "gno.land/r/gnoswap/launchpad/v1"
-	launchpadV2ValidPath = "gno.land/r/gnoswap/launchpad/v2_valid"
+	launchpadV1Path        = "gno.land/r/gnoswap/launchpad/v1"
+	launchpadV2InvalidPath = "gno.land/r/gnoswap/launchpad/v2_invalid"
+	launchpadV2ValidPath   = "gno.land/r/gnoswap/launchpad/v2_valid"
 
 	oblPath = "gno.land/r/onbloc/obl.OBL"
 
@@ -116,7 +118,22 @@ func main(cur realm) {
 	captureV1Snapshot()
 	println()
 
-	println("[SCENARIO] 6. Upgrade to v2_valid and validate the v1 data")
+	println("[SCENARIO] 6. Upgrade to v2_invalid and prove the calls are blocked")
+	upgradeTo(cur, launchpadV2InvalidPath)
+	assertAborts(cur, func() {
+		testing.SetRealm(aliceRealm)
+		launchpad.DepositGns(cross(cur), tier30Id, depositAmount, "")
+	}, "[EXPECTED] DepositGns is blocked by v2_invalid")
+	assertAborts(cur, func() {
+		testing.SetRealm(aliceRealm)
+		launchpad.CollectRewardByDepositId(cross(cur), depositId)
+	}, "[EXPECTED] CollectRewardByDepositId is blocked by v2_invalid")
+	assertAborts(cur, func() {
+		launchpad.GetTotalGNSStakedAmount()
+	}, "[EXPECTED] the getters are blocked by v2_invalid too")
+	println()
+
+	println("[SCENARIO] 6-1. Upgrade to v2_valid and validate the v1 data")
 	upgradeTo(cur, launchpadV2ValidPath)
 	validateSnapshot()
 	println()
@@ -295,7 +312,10 @@ func validateSnapshot() {
 	depositValue, _ := launchpad.GetDepositAmount(depositId)
 	depositTier, _ := launchpad.GetDepositTier(depositId)
 	depositProject, _ := launchpad.GetDepositProjectID(depositId)
-	rewardTotal, _ := launchpad.GetProjectTierRewardTotalDistributeAmount(tier30Id)
+	rewardTotal, err := launchpad.GetProjectTierRewardTotalDistributeAmount(tier30Id)
+	uassert.NoError(t, err)
+	projectActive, err := launchpad.GetProjectActiveStatus(projectId)
+	uassert.NoError(t, err)
 
 	uassert.Equal(t, v1ProjectCount, launchpad.GetProjectCount())
 	uassert.Equal(t, v1ProjectName, projectName)
@@ -312,6 +332,7 @@ func validateSnapshot() {
 	uassert.Equal(t, v1DepositProjectID, depositProject)
 	uassert.Equal(t, v1RewardManagers, launchpad.GetProjectTierRewardManagerCount())
 	uassert.Equal(t, v1RewardTotalAmount, rewardTotal)
+	uassert.Equal(t, v1ProjectActive, projectActive)
 
 	println("[EXPECTED] project / tier / deposit / reward-manager data is unchanged")
 	println("[EXPECTED] project deposit amount:", deposit)
@@ -401,6 +422,11 @@ func transferLeftAfterUpgrade(cur realm) {
 	uassert.True(t, left+tier30Collected <= rewardAmount)
 }
 
+func assertAborts(cur realm, callback func(), logMessage string) {
+	uassert.AbortsContains(t, cur, "implementation", callback)
+	println(logMessage)
+}
+
 // Output:
 // [SCENARIO] 1. Initialize launchpad contract with v1
 // [EXPECTED] implementation: gno.land/r/gnoswap/launchpad/v1
@@ -436,7 +462,13 @@ func transferLeftAfterUpgrade(cur realm) {
 // [EXPECTED] snapshot tier 30 reward total: 100000000
 // [EXPECTED] snapshot project active: true
 //
-// [SCENARIO] 6. Upgrade to v2_valid and validate the v1 data
+// [SCENARIO] 6. Upgrade to v2_invalid and prove the calls are blocked
+// [EXPECTED] implementation: gno.land/r/gnoswap/launchpad/v2_invalid
+// [EXPECTED] DepositGns is blocked by v2_invalid
+// [EXPECTED] CollectRewardByDepositId is blocked by v2_invalid
+// [EXPECTED] the getters are blocked by v2_invalid too
+//
+// [SCENARIO] 6-1. Upgrade to v2_valid and validate the v1 data
 // [EXPECTED] implementation: gno.land/r/gnoswap/launchpad/v2_valid
 // [EXPECTED] project / tier / deposit / reward-manager data is unchanged
 // [EXPECTED] project deposit amount: 1000000000

--- a/contract/r/scenario/upgrade/launchpad_upgrade_with_validate_data_filetest.gno
+++ b/contract/r/scenario/upgrade/launchpad_upgrade_with_validate_data_filetest.gno
@@ -1,0 +1,470 @@
+// PKGPATH: gno.land/r/gnoswap/v1/main
+
+// Launchpad contract upgrade scenario test with data validation.
+//
+// Projects, tiers, deposits and reward managers all live in the shared KV
+// store, so an upgrade must leave them untouched. This test creates a project
+// and a deposit with v1, snapshots everything the public getters expose,
+// upgrades v1 -> v2_valid, asserts the snapshot is unchanged, and keeps
+// operating on the v1-created data through the new implementation (second
+// deposit, reward collection, principal withdrawal and the admin leftover
+// sweep).
+//
+// v2_valid is a copy of the v1 sources under a v2_valid module path, so it must
+// behave identically. (launchpad/v3_valid is deliberately NOT used here: it is a
+// divergent implementation whose CollectDepositGns skips the tier and
+// total-staked bookkeeping, so it is not a behaviour-preservation fixture.)
+package main
+
+import (
+	"testing"
+	"time"
+
+	prbac "gno.land/p/gnoswap/rbac"
+	testutils "gno.land/p/nt/testutils/v0"
+	uassert "gno.land/p/nt/uassert/v0"
+	ufmt "gno.land/p/nt/ufmt/v0"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/gns"
+	govStaker "gno.land/r/gnoswap/gov/staker"
+	"gno.land/r/gnoswap/launchpad"
+	"gno.land/r/onbloc/obl"
+
+	_ "gno.land/r/gnoswap/gov/staker/v1"
+	_ "gno.land/r/gnoswap/launchpad/v1"
+	_ "gno.land/r/gnoswap/launchpad/v2_valid"
+	_ "gno.land/r/gnoswap/protocol_fee/v1"
+	_ "gno.land/r/gnoswap/rbac"
+)
+
+var t *testing.T
+
+const (
+	launchpadV1Path      = "gno.land/r/gnoswap/launchpad/v1"
+	launchpadV2ValidPath = "gno.land/r/gnoswap/launchpad/v2_valid"
+
+	oblPath = "gno.land/r/onbloc/obl.OBL"
+
+	blockTimeSeconds = int64(5)
+	secondsPerDay    = int64(86400)
+
+	rewardAmount   = int64(1_000_000_000)
+	depositAmount  = int64(1_000_000)
+	tier30Duration = int64(30)
+)
+
+var (
+	adminAddr     = access.MustGetAddress(prbac.ROLE_ADMIN.String())
+	launchpadAddr = access.MustGetAddress(prbac.ROLE_LAUNCHPAD.String())
+
+	adminRealm = testing.NewUserRealm(adminAddr)
+
+	aliceAddr  = testutils.TestAddress("alice")
+	aliceRealm = testing.NewUserRealm(aliceAddr)
+
+	bobAddr  = testutils.TestAddress("bob")
+	bobRealm = testing.NewUserRealm(bobAddr)
+
+	projectAddr  = testutils.TestAddress("project-owner")
+	projectRealm = testing.NewUserRealm(projectAddr)
+
+	projectId  string
+	tier30Id   string
+	depositId  string
+	depositId2 string
+
+	// snapshot of the v1-written state
+	v1ProjectCount      int
+	v1ProjectName       string
+	v1ProjectTokenPath  string
+	v1ProjectRecipient  address
+	v1ProjectDeposit    int64
+	v1Tier30Total       int64
+	v1Tier90Total       int64
+	v1Tier180Total      int64
+	v1Tier30Start       int64
+	v1Tier30End         int64
+	v1DepositCount      int
+	v1DepositAmount     int64
+	v1DepositTier       int64
+	v1DepositProjectID  string
+	v1TotalGNSStaked    int64
+	v1RewardManagers    int
+	v1RewardTotalAmount int64
+	v1ProjectActive     bool
+)
+
+func main(cur realm) {
+	println("[SCENARIO] 1. Initialize launchpad contract with v1")
+	initialize(cur)
+	println()
+
+	println("[SCENARIO] 2. Create a project with v1")
+	createProject(cur)
+	println()
+
+	println("[SCENARIO] 3. Deposit GNS into tier 30 with v1")
+	depositWithV1(cur)
+	println()
+
+	println("[SCENARIO] 4. Collect the tier 30 reward with v1")
+	collectRewardWithV1(cur)
+	println()
+
+	println("[SCENARIO] 5. Snapshot v1 data through the getters")
+	captureV1Snapshot()
+	println()
+
+	println("[SCENARIO] 6. Upgrade to v2_valid and validate the v1 data")
+	upgradeTo(cur, launchpadV2ValidPath)
+	validateSnapshot()
+	println()
+
+	println("[SCENARIO] 7. Second deposit through v2_valid on the v1-created tier")
+	depositWithV2Valid(cur)
+	println()
+
+	println("[SCENARIO] 8. Re-validate the v1 data after the v2_valid write")
+	validateSnapshot()
+	println()
+
+	println("[SCENARIO] 9. Collect the deposit principal after the tier ends")
+	collectDepositAfterUpgrade(cur)
+	println()
+
+	println("[SCENARIO] 10. Project recipient collects the launchpad-side rewards")
+	collectProjectRewards(cur)
+	println()
+
+	println("[SCENARIO] 11. Admin sweeps the leftovers after the project ends")
+	transferLeftAfterUpgrade(cur)
+	println()
+}
+
+func initialize(cur realm) {
+	testing.SetRealm(adminRealm)
+	launchpad.UpgradeImpl(cross(cur), launchpadV1Path)
+	println("[EXPECTED] implementation:", launchpad.GetImplementationPackagePath())
+}
+
+func createProject(cur realm) {
+	testing.SetRealm(adminRealm)
+
+	startTime := time.Now().Unix() + 7*secondsPerDay
+	obl.Approve(cross(cur), launchpadAddr, rewardAmount)
+	projectId = launchpad.CreateProject(
+		cross(cur),
+		"OBL launchpad project",
+		oblPath,
+		projectAddr,
+		rewardAmount,
+		"",
+		"",
+		10, // tier30 ratio
+		20, // tier90 ratio
+		70, // tier180 ratio
+		startTime,
+	)
+	testing.SkipHeights(1)
+	tier30Id = ufmt.Sprintf("%s:%d", projectId, tier30Duration)
+
+	name, _ := launchpad.GetProjectName(projectId)
+	tokenPath, _ := launchpad.GetProjectTokenPath(projectId)
+	recipient, _ := launchpad.GetProjectRecipient(projectId)
+	deposit, _ := launchpad.GetProjectDepositAmount(projectId)
+	tier30Total, _ := launchpad.GetProjectTierTotalDistributeAmount(projectId, 30)
+	tier90Total, _ := launchpad.GetProjectTierTotalDistributeAmount(projectId, 90)
+	tier180Total, _ := launchpad.GetProjectTierTotalDistributeAmount(projectId, 180)
+
+	println("[EXPECTED] project id:", projectId)
+	println("[EXPECTED] project name:", name)
+	println("[EXPECTED] project token path:", tokenPath)
+	println("[EXPECTED] project recipient is the project owner:", recipient == projectAddr)
+	println("[EXPECTED] project deposit amount:", deposit)
+	println("[EXPECTED] tier distribute amounts (30/90/180):", tier30Total, tier90Total, tier180Total)
+
+	// the ratios are 10 / 20 / 70 of the funded reward amount
+	uassert.Equal(t, rewardAmount/10, tier30Total)
+	uassert.Equal(t, rewardAmount/5, tier90Total)
+	uassert.Equal(t, rewardAmount*7/10, tier180Total)
+	uassert.Equal(t, rewardAmount, deposit)
+}
+
+func depositWithV1(cur realm) {
+	// the tier only accepts deposits once it has started
+	testing.SkipHeights(7 * secondsPerDay / blockTimeSeconds)
+
+	testing.SetRealm(adminRealm)
+	gns.Transfer(cross(cur), aliceAddr, depositAmount)
+
+	testing.SetRealm(aliceRealm)
+	gns.Approve(cross(cur), launchpadAddr, depositAmount)
+	depositId = launchpad.DepositGns(cross(cur), tier30Id, depositAmount, "")
+	testing.SkipHeights(1)
+
+	amount, _ := launchpad.GetDepositAmount(depositId)
+	tier, _ := launchpad.GetDepositTier(depositId)
+	depositProject, _ := launchpad.GetDepositProjectID(depositId)
+	projectWallet, projectWalletFound := govStaker.GetLaunchpadProjectDeposit(projectAddr.String())
+
+	println("[EXPECTED] deposit id:", depositId)
+	println("[EXPECTED] deposit amount:", amount)
+	println("[EXPECTED] deposit tier:", tier)
+	println("[EXPECTED] deposit project id matches:", depositProject == projectId)
+	println("[EXPECTED] deposit count:", launchpad.GetDepositCount())
+	println("[EXPECTED] total GNS staked:", launchpad.GetTotalGNSStakedAmount())
+	// DepositGns forwards the xGNS accounting to gov/staker
+	println("[EXPECTED] gov staker project wallet:", projectWallet, "found:", projectWalletFound)
+
+	uassert.Equal(t, depositAmount, amount)
+	uassert.Equal(t, tier30Duration, tier)
+	uassert.Equal(t, depositAmount, launchpad.GetTotalGNSStakedAmount())
+	uassert.True(t, projectWalletFound)
+	uassert.Equal(t, depositAmount, projectWallet)
+}
+
+func collectRewardWithV1(cur realm) {
+	// tier 30 rewards become collectable after a 3 day wait; collect on day 4
+	testing.SkipHeights(4 * secondsPerDay / blockTimeSeconds)
+
+	testing.SetRealm(aliceRealm)
+	collected := launchpad.CollectRewardByDepositId(cross(cur), depositId)
+	testing.SkipHeights(1)
+
+	tier30Total, _ := launchpad.GetProjectTierTotalDistributeAmount(projectId, 30)
+	tier30Collected, _ := launchpad.GetProjectTierTotalCollectedAmount(projectId, 30)
+
+	println("[EXPECTED] collected reward:", collected)
+	println("[EXPECTED] tier 30 total collected:", tier30Collected)
+
+	// alice is the only depositor, so after ~4 of the 30 tier days she owns
+	// roughly 4/30 of the tier distribution
+	uassert.True(t, collected > tier30Total*3/30)
+	uassert.True(t, collected < tier30Total*5/30)
+	uassert.Equal(t, collected, tier30Collected)
+}
+
+func captureV1Snapshot() {
+	v1ProjectCount = launchpad.GetProjectCount()
+	v1ProjectName, _ = launchpad.GetProjectName(projectId)
+	v1ProjectTokenPath, _ = launchpad.GetProjectTokenPath(projectId)
+	v1ProjectRecipient, _ = launchpad.GetProjectRecipient(projectId)
+	v1ProjectDeposit, _ = launchpad.GetProjectDepositAmount(projectId)
+	v1Tier30Total, _ = launchpad.GetProjectTierTotalDistributeAmount(projectId, 30)
+	v1Tier90Total, _ = launchpad.GetProjectTierTotalDistributeAmount(projectId, 90)
+	v1Tier180Total, _ = launchpad.GetProjectTierTotalDistributeAmount(projectId, 180)
+	v1Tier30Start, _ = launchpad.GetProjectTierStartTime(projectId, 30)
+	v1Tier30End, _ = launchpad.GetProjectTierEndTime(projectId, 30)
+	v1DepositCount = launchpad.GetDepositCount()
+	v1DepositAmount, _ = launchpad.GetDepositAmount(depositId)
+	v1DepositTier, _ = launchpad.GetDepositTier(depositId)
+	v1DepositProjectID, _ = launchpad.GetDepositProjectID(depositId)
+	v1TotalGNSStaked = launchpad.GetTotalGNSStakedAmount()
+	v1RewardManagers = launchpad.GetProjectTierRewardManagerCount()
+	v1RewardTotalAmount, _ = launchpad.GetProjectTierRewardTotalDistributeAmount(tier30Id)
+	v1ProjectActive, _ = launchpad.GetProjectActiveStatus(projectId)
+
+	println("[EXPECTED] snapshot project count:", v1ProjectCount)
+	println("[EXPECTED] snapshot project deposit amount:", v1ProjectDeposit)
+	println("[EXPECTED] snapshot tier totals:", v1Tier30Total, v1Tier90Total, v1Tier180Total)
+	println("[EXPECTED] snapshot deposit count / amount:", v1DepositCount, v1DepositAmount)
+	println("[EXPECTED] snapshot total GNS staked:", v1TotalGNSStaked)
+	println("[EXPECTED] snapshot reward manager count:", v1RewardManagers)
+	println("[EXPECTED] snapshot tier 30 reward total:", v1RewardTotalAmount)
+	println("[EXPECTED] snapshot project active:", v1ProjectActive)
+}
+
+func upgradeTo(cur realm, packagePath string) {
+	testing.SetRealm(adminRealm)
+	launchpad.UpgradeImpl(cross(cur), packagePath)
+	println("[EXPECTED] implementation:", launchpad.GetImplementationPackagePath())
+	uassert.Equal(t, packagePath, launchpad.GetImplementationPackagePath())
+}
+
+func validateSnapshot() {
+	projectName, _ := launchpad.GetProjectName(projectId)
+	tokenPath, _ := launchpad.GetProjectTokenPath(projectId)
+	recipient, _ := launchpad.GetProjectRecipient(projectId)
+	deposit, _ := launchpad.GetProjectDepositAmount(projectId)
+	tier30Total, _ := launchpad.GetProjectTierTotalDistributeAmount(projectId, 30)
+	tier90Total, _ := launchpad.GetProjectTierTotalDistributeAmount(projectId, 90)
+	tier180Total, _ := launchpad.GetProjectTierTotalDistributeAmount(projectId, 180)
+	tier30Start, _ := launchpad.GetProjectTierStartTime(projectId, 30)
+	tier30End, _ := launchpad.GetProjectTierEndTime(projectId, 30)
+	depositValue, _ := launchpad.GetDepositAmount(depositId)
+	depositTier, _ := launchpad.GetDepositTier(depositId)
+	depositProject, _ := launchpad.GetDepositProjectID(depositId)
+	rewardTotal, _ := launchpad.GetProjectTierRewardTotalDistributeAmount(tier30Id)
+
+	uassert.Equal(t, v1ProjectCount, launchpad.GetProjectCount())
+	uassert.Equal(t, v1ProjectName, projectName)
+	uassert.Equal(t, v1ProjectTokenPath, tokenPath)
+	uassert.Equal(t, v1ProjectRecipient, recipient)
+	uassert.Equal(t, v1ProjectDeposit, deposit)
+	uassert.Equal(t, v1Tier30Total, tier30Total)
+	uassert.Equal(t, v1Tier90Total, tier90Total)
+	uassert.Equal(t, v1Tier180Total, tier180Total)
+	uassert.Equal(t, v1Tier30Start, tier30Start)
+	uassert.Equal(t, v1Tier30End, tier30End)
+	uassert.Equal(t, v1DepositAmount, depositValue)
+	uassert.Equal(t, v1DepositTier, depositTier)
+	uassert.Equal(t, v1DepositProjectID, depositProject)
+	uassert.Equal(t, v1RewardManagers, launchpad.GetProjectTierRewardManagerCount())
+	uassert.Equal(t, v1RewardTotalAmount, rewardTotal)
+
+	println("[EXPECTED] project / tier / deposit / reward-manager data is unchanged")
+	println("[EXPECTED] project deposit amount:", deposit)
+	println("[EXPECTED] deposit amount:", depositValue)
+	println("[EXPECTED] tier 30 reward total:", rewardTotal)
+}
+
+func depositWithV2Valid(cur realm) {
+	testing.SetRealm(adminRealm)
+	gns.Transfer(cross(cur), bobAddr, depositAmount)
+
+	testing.SetRealm(bobRealm)
+	gns.Approve(cross(cur), launchpadAddr, depositAmount)
+	depositId2 = launchpad.DepositGns(cross(cur), tier30Id, depositAmount, "")
+	testing.SkipHeights(1)
+
+	println("[EXPECTED] second deposit id:", depositId2)
+	println("[EXPECTED] deposit count:", launchpad.GetDepositCount())
+	println("[EXPECTED] total GNS staked:", launchpad.GetTotalGNSStakedAmount())
+	println("[EXPECTED] tier 30 deposit count:", launchpad.GetProjectTierDepositCount(projectId, 30))
+
+	uassert.Equal(t, v1DepositCount+1, launchpad.GetDepositCount())
+	uassert.Equal(t, v1TotalGNSStaked+depositAmount, launchpad.GetTotalGNSStakedAmount())
+}
+
+func collectDepositAfterUpgrade(cur realm) {
+	// the principal is only withdrawable once the tier has ended
+	tier30End, err := launchpad.GetProjectTierEndTime(projectId, 30)
+	if err != nil {
+		panic(err)
+	}
+	if remaining := tier30End - time.Now().Unix(); remaining > 0 {
+		testing.SkipHeights(remaining/blockTimeSeconds + 1)
+	}
+
+	testing.SetRealm(aliceRealm)
+	principal, err := launchpad.CollectDepositGns(cross(cur), depositId)
+	if err != nil {
+		panic(err)
+	}
+	testing.SkipHeights(1)
+
+	withdrawnAt, _ := launchpad.GetDepositWithdrawnTime(depositId)
+	tierWithdrawn, _ := launchpad.GetProjectTierTotalWithdrawAmount(projectId, 30)
+
+	println("[EXPECTED] collected principal:", principal)
+	println("[EXPECTED] deposit is marked withdrawn:", withdrawnAt > 0)
+	println("[EXPECTED] tier 30 total withdrawn:", tierWithdrawn)
+	println("[EXPECTED] total GNS staked after withdrawal:", launchpad.GetTotalGNSStakedAmount())
+
+	uassert.Equal(t, depositAmount, principal)
+	uassert.True(t, withdrawnAt > 0)
+	uassert.Equal(t, depositAmount, tierWithdrawn)
+	// only bob's deposit is left staked
+	uassert.Equal(t, depositAmount, launchpad.GetTotalGNSStakedAmount())
+}
+
+func collectProjectRewards(cur realm) {
+	// these route into gov/staker's launchpad-only entry points
+	testing.SetRealm(projectRealm)
+	launchpad.CollectEmissionReward(cross(cur))
+	launchpad.CollectProtocolFee(cross(cur))
+	testing.SkipHeights(1)
+	println("[EXPECTED] project recipient collected the gov-staker side rewards")
+}
+
+func transferLeftAfterUpgrade(cur realm) {
+	tier180End, err := launchpad.GetProjectTierEndTime(projectId, 180)
+	if err != nil {
+		panic(err)
+	}
+	if remaining := tier180End - time.Now().Unix(); remaining > 0 {
+		testing.SkipHeights(remaining/blockTimeSeconds + 1)
+	}
+
+	testing.SetRealm(adminRealm)
+	left := launchpad.TransferLeftFromProjectByAdmin(cross(cur), projectId, projectAddr)
+	testing.SkipHeights(1)
+
+	tier30Collected, _ := launchpad.GetProjectTierTotalCollectedAmount(projectId, 30)
+	println("[EXPECTED] leftover transferred:", left)
+	println("[EXPECTED] tier 30 total collected:", tier30Collected)
+	println("[EXPECTED] implementation:", launchpad.GetImplementationPackagePath())
+
+	// nothing may be handed out twice: what is swept plus what was collected
+	// can never exceed the funded reward amount
+	uassert.True(t, left+tier30Collected <= rewardAmount)
+}
+
+// Output:
+// [SCENARIO] 1. Initialize launchpad contract with v1
+// [EXPECTED] implementation: gno.land/r/gnoswap/launchpad/v1
+//
+// [SCENARIO] 2. Create a project with v1
+// [EXPECTED] project id: gno.land/r/onbloc/obl.OBL:123
+// [EXPECTED] project name: OBL launchpad project
+// [EXPECTED] project token path: gno.land/r/onbloc/obl.OBL
+// [EXPECTED] project recipient is the project owner: true
+// [EXPECTED] project deposit amount: 1000000000
+// [EXPECTED] tier distribute amounts (30/90/180): 100000000 200000000 700000000
+//
+// [SCENARIO] 3. Deposit GNS into tier 30 with v1
+// [EXPECTED] deposit id: 1
+// [EXPECTED] deposit amount: 1000000
+// [EXPECTED] deposit tier: 30
+// [EXPECTED] deposit project id matches: true
+// [EXPECTED] deposit count: 1
+// [EXPECTED] total GNS staked: 1000000
+// [EXPECTED] gov staker project wallet: 1000000 found: true
+//
+// [SCENARIO] 4. Collect the tier 30 reward with v1
+// [EXPECTED] collected reward: 13333719
+// [EXPECTED] tier 30 total collected: 13333719
+//
+// [SCENARIO] 5. Snapshot v1 data through the getters
+// [EXPECTED] snapshot project count: 1
+// [EXPECTED] snapshot project deposit amount: 1000000000
+// [EXPECTED] snapshot tier totals: 100000000 200000000 700000000
+// [EXPECTED] snapshot deposit count / amount: 1 1000000
+// [EXPECTED] snapshot total GNS staked: 1000000
+// [EXPECTED] snapshot reward manager count: 3
+// [EXPECTED] snapshot tier 30 reward total: 100000000
+// [EXPECTED] snapshot project active: true
+//
+// [SCENARIO] 6. Upgrade to v2_valid and validate the v1 data
+// [EXPECTED] implementation: gno.land/r/gnoswap/launchpad/v2_valid
+// [EXPECTED] project / tier / deposit / reward-manager data is unchanged
+// [EXPECTED] project deposit amount: 1000000000
+// [EXPECTED] deposit amount: 1000000
+// [EXPECTED] tier 30 reward total: 100000000
+//
+// [SCENARIO] 7. Second deposit through v2_valid on the v1-created tier
+// [EXPECTED] second deposit id: 2
+// [EXPECTED] deposit count: 2
+// [EXPECTED] total GNS staked: 2000000
+// [EXPECTED] tier 30 deposit count: 2
+//
+// [SCENARIO] 8. Re-validate the v1 data after the v2_valid write
+// [EXPECTED] project / tier / deposit / reward-manager data is unchanged
+// [EXPECTED] project deposit amount: 1000000000
+// [EXPECTED] deposit amount: 1000000
+// [EXPECTED] tier 30 reward total: 100000000
+//
+// [SCENARIO] 9. Collect the deposit principal after the tier ends
+// [EXPECTED] collected principal: 1000000
+// [EXPECTED] deposit is marked withdrawn: true
+// [EXPECTED] tier 30 total withdrawn: 1000000
+// [EXPECTED] total GNS staked after withdrawal: 1000000
+//
+// [SCENARIO] 10. Project recipient collects the launchpad-side rewards
+// [EXPECTED] project recipient collected the gov-staker side rewards
+//
+// [SCENARIO] 11. Admin sweeps the leftovers after the project ends
+// [EXPECTED] leftover transferred: 900000001
+// [EXPECTED] tier 30 total collected: 56666957
+// [EXPECTED] implementation: gno.land/r/gnoswap/launchpad/v2_valid

--- a/contract/r/scenario/upgrade/pool_upgrade_with_validate_data_filetest.gno
+++ b/contract/r/scenario/upgrade/pool_upgrade_with_validate_data_filetest.gno
@@ -4,10 +4,11 @@
 package main
 
 import (
-	"gno.land/p/gnoswap/gnsmath"
 	"math"
 	"testing"
 	"time"
+
+	"gno.land/p/gnoswap/gnsmath"
 
 	prbac "gno.land/p/gnoswap/rbac"
 	uassert "gno.land/p/nt/uassert/v0"
@@ -38,6 +39,43 @@ var (
 
 	barFoo500PoolPath = "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:500"
 	positionId        = uint64(1)
+
+	tickLower = int32(-960)
+	tickUpper = int32(960)
+
+	// snapshot of every getter value written by v1; the KV store is shared
+	// across implementations, so each of these must survive both upgrades
+	v1PoolLiquidity      string
+	v1PoolSqrtPriceX96   string
+	v1PoolTick           int32
+	v1PoolFeeGrowth0     string
+	v1PoolFeeGrowth1     string
+	v1PoolTickSpacing    int32
+	v1PoolFee            uint32
+	v1PoolToken0         string
+	v1PoolToken1         string
+	v1PoolBalance0       int64
+	v1PoolBalance1       int64
+	v1PoolProtocolFee0   int64
+	v1PoolProtocolFee1   int64
+	v1PoolPositionCount  int
+	v1TickLowerGross     string
+	v1TickLowerNet       string
+	v1TickUpperGross     string
+	v1TickUpperNet       string
+	v1TickLowerInit      bool
+	v1PoolPosLiquidity   string
+	v1PoolCreationFee    int64
+	v1WithdrawalFee      uint64
+	v1PositionCount      int
+	v1PositionLiquidity  string
+	v1PositionOwner      address
+	v1PositionTickLower  int32
+	v1PositionTickUpper  int32
+	v1PositionPoolKey    string
+	v1PositionIsBurned   bool
+	v1PositionIsInRange  bool
+	v1PositionTokensOwed int64
 )
 
 const (
@@ -67,22 +105,28 @@ func main(cur realm) {
 	checkPositionData(cur, positionId)
 	println()
 
+	println("[SCENARIO] 5-1. Snapshot every pool / position getter written by v1")
+	captureV1Snapshot()
+	println()
+
 	println("[SCENARIO] 6. Pool Contract Upgrade to v2_invalid")
 	upgradePoolContractToV2Invalid(cur)
 	println()
 
 	println("[SCENARIO] 7. Mint position with v2_invalid (should panic)")
-	withAbortsWithMessage(cur, func() {
-		mintPosition(cur, barPath, fooPath, fee500, -960, 960, "30000000", "30000000", "0", "0", time.Now().Unix()+3600, adminAddr, adminAddr)
-	},
+	withAbortsWithMessage(
+		cur, func() {
+			mintPosition(cur, barPath, fooPath, fee500, -960, 960, "30000000", "30000000", "0", "0", time.Now().Unix()+3600, adminAddr, adminAddr)
+		},
 		"[EXPECTED] Mint position panics correctly with v2_invalid", // log message when success panic
 	)
 	println()
 
 	println("[SCENARIO] 8. Check pool data with v2_invalid (should panic):", barFoo500PoolPath)
-	withAbortsWithMessage(cur, func() {
-		checkPoolData(cur, barFoo500PoolPath)
-	},
+	withAbortsWithMessage(
+		cur, func() {
+			checkPoolData(cur, barFoo500PoolPath)
+		},
 		"[EXPECTED] Check pool data panics correctly with v2_invalid", // log message when success panic
 	)
 	println()
@@ -103,9 +147,131 @@ func main(cur realm) {
 	checkPositionData(cur, positionId)
 	println()
 
-	println("[SCENARIO] 13. Mint position with v3_valid after upgrade")
+	println("[SCENARIO] 13. Validate every v1 getter value after the upgrades")
+	validateV1Snapshot()
+	println()
+
+	println("[SCENARIO] 14. Mint position with v3_valid after upgrade")
 	mintPosition(cur, barPath, fooPath, fee500, -960, 960, "30000000", "30000000", "0", "0", time.Now().Unix()+3600, adminAddr, adminAddr)
 	println()
+
+	println("[SCENARIO] 15. The new mint must only add liquidity, not reshape v1 data")
+	validateAfterSecondMint(cur)
+	println()
+}
+
+// positionKey mirrors the pool-side position key for the tick range used here.
+func positionKey() string {
+	return pool.EncodePositionKey(tickLower, tickUpper)
+}
+
+func captureV1Snapshot() {
+	key := positionKey()
+
+	v1PoolLiquidity = pool.GetLiquidity(barFoo500PoolPath)
+	v1PoolSqrtPriceX96 = pool.GetSlot0SqrtPriceX96(barFoo500PoolPath)
+	v1PoolTick = pool.GetSlot0Tick(barFoo500PoolPath)
+	v1PoolFeeGrowth0, v1PoolFeeGrowth1 = pool.GetFeeGrowthGlobalX128(barFoo500PoolPath)
+	v1PoolTickSpacing = pool.GetTickSpacing(barFoo500PoolPath)
+	v1PoolFee = pool.GetFee(barFoo500PoolPath)
+	v1PoolToken0 = pool.GetToken0Path(barFoo500PoolPath)
+	v1PoolToken1 = pool.GetToken1Path(barFoo500PoolPath)
+	v1PoolBalance0, v1PoolBalance1 = pool.GetBalances(barFoo500PoolPath)
+	v1PoolProtocolFee0, v1PoolProtocolFee1 = pool.GetProtocolFeesTokens(barFoo500PoolPath)
+	v1PoolPositionCount = pool.GetPoolPositionCount(barFoo500PoolPath)
+	v1TickLowerGross = pool.GetTickLiquidityGross(barFoo500PoolPath, tickLower)
+	v1TickLowerNet = pool.GetTickLiquidityNet(barFoo500PoolPath, tickLower)
+	v1TickUpperGross = pool.GetTickLiquidityGross(barFoo500PoolPath, tickUpper)
+	v1TickUpperNet = pool.GetTickLiquidityNet(barFoo500PoolPath, tickUpper)
+	v1TickLowerInit = pool.GetTickInitialized(barFoo500PoolPath, tickLower)
+	v1PoolPosLiquidity = pool.GetPositionLiquidity(barFoo500PoolPath, key)
+	v1PoolCreationFee = pool.GetPoolCreationFee()
+	v1WithdrawalFee = pool.GetWithdrawalFee()
+
+	v1PositionCount = position.GetPositionCount()
+	v1PositionLiquidity = position.GetPositionLiquidity(positionId)
+	v1PositionOwner = position.GetPositionOwner(positionId)
+	v1PositionTickLower = position.GetPositionTickLower(positionId)
+	v1PositionTickUpper = position.GetPositionTickUpper(positionId)
+	v1PositionPoolKey = position.GetPositionPoolKey(positionId)
+	v1PositionIsBurned = position.IsBurned(positionId)
+	v1PositionIsInRange = position.IsInRange(positionId)
+	v1PositionTokensOwed = position.GetPositionTokensOwed0(positionId)
+
+	println("[EXPECTED] pool liquidity:", v1PoolLiquidity)
+	println("[EXPECTED] pool balances:", v1PoolBalance0, v1PoolBalance1)
+	println("[EXPECTED] pool position count:", v1PoolPositionCount)
+	println("[EXPECTED] tick liquidity gross (lower / upper):", v1TickLowerGross, v1TickUpperGross)
+	println("[EXPECTED] tick liquidity net (lower / upper):", v1TickLowerNet, v1TickUpperNet)
+	println("[EXPECTED] pool-side position liquidity:", v1PoolPosLiquidity)
+	println("[EXPECTED] position-side liquidity:", v1PositionLiquidity)
+	println("[EXPECTED] position count:", v1PositionCount)
+
+	// the pool-side and position-side ledgers must agree
+	uassert.Equal(t, v1PoolLiquidity, v1PositionLiquidity)
+	uassert.Equal(t, v1PoolLiquidity, v1PoolPosLiquidity)
+	uassert.Equal(t, v1PoolLiquidity, v1TickLowerGross)
+	uassert.True(t, v1TickLowerInit)
+}
+
+func validateV1Snapshot() {
+	key := positionKey()
+	feeGrowth0, feeGrowth1 := pool.GetFeeGrowthGlobalX128(barFoo500PoolPath)
+	balance0, balance1 := pool.GetBalances(barFoo500PoolPath)
+	protocolFee0, protocolFee1 := pool.GetProtocolFeesTokens(barFoo500PoolPath)
+
+	uassert.Equal(t, v1PoolLiquidity, pool.GetLiquidity(barFoo500PoolPath))
+	uassert.Equal(t, v1PoolSqrtPriceX96, pool.GetSlot0SqrtPriceX96(barFoo500PoolPath))
+	uassert.Equal(t, v1PoolTick, pool.GetSlot0Tick(barFoo500PoolPath))
+	uassert.Equal(t, v1PoolFeeGrowth0, feeGrowth0)
+	uassert.Equal(t, v1PoolFeeGrowth1, feeGrowth1)
+	uassert.Equal(t, v1PoolTickSpacing, pool.GetTickSpacing(barFoo500PoolPath))
+	uassert.Equal(t, v1PoolFee, pool.GetFee(barFoo500PoolPath))
+	uassert.Equal(t, v1PoolToken0, pool.GetToken0Path(barFoo500PoolPath))
+	uassert.Equal(t, v1PoolToken1, pool.GetToken1Path(barFoo500PoolPath))
+	uassert.Equal(t, v1PoolBalance0, balance0)
+	uassert.Equal(t, v1PoolBalance1, balance1)
+	uassert.Equal(t, v1PoolProtocolFee0, protocolFee0)
+	uassert.Equal(t, v1PoolProtocolFee1, protocolFee1)
+	uassert.Equal(t, v1PoolPositionCount, pool.GetPoolPositionCount(barFoo500PoolPath))
+	uassert.Equal(t, v1TickLowerGross, pool.GetTickLiquidityGross(barFoo500PoolPath, tickLower))
+	uassert.Equal(t, v1TickLowerNet, pool.GetTickLiquidityNet(barFoo500PoolPath, tickLower))
+	uassert.Equal(t, v1TickUpperGross, pool.GetTickLiquidityGross(barFoo500PoolPath, tickUpper))
+	uassert.Equal(t, v1TickUpperNet, pool.GetTickLiquidityNet(barFoo500PoolPath, tickUpper))
+	uassert.Equal(t, v1TickLowerInit, pool.GetTickInitialized(barFoo500PoolPath, tickLower))
+	uassert.Equal(t, v1PoolPosLiquidity, pool.GetPositionLiquidity(barFoo500PoolPath, key))
+	uassert.Equal(t, v1PoolCreationFee, pool.GetPoolCreationFee())
+	uassert.Equal(t, v1WithdrawalFee, pool.GetWithdrawalFee())
+
+	uassert.Equal(t, v1PositionCount, position.GetPositionCount())
+	uassert.Equal(t, v1PositionLiquidity, position.GetPositionLiquidity(positionId))
+	uassert.Equal(t, v1PositionOwner, position.GetPositionOwner(positionId))
+	uassert.Equal(t, v1PositionTickLower, position.GetPositionTickLower(positionId))
+	uassert.Equal(t, v1PositionTickUpper, position.GetPositionTickUpper(positionId))
+	uassert.Equal(t, v1PositionPoolKey, position.GetPositionPoolKey(positionId))
+	uassert.Equal(t, v1PositionIsBurned, position.IsBurned(positionId))
+	uassert.Equal(t, v1PositionIsInRange, position.IsInRange(positionId))
+	uassert.Equal(t, v1PositionTokensOwed, position.GetPositionTokensOwed0(positionId))
+	uassert.True(t, pool.ExistsPoolPath(barFoo500PoolPath))
+
+	println("[EXPECTED] every pool and position getter still returns the v1 value")
+}
+
+func validateAfterSecondMint(cur realm) {
+	key := positionKey()
+
+	println("[EXPECTED] pool liquidity after the second mint:", pool.GetLiquidity(barFoo500PoolPath))
+	println("[EXPECTED] pool-side position liquidity:", pool.GetPositionLiquidity(barFoo500PoolPath, key))
+	println("[EXPECTED] pool position count:", pool.GetPoolPositionCount(barFoo500PoolPath))
+	println("[EXPECTED] position count:", position.GetPositionCount())
+	println("[EXPECTED] tick liquidity gross (lower):", pool.GetTickLiquidityGross(barFoo500PoolPath, tickLower))
+
+	// the two positions share the same tick range, so the pool-side position
+	// entry is the sum of both and the first position is untouched
+	uassert.Equal(t, v1PositionCount+1, position.GetPositionCount())
+	uassert.Equal(t, v1PositionLiquidity, position.GetPositionLiquidity(positionId))
+	uassert.Equal(t, pool.GetLiquidity(barFoo500PoolPath), pool.GetPositionLiquidity(barFoo500PoolPath, key))
+	uassert.Equal(t, pool.GetLiquidity(barFoo500PoolPath), pool.GetTickLiquidityGross(barFoo500PoolPath, tickLower))
 }
 
 func initialize(cur realm) {
@@ -222,6 +388,16 @@ func withAbortsWithMessage(cur realm, callback func(), logMessage string) {
 // [EXPECTED] TickLower: -960
 // [EXPECTED] TickUpper: 960
 //
+// [SCENARIO] 5-1. Snapshot every pool / position getter written by v1
+// [EXPECTED] pool liquidity: 1066918731
+// [EXPECTED] pool balances: 50000000 50000000
+// [EXPECTED] pool position count: 1
+// [EXPECTED] tick liquidity gross (lower / upper): 1066918731 1066918731
+// [EXPECTED] tick liquidity net (lower / upper): 1066918731 -1066918731
+// [EXPECTED] pool-side position liquidity: 1066918731
+// [EXPECTED] position-side liquidity: 1066918731
+// [EXPECTED] position count: 1
+//
 // [SCENARIO] 6. Pool Contract Upgrade to v2_invalid
 // [INFO] Upgrade pool contract to v2_invalid
 // [EXPECTED] Upgraded pool contract to v2_invalid: gno.land/r/gnoswap/pool/v2_invalid
@@ -264,9 +440,19 @@ func withAbortsWithMessage(cur realm, callback func(), logMessage string) {
 // [EXPECTED] TickLower: -960
 // [EXPECTED] TickUpper: 960
 //
-// [SCENARIO] 13. Mint position with v3_valid after upgrade
+// [SCENARIO] 13. Validate every v1 getter value after the upgrades
+// [EXPECTED] every pool and position getter still returns the v1 value
+//
+// [SCENARIO] 14. Mint position with v3_valid after upgrade
 // [INFO] Mint position
 // [EXPECTED] Position ID: 2
 // [EXPECTED] Liquidity: 640151238
 // [EXPECTED] Amount0: 30000000
 // [EXPECTED] Amount1: 30000000
+//
+// [SCENARIO] 15. The new mint must only add liquidity, not reshape v1 data
+// [EXPECTED] pool liquidity after the second mint: 1707069969
+// [EXPECTED] pool-side position liquidity: 1707069969
+// [EXPECTED] pool position count: 1
+// [EXPECTED] position count: 2
+// [EXPECTED] tick liquidity gross (lower): 1707069969

--- a/contract/r/scenario/upgrade/position_collectfee_upgrade_with_validate_data_filetest.gno
+++ b/contract/r/scenario/upgrade/position_collectfee_upgrade_with_validate_data_filetest.gno
@@ -117,6 +117,10 @@ func main(cur realm) {
 	upgradePoolContractToV3Valid(cur)
 	println()
 
+	println("[SCENARIO] 9-1. Validate the v1 data exactly, before any post-upgrade activity")
+	validateExactAfterUpgrade()
+	println()
+
 	println("[SCENARIO] 10. Perform swap to generate fees (should panic)")
 	exactInSwapRouteBy(cur, fooPath, barPath, "1000000", "gno.land/r/onbloc/foo.FOO:gno.land/r/onbloc/bar.BAR:500", "100", "1")
 	println()
@@ -125,8 +129,8 @@ func main(cur realm) {
 	collectFee(cur, positionId)
 	println()
 
-	println("[SCENARIO] 12. Validate the v1 position data after the upgrades")
-	validateV1Snapshot()
+	println("[SCENARIO] 12. Validate the post-upgrade accrual on top of the v1 data")
+	validateAccrualAfterUpgrade()
 	println()
 }
 
@@ -160,23 +164,55 @@ func captureV1Snapshot() {
 	uassert.True(t, v1PoolProtocolFee1 > 0)
 }
 
-func validateV1Snapshot() {
+// validateExactAfterUpgrade runs before any post-upgrade transaction, so every
+// snapshot field must match exactly. Checking this only after a new swap would
+// let a wiped-and-rebuilt value pass.
+func validateExactAfterUpgrade() {
 	feeGrowth0, feeGrowth1 := pool.GetFeeGrowthGlobalX128(barFoo500PoolPath)
+	protocolFee0, protocolFee1 := pool.GetProtocolFeesTokens(barFoo500PoolPath)
+	positionFeeGrowth0, positionFeeGrowth1 := position.GetPositionFeeGrowthInsideLastX128(positionId)
+	tokensOwed0, tokensOwed1 := position.GetPositionTokensOwed(positionId)
 	unclaimed0, unclaimed1 := position.GetUnclaimedFee(positionId)
 
-	// identity data must be untouched by the upgrades
 	uassert.Equal(t, v1PositionLiquidity, position.GetPositionLiquidity(positionId))
 	uassert.Equal(t, v1PositionPoolKey, position.GetPositionPoolKey(positionId))
 	uassert.Equal(t, v1PositionOwner, position.GetPositionOwner(positionId))
 	uassert.Equal(t, v1PositionTickLower, position.GetPositionTickLower(positionId))
 	uassert.Equal(t, v1PositionTickUpper, position.GetPositionTickUpper(positionId))
+	uassert.Equal(t, v1PositionFeeGrowth0, positionFeeGrowth0)
+	uassert.Equal(t, v1PositionFeeGrowth1, positionFeeGrowth1)
+	uassert.Equal(t, v1PositionTokensOwed0, tokensOwed0)
+	uassert.Equal(t, v1PositionTokensOwed1, tokensOwed1)
+	uassert.Equal(t, v1PositionUnclaimed0, unclaimed0)
+	uassert.Equal(t, v1PositionUnclaimed1, unclaimed1)
+	uassert.Equal(t, v1PoolFeeGrowth0, feeGrowth0)
+	uassert.Equal(t, v1PoolFeeGrowth1, feeGrowth1)
+	uassert.Equal(t, v1PoolProtocolFee0, protocolFee0)
+	uassert.Equal(t, v1PoolProtocolFee1, protocolFee1)
+	uassert.Equal(t, v1PoolLiquidity, pool.GetLiquidity(barFoo500PoolPath))
+	uassert.Equal(t, v1PoolTick, pool.GetSlot0Tick(barFoo500PoolPath))
+	uassert.False(t, position.IsBurned(positionId))
+
+	println("[EXPECTED] Every snapshot field matches exactly right after the upgrade")
+	println("[EXPECTED] Position fee growth inside last:", positionFeeGrowth0, positionFeeGrowth1)
+	println("[EXPECTED] Pool fee growth global:", feeGrowth0, feeGrowth1)
+	println("[EXPECTED] Pool protocol fees:", protocolFee0, protocolFee1)
+}
+
+// validateAccrualAfterUpgrade runs after the post-upgrade swap and collect: the
+// identity data still must not move, while the fee ledgers may only grow.
+func validateAccrualAfterUpgrade() {
+	feeGrowth0, feeGrowth1 := pool.GetFeeGrowthGlobalX128(barFoo500PoolPath)
+	unclaimed0, unclaimed1 := position.GetUnclaimedFee(positionId)
+
+	uassert.Equal(t, v1PositionLiquidity, position.GetPositionLiquidity(positionId))
+	uassert.Equal(t, v1PositionPoolKey, position.GetPositionPoolKey(positionId))
+	uassert.Equal(t, v1PositionOwner, position.GetPositionOwner(positionId))
 	// no mint / burn happened, so the in-range liquidity is unchanged; the tick
 	// may have moved because of the post-upgrade swap
 	uassert.Equal(t, v1PoolLiquidity, pool.GetLiquidity(barFoo500PoolPath))
 	uassert.False(t, position.IsBurned(positionId))
 
-	// the post-upgrade swap must keep accruing on top of the v1 values, never
-	// reset them
 	uassert.True(t, feeGrowth0 >= v1PoolFeeGrowth0)
 	uassert.True(t, feeGrowth1 >= v1PoolFeeGrowth1)
 	uassert.True(t, pool.GetProtocolFeesToken1(barFoo500PoolPath) >= v1PoolProtocolFee1)
@@ -184,7 +220,7 @@ func validateV1Snapshot() {
 	uassert.Equal(t, "0", unclaimed1)
 
 	println("[EXPECTED] Position identity data is unchanged after the upgrades")
-	println("[EXPECTED] Pool fee growth global after upgrade:", feeGrowth0, feeGrowth1)
+	println("[EXPECTED] Pool fee growth global after the post-upgrade swap:", feeGrowth0, feeGrowth1)
 	println("[EXPECTED] Position unclaimed fee after the second collect:", unclaimed0, unclaimed1)
 	println("[EXPECTED] Pool tick before / after the post-upgrade swap:", v1PoolTick, pool.GetSlot0Tick(barFoo500PoolPath))
 }
@@ -330,6 +366,12 @@ func withAbortsWithMessage(cur realm, callback func(), logMessage string) {
 // [INFO] Upgrade pool contract to v3_valid
 // [EXPECTED] Upgraded pool contract to v3_valid: gno.land/r/gnoswap/pool/v3_valid
 //
+// [SCENARIO] 9-1. Validate the v1 data exactly, before any post-upgrade activity
+// [EXPECTED] Every snapshot field matches exactly right after the upgrade
+// [EXPECTED] Position fee growth inside last: 0 132997709087958021110257564030945
+// [EXPECTED] Pool fee growth global: 0 132997709087958021110257564030945
+// [EXPECTED] Pool protocol fees: 0 83
+//
 // [SCENARIO] 10. Perform swap to generate fees (should panic)
 // [INFO] Exact-In Swap Route
 // [EXPECTED] Input token amount: 1000000
@@ -343,8 +385,8 @@ func withAbortsWithMessage(cur realm, callback func(), logMessage string) {
 // [EXPECTED] Amount0: 0
 // [EXPECTED] Amount1: 416
 //
-// [SCENARIO] 12. Validate the v1 position data after the upgrades
+// [SCENARIO] 12. Validate the post-upgrade accrual on top of the v1 data
 // [EXPECTED] Position identity data is unchanged after the upgrades
-// [EXPECTED] Pool fee growth global after upgrade: 0 265995418175916042220515128061890
+// [EXPECTED] Pool fee growth global after the post-upgrade swap: 0 265995418175916042220515128061890
 // [EXPECTED] Position unclaimed fee after the second collect: 0 0
 // [EXPECTED] Pool tick before / after the post-upgrade swap: 18 37

--- a/contract/r/scenario/upgrade/position_collectfee_upgrade_with_validate_data_filetest.gno
+++ b/contract/r/scenario/upgrade/position_collectfee_upgrade_with_validate_data_filetest.gno
@@ -4,10 +4,11 @@
 package main
 
 import (
-	"gno.land/p/gnoswap/gnsmath"
 	"math"
 	"testing"
 	"time"
+
+	"gno.land/p/gnoswap/gnsmath"
 
 	prbac "gno.land/p/gnoswap/rbac"
 	uassert "gno.land/p/nt/uassert/v0"
@@ -39,6 +40,25 @@ var (
 
 	barFoo500PoolPath = "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:500"
 	positionId        = uint64(1)
+
+	// snapshot of the position / pool getters right after the v1 fee collection
+	v1PositionLiquidity   string
+	v1PositionPoolKey     string
+	v1PositionOwner       address
+	v1PositionTickLower   int32
+	v1PositionTickUpper   int32
+	v1PositionFeeGrowth0  string
+	v1PositionFeeGrowth1  string
+	v1PositionTokensOwed0 int64
+	v1PositionTokensOwed1 int64
+	v1PositionUnclaimed0  string
+	v1PositionUnclaimed1  string
+	v1PoolFeeGrowth0      string
+	v1PoolFeeGrowth1      string
+	v1PoolProtocolFee0    int64
+	v1PoolProtocolFee1    int64
+	v1PoolLiquidity       string
+	v1PoolTick            int32
 )
 
 const (
@@ -68,21 +88,27 @@ func main(cur realm) {
 	collectFee(cur, positionId)
 	println()
 
+	println("[SCENARIO] 5-1. Snapshot the position and pool getters written by v1")
+	captureV1Snapshot()
+	println()
+
 	println("[SCENARIO] 6. Pool Contract Upgrade to v2_invalid")
 	upgradePoolContractToV2Invalid(cur)
 	println()
 
 	println("[SCENARIO] 7. Perform swap to generate fees (should panic)")
-	withAbortsWithMessage(cur, func() {
-		exactInSwapRouteBy(cur, fooPath, barPath, "1000000", "gno.land/r/onbloc/foo.FOO:gno.land/r/onbloc/bar.BAR:500", "100", "1")
-	},
+	withAbortsWithMessage(
+		cur, func() {
+			exactInSwapRouteBy(cur, fooPath, barPath, "1000000", "gno.land/r/onbloc/foo.FOO:gno.land/r/onbloc/bar.BAR:500", "100", "1")
+		},
 		"[EXPECTED] Perform swap to generate fees panics correctly with v2_invalid",
 	)
 
 	println("[SCENARIO] 8. Collect fee from position with v2_invalid (should panic)")
-	withAbortsWithMessage(cur, func() {
-		collectFee(cur, positionId)
-	},
+	withAbortsWithMessage(
+		cur, func() {
+			collectFee(cur, positionId)
+		},
 		"[EXPECTED] Collect fee from position panics correctly with v2_invalid",
 	)
 	println()
@@ -98,6 +124,69 @@ func main(cur realm) {
 	println("[SCENARIO] 11. Collect fee from position:", positionId)
 	collectFee(cur, positionId)
 	println()
+
+	println("[SCENARIO] 12. Validate the v1 position data after the upgrades")
+	validateV1Snapshot()
+	println()
+}
+
+func captureV1Snapshot() {
+	v1PositionLiquidity = position.GetPositionLiquidity(positionId)
+	v1PositionPoolKey = position.GetPositionPoolKey(positionId)
+	v1PositionOwner = position.GetPositionOwner(positionId)
+	v1PositionTickLower = position.GetPositionTickLower(positionId)
+	v1PositionTickUpper = position.GetPositionTickUpper(positionId)
+	v1PositionFeeGrowth0, v1PositionFeeGrowth1 = position.GetPositionFeeGrowthInsideLastX128(positionId)
+	v1PositionTokensOwed0, v1PositionTokensOwed1 = position.GetPositionTokensOwed(positionId)
+	v1PositionUnclaimed0, v1PositionUnclaimed1 = position.GetUnclaimedFee(positionId)
+	v1PoolFeeGrowth0, v1PoolFeeGrowth1 = pool.GetFeeGrowthGlobalX128(barFoo500PoolPath)
+	v1PoolProtocolFee0, v1PoolProtocolFee1 = pool.GetProtocolFeesTokens(barFoo500PoolPath)
+	v1PoolLiquidity = pool.GetLiquidity(barFoo500PoolPath)
+	v1PoolTick = pool.GetSlot0Tick(barFoo500PoolPath)
+
+	println("[EXPECTED] Position liquidity:", v1PositionLiquidity)
+	println("[EXPECTED] Position fee growth inside last:", v1PositionFeeGrowth0, v1PositionFeeGrowth1)
+	println("[EXPECTED] Position tokens owed:", v1PositionTokensOwed0, v1PositionTokensOwed1)
+	println("[EXPECTED] Position unclaimed fee after collect:", v1PositionUnclaimed0, v1PositionUnclaimed1)
+	println("[EXPECTED] Pool fee growth global:", v1PoolFeeGrowth0, v1PoolFeeGrowth1)
+	println("[EXPECTED] Pool protocol fees:", v1PoolProtocolFee0, v1PoolProtocolFee1)
+
+	// everything was just collected, so nothing may be left owed
+	uassert.Equal(t, "0", v1PositionUnclaimed0)
+	uassert.Equal(t, "0", v1PositionUnclaimed1)
+	uassert.Equal(t, int64(0), v1PositionTokensOwed0)
+	uassert.Equal(t, int64(0), v1PositionTokensOwed1)
+	// the swap ran foo -> bar, so only the token1 side accrued protocol fee
+	uassert.True(t, v1PoolProtocolFee1 > 0)
+}
+
+func validateV1Snapshot() {
+	feeGrowth0, feeGrowth1 := pool.GetFeeGrowthGlobalX128(barFoo500PoolPath)
+	unclaimed0, unclaimed1 := position.GetUnclaimedFee(positionId)
+
+	// identity data must be untouched by the upgrades
+	uassert.Equal(t, v1PositionLiquidity, position.GetPositionLiquidity(positionId))
+	uassert.Equal(t, v1PositionPoolKey, position.GetPositionPoolKey(positionId))
+	uassert.Equal(t, v1PositionOwner, position.GetPositionOwner(positionId))
+	uassert.Equal(t, v1PositionTickLower, position.GetPositionTickLower(positionId))
+	uassert.Equal(t, v1PositionTickUpper, position.GetPositionTickUpper(positionId))
+	// no mint / burn happened, so the in-range liquidity is unchanged; the tick
+	// may have moved because of the post-upgrade swap
+	uassert.Equal(t, v1PoolLiquidity, pool.GetLiquidity(barFoo500PoolPath))
+	uassert.False(t, position.IsBurned(positionId))
+
+	// the post-upgrade swap must keep accruing on top of the v1 values, never
+	// reset them
+	uassert.True(t, feeGrowth0 >= v1PoolFeeGrowth0)
+	uassert.True(t, feeGrowth1 >= v1PoolFeeGrowth1)
+	uassert.True(t, pool.GetProtocolFeesToken1(barFoo500PoolPath) >= v1PoolProtocolFee1)
+	uassert.Equal(t, "0", unclaimed0)
+	uassert.Equal(t, "0", unclaimed1)
+
+	println("[EXPECTED] Position identity data is unchanged after the upgrades")
+	println("[EXPECTED] Pool fee growth global after upgrade:", feeGrowth0, feeGrowth1)
+	println("[EXPECTED] Position unclaimed fee after the second collect:", unclaimed0, unclaimed1)
+	println("[EXPECTED] Pool tick before / after the post-upgrade swap:", v1PoolTick, pool.GetSlot0Tick(barFoo500PoolPath))
 }
 
 func initialize(cur realm) {
@@ -219,6 +308,14 @@ func withAbortsWithMessage(cur realm, callback func(), logMessage string) {
 // [EXPECTED] Amount0: 0
 // [EXPECTED] Amount1: 416
 //
+// [SCENARIO] 5-1. Snapshot the position and pool getters written by v1
+// [EXPECTED] Position liquidity: 1066918731
+// [EXPECTED] Position fee growth inside last: 0 132997709087958021110257564030945
+// [EXPECTED] Position tokens owed: 0 0
+// [EXPECTED] Position unclaimed fee after collect: 0 0
+// [EXPECTED] Pool fee growth global: 0 132997709087958021110257564030945
+// [EXPECTED] Pool protocol fees: 0 83
+//
 // [SCENARIO] 6. Pool Contract Upgrade to v2_invalid
 // [INFO] Upgrade pool contract to v2_invalid
 // [EXPECTED] Upgraded pool contract to v2_invalid: gno.land/r/gnoswap/pool/v2_invalid
@@ -245,3 +342,9 @@ func withAbortsWithMessage(cur realm, callback func(), logMessage string) {
 // [EXPECTED] Pool path: gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:500
 // [EXPECTED] Amount0: 0
 // [EXPECTED] Amount1: 416
+//
+// [SCENARIO] 12. Validate the v1 position data after the upgrades
+// [EXPECTED] Position identity data is unchanged after the upgrades
+// [EXPECTED] Pool fee growth global after upgrade: 0 265995418175916042220515128061890
+// [EXPECTED] Position unclaimed fee after the second collect: 0 0
+// [EXPECTED] Pool tick before / after the post-upgrade swap: 18 37

--- a/contract/r/scenario/upgrade/protocol_fee_upgrade_with_validate_data_filetest.gno
+++ b/contract/r/scenario/upgrade/protocol_fee_upgrade_with_validate_data_filetest.gno
@@ -157,6 +157,9 @@ func captureV1Snapshot() {
 
 	println("[EXPECTED] snapshot pct (devops / gov staker):", v1DevOpsPct, v1GovStakerPct)
 	println("[EXPECTED] snapshot reserved tokens:", len(v1ReservedTokens))
+	for _, tokenPath := range v1ReservedTokens {
+		println("[EXPECTED] snapshot reserved token:", tokenPath)
+	}
 	println("[EXPECTED] snapshot BAR accrued:", v1AccuGovStakeBar, v1AccuDevOpsBar)
 	println("[EXPECTED] snapshot FOO accrued:", v1AccuGovStakeFoo, v1AccuDevOpsFoo)
 }
@@ -171,7 +174,13 @@ func upgradeTo(cur realm, packagePath string) {
 func validateSnapshot() {
 	uassert.Equal(t, v1DevOpsPct, protocolFee.GetDevOpsPct())
 	uassert.Equal(t, v1GovStakerPct, protocolFee.GetGovStakerPct())
-	uassert.Equal(t, len(v1ReservedTokens), len(protocolFee.GetReservedTokens()))
+	// the reserved-token list drives the distribution loop, so its contents and
+	// ordering matter, not just its length
+	reservedTokens := protocolFee.GetReservedTokens()
+	uassert.Equal(t, len(v1ReservedTokens), len(reservedTokens))
+	for i, tokenPath := range v1ReservedTokens {
+		uassert.Equal(t, tokenPath, reservedTokens[i])
+	}
 	uassert.Equal(t, v1AccuGovStakeBar, protocolFee.GetAccuTransferToGovStakerByTokenPath(barPath))
 	uassert.Equal(t, v1AccuDevOpsBar, protocolFee.GetAccuTransferToDevOpsByTokenPath(barPath))
 	uassert.Equal(t, v1AccuGovStakeFoo, protocolFee.GetAccuTransferToGovStakerByTokenPath(fooPath))
@@ -185,6 +194,9 @@ func validateSnapshot() {
 	println("[EXPECTED] FOO accrued after upgrade:",
 		protocolFee.GetAccuTransferToGovStakerByTokenPath(fooPath),
 		protocolFee.GetAccuTransferToDevOpsByTokenPath(fooPath))
+	for _, tokenPath := range reservedTokens {
+		println("[EXPECTED] reserved token after upgrade:", tokenPath)
+	}
 	println("[EXPECTED] every v1 value survived the upgrade")
 }
 
@@ -263,6 +275,8 @@ func assertAborts(cur realm, callback func(), logMessage string) {
 // [SCENARIO] 3. Snapshot v1 data through the getters
 // [EXPECTED] snapshot pct (devops / gov staker): 3000 7000
 // [EXPECTED] snapshot reserved tokens: 2
+// [EXPECTED] snapshot reserved token: gno.land/r/onbloc/bar.BAR
+// [EXPECTED] snapshot reserved token: gno.land/r/onbloc/foo.FOO
 // [EXPECTED] snapshot BAR accrued: 700000 300000
 // [EXPECTED] snapshot FOO accrued: 1400000 600000
 //
@@ -280,6 +294,8 @@ func assertAborts(cur realm, callback func(), logMessage string) {
 // [EXPECTED] pct after upgrade (devops / gov staker): 3000 7000
 // [EXPECTED] BAR accrued after upgrade: 700000 300000
 // [EXPECTED] FOO accrued after upgrade: 1400000 600000
+// [EXPECTED] reserved token after upgrade: gno.land/r/onbloc/bar.BAR
+// [EXPECTED] reserved token after upgrade: gno.land/r/onbloc/foo.FOO
 // [EXPECTED] every v1 value survived the upgrade
 //
 // [SCENARIO] 8. Keep operating on the v1-created data with v3_valid

--- a/contract/r/scenario/upgrade/protocol_fee_upgrade_with_validate_data_filetest.gno
+++ b/contract/r/scenario/upgrade/protocol_fee_upgrade_with_validate_data_filetest.gno
@@ -1,0 +1,289 @@
+// PKGPATH: gno.land/r/gnoswap/v1/main
+
+// ProtocolFee contract upgrade scenario test with data validation.
+//
+// The KV store is shared across implementations, so an upgrade must not move,
+// reshape or drop any value. This test writes protocol-fee state with v1,
+// snapshots every value the public getters expose, walks the implementation
+// through v2_invalid (which must block the calls) up to v3_valid, and then
+// asserts the snapshot is byte-for-byte identical before continuing to operate
+// on the v1-created data.
+package main
+
+import (
+	"testing"
+
+	prbac "gno.land/p/gnoswap/rbac"
+	uassert "gno.land/p/nt/uassert/v0"
+
+	"gno.land/r/gnoswap/access"
+	protocolFee "gno.land/r/gnoswap/protocol_fee"
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/foo"
+
+	_ "gno.land/r/gnoswap/protocol_fee/v1"
+	_ "gno.land/r/gnoswap/protocol_fee/v2_invalid"
+	_ "gno.land/r/gnoswap/protocol_fee/v3_valid"
+	_ "gno.land/r/gnoswap/rbac"
+)
+
+var t *testing.T
+
+const (
+	protocolFeeV1Path        = "gno.land/r/gnoswap/protocol_fee/v1"
+	protocolFeeV2InvalidPath = "gno.land/r/gnoswap/protocol_fee/v2_invalid"
+	protocolFeeV3ValidPath   = "gno.land/r/gnoswap/protocol_fee/v3_valid"
+
+	barPath = "gno.land/r/onbloc/bar.BAR"
+	fooPath = "gno.land/r/onbloc/foo.FOO"
+
+	barFeeAmount = int64(1_000_000)
+	fooFeeAmount = int64(2_000_000)
+)
+
+var (
+	adminAddr       = access.MustGetAddress(prbac.ROLE_ADMIN.String())
+	protocolFeeAddr = access.MustGetAddress(prbac.ROLE_PROTOCOL_FEE.String())
+
+	adminRealm  = testing.NewUserRealm(adminAddr)
+	stakerRealm = testing.NewCodeRealm("gno.land/r/gnoswap/staker")
+
+	// AddToProtocolFee transfers from the active implementation realm, so the
+	// fee payer approves whichever implementation is live at that moment.
+	protocolFeeV1Realm      = testing.NewCodeRealm(protocolFeeV1Path)
+	protocolFeeV3ValidRealm = testing.NewCodeRealm(protocolFeeV3ValidPath)
+
+	// snapshot of the v1-written state
+	v1DevOpsPct       int64
+	v1GovStakerPct    int64
+	v1ReservedTokens  []string
+	v1AccuGovStakeBar int64
+	v1AccuDevOpsBar   int64
+	v1AccuGovStakeFoo int64
+	v1AccuDevOpsFoo   int64
+)
+
+func main(cur realm) {
+	println("[SCENARIO] 1. Initialize protocol_fee contract with v1")
+	initialize(cur)
+	println()
+
+	println("[SCENARIO] 2. Write protocol fee data with v1")
+	writeDataWithV1(cur)
+	println()
+
+	println("[SCENARIO] 3. Snapshot v1 data through the getters")
+	captureV1Snapshot()
+	println()
+
+	println("[SCENARIO] 4. Upgrade to v2_invalid")
+	upgradeTo(cur, protocolFeeV2InvalidPath)
+	println()
+
+	println("[SCENARIO] 5. Mutating calls must be blocked by v2_invalid")
+	assertAborts(cur, func() {
+		testing.SetRealm(adminRealm)
+		protocolFee.SetDevOpsPct(cross(cur), 5000)
+	}, "[EXPECTED] SetDevOpsPct is blocked by v2_invalid")
+	assertAborts(cur, func() {
+		testing.SetRealm(adminRealm)
+		protocolFee.DistributeProtocolFee(cross(cur))
+	}, "[EXPECTED] DistributeProtocolFee is blocked by v2_invalid")
+	println()
+
+	println("[SCENARIO] 6. Upgrade to v3_valid")
+	upgradeTo(cur, protocolFeeV3ValidPath)
+	println()
+
+	println("[SCENARIO] 7. Validate the v1 data through v3_valid")
+	validateSnapshot()
+	println()
+
+	println("[SCENARIO] 8. Keep operating on the v1-created data with v3_valid")
+	operateWithV3Valid(cur)
+	println()
+}
+
+func initialize(cur realm) {
+	testing.SetRealm(adminRealm)
+	protocolFee.UpgradeImpl(cross(cur), protocolFeeV1Path)
+	println("[EXPECTED] implementation:", protocolFee.GetImplementationPackagePath())
+}
+
+func writeDataWithV1(cur realm) {
+	testing.SetRealm(adminRealm)
+	protocolFee.SetGovStakerPct(cross(cur), 7000)
+	protocolFee.SetDevOpsPct(cross(cur), 3000)
+	println("[EXPECTED] gov staker pct:", protocolFee.GetGovStakerPct())
+	println("[EXPECTED] devops pct:", protocolFee.GetDevOpsPct())
+
+	// AddToProtocolFee pulls the tokens from the caller, so the caller (a
+	// protocol realm) is funded first and approves both the protocol_fee proxy
+	// and the live implementation realm.
+	fundAndApprove(cur, protocolFeeV1Realm.Address())
+
+	testing.SetRealm(stakerRealm)
+	if err := protocolFee.AddToProtocolFee(cross(cur), barPath, barFeeAmount); err != nil {
+		panic(err)
+	}
+	if err := protocolFee.AddToProtocolFee(cross(cur), fooPath, fooFeeAmount); err != nil {
+		panic(err)
+	}
+	testing.SkipHeights(1)
+
+	println("[EXPECTED] reserved token count:", len(protocolFee.GetReservedTokens()))
+	println("[EXPECTED] BAR accrued (gov staker / devops):",
+		protocolFee.GetAccuTransferToGovStakerByTokenPath(barPath),
+		protocolFee.GetAccuTransferToDevOpsByTokenPath(barPath))
+	println("[EXPECTED] FOO accrued (gov staker / devops):",
+		protocolFee.GetAccuTransferToGovStakerByTokenPath(fooPath),
+		protocolFee.GetAccuTransferToDevOpsByTokenPath(fooPath))
+
+	// the 70 / 30 split must hold for every accrued token
+	uassert.Equal(t, barFeeAmount*7/10, protocolFee.GetAccuTransferToGovStakerByTokenPath(barPath))
+	uassert.Equal(t, barFeeAmount*3/10, protocolFee.GetAccuTransferToDevOpsByTokenPath(barPath))
+	uassert.Equal(t, fooFeeAmount*7/10, protocolFee.GetAccuTransferToGovStakerByTokenPath(fooPath))
+	uassert.Equal(t, fooFeeAmount*3/10, protocolFee.GetAccuTransferToDevOpsByTokenPath(fooPath))
+}
+
+func captureV1Snapshot() {
+	v1DevOpsPct = protocolFee.GetDevOpsPct()
+	v1GovStakerPct = protocolFee.GetGovStakerPct()
+	v1ReservedTokens = protocolFee.GetReservedTokens()
+	v1AccuGovStakeBar = protocolFee.GetAccuTransferToGovStakerByTokenPath(barPath)
+	v1AccuDevOpsBar = protocolFee.GetAccuTransferToDevOpsByTokenPath(barPath)
+	v1AccuGovStakeFoo = protocolFee.GetAccuTransferToGovStakerByTokenPath(fooPath)
+	v1AccuDevOpsFoo = protocolFee.GetAccuTransferToDevOpsByTokenPath(fooPath)
+
+	println("[EXPECTED] snapshot pct (devops / gov staker):", v1DevOpsPct, v1GovStakerPct)
+	println("[EXPECTED] snapshot reserved tokens:", len(v1ReservedTokens))
+	println("[EXPECTED] snapshot BAR accrued:", v1AccuGovStakeBar, v1AccuDevOpsBar)
+	println("[EXPECTED] snapshot FOO accrued:", v1AccuGovStakeFoo, v1AccuDevOpsFoo)
+}
+
+func upgradeTo(cur realm, packagePath string) {
+	testing.SetRealm(adminRealm)
+	protocolFee.UpgradeImpl(cross(cur), packagePath)
+	println("[EXPECTED] implementation:", protocolFee.GetImplementationPackagePath())
+	uassert.Equal(t, packagePath, protocolFee.GetImplementationPackagePath())
+}
+
+func validateSnapshot() {
+	uassert.Equal(t, v1DevOpsPct, protocolFee.GetDevOpsPct())
+	uassert.Equal(t, v1GovStakerPct, protocolFee.GetGovStakerPct())
+	uassert.Equal(t, len(v1ReservedTokens), len(protocolFee.GetReservedTokens()))
+	uassert.Equal(t, v1AccuGovStakeBar, protocolFee.GetAccuTransferToGovStakerByTokenPath(barPath))
+	uassert.Equal(t, v1AccuDevOpsBar, protocolFee.GetAccuTransferToDevOpsByTokenPath(barPath))
+	uassert.Equal(t, v1AccuGovStakeFoo, protocolFee.GetAccuTransferToGovStakerByTokenPath(fooPath))
+	uassert.Equal(t, v1AccuDevOpsFoo, protocolFee.GetAccuTransferToDevOpsByTokenPath(fooPath))
+
+	println("[EXPECTED] pct after upgrade (devops / gov staker):",
+		protocolFee.GetDevOpsPct(), protocolFee.GetGovStakerPct())
+	println("[EXPECTED] BAR accrued after upgrade:",
+		protocolFee.GetAccuTransferToGovStakerByTokenPath(barPath),
+		protocolFee.GetAccuTransferToDevOpsByTokenPath(barPath))
+	println("[EXPECTED] FOO accrued after upgrade:",
+		protocolFee.GetAccuTransferToGovStakerByTokenPath(fooPath),
+		protocolFee.GetAccuTransferToDevOpsByTokenPath(fooPath))
+	println("[EXPECTED] every v1 value survived the upgrade")
+}
+
+func operateWithV3Valid(cur realm) {
+	// add more fee to the SAME token: this read-modify-writes the v1-created
+	// per-token tree entry through the new implementation
+	testing.SetRealm(adminRealm)
+	bar.Transfer(cross(cur), stakerRealm.Address(), barFeeAmount)
+
+	testing.SetRealm(stakerRealm)
+	bar.Approve(cross(cur), protocolFeeAddr, barFeeAmount)
+	bar.Approve(cross(cur), protocolFeeV3ValidRealm.Address(), barFeeAmount)
+
+	testing.SetRealm(stakerRealm)
+	if err := protocolFee.AddToProtocolFee(cross(cur), barPath, barFeeAmount); err != nil {
+		panic(err)
+	}
+	testing.SkipHeights(1)
+	println("[EXPECTED] BAR accrued after v3_valid add:",
+		protocolFee.GetAccuTransferToGovStakerByTokenPath(barPath),
+		protocolFee.GetAccuTransferToDevOpsByTokenPath(barPath))
+
+	// distribute one token explicitly, then everything that is left
+	testing.SetRealm(adminRealm)
+	protocolFee.DistributeProtocolFeeByTokenPath(cross(cur), barPath)
+	testing.SkipHeights(1)
+	println("[EXPECTED] BAR distributed (gov staker / devops):",
+		protocolFee.GetActualDistributedToGovStakerByTokenPath(barPath),
+		protocolFee.GetActualDistributedToDevOpsByTokenPath(barPath))
+
+	protocolFee.DistributeProtocolFee(cross(cur))
+	testing.SkipHeights(1)
+	println("[EXPECTED] FOO distributed (gov staker / devops):",
+		protocolFee.GetActualDistributedToGovStakerByTokenPath(fooPath),
+		protocolFee.GetActualDistributedToDevOpsByTokenPath(fooPath))
+	println("[EXPECTED] reserved token count after distribution:", len(protocolFee.GetReservedTokens()))
+
+	// everything accrued must end up distributed
+	uassert.Equal(t, v1AccuGovStakeBar+barFeeAmount*7/10, protocolFee.GetActualDistributedToGovStakerByTokenPath(barPath))
+	uassert.Equal(t, v1AccuDevOpsBar+barFeeAmount*3/10, protocolFee.GetActualDistributedToDevOpsByTokenPath(barPath))
+	uassert.Equal(t, v1AccuGovStakeFoo, protocolFee.GetActualDistributedToGovStakerByTokenPath(fooPath))
+	uassert.Equal(t, v1AccuDevOpsFoo, protocolFee.GetActualDistributedToDevOpsByTokenPath(fooPath))
+}
+
+// fundAndApprove funds the calling protocol realm and approves both the
+// protocol_fee proxy and the live implementation realm, which is the address
+// SafeGRC20TransferFrom actually spends from.
+func fundAndApprove(cur realm, implRealmAddr address) {
+	testing.SetRealm(adminRealm)
+	bar.Transfer(cross(cur), stakerRealm.Address(), barFeeAmount)
+	foo.Transfer(cross(cur), stakerRealm.Address(), fooFeeAmount)
+
+	testing.SetRealm(stakerRealm)
+	bar.Approve(cross(cur), protocolFeeAddr, barFeeAmount)
+	bar.Approve(cross(cur), implRealmAddr, barFeeAmount)
+	foo.Approve(cross(cur), protocolFeeAddr, fooFeeAmount)
+	foo.Approve(cross(cur), implRealmAddr, fooFeeAmount)
+}
+
+func assertAborts(cur realm, callback func(), logMessage string) {
+	uassert.AbortsContains(t, cur, "implementation", callback)
+	println(logMessage)
+}
+
+// Output:
+// [SCENARIO] 1. Initialize protocol_fee contract with v1
+// [EXPECTED] implementation: gno.land/r/gnoswap/protocol_fee/v1
+//
+// [SCENARIO] 2. Write protocol fee data with v1
+// [EXPECTED] gov staker pct: 7000
+// [EXPECTED] devops pct: 3000
+// [EXPECTED] reserved token count: 2
+// [EXPECTED] BAR accrued (gov staker / devops): 700000 300000
+// [EXPECTED] FOO accrued (gov staker / devops): 1400000 600000
+//
+// [SCENARIO] 3. Snapshot v1 data through the getters
+// [EXPECTED] snapshot pct (devops / gov staker): 3000 7000
+// [EXPECTED] snapshot reserved tokens: 2
+// [EXPECTED] snapshot BAR accrued: 700000 300000
+// [EXPECTED] snapshot FOO accrued: 1400000 600000
+//
+// [SCENARIO] 4. Upgrade to v2_invalid
+// [EXPECTED] implementation: gno.land/r/gnoswap/protocol_fee/v2_invalid
+//
+// [SCENARIO] 5. Mutating calls must be blocked by v2_invalid
+// [EXPECTED] SetDevOpsPct is blocked by v2_invalid
+// [EXPECTED] DistributeProtocolFee is blocked by v2_invalid
+//
+// [SCENARIO] 6. Upgrade to v3_valid
+// [EXPECTED] implementation: gno.land/r/gnoswap/protocol_fee/v3_valid
+//
+// [SCENARIO] 7. Validate the v1 data through v3_valid
+// [EXPECTED] pct after upgrade (devops / gov staker): 3000 7000
+// [EXPECTED] BAR accrued after upgrade: 700000 300000
+// [EXPECTED] FOO accrued after upgrade: 1400000 600000
+// [EXPECTED] every v1 value survived the upgrade
+//
+// [SCENARIO] 8. Keep operating on the v1-created data with v3_valid
+// [EXPECTED] BAR accrued after v3_valid add: 1400000 600000
+// [EXPECTED] BAR distributed (gov staker / devops): 1400000 600000
+// [EXPECTED] FOO distributed (gov staker / devops): 1400000 600000
+// [EXPECTED] reserved token count after distribution: 0

--- a/contract/r/scenario/upgrade/router_swap_upgrade_with_validate_data_filetest.gno
+++ b/contract/r/scenario/upgrade/router_swap_upgrade_with_validate_data_filetest.gno
@@ -98,6 +98,10 @@ func main(cur realm) {
 	upgradeRouterContractToV2Mock(cur)
 	println()
 
+	println("[SCENARIO] 6-2. Validate the v1 swap state exactly, before the second swap")
+	validateExactAfterUpgrade()
+	println()
+
 	println("[SCENARIO] 7. Perform swap to generate fees (check swap by v2_mock)")
 	exactInSwapRouteBy(cur, fooPath, barPath, "1000000", "gno.land/r/onbloc/foo.FOO:gno.land/r/onbloc/bar.BAR:500", "100", "1")
 	println()
@@ -110,8 +114,8 @@ func main(cur realm) {
 	checkPositionData(cur, positionId)
 	println()
 
-	println("[SCENARIO] 10. Validate the v1 swap state after the router upgrade")
-	validateV1Snapshot()
+	println("[SCENARIO] 10. Validate the accrual produced by the second swap")
+	validateAccrualAfterUpgrade()
 	println()
 }
 
@@ -142,7 +146,37 @@ func captureV1Snapshot() {
 	uassert.Equal(t, v1PoolLiquidity, v1PositionLiquidity)
 }
 
-func validateV1Snapshot() {
+// validateExactAfterUpgrade runs before the post-upgrade swap, so every pool and
+// position value must still match the snapshot exactly; a reset that the second
+// swap happens to repopulate would slip past a >= check.
+func validateExactAfterUpgrade() {
+	feeGrowth0, feeGrowth1 := pool.GetFeeGrowthGlobalX128(barFoo500PoolPath)
+	protocolFee0, protocolFee1 := pool.GetProtocolFeesTokens(barFoo500PoolPath)
+	balance0, balance1 := pool.GetBalances(barFoo500PoolPath)
+	unclaimed0, unclaimed1 := position.GetUnclaimedFee(positionId)
+
+	uassert.Equal(t, v1SwapFee, router.GetSwapFee())
+	uassert.Equal(t, v1PoolLiquidity, pool.GetLiquidity(barFoo500PoolPath))
+	uassert.Equal(t, v1PoolTick, pool.GetSlot0Tick(barFoo500PoolPath))
+	uassert.Equal(t, v1PoolFeeGrowth0, feeGrowth0)
+	uassert.Equal(t, v1PoolFeeGrowth1, feeGrowth1)
+	uassert.Equal(t, v1PoolProtocolFee0, protocolFee0)
+	uassert.Equal(t, v1PoolProtocolFee1, protocolFee1)
+	uassert.Equal(t, v1PoolBalance0, balance0)
+	uassert.Equal(t, v1PoolBalance1, balance1)
+	uassert.Equal(t, v1PositionLiquidity, position.GetPositionLiquidity(positionId))
+	uassert.Equal(t, v1PositionPoolKey, position.GetPositionPoolKey(positionId))
+	uassert.Equal(t, v1PositionTickLower, position.GetPositionTickLower(positionId))
+	uassert.Equal(t, v1PositionTickUpper, position.GetPositionTickUpper(positionId))
+	uassert.Equal(t, v1PositionUnclaimed0, unclaimed0)
+	uassert.Equal(t, v1PositionUnclaimed1, unclaimed1)
+
+	println("[EXPECTED] Every snapshot field matches exactly right after the upgrade")
+	println("[EXPECTED] Pool protocol fees:", protocolFee0, protocolFee1)
+	println("[EXPECTED] Position unclaimed fee:", unclaimed0, unclaimed1)
+}
+
+func validateAccrualAfterUpgrade() {
 	feeGrowth0, feeGrowth1 := pool.GetFeeGrowthGlobalX128(barFoo500PoolPath)
 	balance0, balance1 := pool.GetBalances(barFoo500PoolPath)
 	unclaimed0, unclaimed1 := position.GetUnclaimedFee(positionId)
@@ -301,6 +335,11 @@ func upgradeRouterContractToV2Mock(cur realm) {
 // [INFO] Upgrade router contract to v2_mock
 // [EXPECTED] Upgraded router contract to v2_mock: gno.land/r/gnoswap/router/v2_mock
 //
+// [SCENARIO] 6-2. Validate the v1 swap state exactly, before the second swap
+// [EXPECTED] Every snapshot field matches exactly right after the upgrade
+// [EXPECTED] Pool protocol fees: 0 0
+// [EXPECTED] Position unclaimed fee: 0 499
+//
 // [SCENARIO] 7. Perform swap to generate fees (check swap by v2_mock)
 // [INFO] Exact-In Swap Route
 // [INFO] ExactInSwapRoute called by v2_mock contract
@@ -319,7 +358,7 @@ func upgradeRouterContractToV2Mock(cur realm) {
 // [EXPECTED] Tick lower: -960
 // [EXPECTED] Tick upper: 960
 //
-// [SCENARIO] 10. Validate the v1 swap state after the router upgrade
+// [SCENARIO] 10. Validate the accrual produced by the second swap
 // [EXPECTED] Router swap fee is unchanged: 15
 // [EXPECTED] Pool balances after the second swap: 48004739 52000000
 // [EXPECTED] Pool fee growth global after the second swap: 0 318939350330834582998219578011858

--- a/contract/r/scenario/upgrade/router_swap_upgrade_with_validate_data_filetest.gno
+++ b/contract/r/scenario/upgrade/router_swap_upgrade_with_validate_data_filetest.gno
@@ -4,12 +4,14 @@
 package main
 
 import (
-	"gno.land/p/gnoswap/gnsmath"
 	"math"
 	"testing"
 	"time"
 
+	"gno.land/p/gnoswap/gnsmath"
+
 	prbac "gno.land/p/gnoswap/rbac"
+	uassert "gno.land/p/nt/uassert/v0"
 
 	"gno.land/r/gnoswap/access"
 	"gno.land/r/gnoswap/pool"
@@ -38,6 +40,24 @@ var (
 
 	barFoo500PoolPath = "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:500"
 	positionId        = uint64(1)
+
+	// snapshot taken after the v1 swap; the router upgrade must not touch any
+	// of the pool / position state it produced
+	v1SwapFee            uint64
+	v1PoolLiquidity      string
+	v1PoolTick           int32
+	v1PoolFeeGrowth0     string
+	v1PoolFeeGrowth1     string
+	v1PoolProtocolFee0   int64
+	v1PoolProtocolFee1   int64
+	v1PoolBalance0       int64
+	v1PoolBalance1       int64
+	v1PositionLiquidity  string
+	v1PositionPoolKey    string
+	v1PositionTickLower  int32
+	v1PositionTickUpper  int32
+	v1PositionUnclaimed0 string
+	v1PositionUnclaimed1 string
 )
 
 const (
@@ -70,6 +90,10 @@ func main(cur realm) {
 	checkPositionData(cur, positionId)
 	println()
 
+	println("[SCENARIO] 6-1. Snapshot the swap state produced by v1")
+	captureV1Snapshot()
+	println()
+
 	println("[SCENARIO] 6. Router Contract Upgrade to v2_mock")
 	upgradeRouterContractToV2Mock(cur)
 	println()
@@ -85,6 +109,66 @@ func main(cur realm) {
 	println("[SCENARIO] 9. Check position data by v2_mock version")
 	checkPositionData(cur, positionId)
 	println()
+
+	println("[SCENARIO] 10. Validate the v1 swap state after the router upgrade")
+	validateV1Snapshot()
+	println()
+}
+
+func captureV1Snapshot() {
+	v1SwapFee = router.GetSwapFee()
+	v1PoolLiquidity = pool.GetLiquidity(barFoo500PoolPath)
+	v1PoolTick = pool.GetSlot0Tick(barFoo500PoolPath)
+	v1PoolFeeGrowth0, v1PoolFeeGrowth1 = pool.GetFeeGrowthGlobalX128(barFoo500PoolPath)
+	v1PoolProtocolFee0, v1PoolProtocolFee1 = pool.GetProtocolFeesTokens(barFoo500PoolPath)
+	v1PoolBalance0, v1PoolBalance1 = pool.GetBalances(barFoo500PoolPath)
+	v1PositionLiquidity = position.GetPositionLiquidity(positionId)
+	v1PositionPoolKey = position.GetPositionPoolKey(positionId)
+	v1PositionTickLower = position.GetPositionTickLower(positionId)
+	v1PositionTickUpper = position.GetPositionTickUpper(positionId)
+	v1PositionUnclaimed0, v1PositionUnclaimed1 = position.GetUnclaimedFee(positionId)
+
+	println("[EXPECTED] Router swap fee:", v1SwapFee)
+	println("[EXPECTED] Pool tick after the v1 swap:", v1PoolTick)
+	println("[EXPECTED] Pool liquidity:", v1PoolLiquidity)
+	println("[EXPECTED] Pool balances:", v1PoolBalance0, v1PoolBalance1)
+	println("[EXPECTED] Pool fee growth global:", v1PoolFeeGrowth0, v1PoolFeeGrowth1)
+	println("[EXPECTED] Pool protocol fees:", v1PoolProtocolFee0, v1PoolProtocolFee1)
+	println("[EXPECTED] Position unclaimed fee:", v1PositionUnclaimed0, v1PositionUnclaimed1)
+
+	// the v1 swap actually charged an LP fee, otherwise the rest of the test
+	// would be validating an empty state
+	uassert.NotEqual(t, "0", v1PositionUnclaimed1)
+	uassert.Equal(t, v1PoolLiquidity, v1PositionLiquidity)
+}
+
+func validateV1Snapshot() {
+	feeGrowth0, feeGrowth1 := pool.GetFeeGrowthGlobalX128(barFoo500PoolPath)
+	balance0, balance1 := pool.GetBalances(barFoo500PoolPath)
+	unclaimed0, unclaimed1 := position.GetUnclaimedFee(positionId)
+
+	// the router upgrade must not move liquidity or reshape the position
+	uassert.Equal(t, v1SwapFee, router.GetSwapFee())
+	uassert.Equal(t, v1PoolLiquidity, pool.GetLiquidity(barFoo500PoolPath))
+	uassert.Equal(t, v1PositionLiquidity, position.GetPositionLiquidity(positionId))
+	uassert.Equal(t, v1PositionPoolKey, position.GetPositionPoolKey(positionId))
+	uassert.Equal(t, v1PositionTickLower, position.GetPositionTickLower(positionId))
+	uassert.Equal(t, v1PositionTickUpper, position.GetPositionTickUpper(positionId))
+	uassert.False(t, position.IsBurned(positionId))
+
+	// the swap routed through the upgraded router keeps accruing on top of the
+	// v1 values instead of resetting them
+	uassert.True(t, feeGrowth0 >= v1PoolFeeGrowth0)
+	uassert.True(t, feeGrowth1 >= v1PoolFeeGrowth1)
+	uassert.True(t, unclaimed1 >= v1PositionUnclaimed1)
+	uassert.True(t, balance1 > v1PoolBalance1)
+	uassert.True(t, balance0 < v1PoolBalance0)
+
+	println("[EXPECTED] Router swap fee is unchanged:", router.GetSwapFee())
+	println("[EXPECTED] Pool balances after the second swap:", balance0, balance1)
+	println("[EXPECTED] Pool fee growth global after the second swap:", feeGrowth0, feeGrowth1)
+	println("[EXPECTED] Position unclaimed fee after the second swap:", unclaimed0, unclaimed1)
+	println("[EXPECTED] Position identity data is unchanged after the router upgrade")
 }
 
 func initialize(cur realm) {
@@ -204,6 +288,15 @@ func upgradeRouterContractToV2Mock(cur realm) {
 // [EXPECTED] Tick lower: -960
 // [EXPECTED] Tick upper: 960
 //
+// [SCENARIO] 6-1. Snapshot the swap state produced by v1
+// [EXPECTED] Router swap fee: 15
+// [EXPECTED] Pool tick after the v1 swap: 18
+// [EXPECTED] Pool liquidity: 1066918731
+// [EXPECTED] Pool balances: 49001436 51000000
+// [EXPECTED] Pool fee growth global: 0 159469675165417291499109789005929
+// [EXPECTED] Pool protocol fees: 0 0
+// [EXPECTED] Position unclaimed fee: 0 499
+//
 // [SCENARIO] 6. Router Contract Upgrade to v2_mock
 // [INFO] Upgrade router contract to v2_mock
 // [EXPECTED] Upgraded router contract to v2_mock: gno.land/r/gnoswap/router/v2_mock
@@ -225,3 +318,10 @@ func upgradeRouterContractToV2Mock(cur realm) {
 // [EXPECTED] Liquidity: 1066918731
 // [EXPECTED] Tick lower: -960
 // [EXPECTED] Tick upper: 960
+//
+// [SCENARIO] 10. Validate the v1 swap state after the router upgrade
+// [EXPECTED] Router swap fee is unchanged: 15
+// [EXPECTED] Pool balances after the second swap: 48004739 52000000
+// [EXPECTED] Pool fee growth global after the second swap: 0 318939350330834582998219578011858
+// [EXPECTED] Position unclaimed fee after the second swap: 0 999
+// [EXPECTED] Position identity data is unchanged after the router upgrade

--- a/contract/r/scenario/upgrade/staker_collect_reward_upgrade_with_validate_data_filetest.gno
+++ b/contract/r/scenario/upgrade/staker_collect_reward_upgrade_with_validate_data_filetest.gno
@@ -130,6 +130,10 @@ func main(cur realm) {
 	upgradeStakerContractToV3Valid(cur)
 	println()
 
+	println("[SCENARIO] 11-1. Validate the v1 staking data exactly, before collecting again")
+	validateExactAfterUpgrade()
+	println()
+
 	println("[SCENARIO] 12. Check staking info after upgrade to v3_valid")
 	checkStakingInfo(cur, positionId)
 	println()
@@ -142,8 +146,8 @@ func main(cur realm) {
 	checkStakingInfo(cur, positionId)
 	println()
 
-	println("[SCENARIO] 15. Validate the v1 staking state after the upgrades")
-	validateV1Snapshot()
+	println("[SCENARIO] 15. Validate the reward ledgers after the post-upgrade collection")
+	validateAccrualAfterUpgrade()
 	println()
 }
 
@@ -183,7 +187,34 @@ func captureV1Snapshot() {
 	uassert.Equal(t, uint64(1), v1PoolTier)
 }
 
-func validateV1Snapshot() {
+// validateExactAfterUpgrade runs before any post-upgrade collection, so the
+// reward ledgers must still hold exactly their v1 values. Checking only that
+// they grew, after a fresh collection, would let a reset-then-refilled ledger
+// pass.
+func validateExactAfterUpgrade() {
+	uassert.Equal(t, v1DepositOwner, staker.GetDepositOwner(positionId))
+	uassert.Equal(t, v1DepositPoolPath, staker.GetDepositTargetPoolPath(positionId))
+	uassert.Equal(t, v1DepositLiquidity, staker.GetDepositLiquidityAsString(positionId))
+	uassert.Equal(t, v1DepositStakeTime, staker.GetDepositStakeTime(positionId))
+	uassert.Equal(t, v1DepositTickLower, staker.GetDepositTickLower(positionId))
+	uassert.Equal(t, v1DepositTickUpper, staker.GetDepositTickUpper(positionId))
+	uassert.Equal(t, v1DepositWarmupCount, len(staker.GetDepositWarmUp(positionId)))
+	uassert.Equal(t, v1CollectedInternal, staker.GetDepositCollectedInternalReward(positionId))
+	uassert.Equal(t, v1TotalEmissionSent, staker.GetTotalEmissionSent())
+	uassert.Equal(t, v1PoolTier, staker.GetPoolTier(barFoo500PoolPath))
+	uassert.Equal(t, v1PoolTierRatio, staker.GetPoolTierRatio(barFoo500PoolPath))
+	uassert.Equal(t, v1PoolStakedLiq, staker.GetPoolStakedLiquidity(barFoo500PoolPath))
+	uassert.Equal(t, v1UnstakingFee, staker.GetUnstakingFee())
+	uassert.Equal(t, v1DepositGnsAmount, staker.GetDepositGnsAmount())
+	uassert.Equal(t, v1AllowedTokenCount, len(staker.GetAllowedTokens()))
+	uassert.True(t, staker.IsStaked(positionId))
+
+	println("[EXPECTED] Every snapshot field matches exactly right after the upgrade")
+	println("[EXPECTED] Collected internal reward:", staker.GetDepositCollectedInternalReward(positionId))
+	println("[EXPECTED] Total emission sent:", staker.GetTotalEmissionSent())
+}
+
+func validateAccrualAfterUpgrade() {
 	// deposit identity is immutable across upgrades
 	uassert.Equal(t, v1DepositOwner, staker.GetDepositOwner(positionId))
 	uassert.Equal(t, v1DepositPoolPath, staker.GetDepositTargetPoolPath(positionId))
@@ -394,6 +425,11 @@ func withAbortsWithMessage(cur realm, callback func(), logMessage string) {
 // [INFO] Upgrade staker contract to v3_valid
 // [EXPECTED] Upgraded staker contract to v3_valid: gno.land/r/gnoswap/staker/v3_valid
 //
+// [SCENARIO] 11-1. Validate the v1 staking data exactly, before collecting again
+// [EXPECTED] Every snapshot field matches exactly right after the upgrade
+// [EXPECTED] Collected internal reward: 133775649
+// [EXPECTED] Total emission sent: 146751888
+//
 // [SCENARIO] 12. Check staking info after upgrade to v3_valid
 // [INFO] Check staking info
 // [EXPECTED] Is staked: true
@@ -414,7 +450,7 @@ func withAbortsWithMessage(cur realm, callback func(), logMessage string) {
 // [EXPECTED] Staked liquidity: 1066918731
 // [EXPECTED] Stake time: 1234567900
 //
-// [SCENARIO] 15. Validate the v1 staking state after the upgrades
+// [SCENARIO] 15. Validate the reward ledgers after the post-upgrade collection
 // [EXPECTED] Deposit identity data is unchanged after the upgrades
 // [EXPECTED] Collected internal reward grew from 133775649 to 267551299
 // [EXPECTED] Total emission sent grew from 146751888 to 280126212

--- a/contract/r/scenario/upgrade/staker_collect_reward_upgrade_with_validate_data_filetest.gno
+++ b/contract/r/scenario/upgrade/staker_collect_reward_upgrade_with_validate_data_filetest.gno
@@ -9,11 +9,11 @@ import (
 	"testing"
 	"time"
 
-	"gno.land/p/gnoswap/gnsmath"
-	"gno.land/r/gnoswap/scenarioutils"
 	"gno.land/p/demo/tokens/grc721"
+	"gno.land/p/gnoswap/gnsmath"
 	prbac "gno.land/p/gnoswap/rbac"
 	uassert "gno.land/p/nt/uassert/v0"
+	"gno.land/r/gnoswap/scenarioutils"
 
 	"gno.land/r/gnoswap/access"
 	"gno.land/r/gnoswap/emission"
@@ -44,6 +44,23 @@ var (
 
 	barFoo500PoolPath = "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:500"
 	positionId        = uint64(1)
+
+	// snapshot of the staking state written by v1
+	v1DepositOwner       address
+	v1DepositPoolPath    string
+	v1DepositLiquidity   string
+	v1DepositStakeTime   int64
+	v1DepositTickLower   int32
+	v1DepositTickUpper   int32
+	v1DepositWarmupCount int
+	v1CollectedInternal  int64
+	v1PoolTier           uint64
+	v1PoolTierRatio      uint64
+	v1PoolStakedLiq      string
+	v1UnstakingFee       uint64
+	v1DepositGnsAmount   int64
+	v1AllowedTokenCount  int
+	v1TotalEmissionSent  int64
 )
 
 const (
@@ -80,6 +97,10 @@ func main(cur realm) {
 
 	println("[SCENARIO] 7. Check staking info before upgrade")
 	checkStakingInfo(cur, positionId)
+	println()
+
+	println("[SCENARIO] 7-1. Snapshot the staking state written by v1")
+	captureV1Snapshot()
 	println()
 
 	println("[SCENARIO] 8. Staker Contract Upgrade to v2_invalid")
@@ -120,6 +141,74 @@ func main(cur realm) {
 	println("[SCENARIO] 14. Check staking info after reward collection")
 	checkStakingInfo(cur, positionId)
 	println()
+
+	println("[SCENARIO] 15. Validate the v1 staking state after the upgrades")
+	validateV1Snapshot()
+	println()
+}
+
+func captureV1Snapshot() {
+	v1DepositOwner = staker.GetDepositOwner(positionId)
+	v1DepositPoolPath = staker.GetDepositTargetPoolPath(positionId)
+	v1DepositLiquidity = staker.GetDepositLiquidityAsString(positionId)
+	v1DepositStakeTime = staker.GetDepositStakeTime(positionId)
+	v1DepositTickLower = staker.GetDepositTickLower(positionId)
+	v1DepositTickUpper = staker.GetDepositTickUpper(positionId)
+	v1DepositWarmupCount = len(staker.GetDepositWarmUp(positionId))
+	v1CollectedInternal = staker.GetDepositCollectedInternalReward(positionId)
+	v1PoolTier = staker.GetPoolTier(barFoo500PoolPath)
+	v1PoolTierRatio = staker.GetPoolTierRatio(barFoo500PoolPath)
+	v1PoolStakedLiq = staker.GetPoolStakedLiquidity(barFoo500PoolPath)
+	v1UnstakingFee = staker.GetUnstakingFee()
+	v1DepositGnsAmount = staker.GetDepositGnsAmount()
+	v1AllowedTokenCount = len(staker.GetAllowedTokens())
+	v1TotalEmissionSent = staker.GetTotalEmissionSent()
+
+	println("[EXPECTED] Deposit owner:", v1DepositOwner)
+	println("[EXPECTED] Deposit liquidity:", v1DepositLiquidity)
+	println("[EXPECTED] Deposit ticks:", v1DepositTickLower, v1DepositTickUpper)
+	println("[EXPECTED] Deposit warmup tiers:", v1DepositWarmupCount)
+	println("[EXPECTED] Collected internal reward so far:", v1CollectedInternal)
+	println("[EXPECTED] Pool tier / ratio:", v1PoolTier, v1PoolTierRatio)
+	println("[EXPECTED] Pool staked liquidity:", v1PoolStakedLiq)
+	println("[EXPECTED] Unstaking fee / deposit GNS amount:", v1UnstakingFee, v1DepositGnsAmount)
+	println("[EXPECTED] Allowed token count:", v1AllowedTokenCount)
+	println("[EXPECTED] Total emission sent:", v1TotalEmissionSent)
+
+	// the deposit must mirror the staked position and already have collected
+	// a non-zero internal reward
+	uassert.Equal(t, barFoo500PoolPath, v1DepositPoolPath)
+	uassert.Equal(t, v1DepositLiquidity, v1PoolStakedLiq)
+	uassert.True(t, v1CollectedInternal > 0)
+	uassert.Equal(t, uint64(1), v1PoolTier)
+}
+
+func validateV1Snapshot() {
+	// deposit identity is immutable across upgrades
+	uassert.Equal(t, v1DepositOwner, staker.GetDepositOwner(positionId))
+	uassert.Equal(t, v1DepositPoolPath, staker.GetDepositTargetPoolPath(positionId))
+	uassert.Equal(t, v1DepositLiquidity, staker.GetDepositLiquidityAsString(positionId))
+	uassert.Equal(t, v1DepositStakeTime, staker.GetDepositStakeTime(positionId))
+	uassert.Equal(t, v1DepositTickLower, staker.GetDepositTickLower(positionId))
+	uassert.Equal(t, v1DepositTickUpper, staker.GetDepositTickUpper(positionId))
+	uassert.Equal(t, v1DepositWarmupCount, len(staker.GetDepositWarmUp(positionId)))
+	uassert.Equal(t, v1PoolTier, staker.GetPoolTier(barFoo500PoolPath))
+	uassert.Equal(t, v1PoolTierRatio, staker.GetPoolTierRatio(barFoo500PoolPath))
+	uassert.Equal(t, v1PoolStakedLiq, staker.GetPoolStakedLiquidity(barFoo500PoolPath))
+	uassert.Equal(t, v1UnstakingFee, staker.GetUnstakingFee())
+	uassert.Equal(t, v1DepositGnsAmount, staker.GetDepositGnsAmount())
+	uassert.Equal(t, v1AllowedTokenCount, len(staker.GetAllowedTokens()))
+	uassert.True(t, staker.IsStaked(positionId))
+
+	// reward ledgers only ever move forward
+	uassert.True(t, staker.GetDepositCollectedInternalReward(positionId) > v1CollectedInternal)
+	uassert.True(t, staker.GetTotalEmissionSent() > v1TotalEmissionSent)
+
+	println("[EXPECTED] Deposit identity data is unchanged after the upgrades")
+	println("[EXPECTED] Collected internal reward grew from", v1CollectedInternal,
+		"to", staker.GetDepositCollectedInternalReward(positionId))
+	println("[EXPECTED] Total emission sent grew from", v1TotalEmissionSent,
+		"to", staker.GetTotalEmissionSent())
 }
 
 func initialize(cur realm) {
@@ -276,6 +365,18 @@ func withAbortsWithMessage(cur realm, callback func(), logMessage string) {
 // [EXPECTED] Staked liquidity: 1066918731
 // [EXPECTED] Stake time: 1234567900
 //
+// [SCENARIO] 7-1. Snapshot the staking state written by v1
+// [EXPECTED] Deposit owner: g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5
+// [EXPECTED] Deposit liquidity: 1066918731
+// [EXPECTED] Deposit ticks: -960 960
+// [EXPECTED] Deposit warmup tiers: 4
+// [EXPECTED] Collected internal reward so far: 133775649
+// [EXPECTED] Pool tier / ratio: 1 100
+// [EXPECTED] Pool staked liquidity: 1066918731
+// [EXPECTED] Unstaking fee / deposit GNS amount: 100 1000000000
+// [EXPECTED] Allowed token count: 2
+// [EXPECTED] Total emission sent: 146751888
+//
 // [SCENARIO] 8. Staker Contract Upgrade to v2_invalid
 // [INFO] Upgrade staker contract to v2_invalid
 // [EXPECTED] Upgraded staker contract to v2_invalid: gno.land/r/gnoswap/staker/v2_invalid
@@ -312,3 +413,8 @@ func withAbortsWithMessage(cur realm, callback func(), logMessage string) {
 // [EXPECTED] Target pool path: gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:500
 // [EXPECTED] Staked liquidity: 1066918731
 // [EXPECTED] Stake time: 1234567900
+//
+// [SCENARIO] 15. Validate the v1 staking state after the upgrades
+// [EXPECTED] Deposit identity data is unchanged after the upgrades
+// [EXPECTED] Collected internal reward grew from 133775649 to 267551299
+// [EXPECTED] Total emission sent grew from 146751888 to 280126212


### PR DESCRIPTION
## Summary

Adds a single full-lifecycle upgrade scenario that exercises every cross (crossing) entry point of the eight upgradeable contracts, adds the four missing per-contract `upgrade_with_validate_data` filetests, and turns the existing validate-data filetests into real assertions instead of golden-output prints.

## Why

The upgrade filetests we had covered one contract at a time and mostly *printed* getter output into the golden file. A data-layout regression in a new implementation would therefore show up as a golden diff to be re-blessed, not as a failing assertion — and no test drove the whole protocol across an upgrade of every contract at once.

## What changed

### 1. Full-lifecycle cross-function upgrade scenario (new)

`contract/r/scenario/upgrade/full_lifecycle_v2_valid_upgrade_filetest.gno`

20 sections, with `SkipHeights` sized to the behaviour under test rather than to "some blocks":

| Sections | Content | Time advanced |
|---|---|---|
| 1–3 | Activate v1 on all eight contracts, emission start time, canonical pool, every admin setter + getter assertion | 1 block |
| 4–8 | Pool creation (the 100 GNS fee proves `AddToProtocolFee`), observation cardinality, mint / increase / decrease / collect fee / reposition | 1 block each |
| 6 | Router exact-in and exact-out, single and multi hop (covers `pool.Swap` and `router.SwapCallback`) | 1 block each |
| 9–10 | Pool tier, external incentive, stake, then collect across two warm-up tiers | 10 days |
| 11 | Protocol fee distribution, per token and global | 2 blocks |
| 12 | Delegate / redelegate / undelegate / collect, including the lockup window | lockup + 1 day |
| 13 | Three proposals: text → cancel, community-pool spend → execute, parameter change → execute | smoothing + start delay + voting period + execution delay, twice |
| 14 | Launchpad project, deposit, reward collection, recipient-side collection | 7 days + 4 days |
| **15** | **Snapshot 29 getter values while v1 is active** | — |
| 16 | Upgrade all eight implementations to `v2_valid` | 1 block |
| **17** | **Assert every snapshot field is unchanged** | — |
| 18 | Re-run the same operations through `v2_valid` | 1 day |
| 19–20 | End incentive, unstake, remove tier, sweep protocol fees and launchpad leftovers, final invariants | 91 days + dynamic skip to project end |

Role-gated entry points that an EOA cannot reach are covered through their only legitimate caller: `pool.Mint` / `Burn` / `Collect` / `HandleWithdrawalFee` via position, `pool.Swap` via router, the pool swap hooks via the staker initializer, `router.SwapCallback` via pool, `position.SetPositionOperator` via `StakeToken`, `protocol_fee.AddToProtocolFee` via pool/position/router/staker, and the launchpad-only `gov/staker` entry points via the project recipient.

Amounts are asserted, not just printed. A few that pin real arithmetic:

- launchpad: a sole depositor collects `13,333,719` on day 4 of a 30-day tier funded with `100,000,000` (= `100,000,000 × 4/30`)
- protocol fee 40/60 split: `6,023 / 9,036` on the same accrual
- warm-up: 39.8% of the internal reward reaches the user after 10 days (30% for 5 days, then 50%)
- community-pool spend proposal transfers exactly `1,000` to the recipient
- the parameter-change proposal moves `staker.GetUnstakingFee()` from 100 to 150, proving the governance → staker permission path

### 2. `upgrade_with_validate_data` filetests for the remaining contracts (new)

`protocol_fee`, `launchpad`, `gov/governance` and `gov/staker` had none. Each writes state with v1, snapshots the getters, walks v1 → `v2_invalid` (asserting the calls abort) → `v3_valid`, asserts the snapshot is unchanged, and keeps operating on the v1-created data.

`launchpad` goes v1 → `v2_valid` only — see the note below.

### 3. Existing validate-data filetests strengthened

`pool`, `position` (collect fee), `router` (swap) and `staker` (collect reward) now snapshot the getters under v1 and assert them field by field after the upgrade, instead of only printing them:

- **pool** — 30 fields: tick liquidity gross/net, the pool-side position entry, balances, fee growth, protocol fees, plus a check that a post-upgrade mint only adds liquidity to the shared tick range and leaves position 1 untouched
- **position** — fee growth inside last, tokens owed, unclaimed fee, and the invariant that a post-upgrade swap accrues on top of the v1 values rather than resetting them
- **router** — swap fee, pool balance direction, position identity
- **staker** — 15 deposit identity fields, pool tier and ratio, and reward ledgers moving forward only


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified liquidity reduction and fee collection behavior.
  * Documented that accrued swap fees are collected first, returned fees reflect applicable withdrawal charges, and principal is returned separately without that charge.
  * Clarified the distinction between net fees paid out and fees collected before deductions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->