### PR TITLE
refactor(governance): mint emission after proposal and vote validation

### DIFF
--- a/contract/r/gnoswap/gov/governance/v1/governance_execute.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_execute.gno
@@ -53,9 +53,6 @@ func (gv *governanceV1) Execute(_ int, rlm realm, proposalID int64) int64 {
 	currentHeight := runtime.ChainHeight()
 	currentAt := time.Now().Unix()
 
-	// Mint and distribute GNS tokens as part of the execution process
-	emission.MintAndDistributeGns(cross(rlm))
-
 	// Attempt to execute the proposal with current context
 	proposal, err := gv.executeProposal(
 		0, rlm,
@@ -104,6 +101,9 @@ func (gv *governanceV1) executeProposal(
 	if !proposalResolver.IsExecutable(executedAt) {
 		return nil, errors.New(errProposalNotExecutable)
 	}
+
+	// Mint and distribute GNS tokens after proposal validation
+	emission.MintAndDistributeGns(cross(rlm))
 
 	// Mark proposal as executed in its status
 	err := proposalResolver.execute(executedAt, executedHeight, executedBy)

--- a/contract/r/gnoswap/gov/governance/v1/governance_vote.gno
+++ b/contract/r/gnoswap/gov/governance/v1/governance_vote.gno
@@ -49,9 +49,6 @@ func (gv *governanceV1) Vote(_ int, rlm realm, proposalID int64, yes bool) strin
 	currentHeight := runtime.ChainHeight()
 	currentAt := time.Now()
 
-	// Mint and distribute GNS tokens as part of the voting process
-	emission.MintAndDistributeGns(cross(rlm))
-
 	// Extract voter address from realm context
 	voterRealm := rlm.Previous()
 	voter := voterRealm.Address()
@@ -135,6 +132,9 @@ func (gv *governanceV1) vote(
 		return nil, 0, 0, makeErrorWithDetails(
 			errNotEnoughVotingWeight, "no voting weight at snapshot time")
 	}
+
+	// Mint and distribute GNS tokens after vote validation
+	emission.MintAndDistributeGns(cross(rlm))
 
 	// Create or update voting info for this user
 	if userVote == nil {


### PR DESCRIPTION
## Overview

Moves the `emission.MintAndDistributeGns` call in governance `Execute` and `Vote` to run **after** proposal/vote validation, aligning with the protocol-wide ordering convention.

## Background

`Execute` and `Vote` were the only protocol entry points that called `MintAndDistributeGns` *before* validating their inputs:

- `Execute` minted before checking proposal existence, executability, and timing (`governance_execute.gno:57`)
- `Vote` minted before checking proposal existence, voting period, duplicate votes, and voting weight (`governance_vote.gno:53`)

Every other protocol interaction (router swaps, position mint/collect/reposition, staker delegate/undelegate/collect, launchpad, pool manager, governance `Cancel`/`Reconfigure`) validates first and mints after validation.

## Impact

The old ordering has no economic impact — emission is rate-limited to at most one distribution per second chain-wide (`emission.gno:83-108`), and failed validation paths revert the whole transaction (panic → rollback). This change is a consistency/convention cleanup, not a security fix.

## Changes

- `governance_execute.gno`: `MintAndDistributeGns` moved from the public `Execute` entry point into `executeProposal`, after the `IsExecutable` check and before proposal status mutation.
- `governance_vote.gno`: `MintAndDistributeGns` moved from the public `Vote` entry point into `vote`, after all validation (proposal lookup, voting period, duplicate vote, voting weight) and before vote-state mutation.
- `Cancel` and `Reconfigure` were already correct (validation before mint) and are unchanged.

## No test changes

No tests were modified or added because the actual behavior is identical: emission stays limited to at most one distribution per second, and the mint only persists when the transaction commits successfully. Existing governance and emission test suites already cover both success and failure paths.

## Verification

- `make test PKG=gno.land/r/gnoswap/gov/governance/v1` — all tests pass
- `make test PKG=gno.land/r/gnoswap/emission RUN=MintAndDistributeGns` — all tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved governance vote and proposal execution reliability.
  - GNS rewards are now minted and distributed only after all required validation checks succeed.
  - Invalid, duplicate, premature, or otherwise ineligible voting and execution attempts no longer trigger token issuance.
  - Valid governance actions continue to update voting results and execute approved proposals as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->