### PR TITLE
refactor(access): centralize current realm assertion

### DIFF
--- a/contract/r/gnoswap/access/assert.gno
+++ b/contract/r/gnoswap/access/assert.gno
@@ -11,6 +11,13 @@ import (
 // Used to verify that role management functions are called only by RBAC
 const rbacPackagePath = "gno.land/r/gnoswap/rbac"
 
+// AssertIsRlmCurrent panics if the realm token is not the current crossing frame.
+func AssertIsRlmCurrent(_ int, rlm realm) {
+	if !rlm.IsCurrent() {
+		panic(errSpoofedRealm)
+	}
+}
+
 // AssertIsAdminOrGovernance panics if the caller is not admin or governance.
 // Used for functions that require elevated privileges.
 func AssertIsAdminOrGovernance(caller address) {

--- a/contract/r/gnoswap/access/assert_test.gno
+++ b/contract/r/gnoswap/access/assert_test.gno
@@ -11,6 +11,21 @@ import (
 	prbac "gno.land/p/gnoswap/rbac"
 )
 
+func TestAssertIsRlmCurrent(cur realm, t *testing.T) {
+	uassert.NotPanics(t, cur, func() {
+		func(cur realm) {
+			AssertIsRlmCurrent(0, cur)
+		}(cross(cur))
+	})
+
+	stale := cur
+	uassert.AbortsContains(t, cur, errSpoofedRealm, func() {
+		func(cur realm) {
+			AssertIsRlmCurrent(0, stale)
+		}(cross(cur))
+	})
+}
+
 func TestAssertIsAdminOrGovernance(cur realm, t *testing.T) {
 	// Save original state
 	originalRoles := make(map[string]address)

--- a/contract/r/gnoswap/access/errors.gno
+++ b/contract/r/gnoswap/access/errors.gno
@@ -1,6 +1,7 @@
 package access
 
 const (
+	errSpoofedRealm           = "rlm does not match the current crossing frame"
 	errInvalidAddress         = "invalid address for role %s: %s"
 	errRoleNotFound           = "role %s not found"
 	errUnauthorized           = "unauthorized: caller %s is not %s"

--- a/contract/r/gnoswap/gov/governance/upgrade.gno
+++ b/contract/r/gnoswap/gov/governance/upgrade.gno
@@ -1,7 +1,6 @@
 package governance
 
 import (
-	"errors"
 	"gno.land/r/gnoswap/access"
 )
 
@@ -23,9 +22,7 @@ func RegisterInitializer(cur realm, initializer func(_ int, rlm realm, governanc
 	// the initializer performs run under the proxy's identity rather than
 	// the version package's, which would fail the kvStore ACL.
 	initializerFunc := func(_ int, rlm realm, domainStore any) any {
-		if !rlm.IsCurrent() {
-			panic(errors.New(ErrSpoofedRealm))
-		}
+		access.AssertIsRlmCurrent(0, rlm)
 
 		currentGovernanceStore, ok := domainStore.(IGovernanceStore)
 		if !ok {

--- a/contract/r/gnoswap/gov/governance/v1/config.gno
+++ b/contract/r/gnoswap/gov/governance/v1/config.gno
@@ -2,7 +2,6 @@ package governance
 
 import (
 	"chain"
-	"errors"
 	"time"
 
 	"gno.land/p/gnoswap/utils"
@@ -51,9 +50,7 @@ func (gv *governanceV1) Reconfigure(
 	executionDelay int64,
 	executionWindow int64,
 ) int64 {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	// Check if system is halted before proceeding
 	halt.AssertIsNotHaltedGovernance()

--- a/contract/r/gnoswap/gov/governance/v1/errors.gno
+++ b/contract/r/gnoswap/gov/governance/v1/errors.gno
@@ -22,7 +22,6 @@ const (
 	errInvalidConfiguration         = "[GNOSWAP-GOVERNANCE-015] invalid configuration"
 	errInvalidExecution             = "[GNOSWAP-GOVERNANCE-016] invalid execution: handler not found"
 	errInvalidSmoothingPeriod       = "[GNOSWAP-GOVERNANCE-017] invalid smoothing period"
-	errSpoofedRealm                 = "[GNOSWAP-GOVERNANCE-018] spoofed realm: captured cur no longer matches live frame"
 )
 
 // makeErrorWithDetails creates an error with additional context.

--- a/contract/r/gnoswap/gov/governance/v1/governance_execute.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_execute.gno
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"time"
 
+	"gno.land/r/gnoswap/access"
+
 	"gno.land/p/gnoswap/utils"
 
 	"gno.land/r/gnoswap/common"
@@ -40,9 +42,7 @@ import (
 // Returns executed proposal ID.
 // Callable by anyone once proposal is executable.
 func (gv *governanceV1) Execute(_ int, rlm realm, proposalID int64) int64 {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	// Check if execution is allowed (system not halted for execution)
 	halt.AssertIsNotHaltedGovernance()
@@ -154,9 +154,7 @@ func (gv *governanceV1) executeProposal(
 // Returns cancelled proposal ID.
 // Only callable by original proposer before voting begins.
 func (gv *governanceV1) Cancel(_ int, rlm realm, proposalID int64) int64 {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedGovernance()
 

--- a/contract/r/gnoswap/gov/governance/v1/governance_propose.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_propose.gno
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"time"
 
+	"gno.land/r/gnoswap/access"
+
 	gnsmath "gno.land/p/gnoswap/gnsmath"
 	"gno.land/p/gnoswap/utils"
 
@@ -42,9 +44,7 @@ func (gv *governanceV1) ProposeText(
 	title string,
 	description string,
 ) (newProposalId int64) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedGovernance()
 
@@ -155,9 +155,7 @@ func (gv *governanceV1) ProposeCommunityPoolSpend(
 	tokenPath string,
 	amount int64,
 ) (newProposalId int64) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedGovernance()
 
@@ -272,9 +270,7 @@ func (gv *governanceV1) ProposeParameterChange(
 	numToExecute int64,
 	executions string,
 ) (newProposalId int64) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedGovernance()
 

--- a/contract/r/gnoswap/gov/governance/v1/governance_vote.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_vote.gno
@@ -3,8 +3,9 @@ package governance
 import (
 	"chain"
 	"chain/runtime"
-	"errors"
 	"time"
+
+	"gno.land/r/gnoswap/access"
 
 	gnsmath "gno.land/p/gnoswap/gnsmath"
 	"gno.land/p/gnoswap/utils"
@@ -39,9 +40,7 @@ import (
 //
 // Returns voting weight used as string.
 func (gv *governanceV1) Vote(_ int, rlm realm, proposalID int64, yes bool) string {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedGovernance()
 

--- a/contract/r/gnoswap/gov/staker/upgrade.gno
+++ b/contract/r/gnoswap/gov/staker/upgrade.gno
@@ -1,8 +1,6 @@
 package staker
 
 import (
-	"errors"
-
 	"gno.land/r/gnoswap/access"
 )
 
@@ -21,9 +19,7 @@ func RegisterInitializer(cur realm, initializer func(_ int, rlm realm, govStaker
 	// initializer performs run under the proxy's identity rather than the
 	// version package's, which would fail the kvStore ACL.
 	initializerFunc := func(_ int, rlm realm, domainStore any) any {
-		if !rlm.IsCurrent() {
-			panic(errors.New(ErrSpoofedRealm))
-		}
+		access.AssertIsRlmCurrent(0, rlm)
 
 		currentGovStakerStore, ok := domainStore.(IGovStakerStore)
 		if !ok {

--- a/contract/r/gnoswap/gov/staker/v1/errors.gno
+++ b/contract/r/gnoswap/gov/staker/v1/errors.gno
@@ -15,7 +15,6 @@ const (
 	errInvalidSnapshotTime    = "[GNOSWAP-GOV_STAKER-008] invalid snapshot time"
 	errSameDelegatee          = "[GNOSWAP-GOV_STAKER-009] cannot redelegate to same address"
 	errWithdrawNotCollectable = "[GNOSWAP-GOV_STAKER-010] withdraw is not collectable"
-	errSpoofedRealm           = "[GNOSWAP-GOV_STAKER-011] rlm does not match the current crossing frame"
 )
 
 func makeErrorWithDetails(message string, detail string) error {

--- a/contract/r/gnoswap/gov/staker/v1/staker_delegate.gno
+++ b/contract/r/gnoswap/gov/staker/v1/staker_delegate.gno
@@ -55,9 +55,7 @@ func (gs *govStakerV1) Delegate(
 	amount int64,
 	referrer string,
 ) int64 {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedGovStaker()
 
@@ -141,9 +139,7 @@ func (gs *govStakerV1) Undelegate(
 	from address,
 	amount int64,
 ) int64 {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedWithdraw()
 
@@ -220,9 +216,7 @@ func (gs *govStakerV1) Redelegate(
 	newDelegatee address,
 	amount int64,
 ) int64 {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedGovStaker()
 
@@ -284,9 +278,7 @@ func (gs *govStakerV1) Redelegate(
 // Allows users to collect GNS tokens that completed undelegation lockup period.
 // Burns xGNS and returns GNS tokens.
 func (gs *govStakerV1) CollectUndelegatedGns(_ int, rlm realm) int64 {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedWithdraw()
 

--- a/contract/r/gnoswap/gov/staker/v1/staker_delegation_snapshot.gno
+++ b/contract/r/gnoswap/gov/staker/v1/staker_delegation_snapshot.gno
@@ -2,7 +2,6 @@ package staker
 
 import (
 	"chain"
-	"errors"
 
 	"gno.land/p/gnoswap/utils"
 	"gno.land/r/gnoswap/access"
@@ -27,9 +26,7 @@ import (
 //
 // Note: This change affects all future undelegation operations
 func (gs *govStakerV1) SetUnDelegationLockupPeriodByAdmin(_ int, rlm realm, period int64) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedGovStaker()
 
@@ -70,9 +67,7 @@ func (gs *govStakerV1) SetUnDelegationLockupPeriodByAdmin(_ int, rlm realm, peri
 //   - if snapshotTime is invalid (negative or too recent)
 //   - if active proposals have snapshotTime older than the cleanup threshold
 func (gs *govStakerV1) CleanStakerDelegationSnapshotByAdmin(_ int, rlm realm, snapshotTime int64, target address) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedGovStaker()
 

--- a/contract/r/gnoswap/gov/staker/v1/staker_reward.gno
+++ b/contract/r/gnoswap/gov/staker/v1/staker_reward.gno
@@ -2,7 +2,6 @@ package staker
 
 import (
 	"chain"
-	"errors"
 	"time"
 
 	prbac "gno.land/p/gnoswap/rbac"
@@ -42,9 +41,7 @@ import (
 // No parameters required - automatically determines caller's rewards.
 // Transfers rewards directly to caller.
 func (gs *govStakerV1) CollectReward(_ int, rlm realm) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedWithdraw()
 
@@ -95,9 +92,7 @@ func (gs *govStakerV1) CollectReward(_ int, rlm realm) {
 
 // CollectEmissionReward collects accumulated GNS emission rewards only.
 func (gs *govStakerV1) CollectEmissionReward(_ int, rlm realm) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedWithdraw()
 
@@ -127,9 +122,7 @@ func (gs *govStakerV1) CollectEmissionReward(_ int, rlm realm) {
 
 // CollectProtocolFeeReward collects accumulated protocol fee rewards for the provided token path.
 func (gs *govStakerV1) CollectProtocolFeeReward(_ int, rlm realm, tokenPath string) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedWithdraw()
 
@@ -168,9 +161,7 @@ func (gs *govStakerV1) CollectProtocolFeeReward(_ int, rlm realm, tokenPath stri
 //
 // Only callable by launchpad contract.
 func (gs *govStakerV1) CollectRewardFromLaunchPad(_ int, rlm realm, to address) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedWithdraw()
 
@@ -232,9 +223,7 @@ func (gs *govStakerV1) CollectRewardFromLaunchPad(_ int, rlm realm, to address) 
 
 // CollectEmissionRewardFromLaunchPad collects emission rewards only for launchpad project wallets.
 func (gs *govStakerV1) CollectEmissionRewardFromLaunchPad(_ int, rlm realm, to address) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedWithdraw()
 
@@ -275,9 +264,7 @@ func (gs *govStakerV1) CollectEmissionRewardFromLaunchPad(_ int, rlm realm, to a
 
 // CollectProtocolFeeRewardFromLaunchPad collects one token path of protocol fee rewards for launchpad project wallets.
 func (gs *govStakerV1) CollectProtocolFeeRewardFromLaunchPad(_ int, rlm realm, to address, tokenPath string) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedWithdraw()
 
@@ -333,9 +320,7 @@ func (gs *govStakerV1) CollectProtocolFeeRewardFromLaunchPad(_ int, rlm realm, t
 //   - if system is halted for withdrawals
 //   - if access control operations fail
 func (gs *govStakerV1) SetAmountByProjectWallet(_ int, rlm realm, addr address, amount int64, add bool) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	if add {
 		halt.AssertIsNotHaltedGovStaker()

--- a/contract/r/gnoswap/launchpad/upgrade.gno
+++ b/contract/r/gnoswap/launchpad/upgrade.gno
@@ -1,8 +1,6 @@
 package launchpad
 
 import (
-	"errors"
-
 	"gno.land/r/gnoswap/access"
 )
 
@@ -17,9 +15,7 @@ import (
 // Each package path can only register once to prevent duplicate registrations.
 func RegisterInitializer(cur realm, initializer func(_ int, rlm realm, launchpadStore ILaunchpadStore) ILaunchpad) {
 	initializerFunc := func(_ int, rlm realm, domainStore any) any {
-		if !rlm.IsCurrent() {
-			panic(errors.New(ErrSpoofedRealm))
-		}
+		access.AssertIsRlmCurrent(0, rlm)
 
 		currentLaunchpadStore, ok := domainStore.(ILaunchpadStore)
 		if !ok {

--- a/contract/r/gnoswap/launchpad/v1/launchpad_deposit.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_deposit.gno
@@ -3,8 +3,9 @@ package launchpad
 import (
 	"chain"
 	"chain/runtime"
-	"errors"
 	"time"
+
+	"gno.land/r/gnoswap/access"
 
 	gnsmath "gno.land/p/gnoswap/gnsmath"
 	"gno.land/p/gnoswap/utils"
@@ -27,9 +28,7 @@ import (
 //
 // Returns deposit ID.
 func (lp *launchpadV1) DepositGns(_ int, rlm realm, targetProjectTierID string, depositAmount int64, referrer string) string {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedLaunchpad()
 

--- a/contract/r/gnoswap/launchpad/v1/launchpad_project.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_project.gno
@@ -49,9 +49,7 @@ func (lp *launchpadV1) CreateProject(
 	tier180Ratio int64,
 	startTime int64,
 ) string {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedLaunchpad()
 
@@ -246,9 +244,7 @@ func (lp *launchpadV1) createProject(_ int, rlm realm, params *createProjectPara
 // TransferLeftFromProjectByAdmin transfers the remaining rewards of a project to a specified recipient.
 // Only admin can call this function. Returns the amount of rewards transferred.
 func (lp *launchpadV1) TransferLeftFromProjectByAdmin(_ int, rlm realm, projectID string, recipient address) int64 {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedLaunchpad()
 

--- a/contract/r/gnoswap/launchpad/v1/launchpad_protocol_fee.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_protocol_fee.gno
@@ -1,7 +1,7 @@
 package launchpad
 
 import (
-	"errors"
+	"gno.land/r/gnoswap/access"
 
 	gov_staker "gno.land/r/gnoswap/gov/staker"
 	"gno.land/r/gnoswap/halt"
@@ -10,9 +10,7 @@ import (
 // CollectProtocolFee collects protocol fee from gov/staker for project recipient wallets.
 // Only project recipients can call this function.
 func (lp *launchpadV1) CollectProtocolFee(_ int, rlm realm) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedWithdraw()
 
@@ -27,9 +25,7 @@ func (lp *launchpadV1) CollectProtocolFee(_ int, rlm realm) {
 // CollectEmissionReward collects emission rewards from gov/staker for project recipient wallets.
 // Only project recipients can call this function.
 func (lp *launchpadV1) CollectEmissionReward(_ int, rlm realm) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedWithdraw()
 
@@ -44,9 +40,7 @@ func (lp *launchpadV1) CollectEmissionReward(_ int, rlm realm) {
 // CollectProtocolFeeReward collects one token path of protocol fee rewards from gov/staker for project recipient wallets.
 // Only project recipients can call this function.
 func (lp *launchpadV1) CollectProtocolFeeReward(_ int, rlm realm, tokenPath string) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedWithdraw()
 

--- a/contract/r/gnoswap/launchpad/v1/launchpad_reward.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_reward.gno
@@ -3,8 +3,9 @@ package launchpad
 import (
 	"chain"
 	"chain/runtime"
-	"errors"
 	"time"
+
+	"gno.land/r/gnoswap/access"
 
 	gnsmath "gno.land/p/gnoswap/gnsmath"
 	"gno.land/p/gnoswap/utils"
@@ -22,9 +23,7 @@ import (
 // Returns amount of reward collected.
 // Only callable by deposit owner.
 func (lp *launchpadV1) CollectRewardByDepositId(_ int, rlm realm, depositID string) int64 {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedWithdraw()
 

--- a/contract/r/gnoswap/pool/upgrade.gno
+++ b/contract/r/gnoswap/pool/upgrade.gno
@@ -19,9 +19,7 @@ import (
 // Each package path can only register once to prevent duplicate registrations.
 func RegisterInitializer(cur realm, initializer func(_ int, rlm realm, poolStore IPoolStore) IPool) {
 	initializerFunc := func(_ int, rlm realm, domainStore any) any {
-		if !rlm.IsCurrent() {
-			panic(errors.New(ErrSpoofedRealm))
-		}
+		access.AssertIsRlmCurrent(0, rlm)
 
 		currentPoolStore, ok := domainStore.(IPoolStore)
 		if !ok {

--- a/contract/r/gnoswap/pool/v1/errors.gno
+++ b/contract/r/gnoswap/pool/v1/errors.gno
@@ -31,7 +31,7 @@ const (
 	errInsufficientPayment       = "[GNOSWAP-POOL-023] insufficient payment"
 	errNotInitializedObservation = "[GNOSWAP-POOL-024] not initialized observation"
 	errObservationTooOld         = "[GNOSWAP-POOL-025] target timestamp before oldest observation"
-	errObservationBeforeEpoch    = "[GNOSWAP-POOL-027] lookback window starts before unix epoch"
+	errObservationBeforeEpoch    = "[GNOSWAP-POOL-026] lookback window starts before unix epoch"
 )
 
 // newErrorWithDetail adds detail to an error message.

--- a/contract/r/gnoswap/pool/v1/errors.gno
+++ b/contract/r/gnoswap/pool/v1/errors.gno
@@ -31,7 +31,6 @@ const (
 	errInsufficientPayment       = "[GNOSWAP-POOL-023] insufficient payment"
 	errNotInitializedObservation = "[GNOSWAP-POOL-024] not initialized observation"
 	errObservationTooOld         = "[GNOSWAP-POOL-025] target timestamp before oldest observation"
-	errSpoofedRealm              = "[GNOSWAP-POOL-026] rlm does not match the current crossing frame"
 	errObservationBeforeEpoch    = "[GNOSWAP-POOL-027] lookback window starts before unix epoch"
 )
 

--- a/contract/r/gnoswap/pool/v1/init.gno
+++ b/contract/r/gnoswap/pool/v1/init.gno
@@ -1,9 +1,9 @@
 package pool
 
 import (
-	"errors"
-	"gno.land/r/gnoswap/pool"
+	"gno.land/r/gnoswap/access"
 	"gno.land/r/gnoswap/emission"
+	"gno.land/r/gnoswap/pool"
 )
 
 const (
@@ -31,9 +31,7 @@ func init(cur realm) {
 
 func registerPoolV1(cur realm) {
 	pool.RegisterInitializer(cross(cur), func(_ int, rlm realm, poolStore pool.IPoolStore) pool.IPool {
-		if !rlm.IsCurrent() {
-			panic(errors.New(errSpoofedRealm))
-		}
+		access.AssertIsRlmCurrent(0, rlm)
 
 		err := initStoreData(0, rlm, poolStore)
 		if err != nil {

--- a/contract/r/gnoswap/pool/v1/manager.gno
+++ b/contract/r/gnoswap/pool/v1/manager.gno
@@ -62,9 +62,7 @@ func (i *poolV1) CreatePool(
 	fee uint32,
 	sqrtPriceX96 string,
 ) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	i.assertPoolUnlocked()
 	halt.AssertIsNotHaltedPool()
@@ -152,9 +150,7 @@ func (i *poolV1) CreatePool(
 //
 // Only callable by admin or governance.
 func (i *poolV1) SetFeeProtocol(_ int, rlm realm, feeProtocol0, feeProtocol1 uint8) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	i.assertPoolUnlocked()
 	halt.AssertIsNotHaltedPool()

--- a/contract/r/gnoswap/pool/v1/oracle_spec_test.gno
+++ b/contract/r/gnoswap/pool/v1/oracle_spec_test.gno
@@ -370,7 +370,7 @@ func testObserveFailsIfSecondsAgoExceedsCurrentTime(t *testing.T) {
 	os := pl.NewObservationState(0)
 
 	_, _, err := observeSingle(os, 10, 11, 2, 0, u256.NewUint(4), 1)
-	uassert.ErrorContains(t, err, "[GNOSWAP-POOL-027]")
+	uassert.ErrorContains(t, err, "[GNOSWAP-POOL-026]")
 }
 
 // TestOracleLookbackErrorsAreDistinct pins the two rejection reasons to separate error codes.
@@ -379,14 +379,14 @@ func TestOracleLookbackErrorsAreDistinct(cur realm, t *testing.T) {
 	tooOld := pl.NewObservationState(100)
 	_, _, errTooOld := observeSingle(tooOld, 150, 51, 12, 0, u256.NewUint(4), 1)
 	uassert.ErrorContains(t, errTooOld, "[GNOSWAP-POOL-025]")
-	if errTooOld != nil && strings.Contains(errTooOld.Error(), "[GNOSWAP-POOL-027]") {
+	if errTooOld != nil && strings.Contains(errTooOld.Error(), "[GNOSWAP-POOL-026]") {
 		t.Error("too-old lookback must not report the pre-epoch error code")
 	}
 
 	// Malformed request: secondsAgo exceeds the chain's own age.
 	beforeEpoch := pl.NewObservationState(0)
 	_, _, errEpoch := observeSingle(beforeEpoch, 10, 11, 12, 0, u256.NewUint(4), 1)
-	uassert.ErrorContains(t, errEpoch, "[GNOSWAP-POOL-027]")
+	uassert.ErrorContains(t, errEpoch, "[GNOSWAP-POOL-026]")
 	if errEpoch != nil && strings.Contains(errEpoch.Error(), "[GNOSWAP-POOL-025]") {
 		t.Error("pre-epoch lookback must not report the too-old error code")
 	}

--- a/contract/r/gnoswap/pool/v1/pool.gno
+++ b/contract/r/gnoswap/pool/v1/pool.gno
@@ -53,9 +53,7 @@ func (i *poolV1) Mint(
 	liquidityAmount string,
 	positionCaller address,
 ) (string, string) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	i.assertPoolUnlocked()
 	halt.AssertIsNotHaltedPool()
@@ -134,9 +132,7 @@ func (i *poolV1) Burn(
 	liquidityAmount string, // uint128
 	positionCaller address,
 ) (string, string) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	i.assertPoolUnlocked()
 	halt.AssertIsNotHaltedWithdraw()
@@ -215,9 +211,7 @@ func (i *poolV1) Collect(
 	amount0Requested string,
 	amount1Requested string,
 ) (string, string) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	i.assertPoolUnlocked()
 	halt.AssertIsNotHaltedWithdraw()
@@ -293,9 +287,7 @@ func (i *poolV1) CollectProtocol(
 	amount0Requested string, // uint128
 	amount1Requested string, // uint128
 ) (string, string) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	i.assertPoolUnlocked()
 	halt.AssertIsNotHaltedWithdraw()
@@ -417,9 +409,7 @@ func (i *poolV1) IncreaseObservationCardinalityNext(
 	fee uint32,
 	cardinalityNext uint16,
 ) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	i.assertPoolUnlocked()
 	halt.AssertIsNotHaltedPool()

--- a/contract/r/gnoswap/pool/v1/protocol_fee.gno
+++ b/contract/r/gnoswap/pool/v1/protocol_fee.gno
@@ -43,9 +43,7 @@ func (i *poolV1) HandleWithdrawalFee(
 	amount1 string, // uint256
 	positionCaller address,
 ) (string, string, string, string) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	i.assertPoolUnlocked()
 	halt.AssertIsNotHaltedWithdraw()
@@ -124,9 +122,7 @@ func (i *poolV1) addToProtocolFee(_ int, rlm realm) {
 // SetPoolCreationFee sets the poolCreationFee.
 // Only admin or governance can call this function.
 func (i *poolV1) SetPoolCreationFee(_ int, rlm realm, fee int64) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	i.assertPoolUnlocked()
 	halt.AssertIsNotHaltedPool()
@@ -156,9 +152,7 @@ func (i *poolV1) SetPoolCreationFee(_ int, rlm realm, fee int64) {
 // SetWithdrawalFee sets the withdrawal fee.
 // Only admin or governance can call this function.
 func (i *poolV1) SetWithdrawalFee(_ int, rlm realm, fee uint64) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	i.assertPoolUnlocked()
 	halt.AssertIsNotHaltedPool()

--- a/contract/r/gnoswap/pool/v1/swap.gno
+++ b/contract/r/gnoswap/pool/v1/swap.gno
@@ -39,9 +39,7 @@ var (
 //
 // Only callable by staker contract.
 func (i *poolV1) SetTickCrossHook(_ int, rlm realm, hook func(cur realm, poolPath string, tickId int32, zeroForOne bool, timestamp int64)) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	i.assertPoolUnlocked()
 	halt.AssertIsNotHaltedPool()
@@ -65,9 +63,7 @@ func (i *poolV1) SetTickCrossHook(_ int, rlm realm, hook func(cur realm, poolPat
 //
 // Only callable by staker contract.
 func (i *poolV1) SetSwapStartHook(_ int, rlm realm, hook func(cur realm, poolPath string, timestamp int64)) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	i.assertPoolUnlocked()
 	halt.AssertIsNotHaltedPool()
@@ -91,9 +87,7 @@ func (i *poolV1) SetSwapStartHook(_ int, rlm realm, hook func(cur realm, poolPat
 //
 // Only callable by staker contract.
 func (i *poolV1) SetSwapEndHook(_ int, rlm realm, hook func(cur realm, poolPath string) error) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	i.assertPoolUnlocked()
 	halt.AssertIsNotHaltedPool()
@@ -166,9 +160,7 @@ func (i *poolV1) Swap(
 	sqrtPriceLimitX96 string,
 	swapCallback func(cur realm, amount0Delta, amount1Delta int64, _ *pl.CallbackMarker) error,
 ) (string, string) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	i.assertPoolUnlocked()
 	halt.AssertIsNotHaltedPool()

--- a/contract/r/gnoswap/pool/v1/twap_consistency_test.gno
+++ b/contract/r/gnoswap/pool/v1/twap_consistency_test.gno
@@ -135,7 +135,7 @@ func TestOracle_TWAPConsistencyCases(cur realm, t *testing.T) {
 				{timestamp: 0, tickCumulative: 0},
 				{timestamp: 10, tickCumulative: 120},
 			},
-			wantErr: "[GNOSWAP-POOL-027]",
+			wantErr: "[GNOSWAP-POOL-026]",
 		},
 		{
 			// Timestamps are int64. A uint32-based comparison would sort

--- a/contract/r/gnoswap/position/upgrade.gno
+++ b/contract/r/gnoswap/position/upgrade.gno
@@ -1,8 +1,6 @@
 package position
 
 import (
-	"errors"
-
 	"gno.land/r/gnoswap/access"
 )
 
@@ -17,9 +15,7 @@ import (
 // Each package path can only register once to prevent duplicate registrations.
 func RegisterInitializer(cur realm, initializer func(_ int, rlm realm, positionStore IPositionStore) IPosition) {
 	initializerFunc := func(_ int, rlm realm, domainStore any) any {
-		if !rlm.IsCurrent() {
-			panic(errors.New(ErrSpoofedRealm))
-		}
+		access.AssertIsRlmCurrent(0, rlm)
 
 		currentPositionStore, ok := domainStore.(IPositionStore)
 		if !ok {

--- a/contract/r/gnoswap/position/upgrade_test.gno
+++ b/contract/r/gnoswap/position/upgrade_test.gno
@@ -4,6 +4,8 @@ import (
 	"chain/runtime"
 	"testing"
 
+	"gno.land/r/gnoswap/access"
+
 	u256 "gno.land/p/gnoswap/uint256"
 	uassert "gno.land/p/nt/uassert/v0"
 )
@@ -110,9 +112,7 @@ func TestRegisterInitializerLiveRealmBootstrap(cur realm, t *testing.T) {
 
 	initializerCalls := 0
 	initializer := func(_ int, rlm realm, s IPositionStore) IPosition {
-		if !rlm.IsCurrent() {
-			panic(ErrSpoofedRealm)
-		}
+		access.AssertIsRlmCurrent(0, rlm)
 
 		initializerCalls++
 		err := s.SetPositionNextID(0, rlm, uint64(initializerCalls))

--- a/contract/r/gnoswap/position/v1/init.gno
+++ b/contract/r/gnoswap/position/v1/init.gno
@@ -1,7 +1,7 @@
 package position
 
 import (
-	"errors"
+	"gno.land/r/gnoswap/access"
 	"gno.land/r/gnoswap/position"
 )
 
@@ -13,9 +13,7 @@ func registerPositionV1(cur realm) {
 	position.RegisterInitializer(
 		cross(cur),
 		func(_ int, rlm realm, positionStore position.IPositionStore) position.IPosition {
-			if !rlm.IsCurrent() {
-				panic(errors.New(errSpoofedRealm))
-			}
+			access.AssertIsRlmCurrent(0, rlm)
 
 			err := initStoreData(0, rlm, positionStore)
 			if err != nil {

--- a/contract/r/gnoswap/position/v1/instance.gno
+++ b/contract/r/gnoswap/position/v1/instance.gno
@@ -2,7 +2,9 @@ package position
 
 import (
 	"errors"
+
 	"gno.land/p/demo/tokens/grc721"
+	"gno.land/r/gnoswap/access"
 	"gno.land/r/gnoswap/gnft"
 	"gno.land/r/gnoswap/position"
 )
@@ -39,17 +41,13 @@ func (n *gnftAccessor) Approve(_ int, rlm realm, approved address, tid grc721.To
 }
 
 func (n *gnftAccessor) Mint(_ int, rlm realm, to address, tid grc721.TokenID) grc721.TokenID {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	return gnft.Mint(cross(rlm), to, tid)
 }
 
 func (n *gnftAccessor) Burn(_ int, rlm realm, tid grc721.TokenID) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	gnft.Burn(cross(rlm), tid)
 }

--- a/contract/r/gnoswap/position/v1/position.gno
+++ b/contract/r/gnoswap/position/v1/position.gno
@@ -2,7 +2,6 @@ package position
 
 import (
 	"chain"
-	"errors"
 
 	"gno.land/p/gnoswap/gnsmath"
 	u256 "gno.land/p/gnoswap/uint256"
@@ -48,9 +47,7 @@ func (p *positionV1) Mint(
 	mintTo address,
 	referrer string,
 ) (uint64, string, string, string) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedPosition()
 	access.AssertIsValidAddress(mintTo)
@@ -161,9 +158,7 @@ func (p *positionV1) IncreaseLiquidity(
 	amount1MinStr string,
 	deadline int64,
 ) (uint64, string, string, string, string) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedPosition()
 
@@ -262,9 +257,7 @@ func (p *positionV1) DecreaseLiquidity(
 	amount1MinStr string,
 	deadline int64,
 ) (uint64, string, string, string, string, string, string) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedWithdraw()
 
@@ -345,9 +338,7 @@ func (p *positionV1) DecreaseLiquidity(
 //   - Caller must be owner or approved operator
 //   - Position must have accumulated fees
 func (p *positionV1) CollectFee(_ int, rlm realm, positionId uint64) (uint64, string, string, string, string, string) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedWithdraw()
 
@@ -453,9 +444,7 @@ func (p *positionV1) collectFee(_ int, rlm realm, positionId uint64, caller addr
 // SetPositionOperator sets an operator for a position.
 // Only staker can call this function.
 func (p *positionV1) SetPositionOperator(_ int, rlm realm, id uint64, operator address) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	previousRealm := rlm.Previous()
 	access.AssertIsStaker(previousRealm.Address())

--- a/contract/r/gnoswap/position/v1/reposition.gno
+++ b/contract/r/gnoswap/position/v1/reposition.gno
@@ -2,7 +2,8 @@ package position
 
 import (
 	"chain"
-	"errors"
+
+	"gno.land/r/gnoswap/access"
 
 	u256 "gno.land/p/gnoswap/uint256"
 	"gno.land/p/gnoswap/utils"
@@ -36,9 +37,7 @@ func (p *positionV1) Reposition(
 	amount1MinStr string,
 	deadline int64,
 ) (uint64, string, int32, int32, string, string) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedPosition()
 

--- a/contract/r/gnoswap/protocol_fee/upgrade.gno
+++ b/contract/r/gnoswap/protocol_fee/upgrade.gno
@@ -1,7 +1,6 @@
 package protocol_fee
 
 import (
-	"errors"
 	"gno.land/r/gnoswap/access"
 )
 
@@ -24,9 +23,7 @@ func RegisterInitializer(cur realm, initializer func(_ int, rlm realm, protocolF
 	// initializer performs run under the proxy's identity rather than the
 	// version package's, which would fail the kvStore ACL.
 	initializerFunc := func(_ int, rlm realm, domainStore any) any {
-		if !rlm.IsCurrent() {
-			panic(errors.New(errSpoofedRealm))
-		}
+		access.AssertIsRlmCurrent(0, rlm)
 
 		currentProtocolFeeStore, ok := domainStore.(IProtocolFeeStore)
 		if !ok {

--- a/contract/r/gnoswap/protocol_fee/v1/protocol_fee.gno
+++ b/contract/r/gnoswap/protocol_fee/v1/protocol_fee.gno
@@ -22,9 +22,7 @@ import (
 // Only callable by admin or gov/staker contract.
 // Note: Default split is 0% devOps, 100% gov/staker.
 func (pf *protocolFeeV1) DistributeProtocolFee(_ int, rlm realm) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	prev := rlm.Previous()
 	assertIsAdminOrGovStaker(prev.Address())
@@ -51,9 +49,7 @@ func (pf *protocolFeeV1) DistributeProtocolFee(_ int, rlm realm) {
 
 // DistributeProtocolFeeByTokenPath distributes collected protocol fees for one token path.
 func (pf *protocolFeeV1) DistributeProtocolFeeByTokenPath(_ int, rlm realm, tokenPath string) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	prev := rlm.Previous()
 	assertIsAdminOrGovStaker(prev.Address())
@@ -146,9 +142,7 @@ func containsString(values []string, target string) bool {
 // Only callable by admin or governance.
 // Note: GovStaker percentage is automatically adjusted to (10000 - devOpsPct).
 func (pf *protocolFeeV1) SetDevOpsPct(_ int, rlm realm, pct int64) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedProtocolFee()
 
@@ -185,9 +179,7 @@ func (pf *protocolFeeV1) SetDevOpsPct(_ int, rlm realm, pct int64) {
 // Only callable by admin or governance.
 // Note: DevOps percentage is automatically adjusted to (10000 - govStakerPct).
 func (pf *protocolFeeV1) SetGovStakerPct(_ int, rlm realm, pct int64) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedProtocolFee()
 

--- a/contract/r/gnoswap/router/upgrade.gno
+++ b/contract/r/gnoswap/router/upgrade.gno
@@ -1,7 +1,6 @@
 package router
 
 import (
-	"errors"
 	"gno.land/r/gnoswap/access"
 )
 
@@ -16,9 +15,7 @@ import (
 // Each package path can only register once to prevent duplicate registrations.
 func RegisterInitializer(cur realm, initializer func(_ int, rlm realm, routerStore IRouterStore) IRouter) {
 	initializerFunc := func(_ int, rlm realm, domainStore any) any {
-		if !rlm.IsCurrent() {
-			panic(errors.New(errSpoofedRealm))
-		}
+		access.AssertIsRlmCurrent(0, rlm)
 
 		currentRouterStore, ok := domainStore.(IRouterStore)
 		if !ok {

--- a/contract/r/gnoswap/router/v1/exact_in.gno
+++ b/contract/r/gnoswap/router/v1/exact_in.gno
@@ -2,7 +2,8 @@ package router
 
 import (
 	"chain"
-	"errors"
+
+	"gno.land/r/gnoswap/access"
 
 	ufmt "gno.land/p/nt/ufmt/v0"
 
@@ -52,9 +53,7 @@ func (r *routerV1) ExactInSwapRoute(
 	deadline int64,
 	referrer string,
 ) (string, string) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedRouter()
 
@@ -119,9 +118,7 @@ func (r *routerV1) ExactInSingleSwapRoute(
 	deadline int64,
 	referrer string,
 ) (string, string) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedRouter()
 

--- a/contract/r/gnoswap/router/v1/exact_out.gno
+++ b/contract/r/gnoswap/router/v1/exact_out.gno
@@ -2,7 +2,8 @@ package router
 
 import (
 	"chain"
-	"errors"
+
+	"gno.land/r/gnoswap/access"
 
 	ufmt "gno.land/p/nt/ufmt/v0"
 
@@ -52,9 +53,7 @@ func (r *routerV1) ExactOutSwapRoute(
 	deadline int64,
 	referrer string,
 ) (string, string) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedRouter()
 
@@ -119,9 +118,7 @@ func (r *routerV1) ExactOutSingleSwapRoute(
 	deadline int64,
 	referrer string,
 ) (string, string) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedRouter()
 

--- a/contract/r/gnoswap/router/v1/protocol_fee_swap.gno
+++ b/contract/r/gnoswap/router/v1/protocol_fee_swap.gno
@@ -2,7 +2,6 @@ package router
 
 import (
 	"chain"
-	"errors"
 
 	ufmt "gno.land/p/nt/ufmt/v0"
 
@@ -44,9 +43,7 @@ func (r *routerV1) GetSwapFee() uint64 {
 //   - Fee > 1000 bps (10%)
 //   - Router or ProtocolFee is halted
 func (r *routerV1) SetSwapFee(_ int, rlm realm, fee uint64) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedRouter()
 	halt.AssertIsNotHaltedProtocolFee()

--- a/contract/r/gnoswap/staker/accessor.gno
+++ b/contract/r/gnoswap/staker/accessor.gno
@@ -2,7 +2,9 @@ package staker
 
 import (
 	"errors"
+
 	"gno.land/p/demo/tokens/grc721"
+	"gno.land/r/gnoswap/access"
 	"gno.land/r/gnoswap/emission"
 	"gno.land/r/gnoswap/gnft"
 	"gno.land/r/gnoswap/pool"
@@ -33,9 +35,7 @@ func (p *poolAccessor) GetSlot0SqrtPriceX96(poolPath string) string {
 }
 
 func (p *poolAccessor) SetTickCrossHook(_ int, rlm realm, hook func(_ int, rlm realm, poolPath string, tickId int32, zeroForOne bool, timestamp int64)) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(ErrSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	pool.SetTickCrossHook(cross(rlm), func(cur realm, poolPath string, tickId int32, zeroForOne bool, timestamp int64) {
 		hook(0, cur, poolPath, tickId, zeroForOne, timestamp)
@@ -43,9 +43,7 @@ func (p *poolAccessor) SetTickCrossHook(_ int, rlm realm, hook func(_ int, rlm r
 }
 
 func (p *poolAccessor) SetSwapStartHook(_ int, rlm realm, hook func(_ int, rlm realm, poolPath string, timestamp int64)) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(ErrSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	pool.SetSwapStartHook(cross(rlm), func(cur realm, poolPath string, timestamp int64) {
 		hook(0, cur, poolPath, timestamp)
@@ -53,9 +51,7 @@ func (p *poolAccessor) SetSwapStartHook(_ int, rlm realm, hook func(_ int, rlm r
 }
 
 func (p *poolAccessor) SetSwapEndHook(_ int, rlm realm, hook func(_ int, rlm realm, poolPath string) error) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(ErrSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	pool.SetSwapEndHook(cross(rlm), func(cur realm, poolPath string) error {
 		return hook(0, cur, poolPath)
@@ -76,9 +72,7 @@ type EmissionAccessor interface {
 type emissionAccessor struct{}
 
 func (e *emissionAccessor) MintAndDistributeGns(_ int, rlm realm) (int64, bool) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(ErrSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	return emission.MintAndDistributeGns(cross(rlm))
 }
@@ -92,9 +86,7 @@ func (e *emissionAccessor) GetStakerEmissionAmountPerSecondInRange(start, end in
 }
 
 func (e *emissionAccessor) SetOnDistributionPctChangeCallback(_ int, rlm realm, callback func(_ int, rlm realm, emissionAmountPerSecond int64)) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(ErrSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	// Wrap the caller-provided callback in an adapter constructed HERE, inside
 	// the /r/gnoswap/staker domain package. By borrow rule #3 the wrapper
@@ -134,17 +126,13 @@ func (n *gnftAccessor) Approve(_ int, rlm realm, approved address, tid grc721.To
 }
 
 func (n *gnftAccessor) Mint(_ int, rlm realm, to address, tid grc721.TokenID) grc721.TokenID {
-	if !rlm.IsCurrent() {
-		panic(errors.New(ErrSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	return gnft.Mint(cross(rlm), to, tid)
 }
 
 func (n *gnftAccessor) Burn(_ int, rlm realm, tid grc721.TokenID) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(ErrSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	gnft.Burn(cross(rlm), tid)
 }

--- a/contract/r/gnoswap/staker/upgrade.gno
+++ b/contract/r/gnoswap/staker/upgrade.gno
@@ -1,8 +1,6 @@
 package staker
 
 import (
-	"errors"
-
 	"gno.land/r/gnoswap/access"
 )
 
@@ -17,9 +15,7 @@ import (
 // Each package path can only register once to prevent duplicate registrations.
 func RegisterInitializer(cur realm, initializer func(_ int, rlm realm, stakerStore IStakerStore, poolAccessor PoolAccessor, emissionAccessor EmissionAccessor, nftAccessor NFTAccessor) IStaker) {
 	initializerFunc := func(_ int, rlm realm, domainStore any) any {
-		if !rlm.IsCurrent() {
-			panic(errors.New(ErrSpoofedRealm))
-		}
+		access.AssertIsRlmCurrent(0, rlm)
 
 		currentStakerStore, ok := domainStore.(IStakerStore)
 		if !ok {

--- a/contract/r/gnoswap/staker/v1/_mock_test.gno
+++ b/contract/r/gnoswap/staker/v1/_mock_test.gno
@@ -3,6 +3,8 @@ package staker
 import (
 	"testing"
 
+	"gno.land/r/gnoswap/access"
+
 	"gno.land/p/demo/tokens/grc721"
 	bptree "gno.land/p/nt/bptree/v0"
 	ufmt "gno.land/p/nt/ufmt/v0"
@@ -396,9 +398,7 @@ func (p *mockPoolAccessor) GetSlot0SqrtPriceX96(poolPath string) string {
 }
 
 func (p *mockPoolAccessor) SetTickCrossHook(_ int, rlm realm, hook func(_ int, rlm realm, poolPath string, tickId int32, zeroForOne bool, timestamp int64)) {
-	if !rlm.IsCurrent() {
-		panic(sr.ErrSpoofedRealm)
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	pool.SetTickCrossHook(cross(rlm), func(cur realm, poolPath string, tickId int32, zeroForOne bool, timestamp int64) {
 		hook(0, cur, poolPath, tickId, zeroForOne, timestamp)
@@ -406,9 +406,7 @@ func (p *mockPoolAccessor) SetTickCrossHook(_ int, rlm realm, hook func(_ int, r
 }
 
 func (p *mockPoolAccessor) SetSwapStartHook(_ int, rlm realm, hook func(_ int, rlm realm, poolPath string, timestamp int64)) {
-	if !rlm.IsCurrent() {
-		panic(sr.ErrSpoofedRealm)
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	pool.SetSwapStartHook(cross(rlm), func(cur realm, poolPath string, timestamp int64) {
 		hook(0, cur, poolPath, timestamp)
@@ -416,9 +414,7 @@ func (p *mockPoolAccessor) SetSwapStartHook(_ int, rlm realm, hook func(_ int, r
 }
 
 func (p *mockPoolAccessor) SetSwapEndHook(_ int, rlm realm, hook func(_ int, rlm realm, poolPath string) error) {
-	if !rlm.IsCurrent() {
-		panic(sr.ErrSpoofedRealm)
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	pool.SetSwapEndHook(cross(rlm), func(cur realm, poolPath string) error {
 		return hook(0, cur, poolPath)
@@ -432,9 +428,7 @@ func newMockPoolAccessor() sr.PoolAccessor {
 type mockEmissionAccessor struct{}
 
 func (e *mockEmissionAccessor) MintAndDistributeGns(_ int, rlm realm) (int64, bool) {
-	if !rlm.IsCurrent() {
-		panic(sr.ErrSpoofedRealm)
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	return emission.MintAndDistributeGns(cross(rlm))
 }
@@ -448,9 +442,7 @@ func (e *mockEmissionAccessor) GetStakerEmissionAmountPerSecondInRange(start, en
 }
 
 func (e *mockEmissionAccessor) SetOnDistributionPctChangeCallback(_ int, rlm realm, callback func(_ int, rlm realm, emissionAmountPerSecond int64)) {
-	if !rlm.IsCurrent() {
-		panic(sr.ErrSpoofedRealm)
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	emission.SetOnDistributionPctChangeCallback(cross(rlm), func(cur realm, emissionAmountPerSecond int64) {
 		callback(0, cur, emissionAmountPerSecond)

--- a/contract/r/gnoswap/staker/v1/errors.gno
+++ b/contract/r/gnoswap/staker/v1/errors.gno
@@ -27,7 +27,6 @@ const (
 	errAddExistingToken              = "[GNOSWAP-STAKER-020] cannot add existing token"
 	errInvalidAddress                = "[GNOSWAP-STAKER-021] invalid address"
 	errIsNotEndedIncentive           = "[GNOSWAP-STAKER-022] incentive is not ended yet"
-	errSpoofedRealm                  = "[GNOSWAP-STAKER-023] rlm does not match the current crossing frame"
 )
 
 func makeErrorWithDetails(message string, details string) error {

--- a/contract/r/gnoswap/staker/v1/external_deposit_fee.gno
+++ b/contract/r/gnoswap/staker/v1/external_deposit_fee.gno
@@ -2,7 +2,6 @@ package staker
 
 import (
 	"chain"
-	"errors"
 	"strconv"
 	"strings"
 
@@ -45,9 +44,7 @@ func (s *stakerV1) GetSpecificTokenMinimumRewardAmount(tokenPath string) (int64,
 // SetDepositGnsAmount sets the GNS deposit amount required for creating external incentives.
 // Only admin or governance can call this function.
 func (s *stakerV1) SetDepositGnsAmount(_ int, rlm realm, amount int64) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedStaker()
 
@@ -72,9 +69,7 @@ func (s *stakerV1) SetDepositGnsAmount(_ int, rlm realm, amount int64) {
 // SetMinimumRewardAmount sets the default minimum reward amount for external incentives.
 // Only admin or governance can call this function.
 func (s *stakerV1) SetMinimumRewardAmount(_ int, rlm realm, amount int64) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedStaker()
 
@@ -99,9 +94,7 @@ func (s *stakerV1) SetMinimumRewardAmount(_ int, rlm realm, amount int64) {
 // SetTokenMinimumRewardAmount sets the minimum reward amount for a specific token.
 // Only admin or governance can call this function.
 func (s *stakerV1) SetTokenMinimumRewardAmount(_ int, rlm realm, paramsStr string) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedStaker()
 

--- a/contract/r/gnoswap/staker/v1/external_incentive.gno
+++ b/contract/r/gnoswap/staker/v1/external_incentive.gno
@@ -1,7 +1,6 @@
 package staker
 
 import (
-	"errors"
 	"chain"
 	"chain/runtime"
 	"time"
@@ -38,9 +37,7 @@ func (s *stakerV1) CreateExternalIncentive(
 	startTimestamp int64,
 	endTimestamp int64,
 ) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedStaker()
 
@@ -140,9 +137,7 @@ func (s *stakerV1) CreateExternalIncentive(
 //
 // Only callable by Creator or Admin.
 func (s *stakerV1) EndExternalIncentive(_ int, rlm realm, targetPoolPath, incentiveId string, refundAddress address) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedWithdraw()
 
@@ -306,9 +301,7 @@ func (s *stakerV1) CollectExternalIncentivePenalty(
 	incentiveId string,
 	refundAddress address,
 ) int64 {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedWithdraw()
 

--- a/contract/r/gnoswap/staker/v1/external_token_list.gno
+++ b/contract/r/gnoswap/staker/v1/external_token_list.gno
@@ -2,7 +2,6 @@ package staker
 
 import (
 	"chain"
-	"errors"
 
 	ufmt "gno.land/p/nt/ufmt/v0"
 	"gno.land/r/gnoswap/access"
@@ -19,9 +18,7 @@ import (
 // Panics:
 //   - If the caller is not the admin
 func (s *stakerV1) AddToken(_ int, rlm realm, tokenPath string) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedStaker()
 
@@ -56,9 +53,7 @@ func (s *stakerV1) AddToken(_ int, rlm realm, tokenPath string) {
 // Panics:
 //   - If the caller is not the admin
 func (s *stakerV1) RemoveToken(_ int, rlm realm, tokenPath string) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedStaker()
 

--- a/contract/r/gnoswap/staker/v1/init.gno
+++ b/contract/r/gnoswap/staker/v1/init.gno
@@ -1,8 +1,9 @@
 package staker
 
 import (
-	"errors"
 	"time"
+
+	"gno.land/r/gnoswap/access"
 
 	"gno.land/r/gnoswap/emission"
 
@@ -24,9 +25,7 @@ func init(cur realm) {
 
 func registerStakerV1(cur realm) {
 	sr.RegisterInitializer(cross(cur), func(_ int, rlm realm, stakerStore sr.IStakerStore, poolAccessor sr.PoolAccessor, emissionAccessor sr.EmissionAccessor, nftAccessor sr.NFTAccessor) sr.IStaker {
-		if !rlm.IsCurrent() {
-			panic(errors.New(errSpoofedRealm))
-		}
+		access.AssertIsRlmCurrent(0, rlm)
 
 		err := initStoreData(0, rlm, stakerStore, emissionAccessor)
 		if err != nil {

--- a/contract/r/gnoswap/staker/v1/manage_pool_tier_and_warmup.gno
+++ b/contract/r/gnoswap/staker/v1/manage_pool_tier_and_warmup.gno
@@ -3,7 +3,6 @@ package staker
 import (
 	"chain"
 	"chain/runtime"
-	"errors"
 	"time"
 
 	"gno.land/p/gnoswap/utils"
@@ -20,9 +19,7 @@ const (
 // SetPoolTier assigns a tier level to a pool for internal GNS emission rewards.
 // Only admin or governance can call this function.
 func (s *stakerV1) SetPoolTier(_ int, rlm realm, poolPath string, tier uint64) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedStaker()
 
@@ -58,9 +55,7 @@ func (s *stakerV1) SetPoolTier(_ int, rlm realm, poolPath string, tier uint64) {
 // ChangePoolTier modifies the tier level of an existing pool.
 // Only admin or governance can call this function.
 func (s *stakerV1) ChangePoolTier(_ int, rlm realm, poolPath string, tier uint64) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedStaker()
 
@@ -104,9 +99,7 @@ func (s *stakerV1) ChangePoolTier(_ int, rlm realm, poolPath string, tier uint64
 // RemovePoolTier removes a pool from internal GNS emission rewards.
 // Only admin or governance can call this function.
 func (s *stakerV1) RemovePoolTier(_ int, rlm realm, poolPath string) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedStaker()
 
@@ -147,9 +140,7 @@ func (s *stakerV1) RemovePoolTier(_ int, rlm realm, poolPath string) {
 // SetWarmUp configures the warm-up percentage and duration for rewards.
 // Only admin or governance can call this function.
 func (s *stakerV1) SetWarmUp(_ int, rlm realm, pct, timeDuration int64) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedStaker()
 

--- a/contract/r/gnoswap/staker/v1/protocol_fee_unstaking.gno
+++ b/contract/r/gnoswap/staker/v1/protocol_fee_unstaking.gno
@@ -100,9 +100,7 @@ func (s *stakerV1) addToProtocolFee(_ int, rlm realm) {
 // SetUnStakingFee sets the unstaking fee rate in basis points.
 // Only admin or governance can call this function.
 func (s *stakerV1) SetUnStakingFee(_ int, rlm realm, fee uint64) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedStaker()
 

--- a/contract/r/gnoswap/staker/v1/staker.gno
+++ b/contract/r/gnoswap/staker/v1/staker.gno
@@ -3,7 +3,6 @@ package staker
 import (
 	"chain"
 	"chain/runtime"
-	"errors"
 	"time"
 
 	bptree "gno.land/p/nt/bptree/v0"
@@ -203,9 +202,7 @@ func stakeScanLowerBound(currentTime int64) int64 {
 //
 // Note: Out-of-range positions earn no rewards but can be staked.
 func (s *stakerV1) StakeToken(_ int, rlm realm, positionId uint64, referrer string) string {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedStaker()
 
@@ -419,9 +416,7 @@ func (s *stakerV1) transferDeposit(_ int, rlm realm, positionId uint64, owner, c
 //
 // Returns poolPath, gnsAmount, externalRewards map, externalPenalties map.
 func (s *stakerV1) CollectReward(_ int, rlm realm, positionId uint64) (string, string, map[string]int64, map[string]int64) {
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedWithdraw()
 
@@ -712,9 +707,7 @@ func (s *stakerV1) CollectReward(_ int, rlm realm, positionId uint64) (string, s
 //   - Caller must be the depositor
 //   - Position must be currently staked
 func (s *stakerV1) UnStakeToken(_ int, rlm realm, positionId uint64) string { // poolPath
-	if !rlm.IsCurrent() {
-		panic(errors.New(errSpoofedRealm))
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	caller := rlm.Previous().Address()
 	halt.AssertIsNotHaltedWithdraw()

--- a/contract/r/gnoswap/test/fuzz/_mock_test.gno
+++ b/contract/r/gnoswap/test/fuzz/_mock_test.gno
@@ -4,6 +4,8 @@ import (
 	"strconv"
 	"testing"
 
+	"gno.land/r/gnoswap/access"
+
 	"gno.land/p/demo/tokens/grc721"
 	bptree "gno.land/p/nt/bptree/v0"
 	ufmt "gno.land/p/nt/ufmt/v0"
@@ -765,9 +767,7 @@ func (p *mockPoolAccessor) GetSlot0SqrtPriceX96(poolPath string) string {
 }
 
 func (p *mockPoolAccessor) SetTickCrossHook(_ int, rlm realm, hook func(_ int, rlm realm, poolPath string, tickId int32, zeroForOne bool, timestamp int64)) {
-	if !rlm.IsCurrent() {
-		panic(sr.ErrSpoofedRealm)
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	pool.SetTickCrossHook(cross(rlm), func(cur realm, poolPath string, tickId int32, zeroForOne bool, timestamp int64) {
 		hook(0, cur, poolPath, tickId, zeroForOne, timestamp)
@@ -775,9 +775,7 @@ func (p *mockPoolAccessor) SetTickCrossHook(_ int, rlm realm, hook func(_ int, r
 }
 
 func (p *mockPoolAccessor) SetSwapStartHook(_ int, rlm realm, hook func(_ int, rlm realm, poolPath string, timestamp int64)) {
-	if !rlm.IsCurrent() {
-		panic(sr.ErrSpoofedRealm)
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	pool.SetSwapStartHook(cross(rlm), func(cur realm, poolPath string, timestamp int64) {
 		hook(0, cur, poolPath, timestamp)
@@ -785,9 +783,7 @@ func (p *mockPoolAccessor) SetSwapStartHook(_ int, rlm realm, hook func(_ int, r
 }
 
 func (p *mockPoolAccessor) SetSwapEndHook(_ int, rlm realm, hook func(_ int, rlm realm, poolPath string) error) {
-	if !rlm.IsCurrent() {
-		panic(sr.ErrSpoofedRealm)
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	pool.SetSwapEndHook(cross(rlm), func(cur realm, poolPath string) error {
 		return hook(0, cur, poolPath)
@@ -803,9 +799,7 @@ type mockEmissionAccessor struct{}
 var _ sr.EmissionAccessor = (*mockEmissionAccessor)(nil)
 
 func (e *mockEmissionAccessor) MintAndDistributeGns(_ int, rlm realm) (int64, bool) {
-	if !rlm.IsCurrent() {
-		panic(sr.ErrSpoofedRealm)
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	return emission.MintAndDistributeGns(cross(rlm))
 }
@@ -819,9 +813,7 @@ func (e *mockEmissionAccessor) GetStakerEmissionAmountPerSecondInRange(start, en
 }
 
 func (e *mockEmissionAccessor) SetOnDistributionPctChangeCallback(_ int, rlm realm, callback func(_ int, rlm realm, emissionAmountPerSecond int64)) {
-	if !rlm.IsCurrent() {
-		panic(sr.ErrSpoofedRealm)
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	emission.SetOnDistributionPctChangeCallback(cross(rlm), func(cur realm, emissionAmountPerSecond int64) {
 		callback(0, cur, emissionAmountPerSecond)

--- a/contract/r/scenario/upgrade/implements/mock/position/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/mock/position/test_impl.gno
@@ -4,6 +4,8 @@ package mock
 import (
 	"errors"
 
+	"gno.land/r/gnoswap/access"
+
 	"gno.land/p/demo/tokens/grc721"
 	u256 "gno.land/p/gnoswap/uint256"
 
@@ -24,17 +26,13 @@ func (n *gnftAccessor) Approve(_ int, rlm realm, approved address, tid grc721.To
 }
 
 func (n *gnftAccessor) Mint(_ int, rlm realm, to address, tid grc721.TokenID) grc721.TokenID {
-	if !rlm.IsCurrent() {
-		panic(position.ErrSpoofedRealm)
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	return gnft.Mint(cross(rlm), to, tid)
 }
 
 func (n *gnftAccessor) Burn(_ int, rlm realm, tid grc721.TokenID) {
-	if !rlm.IsCurrent() {
-		panic(position.ErrSpoofedRealm)
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	gnft.Burn(cross(rlm), tid)
 }

--- a/contract/r/scenario/upgrade/implements/v2_invalid/position/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v2_invalid/position/test_impl.gno
@@ -4,6 +4,8 @@ package v2_invalid
 import (
 	"errors"
 
+	"gno.land/r/gnoswap/access"
+
 	grc721 "gno.land/p/demo/tokens/grc721"
 	u256 "gno.land/p/gnoswap/uint256"
 
@@ -24,17 +26,13 @@ func (n *gnftAccessor) Approve(_ int, rlm realm, approved address, tid grc721.To
 }
 
 func (n *gnftAccessor) Mint(_ int, rlm realm, to address, tid grc721.TokenID) grc721.TokenID {
-	if !rlm.IsCurrent() {
-		panic(position.ErrSpoofedRealm)
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	return gnft.Mint(cross(rlm), to, tid)
 }
 
 func (n *gnftAccessor) Burn(_ int, rlm realm, tid grc721.TokenID) {
-	if !rlm.IsCurrent() {
-		panic(position.ErrSpoofedRealm)
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	gnft.Burn(cross(rlm), tid)
 }

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_deposit.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_deposit.gno
@@ -5,6 +5,8 @@ import (
 	"chain/runtime"
 	"time"
 
+	"gno.land/r/gnoswap/access"
+
 	"gno.land/r/gnoswap/common"
 	"gno.land/r/gnoswap/gns"
 	gov_staker "gno.land/r/gnoswap/gov/staker"
@@ -23,9 +25,7 @@ import (
 //
 // Returns deposit ID.
 func (lp *launchpadV1) DepositGns(_ int, rlm realm, targetProjectTierID string, depositAmount int64, referrer string) string {
-	if !rlm.IsCurrent() {
-		panic(errSpoofedRealm)
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedLaunchpad()
 

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_project.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_project.gno
@@ -47,9 +47,7 @@ func (lp *launchpadV1) CreateProject(
 	tier180Ratio int64,
 	startTime int64,
 ) string {
-	if !rlm.IsCurrent() {
-		panic(errSpoofedRealm)
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedLaunchpad()
 
@@ -223,9 +221,7 @@ func (lp *launchpadV1) createProject(_ int, rlm realm, params *createProjectPara
 // TransferLeftFromProjectByAdmin transfers the remaining rewards of a project to a specified recipient.
 // Only admin can call this function. Returns the amount of rewards transferred.
 func (lp *launchpadV1) TransferLeftFromProjectByAdmin(_ int, rlm realm, projectID string, recipient address) int64 {
-	if !rlm.IsCurrent() {
-		panic(errSpoofedRealm)
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedLaunchpad()
 

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_protocol_fee.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_protocol_fee.gno
@@ -1,6 +1,7 @@
 package v3_valid
 
 import (
+	"gno.land/r/gnoswap/access"
 	gov_staker "gno.land/r/gnoswap/gov/staker"
 	"gno.land/r/gnoswap/halt"
 )
@@ -8,9 +9,7 @@ import (
 // CollectProtocolFee collects protocol fee from gov/staker for project recipient wallets.
 // Only project recipients can call this function.
 func (lp *launchpadV1) CollectProtocolFee(_ int, rlm realm) {
-	if !rlm.IsCurrent() {
-		panic(errSpoofedRealm)
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedLaunchpad()
 	halt.AssertIsNotHaltedWithdraw()
@@ -26,9 +25,7 @@ func (lp *launchpadV1) CollectProtocolFee(_ int, rlm realm) {
 // CollectEmissionReward collects emission rewards from gov/staker for project recipient wallets.
 // Only project recipients can call this function.
 func (lp *launchpadV1) CollectEmissionReward(_ int, rlm realm) {
-	if !rlm.IsCurrent() {
-		panic(errSpoofedRealm)
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedLaunchpad()
 	halt.AssertIsNotHaltedWithdraw()
@@ -44,9 +41,7 @@ func (lp *launchpadV1) CollectEmissionReward(_ int, rlm realm) {
 // CollectProtocolFeeReward collects one token path of protocol fee rewards from gov/staker for project recipient wallets.
 // Only project recipients can call this function.
 func (lp *launchpadV1) CollectProtocolFeeReward(_ int, rlm realm, tokenPath string) {
-	if !rlm.IsCurrent() {
-		panic(errSpoofedRealm)
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedLaunchpad()
 	halt.AssertIsNotHaltedWithdraw()

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_reward.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_reward.gno
@@ -5,6 +5,8 @@ import (
 	"chain/runtime"
 	"time"
 
+	"gno.land/r/gnoswap/access"
+
 	"gno.land/r/gnoswap/halt"
 	"gno.land/r/gnoswap/launchpad"
 )
@@ -17,9 +19,7 @@ import (
 // Returns amount of reward collected.
 // Only callable by deposit owner.
 func (lp *launchpadV1) CollectRewardByDepositId(_ int, rlm realm, depositID string) int64 {
-	if !rlm.IsCurrent() {
-		panic(errSpoofedRealm)
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	halt.AssertIsNotHaltedLaunchpad()
 	halt.AssertIsNotHaltedWithdraw()

--- a/contract/r/scenario/upgrade/implements/v3_valid/position/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/position/test_impl.gno
@@ -4,6 +4,8 @@ package v3_valid
 import (
 	"errors"
 
+	"gno.land/r/gnoswap/access"
+
 	"gno.land/p/demo/tokens/grc721"
 	u256 "gno.land/p/gnoswap/uint256"
 
@@ -24,17 +26,13 @@ func (n *gnftAccessor) Approve(_ int, rlm realm, approved address, tid grc721.To
 }
 
 func (n *gnftAccessor) Mint(_ int, rlm realm, to address, tid grc721.TokenID) grc721.TokenID {
-	if !rlm.IsCurrent() {
-		panic(position.ErrSpoofedRealm)
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	return gnft.Mint(cross(rlm), to, tid)
 }
 
 func (n *gnftAccessor) Burn(_ int, rlm realm, tid grc721.TokenID) {
-	if !rlm.IsCurrent() {
-		panic(position.ErrSpoofedRealm)
-	}
+	access.AssertIsRlmCurrent(0, rlm)
 
 	gnft.Burn(cross(rlm), tid)
 }


### PR DESCRIPTION
## Summary
- Add `access.AssertIsRlmCurrent` as the canonical current-realm assertion.
- Replace realm-local panic checks across production, test, and upgrade-scenario code.
- Preserve checks that intentionally return spoofed-realm errors.

## Stacked on
- #1395 (`fix/initializer-spoofed-realm-consistency`)

## Tests
- `make test PKG=gno.land/r/gnoswap/access RUN=TestAssertIsRlmCurrent`
- All 8 root `TestRegisterInitializer` suites
- Representative root/v1 suites and upgrade-scenario compile checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Standardized validation across governance, staking, liquidity, trading, launchpad, position, and fee-management operations.
  * Transactions submitted from an outdated or invalid execution realm are now consistently rejected.
  * Existing operation behavior remains unchanged when the execution realm is valid.

* **Tests**
  * Added coverage confirming valid realm access succeeds and stale realm access is rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->