### PR TITLE
fix: reject spoofed initializer realms consistently

### DIFF
--- a/contract/r/gnoswap/access/README.md
+++ b/contract/r/gnoswap/access/README.md
@@ -171,14 +171,6 @@ Panics if the address is invalid.
 access.AssertIsValidAddress(addr)
 ```
 
-#### `AssertIsUser`
-
-Panics if the caller is not a user realm (i.e., a contract is calling).
-
-```go
-access.AssertIsUser(r)
-```
-
 ## Usage Examples
 
 ### Example 1: Protecting Admin Functions
@@ -290,7 +282,6 @@ Authorization failures result in panics with descriptive error messages:
 - `"unauthorized: caller X is not Y"` - Caller doesn't have required role
 - `"role X does not exist"` - Role hasn't been registered
 - `"invalid address: X"` - Address validation failed
-- `"caller is not user"` - Contract called user-only function
 
 ## Limitations
 

--- a/contract/r/gnoswap/access/assert.gno
+++ b/contract/r/gnoswap/access/assert.gno
@@ -2,7 +2,6 @@ package access
 
 import (
 	"chain"
-	"errors"
 
 	prbac "gno.land/p/gnoswap/rbac"
 	ufmt "gno.land/p/nt/ufmt/v0"
@@ -122,14 +121,6 @@ func AssertHasAnyRole(caller address, roleNames ...string) {
 func AssertIsValidAddress(addr address) {
 	if !addr.IsValid() {
 		panic(ufmt.Errorf(errInvalidAddressShort, addr))
-	}
-}
-
-// AssertIsUser panics if the caller is not a user realm.
-// Used to ensure calls come from user accounts, not other contracts.
-func AssertIsUser(_ int, rlm realm) {
-	if !rlm.IsUser() {
-		panic(errors.New(errCallerNotUser))
 	}
 }
 

--- a/contract/r/gnoswap/access/assert_test.gno
+++ b/contract/r/gnoswap/access/assert_test.gno
@@ -2,7 +2,6 @@ package access
 
 import (
 	"chain"
-	"chain/runtime"
 	"testing"
 
 	testutils "gno.land/p/nt/testutils/v0"
@@ -731,43 +730,6 @@ func TestAssertIsValidAddress(cur realm, t *testing.T) {
 			} else {
 				uassert.NotPanics(t, cur, func() {
 					AssertIsValidAddress(tt.addr)
-				})
-			}
-		})
-	}
-}
-
-func TestAssertIsUser(cur realm, t *testing.T) {
-	tests := []struct {
-		name         string
-		currentRealm runtime.Realm
-		shouldPanic  bool
-		expectedMsg  string
-	}{
-		{
-			name:         "user realm",
-			currentRealm: testing.NewUserRealm(testutils.TestAddress("user")),
-			shouldPanic:  false,
-		},
-		{
-			name:         "code realm",
-			currentRealm: testing.NewCodeRealm("gno.land/r/demo/example"),
-			shouldPanic:  true,
-			expectedMsg:  "caller is not user",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(cur realm, t *testing.T) {
-			testing.SetRealm(tt.currentRealm)
-
-			if tt.shouldPanic {
-				uassert.PanicsWithMessage(t, cur, tt.expectedMsg, func() {
-					AssertIsUser(0, cur)
-				})
-			} else {
-				uassert.NotPanics(t, cur, func() {
-					AssertIsUser(0, cur)
 				})
 			}
 		})

--- a/contract/r/gnoswap/access/errors.gno
+++ b/contract/r/gnoswap/access/errors.gno
@@ -8,5 +8,4 @@ const (
 	errUnauthorizedAnyRole    = "unauthorized: caller %s is not any of the roles %v"
 	errUnauthorizedRBAC       = "unauthorized: caller %s is not rbac"
 	errInvalidAddressShort    = "invalid address: %s"
-	errCallerNotUser          = "caller is not user"
 )

--- a/contract/r/gnoswap/gov/governance/upgrade_test.gno
+++ b/contract/r/gnoswap/gov/governance/upgrade_test.gno
@@ -77,6 +77,25 @@ func TestUpgrade_RegisterInitializer(cur realm, t *testing.T) {
 	}
 }
 
+func invokeGovernanceInitializerWithStaleRealm(cur realm, stale realm, initializer func(_ int, rlm realm, store any) any, store any) {
+	initializer(0, stale, store)
+}
+
+func TestRegisterInitializerRejectsSpoofedInitializerRealm(cur realm, t *testing.T) {
+	resetTestState(t)
+
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/gov/governance/v1"))
+	RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+
+	initializer := versionManager.GetInitializers()[versionManager.GetCurrentPackagePath()]
+	stale := cur
+	store := initializeDomainStore(0, cur, kvStore)
+
+	uassert.AbortsContains(t, cur, ErrSpoofedRealm, func() {
+		invokeGovernanceInitializerWithStaleRealm(cross(cur), stale, initializer, store)
+	})
+}
+
 func TestUpgrade_UpgradeImpl(cur realm, t *testing.T) {
 	tests := []struct {
 		name                 string

--- a/contract/r/gnoswap/gov/staker/upgrade.gno
+++ b/contract/r/gnoswap/gov/staker/upgrade.gno
@@ -1,6 +1,8 @@
 package staker
 
 import (
+	"errors"
+
 	"gno.land/r/gnoswap/access"
 )
 
@@ -19,6 +21,10 @@ func RegisterInitializer(cur realm, initializer func(_ int, rlm realm, govStaker
 	// initializer performs run under the proxy's identity rather than the
 	// version package's, which would fail the kvStore ACL.
 	initializerFunc := func(_ int, rlm realm, domainStore any) any {
+		if !rlm.IsCurrent() {
+			panic(errors.New(ErrSpoofedRealm))
+		}
+
 		currentGovStakerStore, ok := domainStore.(IGovStakerStore)
 		if !ok {
 			panic("domainStore is not an IGovStakerStore")

--- a/contract/r/gnoswap/gov/staker/upgrade_test.gno
+++ b/contract/r/gnoswap/gov/staker/upgrade_test.gno
@@ -77,6 +77,25 @@ func TestRegisterInitializer(cur realm, t *testing.T) {
 	}
 }
 
+func invokeGovStakerInitializerWithStaleRealm(cur realm, stale realm, initializer func(_ int, rlm realm, store any) any, store any) {
+	initializer(0, stale, store)
+}
+
+func TestRegisterInitializerRejectsSpoofedInitializerRealm(cur realm, t *testing.T) {
+	resetTestState(t)
+
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/gov/staker/v1"))
+	RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+
+	initializer := versionManager.GetInitializers()[versionManager.GetCurrentPackagePath()]
+	stale := cur
+	store := initializeDomainStore(0, cur, kvStore)
+
+	uassert.AbortsContains(t, cur, ErrSpoofedRealm, func() {
+		invokeGovStakerInitializerWithStaleRealm(cross(cur), stale, initializer, store)
+	})
+}
+
 // TestDelegate tests the Delegate proxy function
 func TestDelegate(cur realm, t *testing.T) {
 	tests := []struct {

--- a/contract/r/gnoswap/launchpad/upgrade.gno
+++ b/contract/r/gnoswap/launchpad/upgrade.gno
@@ -1,6 +1,10 @@
 package launchpad
 
-import "gno.land/r/gnoswap/access"
+import (
+	"errors"
+
+	"gno.land/r/gnoswap/access"
+)
 
 // RegisterInitializer registers a new launchpad implementation version.
 // This function is called by each version (v1, v2, etc.) during initialization
@@ -13,6 +17,10 @@ import "gno.land/r/gnoswap/access"
 // Each package path can only register once to prevent duplicate registrations.
 func RegisterInitializer(cur realm, initializer func(_ int, rlm realm, launchpadStore ILaunchpadStore) ILaunchpad) {
 	initializerFunc := func(_ int, rlm realm, domainStore any) any {
+		if !rlm.IsCurrent() {
+			panic(errors.New(ErrSpoofedRealm))
+		}
+
 		currentLaunchpadStore, ok := domainStore.(ILaunchpadStore)
 		if !ok {
 			panic("domainStore is not an ILaunchpadStore")

--- a/contract/r/gnoswap/launchpad/upgrade_test.gno
+++ b/contract/r/gnoswap/launchpad/upgrade_test.gno
@@ -63,6 +63,25 @@ func TestRegisterInitializer(cur realm, t *testing.T) {
 	}
 }
 
+func invokeLaunchpadInitializerWithStaleRealm(cur realm, stale realm, initializer func(_ int, rlm realm, store any) any, store any) {
+	initializer(0, stale, store)
+}
+
+func TestRegisterInitializerRejectsSpoofedInitializerRealm(cur realm, t *testing.T) {
+	resetTestState(cur, t)
+
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad/v1"))
+	RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+
+	initializer := versionManager.GetInitializers()[versionManager.GetCurrentPackagePath()]
+	stale := cur
+	store := initializeDomainStore(0, cur, kvStore)
+
+	uassert.AbortsContains(t, cur, ErrSpoofedRealm, func() {
+		invokeLaunchpadInitializerWithStaleRealm(cross(cur), stale, initializer, store)
+	})
+}
+
 func TestUpgradeImpl(cur realm, t *testing.T) {
 	govAddr := access.MustGetAddress(prbac.ROLE_GOVERNANCE.String())
 

--- a/contract/r/gnoswap/pool/upgrade_test.gno
+++ b/contract/r/gnoswap/pool/upgrade_test.gno
@@ -80,6 +80,25 @@ func TestRegisterInitializer(cur realm, t *testing.T) {
 	}
 }
 
+func invokePoolInitializerWithStaleRealm(cur realm, stale realm, initializer func(_ int, rlm realm, store any) any, store any) {
+	initializer(0, stale, store)
+}
+
+func TestRegisterInitializerRejectsSpoofedInitializerRealm(cur realm, t *testing.T) {
+	resetTestState(t)
+
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/pool/v1"))
+	RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+
+	initializer := versionManager.GetInitializers()[versionManager.GetCurrentPackagePath()]
+	stale := cur
+	store := initializeDomainStore(0, cur, kvStore)
+
+	uassert.AbortsContains(t, cur, ErrSpoofedRealm, func() {
+		invokePoolInitializerWithStaleRealm(cross(cur), stale, initializer, store)
+	})
+}
+
 // TestUpgradeImpl tests the pool upgrade implementation
 func TestUpgradeImpl(cur realm, t *testing.T) {
 	tests := []struct {

--- a/contract/r/gnoswap/position/upgrade_test.gno
+++ b/contract/r/gnoswap/position/upgrade_test.gno
@@ -86,6 +86,25 @@ func TestRegisterInitializer(cur realm, t *testing.T) {
 	}
 }
 
+func invokePositionInitializerWithStaleRealm(cur realm, stale realm, initializer func(_ int, rlm realm, store any) any, store any) {
+	initializer(0, stale, store)
+}
+
+func TestRegisterInitializerRejectsSpoofedInitializerRealm(cur realm, t *testing.T) {
+	resetTestState(t)
+
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/position/v1"))
+	RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+
+	initializer := versionManager.GetInitializers()[versionManager.GetCurrentPackagePath()]
+	stale := cur
+	store := initializeDomainStore(0, cur, kvStore)
+
+	uassert.AbortsContains(t, cur, ErrSpoofedRealm, func() {
+		invokePositionInitializerWithStaleRealm(cross(cur), stale, initializer, store)
+	})
+}
+
 func TestRegisterInitializerLiveRealmBootstrap(cur realm, t *testing.T) {
 	resetTestState(t)
 

--- a/contract/r/gnoswap/protocol_fee/upgrade.gno
+++ b/contract/r/gnoswap/protocol_fee/upgrade.gno
@@ -25,7 +25,7 @@ func RegisterInitializer(cur realm, initializer func(_ int, rlm realm, protocolF
 	// version package's, which would fail the kvStore ACL.
 	initializerFunc := func(_ int, rlm realm, domainStore any) any {
 		if !rlm.IsCurrent() {
-			return errors.New(errSpoofedRealm)
+			panic(errors.New(errSpoofedRealm))
 		}
 
 		currentProtocolFeeStore, ok := domainStore.(IProtocolFeeStore)

--- a/contract/r/gnoswap/protocol_fee/upgrade_test.gno
+++ b/contract/r/gnoswap/protocol_fee/upgrade_test.gno
@@ -77,6 +77,25 @@ func TestRegisterInitializer(cur realm, t *testing.T) {
 	}
 }
 
+func invokeProtocolFeeInitializerWithStaleRealm(cur realm, stale realm, initializer func(_ int, rlm realm, store any) any, store any) {
+	initializer(0, stale, store)
+}
+
+func TestRegisterInitializerRejectsSpoofedInitializerRealm(cur realm, t *testing.T) {
+	resetTestState(cur, t)
+
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/protocol_fee/v1"))
+	RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+
+	initializer := versionManager.GetInitializers()[versionManager.GetCurrentPackagePath()]
+	stale := cur
+	store := initializeDomainStore(0, cur, kvStore)
+
+	uassert.AbortsContains(t, cur, errSpoofedRealm, func() {
+		invokeProtocolFeeInitializerWithStaleRealm(cross(cur), stale, initializer, store)
+	})
+}
+
 func TestUpgradeImpl(cur realm, t *testing.T) {
 	tests := []struct {
 		name                 string

--- a/contract/r/gnoswap/router/upgrade.gno
+++ b/contract/r/gnoswap/router/upgrade.gno
@@ -17,7 +17,7 @@ import (
 func RegisterInitializer(cur realm, initializer func(_ int, rlm realm, routerStore IRouterStore) IRouter) {
 	initializerFunc := func(_ int, rlm realm, domainStore any) any {
 		if !rlm.IsCurrent() {
-			return errors.New(errSpoofedRealm)
+			panic(errors.New(errSpoofedRealm))
 		}
 
 		currentRouterStore, ok := domainStore.(IRouterStore)

--- a/contract/r/gnoswap/router/upgrade_test.gno
+++ b/contract/r/gnoswap/router/upgrade_test.gno
@@ -78,6 +78,25 @@ func TestRegisterInitializer(cur realm, t *testing.T) {
 	}
 }
 
+func invokeRouterInitializerWithStaleRealm(cur realm, stale realm, initializer func(_ int, rlm realm, store any) any, store any) {
+	initializer(0, stale, store)
+}
+
+func TestRegisterInitializerRejectsSpoofedInitializerRealm(cur realm, t *testing.T) {
+	resetTestState(t)
+
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/router/v1"))
+	RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+
+	initializer := versionManager.GetInitializers()[versionManager.GetCurrentPackagePath()]
+	stale := cur
+	store := initializeDomainStore(0, cur, kvStore)
+
+	uassert.AbortsContains(t, cur, errSpoofedRealm, func() {
+		invokeRouterInitializerWithStaleRealm(cross(cur), stale, initializer, store)
+	})
+}
+
 // TestUpgradeImpl tests the router upgrade implementation
 func TestUpgradeImpl(cur realm, t *testing.T) {
 	tests := []struct {

--- a/contract/r/gnoswap/staker/upgrade_test.gno
+++ b/contract/r/gnoswap/staker/upgrade_test.gno
@@ -78,6 +78,25 @@ func TestRegisterInitializer(cur realm, t *testing.T) {
 	}
 }
 
+func invokeStakerInitializerWithStaleRealm(cur realm, stale realm, initializer func(_ int, rlm realm, store any) any, store any) {
+	initializer(0, stale, store)
+}
+
+func TestRegisterInitializerRejectsSpoofedInitializerRealm(cur realm, t *testing.T) {
+	resetTestState(t)
+
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/staker/v1"))
+	RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+
+	initializer := versionManager.GetInitializers()[versionManager.GetCurrentPackagePath()]
+	stale := cur
+	store := initializeDomainStore(0, cur, kvStore)
+
+	uassert.AbortsContains(t, cur, ErrSpoofedRealm, func() {
+		invokeStakerInitializerWithStaleRealm(cross(cur), stale, initializer, store)
+	})
+}
+
 // TestUpgradeImpl tests the staker upgrade implementation
 func TestUpgradeImpl(cur realm, t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

- standardize spoofed-realm rejection across upgrade initializer wrappers
- add regression coverage for spoofed initializer calls across all eight `RegisterInitializer` realms
- remove the unused `access.AssertIsUser` helper and `errCallerNotUser`

## Validation

- `make test PKG=gno.land/r/gnoswap/access`
- `make test PKG=...` for router, pool, staker, position, launchpad, protocol_fee, gov/governance, and gov/staker
- `git diff --check`