### PR TITLE
refactor(position): return errors in getters

### DIFF
--- a/contract/r/gnoswap/position/_mock_test.gno
+++ b/contract/r/gnoswap/position/_mock_test.gno
@@ -186,6 +186,24 @@ func (m *MockPosition) GetPositionFeeGrowthInside1LastX128(positionId uint64) (s
 	return res[0].(string), nil
 }
 
+func (m *MockPosition) GetPositionFeeGrowthInsideLastX128(positionId uint64) (string, string, error) {
+	res, ok := m.Response.Get("GetPositionFeeGrowthInsideLastX128")
+	if !ok {
+		return "", "", ufmt.Errorf("position %d not found", positionId)
+	}
+
+	return res[0].(string), res[1].(string), nil
+}
+
+func (m *MockPosition) GetPositionTicks(positionId uint64) (int32, int32, error) {
+	res, ok := m.Response.Get("GetPositionTicks")
+	if !ok {
+		return 0, 0, ufmt.Errorf("position %d not found", positionId)
+	}
+
+	return res[0].(int32), res[1].(int32), nil
+}
+
 func (m *MockPosition) GetPositionLiquidity(positionId uint64) (string, error) {
 	res, ok := m.Response.Get("GetPositionLiquidity")
 	if !ok {
@@ -274,6 +292,15 @@ func (m *MockPosition) GetPositionTokensOwed1(positionId uint64) (int64, error) 
 	}
 
 	return res[0].(int64), nil
+}
+
+func (m *MockPosition) GetPositionTokensOwed(positionId uint64) (int64, int64, error) {
+	res, ok := m.Response.Get("GetPositionTokensOwed")
+	if !ok {
+		return 0, 0, ufmt.Errorf("position %d not found", positionId)
+	}
+
+	return res[0].(int64), res[1].(int64), nil
 }
 
 func (m *MockPosition) GetUnclaimedFee(positionId uint64) (*u256.Uint, *u256.Uint, error) {

--- a/contract/r/gnoswap/position/_mock_test.gno
+++ b/contract/r/gnoswap/position/_mock_test.gno
@@ -3,6 +3,7 @@ package position
 import (
 	u256 "gno.land/p/gnoswap/uint256"
 	rotree "gno.land/p/nt/bptree/v0/rotree"
+	ufmt "gno.land/p/nt/ufmt/v0"
 )
 
 // MockResponse is a simple mock response helper
@@ -149,58 +150,58 @@ func (m *MockPosition) GetPositions() *rotree.ReadOnlyTree {
 	return res[0].(*rotree.ReadOnlyTree)
 }
 
-func (m *MockPosition) IsBurned(positionId uint64) bool {
+func (m *MockPosition) IsBurned(positionId uint64) (bool, error) {
 	res, ok := m.Response.Get("IsBurned")
 	if !ok {
-		return false
+		return false, ufmt.Errorf("position %d not found", positionId)
 	}
 
-	return res[0].(bool)
+	return res[0].(bool), nil
 }
 
-func (m *MockPosition) IsInRange(positionId uint64) bool {
+func (m *MockPosition) IsInRange(positionId uint64) (bool, error) {
 	res, ok := m.Response.Get("IsInRange")
 	if !ok {
-		return false
+		return false, ufmt.Errorf("position %d not found", positionId)
 	}
 
-	return res[0].(bool)
+	return res[0].(bool), nil
 }
 
-func (m *MockPosition) GetPositionFeeGrowthInside0LastX128(positionId uint64) string {
+func (m *MockPosition) GetPositionFeeGrowthInside0LastX128(positionId uint64) (string, error) {
 	res, ok := m.Response.Get("GetPositionFeeGrowthInside0LastX128")
 	if !ok {
-		return ""
+		return "", ufmt.Errorf("position %d not found", positionId)
 	}
 
-	return res[0].(string)
+	return res[0].(string), nil
 }
 
-func (m *MockPosition) GetPositionFeeGrowthInside1LastX128(positionId uint64) string {
+func (m *MockPosition) GetPositionFeeGrowthInside1LastX128(positionId uint64) (string, error) {
 	res, ok := m.Response.Get("GetPositionFeeGrowthInside1LastX128")
 	if !ok {
-		return ""
+		return "", ufmt.Errorf("position %d not found", positionId)
 	}
 
-	return res[0].(string)
+	return res[0].(string), nil
 }
 
-func (m *MockPosition) GetPositionLiquidity(positionId uint64) string {
+func (m *MockPosition) GetPositionLiquidity(positionId uint64) (string, error) {
 	res, ok := m.Response.Get("GetPositionLiquidity")
 	if !ok {
-		return ""
+		return "", ufmt.Errorf("position %d not found", positionId)
 	}
 
-	return res[0].(string)
+	return res[0].(string), nil
 }
 
-func (m *MockPosition) GetPositionTokenBalances(positionId uint64) (int64, int64) {
+func (m *MockPosition) GetPositionTokenBalances(positionId uint64) (int64, int64, error) {
 	res, ok := m.Response.Get("GetPositionTokenBalances")
 	if !ok {
-		return 0, 0
+		return 0, 0, ufmt.Errorf("position %d not found", positionId)
 	}
 
-	return res[0].(int64), res[1].(int64)
+	return res[0].(int64), res[1].(int64), nil
 }
 
 func (m *MockPosition) GetPositionToken0Balance(positionId uint64) *u256.Uint {
@@ -221,76 +222,76 @@ func (m *MockPosition) GetPositionToken1Balance(positionId uint64) *u256.Uint {
 	return res[0].(*u256.Uint)
 }
 
-func (m *MockPosition) GetPositionOperator(positionId uint64) address {
+func (m *MockPosition) GetPositionOperator(positionId uint64) (address, error) {
 	res, ok := m.Response.Get("GetPositionOperator")
 	if !ok {
-		return ""
+		return "", ufmt.Errorf("position %d not found", positionId)
 	}
 
-	return res[0].(address)
+	return res[0].(address), nil
 }
 
-func (m *MockPosition) GetPositionPoolKey(positionId uint64) string {
+func (m *MockPosition) GetPositionPoolKey(positionId uint64) (string, error) {
 	res, ok := m.Response.Get("GetPositionPoolKey")
 	if !ok {
-		return ""
+		return "", ufmt.Errorf("position %d not found", positionId)
 	}
 
-	return res[0].(string)
+	return res[0].(string), nil
 }
 
-func (m *MockPosition) GetPositionTickLower(positionId uint64) int32 {
+func (m *MockPosition) GetPositionTickLower(positionId uint64) (int32, error) {
 	res, ok := m.Response.Get("GetPositionTickLower")
 	if !ok {
-		return 0
+		return 0, ufmt.Errorf("position %d not found", positionId)
 	}
 
-	return res[0].(int32)
+	return res[0].(int32), nil
 }
 
-func (m *MockPosition) GetPositionTickUpper(positionId uint64) int32 {
+func (m *MockPosition) GetPositionTickUpper(positionId uint64) (int32, error) {
 	res, ok := m.Response.Get("GetPositionTickUpper")
 	if !ok {
-		return 0
+		return 0, ufmt.Errorf("position %d not found", positionId)
 	}
 
-	return res[0].(int32)
+	return res[0].(int32), nil
 }
 
-func (m *MockPosition) GetPositionTokensOwed0(positionId uint64) int64 {
+func (m *MockPosition) GetPositionTokensOwed0(positionId uint64) (int64, error) {
 	res, ok := m.Response.Get("GetPositionTokensOwed0")
 	if !ok {
-		return 0
+		return 0, ufmt.Errorf("position %d not found", positionId)
 	}
 
-	return res[0].(int64)
+	return res[0].(int64), nil
 }
 
-func (m *MockPosition) GetPositionTokensOwed1(positionId uint64) int64 {
+func (m *MockPosition) GetPositionTokensOwed1(positionId uint64) (int64, error) {
 	res, ok := m.Response.Get("GetPositionTokensOwed1")
 	if !ok {
-		return 0
+		return 0, ufmt.Errorf("position %d not found", positionId)
 	}
 
-	return res[0].(int64)
+	return res[0].(int64), nil
 }
 
-func (m *MockPosition) GetUnclaimedFee(positionId uint64) (*u256.Uint, *u256.Uint) {
+func (m *MockPosition) GetUnclaimedFee(positionId uint64) (*u256.Uint, *u256.Uint, error) {
 	res, ok := m.Response.Get("GetUnclaimedFee")
 	if !ok {
-		return u256.Zero(), u256.Zero()
+		return u256.Zero(), u256.Zero(), ufmt.Errorf("position %d not found", positionId)
 	}
 
-	return res[0].(*u256.Uint), res[1].(*u256.Uint)
+	return res[0].(*u256.Uint), res[1].(*u256.Uint), nil
 }
 
-func (m *MockPosition) GetPositionOwner(positionId uint64) address {
+func (m *MockPosition) GetPositionOwner(positionId uint64) (address, error) {
 	res, ok := m.Response.Get("GetPositionOwner")
 	if !ok {
-		return ""
+		return "", ufmt.Errorf("position %d not found", positionId)
 	}
 
-	return res[0].(address)
+	return res[0].(address), nil
 }
 
 func newMockPosition(version string) *MockPosition {

--- a/contract/r/gnoswap/position/getter.gno
+++ b/contract/r/gnoswap/position/getter.gno
@@ -1,9 +1,7 @@
 package position
 
 import (
-	"gno.land/p/gnoswap/utils"
 	rotree "gno.land/p/nt/bptree/v0/rotree"
-	ufmt "gno.land/p/nt/ufmt/v0"
 )
 
 // GetPositions returns a read-only view of every position, keyed by the decimal
@@ -11,20 +9,6 @@ import (
 // IterateByOffset.
 func GetPositions() *rotree.ReadOnlyTree {
 	return getImplementation().GetPositions()
-}
-
-func getPosition(positionId uint64) (Position, error) {
-	positions := GetPositions()
-	if positions == nil {
-		return Position{}, ufmt.Errorf("position %d not found", positionId)
-	}
-
-	position, ok := positions.Get(utils.Uint64ToString(positionId)).(Position)
-	if !ok {
-		return Position{}, ufmt.Errorf("position %d not found", positionId)
-	}
-
-	return position, nil
 }
 
 // IsBurned returns whether a position has been burned.
@@ -72,12 +56,7 @@ func GetPositionFeeGrowthInside1LastX128(positionId uint64) (string, error) {
 
 // GetPositionFeeGrowthInsideLastX128 returns the last recorded fee growth inside for both tokens.
 func GetPositionFeeGrowthInsideLastX128(positionId uint64) (string, string, error) {
-	position, err := getPosition(positionId)
-	if err != nil {
-		return "", "", err
-	}
-
-	return position.FeeGrowthInside0LastX128(), position.FeeGrowthInside1LastX128(), nil
+	return getImplementation().GetPositionFeeGrowthInsideLastX128(positionId)
 }
 
 // GetPositionLiquidity returns the liquidity amount of a position.
@@ -107,12 +86,7 @@ func GetPositionTickUpper(positionId uint64) (int32, error) {
 
 // GetPositionTicks returns the lower and upper ticks of a position.
 func GetPositionTicks(positionId uint64) (int32, int32, error) {
-	position, err := getPosition(positionId)
-	if err != nil {
-		return 0, 0, err
-	}
-
-	return position.TickLower(), position.TickUpper(), nil
+	return getImplementation().GetPositionTicks(positionId)
 }
 
 // GetPositionTokensOwed0 returns the amount of token0 owed to a position.
@@ -127,12 +101,7 @@ func GetPositionTokensOwed1(positionId uint64) (int64, error) {
 
 // GetPositionTokensOwed returns the amount of tokens owed to a position.
 func GetPositionTokensOwed(positionId uint64) (int64, int64, error) {
-	position, err := getPosition(positionId)
-	if err != nil {
-		return 0, 0, err
-	}
-
-	return position.TokensOwed0(), position.TokensOwed1(), nil
+	return getImplementation().GetPositionTokensOwed(positionId)
 }
 
 // GetUnclaimedFee returns the unclaimed fees for both tokens of a position.

--- a/contract/r/gnoswap/position/getter.gno
+++ b/contract/r/gnoswap/position/getter.gno
@@ -3,6 +3,7 @@ package position
 import (
 	"gno.land/p/gnoswap/utils"
 	rotree "gno.land/p/nt/bptree/v0/rotree"
+	ufmt "gno.land/p/nt/ufmt/v0"
 )
 
 // GetPositions returns a read-only view of every position, keyed by the decimal
@@ -12,129 +13,139 @@ func GetPositions() *rotree.ReadOnlyTree {
 	return getImplementation().GetPositions()
 }
 
+func getPosition(positionId uint64) (Position, error) {
+	positions := GetPositions()
+	if positions == nil {
+		return Position{}, ufmt.Errorf("position %d not found", positionId)
+	}
+
+	position, ok := positions.Get(utils.Uint64ToString(positionId)).(Position)
+	if !ok {
+		return Position{}, ufmt.Errorf("position %d not found", positionId)
+	}
+
+	return position, nil
+}
+
 // IsBurned returns whether a position has been burned.
-func IsBurned(positionId uint64) bool {
+func IsBurned(positionId uint64) (bool, error) {
 	return getImplementation().IsBurned(positionId)
 }
 
 // IsInRange returns whether a position's ticks are within the current price range.
-func IsInRange(positionId uint64) bool {
+func IsInRange(positionId uint64) (bool, error) {
 	return getImplementation().IsInRange(positionId)
 }
 
 // GetPositionTokenBalances returns the token0 balance of a position.
-func GetPositionTokenBalances(positionId uint64) (int64, int64) {
-	balance0, balance1 := getImplementation().GetPositionTokenBalances(positionId)
-	return balance0, balance1
+func GetPositionTokenBalances(positionId uint64) (int64, int64, error) {
+	return getImplementation().GetPositionTokenBalances(positionId)
 }
 
-func GetPositionToken0Balance(positionId uint64) int64 {
-	balance0, _ := GetPositionTokenBalances(positionId)
-	return balance0
+func GetPositionToken0Balance(positionId uint64) (int64, error) {
+	balance0, _, err := GetPositionTokenBalances(positionId)
+	if err != nil {
+		return 0, err
+	}
+
+	return balance0, nil
 }
 
-func GetPositionToken1Balance(positionId uint64) int64 {
-	_, balance1 := GetPositionTokenBalances(positionId)
-	return balance1
+func GetPositionToken1Balance(positionId uint64) (int64, error) {
+	_, balance1, err := GetPositionTokenBalances(positionId)
+	if err != nil {
+		return 0, err
+	}
+
+	return balance1, nil
 }
 
 // GetPositionFeeGrowthInside0LastX128 returns the last recorded fee growth inside for token0.
-func GetPositionFeeGrowthInside0LastX128(positionId uint64) string {
+func GetPositionFeeGrowthInside0LastX128(positionId uint64) (string, error) {
 	return getImplementation().GetPositionFeeGrowthInside0LastX128(positionId)
 }
 
 // GetPositionFeeGrowthInside1LastX128 returns the last recorded fee growth inside for token1.
-func GetPositionFeeGrowthInside1LastX128(positionId uint64) string {
+func GetPositionFeeGrowthInside1LastX128(positionId uint64) (string, error) {
 	return getImplementation().GetPositionFeeGrowthInside1LastX128(positionId)
 }
 
 // GetPositionFeeGrowthInsideLastX128 returns the last recorded fee growth inside for both tokens.
-func GetPositionFeeGrowthInsideLastX128(positionId uint64) (string, string) {
-	positions := GetPositions()
-	if positions == nil {
-		return "0", "0"
+func GetPositionFeeGrowthInsideLastX128(positionId uint64) (string, string, error) {
+	position, err := getPosition(positionId)
+	if err != nil {
+		return "", "", err
 	}
 
-	position, ok := positions.Get(utils.Uint64ToString(positionId)).(Position)
-	if !ok {
-		return "0", "0"
-	}
-
-	return position.FeeGrowthInside0LastX128(), position.FeeGrowthInside1LastX128()
+	return position.FeeGrowthInside0LastX128(), position.FeeGrowthInside1LastX128(), nil
 }
 
 // GetPositionLiquidity returns the liquidity amount of a position.
-func GetPositionLiquidity(positionId uint64) string {
+func GetPositionLiquidity(positionId uint64) (string, error) {
 	return getImplementation().GetPositionLiquidity(positionId)
 }
 
 // GetPositionOperator returns the operator address of a position.
-func GetPositionOperator(positionId uint64) address {
+func GetPositionOperator(positionId uint64) (address, error) {
 	return getImplementation().GetPositionOperator(positionId)
 }
 
 // GetPositionPoolKey returns the pool key of a position.
-func GetPositionPoolKey(positionId uint64) string {
+func GetPositionPoolKey(positionId uint64) (string, error) {
 	return getImplementation().GetPositionPoolKey(positionId)
 }
 
 // GetPositionTickLower returns the lower tick of a position.
-func GetPositionTickLower(positionId uint64) int32 {
+func GetPositionTickLower(positionId uint64) (int32, error) {
 	return getImplementation().GetPositionTickLower(positionId)
 }
 
 // GetPositionTickUpper returns the upper tick of a position.
-func GetPositionTickUpper(positionId uint64) int32 {
+func GetPositionTickUpper(positionId uint64) (int32, error) {
 	return getImplementation().GetPositionTickUpper(positionId)
 }
 
 // GetPositionTicks returns the lower and upper ticks of a position.
-func GetPositionTicks(positionId uint64) (int32, int32) {
-	positions := GetPositions()
-	if positions == nil {
-		return 0, 0
+func GetPositionTicks(positionId uint64) (int32, int32, error) {
+	position, err := getPosition(positionId)
+	if err != nil {
+		return 0, 0, err
 	}
 
-	position, ok := positions.Get(utils.Uint64ToString(positionId)).(Position)
-	if !ok {
-		return 0, 0
-	}
-
-	return position.TickLower(), position.TickUpper()
+	return position.TickLower(), position.TickUpper(), nil
 }
 
 // GetPositionTokensOwed0 returns the amount of token0 owed to a position.
-func GetPositionTokensOwed0(positionId uint64) int64 {
+func GetPositionTokensOwed0(positionId uint64) (int64, error) {
 	return getImplementation().GetPositionTokensOwed0(positionId)
 }
 
 // GetPositionTokensOwed1 returns the amount of token1 owed to a position.
-func GetPositionTokensOwed1(positionId uint64) int64 {
+func GetPositionTokensOwed1(positionId uint64) (int64, error) {
 	return getImplementation().GetPositionTokensOwed1(positionId)
 }
 
 // GetPositionTokensOwed returns the amount of tokens owed to a position.
-func GetPositionTokensOwed(positionId uint64) (int64, int64) {
-	positions := GetPositions()
-	if positions == nil {
-		return 0, 0
+func GetPositionTokensOwed(positionId uint64) (int64, int64, error) {
+	position, err := getPosition(positionId)
+	if err != nil {
+		return 0, 0, err
 	}
 
-	position, ok := positions.Get(utils.Uint64ToString(positionId)).(Position)
-	if !ok {
-		return 0, 0
-	}
-
-	return position.TokensOwed0(), position.TokensOwed1()
+	return position.TokensOwed0(), position.TokensOwed1(), nil
 }
 
 // GetUnclaimedFee returns the unclaimed fees for both tokens of a position.
-func GetUnclaimedFee(positionId uint64) (string, string) {
-	fee0, fee1 := getImplementation().GetUnclaimedFee(positionId)
-	return fee0.ToString(), fee1.ToString()
+func GetUnclaimedFee(positionId uint64) (string, string, error) {
+	fee0, fee1, err := getImplementation().GetUnclaimedFee(positionId)
+	if err != nil {
+		return "", "", err
+	}
+
+	return fee0.ToString(), fee1.ToString(), nil
 }
 
 // GetPositionOwner returns the owner address of a position NFT.
-func GetPositionOwner(positionId uint64) address {
+func GetPositionOwner(positionId uint64) (address, error) {
 	return getImplementation().GetPositionOwner(positionId)
 }

--- a/contract/r/gnoswap/position/getter_test.gno
+++ b/contract/r/gnoswap/position/getter_test.gno
@@ -73,11 +73,16 @@ func TestPositionTokenBalanceGetterComposition(t *testing.T) {
 		int64(7000),
 	)
 
-	balance0, balance1 := GetPositionTokenBalances(1)
+	balance0, balance1, err := GetPositionTokenBalances(1)
+	uassert.NoError(t, err)
 	uassert.Equal(t, int64(6000), balance0)
 	uassert.Equal(t, int64(7000), balance1)
-	uassert.Equal(t, int64(6000), GetPositionToken0Balance(1))
-	uassert.Equal(t, int64(7000), GetPositionToken1Balance(1))
+	balance0, err = GetPositionToken0Balance(1)
+	uassert.NoError(t, err)
+	uassert.Equal(t, int64(6000), balance0)
+	balance1, err = GetPositionToken1Balance(1)
+	uassert.NoError(t, err)
+	uassert.Equal(t, int64(7000), balance1)
 	uassert.Equal(t, 3, mockPosition.Response.CallCount("GetPositionTokenBalances"))
 }
 
@@ -96,7 +101,13 @@ func TestMutablePositionGetterIsolation(t *testing.T) {
 				m.Response.Set("GetPositionFeeGrowthInside0LastX128", "2000")
 				return nil
 			},
-			getter:     func() any { return GetPositionFeeGrowthInside0LastX128(1) },
+			getter: func() any {
+				value, err := GetPositionFeeGrowthInside0LastX128(1)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return value
+			},
 			mutate:     func(result any) { _ = result.(string) },
 			assertSame: func(t *testing.T, result any) { uassert.Equal(t, "2000", result.(string)) },
 			assertRaw: func(t *testing.T, raw *Position) {
@@ -109,7 +120,13 @@ func TestMutablePositionGetterIsolation(t *testing.T) {
 				m.Response.Set("GetPositionFeeGrowthInside1LastX128", "3000")
 				return nil
 			},
-			getter:     func() any { return GetPositionFeeGrowthInside1LastX128(1) },
+			getter: func() any {
+				value, err := GetPositionFeeGrowthInside1LastX128(1)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return value
+			},
 			mutate:     func(result any) { _ = result.(string) },
 			assertSame: func(t *testing.T, result any) { uassert.Equal(t, "3000", result.(string)) },
 			assertRaw: func(t *testing.T, raw *Position) {
@@ -126,7 +143,10 @@ func TestMutablePositionGetterIsolation(t *testing.T) {
 				return stored
 			},
 			getter: func() any {
-				fee0, fee1 := GetPositionFeeGrowthInsideLastX128(1)
+				fee0, fee1, err := GetPositionFeeGrowthInsideLastX128(1)
+				if err != nil {
+					t.Fatal(err)
+				}
 				return []any{fee0, fee1}
 			},
 			mutate: func(result any) {
@@ -150,7 +170,13 @@ func TestMutablePositionGetterIsolation(t *testing.T) {
 				m.Response.Set("GetPositionLiquidity", "1000")
 				return nil
 			},
-			getter:     func() any { return GetPositionLiquidity(1) },
+			getter: func() any {
+				value, err := GetPositionLiquidity(1)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return value
+			},
 			mutate:     func(result any) { _ = result.(string) },
 			assertSame: func(t *testing.T, result any) { uassert.Equal(t, "1000", result.(string)) },
 			assertRaw: func(t *testing.T, raw *Position) {
@@ -163,7 +189,13 @@ func TestMutablePositionGetterIsolation(t *testing.T) {
 				m.Response.Set("GetPositionTokensOwed0", int64(4000))
 				return nil
 			},
-			getter:     func() any { return GetPositionTokensOwed0(1) },
+			getter: func() any {
+				value, err := GetPositionTokensOwed0(1)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return value
+			},
 			mutate:     func(result any) { _ = result.(int64) },
 			assertSame: func(t *testing.T, result any) { uassert.Equal(t, int64(4000), result.(int64)) },
 			assertRaw: func(t *testing.T, raw *Position) {
@@ -176,7 +208,13 @@ func TestMutablePositionGetterIsolation(t *testing.T) {
 				m.Response.Set("GetPositionTokensOwed1", int64(5000))
 				return nil
 			},
-			getter:     func() any { return GetPositionTokensOwed1(1) },
+			getter: func() any {
+				value, err := GetPositionTokensOwed1(1)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return value
+			},
 			mutate:     func(result any) { _ = result.(int64) },
 			assertSame: func(t *testing.T, result any) { uassert.Equal(t, int64(5000), result.(int64)) },
 			assertRaw: func(t *testing.T, raw *Position) {
@@ -193,7 +231,10 @@ func TestMutablePositionGetterIsolation(t *testing.T) {
 				return stored
 			},
 			getter: func() any {
-				owed0, owed1 := GetPositionTokensOwed(1)
+				owed0, owed1, err := GetPositionTokensOwed(1)
+				if err != nil {
+					t.Fatal(err)
+				}
 				return []any{owed0, owed1}
 			},
 			mutate: func(result any) {
@@ -218,7 +259,10 @@ func TestMutablePositionGetterIsolation(t *testing.T) {
 				return nil
 			},
 			getter: func() any {
-				fee0, fee1 := GetUnclaimedFee(1)
+				fee0, fee1, err := GetUnclaimedFee(1)
+				if err != nil {
+					t.Fatal(err)
+				}
 				return []any{fee0, fee1}
 			},
 			mutate: func(result any) {
@@ -262,7 +306,8 @@ func TestGetPositionTokenBalances(t *testing.T) {
 
 		mockPosition.Response.Set("GetPositionTokenBalances", int64(6000), int64(7000))
 
-		token0Balance, token1Balance := GetPositionTokenBalances(1)
+		token0Balance, token1Balance, err := GetPositionTokenBalances(1)
+		uassert.NoError(t, err)
 		uassert.Equal(t, int64(6000), token0Balance)
 		uassert.Equal(t, int64(7000), token1Balance)
 	})
@@ -272,7 +317,8 @@ func TestGetPositionTokenBalances(t *testing.T) {
 		mockPosition := newMockPosition("v1")
 		implementation = mockPosition
 
-		token0Balance, token1Balance := GetPositionTokenBalances(999)
+		token0Balance, token1Balance, err := GetPositionTokenBalances(999)
+		uassert.NotNil(t, err)
 		uassert.Equal(t, int64(0), token0Balance)
 		uassert.Equal(t, int64(0), token1Balance)
 	})

--- a/contract/r/gnoswap/position/getter_test.gno
+++ b/contract/r/gnoswap/position/getter_test.gno
@@ -136,11 +136,8 @@ func TestMutablePositionGetterIsolation(t *testing.T) {
 		{
 			name: "GetPositionFeeGrowthInsideLastX128",
 			setup: func(m *MockPosition) *Position {
-				stored := newStoredPosition()
-				tree := bptree.NewBPTree32()
-				tree.Set("1", *stored)
-				m.Response.Set("GetPositions", rotree.Wrap(tree, nil))
-				return stored
+				m.Response.Set("GetPositionFeeGrowthInsideLastX128", "2000", "3000")
+				return nil
 			},
 			getter: func() any {
 				fee0, fee1, err := GetPositionFeeGrowthInsideLastX128(1)
@@ -159,9 +156,10 @@ func TestMutablePositionGetterIsolation(t *testing.T) {
 				uassert.Equal(t, "2000", values[0].(string))
 				uassert.Equal(t, "3000", values[1].(string))
 			},
-			assertRaw: func(t *testing.T, raw *Position) {
-				uassert.Equal(t, "2000", raw.FeeGrowthInside0LastX128())
-				uassert.Equal(t, "3000", raw.FeeGrowthInside1LastX128())
+			assertRaw: func(t *testing.T, _ *Position) {
+				values := implementation.(*MockPosition).Response.data["GetPositionFeeGrowthInsideLastX128"]
+				uassert.Equal(t, "2000", values[0].(string))
+				uassert.Equal(t, "3000", values[1].(string))
 			},
 		},
 		{
@@ -181,6 +179,35 @@ func TestMutablePositionGetterIsolation(t *testing.T) {
 			assertSame: func(t *testing.T, result any) { uassert.Equal(t, "1000", result.(string)) },
 			assertRaw: func(t *testing.T, raw *Position) {
 				uassert.Equal(t, "1000", implementation.(*MockPosition).Response.data["GetPositionLiquidity"][0].(string))
+			},
+		},
+		{
+			name: "GetPositionTicks",
+			setup: func(m *MockPosition) *Position {
+				m.Response.Set("GetPositionTicks", int32(-100), int32(100))
+				return nil
+			},
+			getter: func() any {
+				tickLower, tickUpper, err := GetPositionTicks(1)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return []any{tickLower, tickUpper}
+			},
+			mutate: func(result any) {
+				values := result.([]any)
+				_ = values[0].(int32)
+				_ = values[1].(int32)
+			},
+			assertSame: func(t *testing.T, result any) {
+				values := result.([]any)
+				uassert.Equal(t, int32(-100), values[0].(int32))
+				uassert.Equal(t, int32(100), values[1].(int32))
+			},
+			assertRaw: func(t *testing.T, _ *Position) {
+				values := implementation.(*MockPosition).Response.data["GetPositionTicks"]
+				uassert.Equal(t, int32(-100), values[0].(int32))
+				uassert.Equal(t, int32(100), values[1].(int32))
 			},
 		},
 		{
@@ -224,11 +251,8 @@ func TestMutablePositionGetterIsolation(t *testing.T) {
 		{
 			name: "GetPositionTokensOwed",
 			setup: func(m *MockPosition) *Position {
-				stored := newStoredPosition()
-				tree := bptree.NewBPTree32()
-				tree.Set("1", *stored)
-				m.Response.Set("GetPositions", rotree.Wrap(tree, nil))
-				return stored
+				m.Response.Set("GetPositionTokensOwed", int64(4000), int64(5000))
+				return nil
 			},
 			getter: func() any {
 				owed0, owed1, err := GetPositionTokensOwed(1)
@@ -247,9 +271,10 @@ func TestMutablePositionGetterIsolation(t *testing.T) {
 				uassert.Equal(t, int64(4000), values[0].(int64))
 				uassert.Equal(t, int64(5000), values[1].(int64))
 			},
-			assertRaw: func(t *testing.T, raw *Position) {
-				uassert.Equal(t, int64(4000), raw.TokensOwed0())
-				uassert.Equal(t, int64(5000), raw.TokensOwed1())
+			assertRaw: func(t *testing.T, _ *Position) {
+				values := implementation.(*MockPosition).Response.data["GetPositionTokensOwed"]
+				uassert.Equal(t, int64(4000), values[0].(int64))
+				uassert.Equal(t, int64(5000), values[1].(int64))
 			},
 		},
 		{

--- a/contract/r/gnoswap/position/types.gno
+++ b/contract/r/gnoswap/position/types.gno
@@ -79,20 +79,20 @@ type IPositionManager interface {
 
 type IPositionGetter interface {
 	GetPositions() *rotree.ReadOnlyTree
-	IsBurned(positionId uint64) bool
-	IsInRange(positionId uint64) bool
-	GetPositionOperator(positionId uint64) address
-	GetPositionPoolKey(positionId uint64) string
-	GetPositionTickLower(positionId uint64) int32
-	GetPositionTickUpper(positionId uint64) int32
-	GetPositionLiquidity(positionId uint64) string
-	GetPositionTokenBalances(positionId uint64) (int64, int64)
-	GetPositionFeeGrowthInside0LastX128(positionId uint64) string
-	GetPositionFeeGrowthInside1LastX128(positionId uint64) string
-	GetPositionTokensOwed0(positionId uint64) int64
-	GetPositionTokensOwed1(positionId uint64) int64
-	GetUnclaimedFee(positionId uint64) (*u256.Uint, *u256.Uint)
-	GetPositionOwner(positionId uint64) address
+	IsBurned(positionId uint64) (bool, error)
+	IsInRange(positionId uint64) (bool, error)
+	GetPositionOperator(positionId uint64) (address, error)
+	GetPositionPoolKey(positionId uint64) (string, error)
+	GetPositionTickLower(positionId uint64) (int32, error)
+	GetPositionTickUpper(positionId uint64) (int32, error)
+	GetPositionLiquidity(positionId uint64) (string, error)
+	GetPositionTokenBalances(positionId uint64) (int64, int64, error)
+	GetPositionFeeGrowthInside0LastX128(positionId uint64) (string, error)
+	GetPositionFeeGrowthInside1LastX128(positionId uint64) (string, error)
+	GetPositionTokensOwed0(positionId uint64) (int64, error)
+	GetPositionTokensOwed1(positionId uint64) (int64, error)
+	GetUnclaimedFee(positionId uint64) (*u256.Uint, *u256.Uint, error)
+	GetPositionOwner(positionId uint64) (address, error)
 }
 
 type IPositionStore interface {

--- a/contract/r/gnoswap/position/types.gno
+++ b/contract/r/gnoswap/position/types.gno
@@ -89,8 +89,11 @@ type IPositionGetter interface {
 	GetPositionTokenBalances(positionId uint64) (int64, int64, error)
 	GetPositionFeeGrowthInside0LastX128(positionId uint64) (string, error)
 	GetPositionFeeGrowthInside1LastX128(positionId uint64) (string, error)
+	GetPositionFeeGrowthInsideLastX128(positionId uint64) (string, string, error)
+	GetPositionTicks(positionId uint64) (int32, int32, error)
 	GetPositionTokensOwed0(positionId uint64) (int64, error)
 	GetPositionTokensOwed1(positionId uint64) (int64, error)
+	GetPositionTokensOwed(positionId uint64) (int64, int64, error)
 	GetUnclaimedFee(positionId uint64) (*u256.Uint, *u256.Uint, error)
 	GetPositionOwner(positionId uint64) (address, error)
 }

--- a/contract/r/gnoswap/position/upgrade_test.gno
+++ b/contract/r/gnoswap/position/upgrade_test.gno
@@ -607,7 +607,7 @@ func TestIsBurned(cur realm, t *testing.T) {
 		setCallerRealm(tt.callerRealmPath, tt.callerAddress)
 
 		// Action
-		result := IsBurned(tt.positionId)
+		result, _ := IsBurned(tt.positionId)
 
 		// Assert
 		if mockPosition.Response.CallCount("IsBurned") != 1 {
@@ -657,7 +657,7 @@ func TestIsInRange(cur realm, t *testing.T) {
 		setCallerRealm(tt.callerRealmPath, tt.callerAddress)
 
 		// Action
-		result := IsInRange(tt.positionId)
+		result, _ := IsInRange(tt.positionId)
 
 		// Assert
 		if mockPosition.Response.CallCount("IsInRange") != 1 {
@@ -707,7 +707,7 @@ func TestGetPositionFeeGrowthInside0LastX128(cur realm, t *testing.T) {
 		setCallerRealm(tt.callerRealmPath, tt.callerAddress)
 
 		// Action
-		result := GetPositionFeeGrowthInside0LastX128(tt.positionId)
+		result, _ := GetPositionFeeGrowthInside0LastX128(tt.positionId)
 
 		// Assert
 		if mockPosition.Response.CallCount("GetPositionFeeGrowthInside0LastX128") != 1 {
@@ -757,7 +757,7 @@ func TestGetPositionFeeGrowthInside1LastX128(cur realm, t *testing.T) {
 		setCallerRealm(tt.callerRealmPath, tt.callerAddress)
 
 		// Action
-		result := GetPositionFeeGrowthInside1LastX128(tt.positionId)
+		result, _ := GetPositionFeeGrowthInside1LastX128(tt.positionId)
 
 		// Assert
 		if mockPosition.Response.CallCount("GetPositionFeeGrowthInside1LastX128") != 1 {
@@ -807,7 +807,7 @@ func TestGetPositionLiquidity(cur realm, t *testing.T) {
 		setCallerRealm(tt.callerRealmPath, tt.callerAddress)
 
 		// Action
-		result := GetPositionLiquidity(tt.positionId)
+		result, _ := GetPositionLiquidity(tt.positionId)
 
 		// Assert
 		if mockPosition.Response.CallCount("GetPositionLiquidity") != 1 {
@@ -857,7 +857,7 @@ func TestGetPositionOperator(cur realm, t *testing.T) {
 		setCallerRealm(tt.callerRealmPath, tt.callerAddress)
 
 		// Action
-		result := GetPositionOperator(tt.positionId)
+		result, _ := GetPositionOperator(tt.positionId)
 
 		// Assert
 		if mockPosition.Response.CallCount("GetPositionOperator") != 1 {
@@ -907,7 +907,7 @@ func TestGetPositionPoolKey(cur realm, t *testing.T) {
 		setCallerRealm(tt.callerRealmPath, tt.callerAddress)
 
 		// Action
-		result := GetPositionPoolKey(tt.positionId)
+		result, _ := GetPositionPoolKey(tt.positionId)
 
 		// Assert
 		if mockPosition.Response.CallCount("GetPositionPoolKey") != 1 {
@@ -957,7 +957,7 @@ func TestGetPositionTickLower(cur realm, t *testing.T) {
 		setCallerRealm(tt.callerRealmPath, tt.callerAddress)
 
 		// Action
-		result := GetPositionTickLower(tt.positionId)
+		result, _ := GetPositionTickLower(tt.positionId)
 
 		// Assert
 		if mockPosition.Response.CallCount("GetPositionTickLower") != 1 {
@@ -1007,7 +1007,7 @@ func TestGetPositionTickUpper(cur realm, t *testing.T) {
 		setCallerRealm(tt.callerRealmPath, tt.callerAddress)
 
 		// Action
-		result := GetPositionTickUpper(tt.positionId)
+		result, _ := GetPositionTickUpper(tt.positionId)
 
 		// Assert
 		if mockPosition.Response.CallCount("GetPositionTickUpper") != 1 {
@@ -1057,7 +1057,7 @@ func TestGetPositionTokensOwed0(cur realm, t *testing.T) {
 		setCallerRealm(tt.callerRealmPath, tt.callerAddress)
 
 		// Action
-		result := GetPositionTokensOwed0(tt.positionId)
+		result, _ := GetPositionTokensOwed0(tt.positionId)
 
 		// Assert
 		if mockPosition.Response.CallCount("GetPositionTokensOwed0") != 1 {
@@ -1107,7 +1107,7 @@ func TestGetPositionTokensOwed1(cur realm, t *testing.T) {
 		setCallerRealm(tt.callerRealmPath, tt.callerAddress)
 
 		// Action
-		result := GetPositionTokensOwed1(tt.positionId)
+		result, _ := GetPositionTokensOwed1(tt.positionId)
 
 		// Assert
 		if mockPosition.Response.CallCount("GetPositionTokensOwed1") != 1 {
@@ -1159,7 +1159,7 @@ func TestGetUnclaimedFee(cur realm, t *testing.T) {
 		setCallerRealm(tt.callerRealmPath, tt.callerAddress)
 
 		// Action
-		fee0, fee1 := GetUnclaimedFee(tt.positionId)
+		fee0, fee1, _ := GetUnclaimedFee(tt.positionId)
 
 		// Assert
 		if mockPosition.Response.CallCount("GetUnclaimedFee") != 1 {
@@ -1209,7 +1209,7 @@ func TestGetPositionOwner(cur realm, t *testing.T) {
 		setCallerRealm(tt.callerRealmPath, tt.callerAddress)
 
 		// Action
-		result := GetPositionOwner(tt.positionId)
+		result, _ := GetPositionOwner(tt.positionId)
 
 		// Assert
 		if mockPosition.Response.CallCount("GetPositionOwner") != 1 {

--- a/contract/r/gnoswap/position/v1/getter.gno
+++ b/contract/r/gnoswap/position/v1/getter.gno
@@ -164,6 +164,30 @@ func (p *positionV1) GetPositionFeeGrowthInside1LastX128(positionId uint64) (str
 	return position.FeeGrowthInside1LastX128(), nil
 }
 
+func (p *positionV1) GetPositionFeeGrowthInsideLastX128(positionId uint64) (string, string, error) {
+	position, exists := p.store.GetPosition(positionId)
+	if !exists {
+		return "", "", ufmt.Errorf("%s", newErrorWithDetail(
+			errPositionDoesNotExist,
+			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
+		))
+	}
+
+	return position.FeeGrowthInside0LastX128(), position.FeeGrowthInside1LastX128(), nil
+}
+
+func (p *positionV1) GetPositionTicks(positionId uint64) (int32, int32, error) {
+	position, exists := p.store.GetPosition(positionId)
+	if !exists {
+		return 0, 0, ufmt.Errorf("%s", newErrorWithDetail(
+			errPositionDoesNotExist,
+			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
+		))
+	}
+
+	return position.TickLower(), position.TickUpper(), nil
+}
+
 func (p *positionV1) GetPositionTokensOwed0(positionId uint64) (int64, error) {
 	position, exists := p.store.GetPosition(positionId)
 	if !exists {
@@ -186,6 +210,18 @@ func (p *positionV1) GetPositionTokensOwed1(positionId uint64) (int64, error) {
 	}
 
 	return position.TokensOwed1(), nil
+}
+
+func (p *positionV1) GetPositionTokensOwed(positionId uint64) (int64, int64, error) {
+	position, exists := p.store.GetPosition(positionId)
+	if !exists {
+		return 0, 0, ufmt.Errorf("%s", newErrorWithDetail(
+			errPositionDoesNotExist,
+			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
+		))
+	}
+
+	return position.TokensOwed0(), position.TokensOwed1(), nil
 }
 
 func (p *positionV1) GetPositionOwner(positionId uint64) (address, error) {

--- a/contract/r/gnoswap/position/v1/getter.gno
+++ b/contract/r/gnoswap/position/v1/getter.gno
@@ -1,6 +1,8 @@
 package position
 
 import (
+	"errors"
+
 	"gno.land/p/gnoswap/consts"
 	u256 "gno.land/p/gnoswap/uint256"
 	rotree "gno.land/p/nt/bptree/v0/rotree"
@@ -10,18 +12,29 @@ import (
 	"gno.land/r/gnoswap/position"
 )
 
-// MustGetPosition returns a position for a given position ID.
-// panics if position doesn't exist
-func (p *positionV1) mustGetPosition(positionId uint64) *position.Position {
-	pos, exist := p.store.GetPosition(positionId)
-	if !exist {
-		panic(newErrorWithDetail(
+// getPosition returns a position for a given position ID.
+// Returns an error if the position doesn't exist.
+func (p *positionV1) getPosition(positionId uint64) (position.Position, error) {
+	pos, exists := p.store.GetPosition(positionId)
+	if !exists {
+		return pos, errors.New(newErrorWithDetail(
 			errPositionDoesNotExist,
 			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
 		))
 	}
 
-	return &pos
+	return pos, nil
+}
+
+// mustGetPosition returns a position for a given position ID.
+// panics if position doesn't exist
+func (p *positionV1) mustGetPosition(positionId uint64) *position.Position {
+	position, err := p.getPosition(positionId)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	return &position
 }
 
 // GetPositions returns a read-only view of every position, keyed by the decimal
@@ -38,24 +51,18 @@ func (p *positionV1) ExistPosition(positionId uint64) bool {
 }
 
 func (p *positionV1) IsBurned(positionId uint64) (bool, error) {
-	position, exists := p.store.GetPosition(positionId)
-	if !exists {
-		return false, ufmt.Errorf("%s", newErrorWithDetail(
-			errPositionDoesNotExist,
-			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
-		))
+	position, err := p.getPosition(positionId)
+	if err != nil {
+		return false, err
 	}
 
 	return position.Burned(), nil
 }
 
 func (p *positionV1) IsInRange(positionId uint64) (bool, error) {
-	position, exists := p.store.GetPosition(positionId)
-	if !exists {
-		return false, ufmt.Errorf("%s", newErrorWithDetail(
-			errPositionDoesNotExist,
-			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
-		))
+	position, err := p.getPosition(positionId)
+	if err != nil {
+		return false, err
 	}
 
 	poolPath := position.PoolKey()
@@ -68,72 +75,54 @@ func (p *positionV1) IsInRange(positionId uint64) (bool, error) {
 }
 
 func (p *positionV1) GetPositionOperator(positionId uint64) (address, error) {
-	position, exists := p.store.GetPosition(positionId)
-	if !exists {
-		return address(""), ufmt.Errorf("%s", newErrorWithDetail(
-			errPositionDoesNotExist,
-			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
-		))
+	position, err := p.getPosition(positionId)
+	if err != nil {
+		return address(""), err
 	}
 
 	return position.Operator(), nil
 }
 
 func (p *positionV1) GetPositionPoolKey(positionId uint64) (string, error) {
-	position, exists := p.store.GetPosition(positionId)
-	if !exists {
-		return "", ufmt.Errorf("%s", newErrorWithDetail(
-			errPositionDoesNotExist,
-			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
-		))
+	position, err := p.getPosition(positionId)
+	if err != nil {
+		return "", err
 	}
 
 	return position.PoolKey(), nil
 }
 
 func (p *positionV1) GetPositionTickLower(positionId uint64) (int32, error) {
-	position, exists := p.store.GetPosition(positionId)
-	if !exists {
-		return 0, ufmt.Errorf("%s", newErrorWithDetail(
-			errPositionDoesNotExist,
-			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
-		))
+	position, err := p.getPosition(positionId)
+	if err != nil {
+		return 0, err
 	}
 
 	return position.TickLower(), nil
 }
 
 func (p *positionV1) GetPositionTickUpper(positionId uint64) (int32, error) {
-	position, exists := p.store.GetPosition(positionId)
-	if !exists {
-		return 0, ufmt.Errorf("%s", newErrorWithDetail(
-			errPositionDoesNotExist,
-			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
-		))
+	position, err := p.getPosition(positionId)
+	if err != nil {
+		return 0, err
 	}
 
 	return position.TickUpper(), nil
 }
 
 func (p *positionV1) GetPositionLiquidity(positionId uint64) (string, error) {
-	position, exists := p.store.GetPosition(positionId)
-	if !exists {
-		return "", ufmt.Errorf("%s", newErrorWithDetail(
-			errPositionDoesNotExist,
-			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
-		))
+	position, err := p.getPosition(positionId)
+	if err != nil {
+		return "", err
 	}
 
 	return position.Liquidity(), nil
 }
 
 func (p *positionV1) GetPositionTokenBalances(positionId uint64) (int64, int64, error) {
-	position, exists := p.store.GetPosition(positionId)
-	if !exists {
-		return 0, 0, ufmt.Errorf("%s", newErrorWithDetail(
-			errPositionDoesNotExist,
-			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
-		))
+	position, err := p.getPosition(positionId)
+	if err != nil {
+		return 0, 0, err
 	}
 
 	balance0, balance1 := calculatePositionBalances(&position)
@@ -141,84 +130,63 @@ func (p *positionV1) GetPositionTokenBalances(positionId uint64) (int64, int64, 
 }
 
 func (p *positionV1) GetPositionFeeGrowthInside0LastX128(positionId uint64) (string, error) {
-	position, exists := p.store.GetPosition(positionId)
-	if !exists {
-		return "", ufmt.Errorf("%s", newErrorWithDetail(
-			errPositionDoesNotExist,
-			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
-		))
+	position, err := p.getPosition(positionId)
+	if err != nil {
+		return "", err
 	}
 
 	return position.FeeGrowthInside0LastX128(), nil
 }
 
 func (p *positionV1) GetPositionFeeGrowthInside1LastX128(positionId uint64) (string, error) {
-	position, exists := p.store.GetPosition(positionId)
-	if !exists {
-		return "", ufmt.Errorf("%s", newErrorWithDetail(
-			errPositionDoesNotExist,
-			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
-		))
+	position, err := p.getPosition(positionId)
+	if err != nil {
+		return "", err
 	}
 
 	return position.FeeGrowthInside1LastX128(), nil
 }
 
 func (p *positionV1) GetPositionFeeGrowthInsideLastX128(positionId uint64) (string, string, error) {
-	position, exists := p.store.GetPosition(positionId)
-	if !exists {
-		return "", "", ufmt.Errorf("%s", newErrorWithDetail(
-			errPositionDoesNotExist,
-			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
-		))
+	position, err := p.getPosition(positionId)
+	if err != nil {
+		return "", "", err
 	}
 
 	return position.FeeGrowthInside0LastX128(), position.FeeGrowthInside1LastX128(), nil
 }
 
 func (p *positionV1) GetPositionTicks(positionId uint64) (int32, int32, error) {
-	position, exists := p.store.GetPosition(positionId)
-	if !exists {
-		return 0, 0, ufmt.Errorf("%s", newErrorWithDetail(
-			errPositionDoesNotExist,
-			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
-		))
+	position, err := p.getPosition(positionId)
+	if err != nil {
+		return 0, 0, err
 	}
 
 	return position.TickLower(), position.TickUpper(), nil
 }
 
 func (p *positionV1) GetPositionTokensOwed0(positionId uint64) (int64, error) {
-	position, exists := p.store.GetPosition(positionId)
-	if !exists {
-		return 0, ufmt.Errorf("%s", newErrorWithDetail(
-			errPositionDoesNotExist,
-			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
-		))
+	position, err := p.getPosition(positionId)
+	if err != nil {
+		return 0, err
 	}
 
 	return position.TokensOwed0(), nil
 }
 
 func (p *positionV1) GetPositionTokensOwed1(positionId uint64) (int64, error) {
-	position, exists := p.store.GetPosition(positionId)
-	if !exists {
-		return 0, ufmt.Errorf("%s", newErrorWithDetail(
-			errPositionDoesNotExist,
-			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
-		))
+	position, err := p.getPosition(positionId)
+	if err != nil {
+		return 0, err
 	}
 
 	return position.TokensOwed1(), nil
 }
 
 func (p *positionV1) GetPositionTokensOwed(positionId uint64) (int64, int64, error) {
-	position, exists := p.store.GetPosition(positionId)
-	if !exists {
-		return 0, 0, ufmt.Errorf("%s", newErrorWithDetail(
-			errPositionDoesNotExist,
-			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
-		))
+	position, err := p.getPosition(positionId)
+	if err != nil {
+		return 0, 0, err
 	}
 
 	return position.TokensOwed0(), position.TokensOwed1(), nil
@@ -235,12 +203,9 @@ func (p *positionV1) GetPositionOwner(positionId uint64) (address, error) {
 
 func (p *positionV1) GetUnclaimedFee(positionId uint64) (*u256.Uint, *u256.Uint, error) {
 	// ref: https://blog.uniswap.org/uniswap-v3-math-primer-2#calculating-uncollected-fees
-	position, exists := p.store.GetPosition(positionId)
-	if !exists {
-		return nil, nil, ufmt.Errorf("%s", newErrorWithDetail(
-			errPositionDoesNotExist,
-			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
-		))
+	position, err := p.getPosition(positionId)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	liquidity := u256.MustFromDecimal(position.Liquidity())

--- a/contract/r/gnoswap/position/v1/getter.gno
+++ b/contract/r/gnoswap/position/v1/getter.gno
@@ -37,76 +37,175 @@ func (p *positionV1) ExistPosition(positionId uint64) bool {
 	return p.store.HasPosition(positionId)
 }
 
-func (p *positionV1) IsBurned(positionId uint64) bool {
-	return p.mustGetPosition(positionId).Burned()
+func (p *positionV1) IsBurned(positionId uint64) (bool, error) {
+	position, exists := p.store.GetPosition(positionId)
+	if !exists {
+		return false, ufmt.Errorf("%s", newErrorWithDetail(
+			errPositionDoesNotExist,
+			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
+		))
+	}
+
+	return position.Burned(), nil
 }
 
-func (p *positionV1) IsInRange(positionId uint64) bool {
-	position := p.mustGetPosition(positionId)
+func (p *positionV1) IsInRange(positionId uint64) (bool, error) {
+	position, exists := p.store.GetPosition(positionId)
+	if !exists {
+		return false, ufmt.Errorf("%s", newErrorWithDetail(
+			errPositionDoesNotExist,
+			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
+		))
+	}
+
 	poolPath := position.PoolKey()
 	poolCurrentTick, err := pl.GetSlot0Tick(poolPath)
 	if err != nil {
-		panic(err)
+		return false, err
 	}
 
-	return position.TickLower() <= poolCurrentTick && poolCurrentTick < position.TickUpper()
+	return position.TickLower() <= poolCurrentTick && poolCurrentTick < position.TickUpper(), nil
 }
 
-func (p *positionV1) GetPositionOperator(positionId uint64) address {
-	return p.mustGetPosition(positionId).Operator()
+func (p *positionV1) GetPositionOperator(positionId uint64) (address, error) {
+	position, exists := p.store.GetPosition(positionId)
+	if !exists {
+		return address(""), ufmt.Errorf("%s", newErrorWithDetail(
+			errPositionDoesNotExist,
+			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
+		))
+	}
+
+	return position.Operator(), nil
 }
 
-func (p *positionV1) GetPositionPoolKey(positionId uint64) string {
-	return p.mustGetPosition(positionId).PoolKey()
+func (p *positionV1) GetPositionPoolKey(positionId uint64) (string, error) {
+	position, exists := p.store.GetPosition(positionId)
+	if !exists {
+		return "", ufmt.Errorf("%s", newErrorWithDetail(
+			errPositionDoesNotExist,
+			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
+		))
+	}
+
+	return position.PoolKey(), nil
 }
 
-func (p *positionV1) GetPositionTickLower(positionId uint64) int32 {
-	return p.mustGetPosition(positionId).TickLower()
+func (p *positionV1) GetPositionTickLower(positionId uint64) (int32, error) {
+	position, exists := p.store.GetPosition(positionId)
+	if !exists {
+		return 0, ufmt.Errorf("%s", newErrorWithDetail(
+			errPositionDoesNotExist,
+			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
+		))
+	}
+
+	return position.TickLower(), nil
 }
 
-func (p *positionV1) GetPositionTickUpper(positionId uint64) int32 {
-	return p.mustGetPosition(positionId).TickUpper()
+func (p *positionV1) GetPositionTickUpper(positionId uint64) (int32, error) {
+	position, exists := p.store.GetPosition(positionId)
+	if !exists {
+		return 0, ufmt.Errorf("%s", newErrorWithDetail(
+			errPositionDoesNotExist,
+			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
+		))
+	}
+
+	return position.TickUpper(), nil
 }
 
-func (p *positionV1) GetPositionLiquidity(positionId uint64) string {
-	return p.mustGetPosition(positionId).Liquidity()
+func (p *positionV1) GetPositionLiquidity(positionId uint64) (string, error) {
+	position, exists := p.store.GetPosition(positionId)
+	if !exists {
+		return "", ufmt.Errorf("%s", newErrorWithDetail(
+			errPositionDoesNotExist,
+			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
+		))
+	}
+
+	return position.Liquidity(), nil
 }
 
-func (p *positionV1) GetPositionTokenBalances(positionId uint64) (int64, int64) {
-	position := p.mustGetPosition(positionId)
+func (p *positionV1) GetPositionTokenBalances(positionId uint64) (int64, int64, error) {
+	position, exists := p.store.GetPosition(positionId)
+	if !exists {
+		return 0, 0, ufmt.Errorf("%s", newErrorWithDetail(
+			errPositionDoesNotExist,
+			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
+		))
+	}
 
-	return calculatePositionBalances(position)
+	balance0, balance1 := calculatePositionBalances(&position)
+	return balance0, balance1, nil
 }
 
-func (p *positionV1) GetPositionFeeGrowthInside0LastX128(positionId uint64) string {
-	return p.mustGetPosition(positionId).FeeGrowthInside0LastX128()
+func (p *positionV1) GetPositionFeeGrowthInside0LastX128(positionId uint64) (string, error) {
+	position, exists := p.store.GetPosition(positionId)
+	if !exists {
+		return "", ufmt.Errorf("%s", newErrorWithDetail(
+			errPositionDoesNotExist,
+			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
+		))
+	}
+
+	return position.FeeGrowthInside0LastX128(), nil
 }
 
-func (p *positionV1) GetPositionFeeGrowthInside1LastX128(positionId uint64) string {
-	return p.mustGetPosition(positionId).FeeGrowthInside1LastX128()
+func (p *positionV1) GetPositionFeeGrowthInside1LastX128(positionId uint64) (string, error) {
+	position, exists := p.store.GetPosition(positionId)
+	if !exists {
+		return "", ufmt.Errorf("%s", newErrorWithDetail(
+			errPositionDoesNotExist,
+			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
+		))
+	}
+
+	return position.FeeGrowthInside1LastX128(), nil
 }
 
-func (p *positionV1) GetPositionTokensOwed0(positionId uint64) int64 {
-	return p.mustGetPosition(positionId).TokensOwed0()
+func (p *positionV1) GetPositionTokensOwed0(positionId uint64) (int64, error) {
+	position, exists := p.store.GetPosition(positionId)
+	if !exists {
+		return 0, ufmt.Errorf("%s", newErrorWithDetail(
+			errPositionDoesNotExist,
+			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
+		))
+	}
+
+	return position.TokensOwed0(), nil
 }
 
-func (p *positionV1) GetPositionTokensOwed1(positionId uint64) int64 {
-	return p.mustGetPosition(positionId).TokensOwed1()
+func (p *positionV1) GetPositionTokensOwed1(positionId uint64) (int64, error) {
+	position, exists := p.store.GetPosition(positionId)
+	if !exists {
+		return 0, ufmt.Errorf("%s", newErrorWithDetail(
+			errPositionDoesNotExist,
+			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
+		))
+	}
+
+	return position.TokensOwed1(), nil
 }
 
-func (p *positionV1) GetPositionOwner(positionId uint64) address {
+func (p *positionV1) GetPositionOwner(positionId uint64) (address, error) {
 	owner, err := p.nftAccessor.OwnerOf(positionIdFrom(positionId))
 	if err != nil {
-		panic(newErrorWithDetail(
-			errDataNotFound, err.Error()))
+		return address(""), err
 	}
 
-	return owner
+	return owner, nil
 }
 
-func (p *positionV1) GetUnclaimedFee(positionId uint64) (*u256.Uint, *u256.Uint) {
+func (p *positionV1) GetUnclaimedFee(positionId uint64) (*u256.Uint, *u256.Uint, error) {
 	// ref: https://blog.uniswap.org/uniswap-v3-math-primer-2#calculating-uncollected-fees
-	position := p.mustGetPosition(positionId)
+	position, exists := p.store.GetPosition(positionId)
+	if !exists {
+		return nil, nil, ufmt.Errorf("%s", newErrorWithDetail(
+			errPositionDoesNotExist,
+			ufmt.Sprintf("position with position ID(%d) doesn't exist", positionId),
+		))
+	}
 
 	liquidity := u256.MustFromDecimal(position.Liquidity())
 	tickLower := position.TickLower()
@@ -116,26 +215,26 @@ func (p *positionV1) GetUnclaimedFee(positionId uint64) (*u256.Uint, *u256.Uint)
 
 	currentTick, err := pl.GetSlot0Tick(poolKey)
 	if err != nil {
-		panic(err)
+		return nil, nil, err
 	}
 
 	feeGrowthGlobal0X128Str, feeGrowthGlobal1X128Str, err := pl.GetFeeGrowthGlobalX128(poolKey)
 	if err != nil {
-		panic(err)
+		return nil, nil, err
 	}
 	feeGrowthGlobal0X128 := u256.MustFromDecimal(feeGrowthGlobal0X128Str)
 	feeGrowthGlobal1X128 := u256.MustFromDecimal(feeGrowthGlobal1X128Str)
 
 	tickUpperFeeGrowthOutside0X128Str, tickUpperFeeGrowthOutside1X128Str, err := pl.GetTickFeeGrowthOutsideX128(poolKey, tickUpper)
 	if err != nil {
-		panic(err)
+		return nil, nil, err
 	}
 	tickUpperFeeGrowthOutside0X128 := u256.MustFromDecimal(tickUpperFeeGrowthOutside0X128Str)
 	tickUpperFeeGrowthOutside1X128 := u256.MustFromDecimal(tickUpperFeeGrowthOutside1X128Str)
 
 	tickLowerFeeGrowthOutside0X128Str, tickLowerFeeGrowthOutside1X128Str, err := pl.GetTickFeeGrowthOutsideX128(poolKey, tickLower)
 	if err != nil {
-		panic(err)
+		return nil, nil, err
 	}
 	tickLowerFeeGrowthOutside0X128 := u256.MustFromDecimal(tickLowerFeeGrowthOutside0X128Str)
 	tickLowerFeeGrowthOutside1X128 := u256.MustFromDecimal(tickLowerFeeGrowthOutside1X128Str)
@@ -172,5 +271,5 @@ func (p *positionV1) GetUnclaimedFee(positionId uint64) (*u256.Uint, *u256.Uint)
 
 	diffGrowthInside1X128 := u256.Zero().Sub(feeGrowthInside1X128, feeGrowthInside1LastX128)
 	unclaimedFee1 := u256.MulDiv(diffGrowthInside1X128, liquidity, consts.Q128())
-	return unclaimedFee0, unclaimedFee1
+	return unclaimedFee0, unclaimedFee1, nil
 }

--- a/contract/r/gnoswap/position/v1/getter_test.gno
+++ b/contract/r/gnoswap/position/v1/getter_test.gno
@@ -151,14 +151,22 @@ func TestPositionGetter(cur realm, t *testing.T) {
 		{
 			name: "get position is success by isBurned",
 			testFunc: func() any {
-				return mockInstance.IsBurned(positionId)
+				burned, err := mockInstance.IsBurned(positionId)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return burned
 			},
 			expected: false,
 		},
 		{
 			name: "get position is success by isInRange",
 			testFunc: func() any {
-				return mockInstance.IsInRange(positionId)
+				inRange, err := mockInstance.IsInRange(positionId)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return inRange
 			},
 			expected: true,
 		},
@@ -252,14 +260,20 @@ func TestGetPositionTokenBalances(cur realm, t *testing.T) {
 		{
 			name: "token0 balance is not zero after mint",
 			testFunc: func() bool {
-				balance0, _ := mockInstance.GetPositionTokenBalances(positionId)
+				balance0, _, err := mockInstance.GetPositionTokenBalances(positionId)
+				if err != nil {
+					t.Fatal(err)
+				}
 				return balance0 != 0
 			},
 		},
 		{
 			name: "token1 balance is not zero after mint",
 			testFunc: func() bool {
-				_, balance1 := mockInstance.GetPositionTokenBalances(positionId)
+				_, balance1, err := mockInstance.GetPositionTokenBalances(positionId)
+				if err != nil {
+					t.Fatal(err)
+				}
 				return balance1 != 0
 			},
 		},
@@ -281,7 +295,8 @@ func TestGetPositionTokenBalances_LiquidityBoundaries(cur realm, t *testing.T) {
 		pos.SetLiquidity("1000000000000")
 		mockInstance.mustUpdatePosition(0, cur, positionId, *pos)
 
-		balance0, balance1 := mockInstance.GetPositionTokenBalances(positionId)
+		balance0, balance1, err := mockInstance.GetPositionTokenBalances(positionId)
+		uassert.NoError(t, err)
 		uassert.True(t, balance0 >= 0)
 		uassert.True(t, balance1 >= 0)
 		uassert.True(t, balance0 != 0 || balance1 != 0)
@@ -381,63 +396,99 @@ func TestGetPositionDetailsGetter(cur realm, t *testing.T) {
 		{
 			name: "GetPositionOwner returns correct owner",
 			testFunc: func() any {
-				return mockInstance.GetPositionOwner(positionId)
+				owner, err := mockInstance.GetPositionOwner(positionId)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return owner
 			},
 			expected: adminAddr,
 		},
 		{
 			name: "GetPositionPoolKey returns correct pool key",
 			testFunc: func() any {
-				return mockInstance.GetPositionPoolKey(positionId)
+				poolKey, err := mockInstance.GetPositionPoolKey(positionId)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return poolKey
 			},
 			expected: "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:500",
 		},
 		{
 			name: "GetPositionTickLower returns correct tick lower",
 			testFunc: func() any {
-				return mockInstance.GetPositionTickLower(positionId)
+				tickLower, err := mockInstance.GetPositionTickLower(positionId)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return tickLower
 			},
 			expected: int32(-10000),
 		},
 		{
 			name: "GetPositionTickUpper returns correct tick upper",
 			testFunc: func() any {
-				return mockInstance.GetPositionTickUpper(positionId)
+				tickUpper, err := mockInstance.GetPositionTickUpper(positionId)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return tickUpper
 			},
 			expected: int32(10000),
 		},
 		{
 			name: "GetPositionLiquidity returns non-zero liquidity",
 			testFunc: func() any {
-				return mockInstance.GetPositionLiquidity(positionId)
+				liquidity, err := mockInstance.GetPositionLiquidity(positionId)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return liquidity
 			},
 			expected: "2541592",
 		},
 		{
 			name: "GetPositionFeeGrowthInside0LastX128 returns zero initially",
 			testFunc: func() any {
-				return mockInstance.GetPositionFeeGrowthInside0LastX128(positionId)
+				feeGrowth, err := mockInstance.GetPositionFeeGrowthInside0LastX128(positionId)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return feeGrowth
 			},
 			expected: "0",
 		},
 		{
 			name: "GetPositionFeeGrowthInside1LastX128 returns zero initially",
 			testFunc: func() any {
-				return mockInstance.GetPositionFeeGrowthInside1LastX128(positionId)
+				feeGrowth, err := mockInstance.GetPositionFeeGrowthInside1LastX128(positionId)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return feeGrowth
 			},
 			expected: "0",
 		},
 		{
 			name: "GetPositionTokensOwed0 returns zero initially",
 			testFunc: func() any {
-				return mockInstance.GetPositionTokensOwed0(positionId)
+				tokensOwed, err := mockInstance.GetPositionTokensOwed0(positionId)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return tokensOwed
 			},
 			expected: int64(0),
 		},
 		{
 			name: "GetPositionTokensOwed1 returns zero initially",
 			testFunc: func() any {
-				return mockInstance.GetPositionTokensOwed1(positionId)
+				tokensOwed, err := mockInstance.GetPositionTokensOwed1(positionId)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return tokensOwed
 			},
 			expected: int64(0),
 		},
@@ -471,7 +522,8 @@ func TestIsBurned(cur realm, t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(cur realm, t *testing.T) {
 			tc.setup(cur, t)
-			result := mockInstance.IsBurned(tc.positionId)
+			result, err := mockInstance.IsBurned(tc.positionId)
+			uassert.NoError(t, err)
 			uassert.Equal(t, tc.expected, result)
 		})
 	}
@@ -497,7 +549,8 @@ func TestIsInRange(cur realm, t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(cur realm, t *testing.T) {
 			tc.setup(cur, t)
-			result := mockInstance.IsInRange(tc.positionId)
+			result, err := mockInstance.IsInRange(tc.positionId)
+			uassert.NoError(t, err)
 			uassert.Equal(t, tc.expected, result)
 		})
 	}
@@ -523,7 +576,8 @@ func TestGetPositionOperator(cur realm, t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(cur realm, t *testing.T) {
 			tc.setup(cur, t)
-			result := mockInstance.GetPositionOperator(tc.positionId)
+			result, err := mockInstance.GetPositionOperator(tc.positionId)
+			uassert.NoError(t, err)
 			uassert.Equal(t, tc.expected, result)
 		})
 	}
@@ -551,7 +605,8 @@ func TestGetUnclaimedFee(cur realm, t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(cur realm, t *testing.T) {
 			tc.setup(cur, t)
-			fee0, fee1 := mockInstance.GetUnclaimedFee(tc.positionId)
+			fee0, fee1, err := mockInstance.GetUnclaimedFee(tc.positionId)
+			uassert.NoError(t, err)
 			uassert.Equal(t, tc.expectedFee0, fee0.ToString())
 			uassert.Equal(t, tc.expectedFee1, fee1.ToString())
 		})
@@ -589,7 +644,8 @@ func TestGetUnclaimedFeeUsesMulDivForLargeIntermediateProduct(cur realm, t *test
 
 	expectedFee0 := u256.MulDiv(u256.NewUint(2), u256.MustFromDecimal(MAX_UINT256), consts.Q128())
 
-	fee0, fee1 := mockInstance.GetUnclaimedFee(1)
+	fee0, fee1, err := mockInstance.GetUnclaimedFee(1)
+	uassert.NoError(t, err)
 
 	uassert.Equal(t, expectedFee0.ToString(), fee0.ToString())
 	uassert.Equal(t, "0", fee1.ToString())
@@ -624,7 +680,8 @@ func TestGetUnclaimedFeeReconstructsWrappedInsideGrowth(cur realm, t *testing.T)
 	upperTick.SetFeeGrowthOutside1X128("5")
 	storedPool.SetTick(position.TickUpper(), upperTick)
 
-	fee0, fee1 := mockInstance.GetUnclaimedFee(1)
+	fee0, fee1, err := mockInstance.GetUnclaimedFee(1)
+	uassert.NoError(t, err)
 
 	uassert.Equal(t, "16", fee0.ToString())
 	uassert.Equal(t, "13", fee1.ToString())

--- a/contract/r/gnoswap/position/v1/position.gno
+++ b/contract/r/gnoswap/position/v1/position.gno
@@ -94,6 +94,10 @@ func (p *positionV1) Mint(
 	id, liquidity, amount0, amount1 := p.mint(0, rlm, params)
 
 	pool := mustGetPool(processedInput.poolPath)
+	positionLiquidity, err := p.GetPositionLiquidity(id)
+	if err != nil {
+		panic(err)
+	}
 	tickCumulative, secondsPerLiquidityCumulativeX128, observationTimestamp, err := pl.GetLastObservation(processedInput.poolPath)
 	if err != nil {
 		panic(err)
@@ -113,7 +117,7 @@ func (p *positionV1) Mint(
 		"amount0", amount0.ToString(),
 		"amount1", amount1.ToString(),
 		"sqrtPriceX96", pool.Slot0SqrtPriceX96().ToString(),
-		"positionLiquidity", p.GetPositionLiquidity(id),
+		"positionLiquidity", positionLiquidity,
 		"poolLiquidity", pool.Liquidity().ToString(),
 		"token0Balance", utils.FormatInt(pool.BalanceToken0()),
 		"token1Balance", utils.FormatInt(pool.BalanceToken1()),
@@ -203,6 +207,10 @@ func (p *positionV1) IncreaseLiquidity(
 	}
 
 	pool := mustGetPool(poolPath)
+	positionLiquidity, err := p.GetPositionLiquidity(positionId)
+	if err != nil {
+		panic(err)
+	}
 	tickCumulative, secondsPerLiquidityCumulativeX128, observationTimestamp, err := pl.GetLastObservation(poolPath)
 	if err != nil {
 		panic(err)
@@ -220,7 +228,7 @@ func (p *positionV1) IncreaseLiquidity(
 		"amount0", amount0.ToString(),
 		"amount1", amount1.ToString(),
 		"sqrtPriceX96", pool.Slot0SqrtPriceX96().ToString(),
-		"positionLiquidity", p.GetPositionLiquidity(positionId),
+		"positionLiquidity", positionLiquidity,
 		"poolLiquidity", pool.Liquidity().ToString(),
 		"token0Balance", utils.FormatInt(pool.BalanceToken0()),
 		"token1Balance", utils.FormatInt(pool.BalanceToken1()),
@@ -295,6 +303,10 @@ func (p *positionV1) DecreaseLiquidity(
 	}
 
 	pool := mustGetPool(poolPath)
+	positionLiquidity, err := p.GetPositionLiquidity(positionId)
+	if err != nil {
+		panic(err)
+	}
 	tickCumulative, secondsPerLiquidityCumulativeX128, observationTimestamp, err := pl.GetLastObservation(poolPath)
 	if err != nil {
 		panic(err)
@@ -313,7 +325,7 @@ func (p *positionV1) DecreaseLiquidity(
 		"amount0", amount0,
 		"amount1", amount1,
 		"sqrtPriceX96", pool.Slot0SqrtPriceX96().ToString(),
-		"positionLiquidity", p.GetPositionLiquidity(positionId),
+		"positionLiquidity", positionLiquidity,
 		"poolLiquidity", pool.Liquidity().ToString(),
 		"token0Balance", utils.FormatInt(pool.BalanceToken0()),
 		"token1Balance", utils.FormatInt(pool.BalanceToken1()),

--- a/contract/r/gnoswap/position/v1/position.gno
+++ b/contract/r/gnoswap/position/v1/position.gno
@@ -109,6 +109,10 @@ func (p *positionV1) Mint(
 	if err != nil {
 		panic(err)
 	}
+	positionLiquidity, err := p.GetPositionLiquidity(id)
+	if err != nil {
+		panic(err)
+	}
 	tickCumulative, secondsPerLiquidityCumulativeX128, observationTimestamp, err := pl.GetLastObservation(processedInput.poolPath)
 	if err != nil {
 		panic(err)
@@ -128,7 +132,7 @@ func (p *positionV1) Mint(
 		"amount0", amount0.ToString(),
 		"amount1", amount1.ToString(),
 		"sqrtPriceX96", poolSqrtPriceX96,
-		"positionLiquidity", p.GetPositionLiquidity(id),
+		"positionLiquidity", positionLiquidity,
 		"poolLiquidity", poolLiquidity,
 		"token0Balance", utils.FormatInt(poolBalanceToken0),
 		"token1Balance", utils.FormatInt(poolBalanceToken1),
@@ -237,6 +241,10 @@ func (p *positionV1) IncreaseLiquidity(
 	if err != nil {
 		panic(err)
 	}
+	positionLiquidity, err := p.GetPositionLiquidity(positionId)
+	if err != nil {
+		panic(err)
+	}
 
 	chain.Emit(
 		"IncreaseLiquidity",
@@ -251,7 +259,7 @@ func (p *positionV1) IncreaseLiquidity(
 		"amount0", amount0.ToString(),
 		"amount1", amount1.ToString(),
 		"sqrtPriceX96", poolSqrtPriceX96,
-		"positionLiquidity", p.GetPositionLiquidity(positionId),
+		"positionLiquidity", positionLiquidity,
 		"poolLiquidity", poolLiquidity,
 		"token0Balance", utils.FormatInt(poolBalanceToken0),
 		"token1Balance", utils.FormatInt(poolBalanceToken1),
@@ -345,6 +353,10 @@ func (p *positionV1) DecreaseLiquidity(
 	if err != nil {
 		panic(err)
 	}
+	positionLiquidity, err := p.GetPositionLiquidity(positionId)
+	if err != nil {
+		panic(err)
+	}
 
 	chain.Emit(
 		"DecreaseLiquidity",
@@ -360,7 +372,7 @@ func (p *positionV1) DecreaseLiquidity(
 		"amount0", amount0,
 		"amount1", amount1,
 		"sqrtPriceX96", poolSqrtPriceX96,
-		"positionLiquidity", p.GetPositionLiquidity(positionId),
+		"positionLiquidity", positionLiquidity,
 		"poolLiquidity", poolLiquidity,
 		"token0Balance", utils.FormatInt(poolBalanceToken0),
 		"token1Balance", utils.FormatInt(poolBalanceToken1),

--- a/contract/r/gnoswap/position/v1/reposition.gno
+++ b/contract/r/gnoswap/position/v1/reposition.gno
@@ -133,6 +133,10 @@ func (p *positionV1) Reposition(
 	if err != nil {
 		panic(err)
 	}
+	positionLiquidity, err := p.GetPositionLiquidity(positionId)
+	if err != nil {
+		panic(err)
+	}
 
 	chain.Emit(
 		"Reposition",
@@ -148,7 +152,7 @@ func (p *positionV1) Reposition(
 		"prevTickUpper", utils.FormatInt(oldTickUpper),
 		"poolPath", poolKey,
 		"sqrtPriceX96", poolSqrtPriceX96,
-		"positionLiquidity", p.GetPositionLiquidity(positionId),
+		"positionLiquidity", positionLiquidity,
 		"poolLiquidity", poolLiquidity,
 		"token0Balance", utils.FormatInt(poolToken0Balance),
 		"token1Balance", utils.FormatInt(poolToken1Balance),

--- a/contract/r/gnoswap/position/v1/reposition.gno
+++ b/contract/r/gnoswap/position/v1/reposition.gno
@@ -114,6 +114,10 @@ func (p *positionV1) Reposition(
 	p.mustUpdatePosition(0, rlm, positionId, *position)
 
 	pool := mustGetPool(poolKey)
+	positionLiquidity, err := p.GetPositionLiquidity(positionId)
+	if err != nil {
+		panic(err)
+	}
 	tickCumulative, secondsPerLiquidityCumulativeX128, observationTimestamp, err := pl.GetLastObservation(poolKey)
 	if err != nil {
 		panic(err)
@@ -133,7 +137,7 @@ func (p *positionV1) Reposition(
 		"prevTickUpper", utils.FormatInt(oldTickUpper),
 		"poolPath", poolKey,
 		"sqrtPriceX96", pool.Slot0SqrtPriceX96().ToString(),
-		"positionLiquidity", p.GetPositionLiquidity(positionId),
+		"positionLiquidity", positionLiquidity,
 		"poolLiquidity", pool.Liquidity().ToString(),
 		"token0Balance", utils.FormatInt(pool.BalanceToken0()),
 		"token1Balance", utils.FormatInt(pool.BalanceToken1()),

--- a/contract/r/gnoswap/position/v1/utils.gno
+++ b/contract/r/gnoswap/position/v1/utils.gno
@@ -60,7 +60,8 @@ func (p *positionV1) isOwner(positionId uint64, addr address) bool {
 // input: positionId uint64, addr std.Address
 // output: bool
 func (p *positionV1) isOperator(positionId uint64, addr address) bool {
-	return p.GetPositionOperator(positionId) == addr
+	operator, err := p.GetPositionOperator(positionId)
+	return err == nil && operator == addr
 }
 
 // isStaked checks whether positionId is staked

--- a/contract/r/gnoswap/position/v1/utils.gno
+++ b/contract/r/gnoswap/position/v1/utils.gno
@@ -49,7 +49,8 @@ func (p *positionV1) isOwner(positionId uint64, addr address) bool {
 // input: positionId uint64, addr std.Address
 // output: bool
 func (p *positionV1) isOperator(positionId uint64, addr address) bool {
-	return p.GetPositionOperator(positionId) == addr
+	operator, err := p.GetPositionOperator(positionId)
+	return err == nil && operator == addr
 }
 
 // isStaked checks whether positionId is staked

--- a/contract/r/gnoswap/staker/v1/_helper_test.gno
+++ b/contract/r/gnoswap/staker/v1/_helper_test.gno
@@ -548,7 +548,11 @@ func mockNFTApprove(cur realm, approved address, positionId uint64) {
 
 func getPositionOperator(positionId uint64) address {
 	testing.SetRealm(adminRealm)
-	return pn.GetPositionOperator(positionId)
+	operator, err := pn.GetPositionOperator(positionId)
+	if err != nil {
+		panic(err)
+	}
+	return operator
 }
 
 // rewardPerSecondFromX128 returns the floored integer reward-per-second

--- a/contract/r/gnoswap/staker/v1/_helper_test.gno
+++ b/contract/r/gnoswap/staker/v1/_helper_test.gno
@@ -553,7 +553,11 @@ func mockNFTApprove(cur realm, approved address, positionId uint64) {
 
 func getPositionOperator(positionId uint64) address {
 	testing.SetRealm(adminRealm)
-	return pn.GetPositionOperator(positionId)
+	operator, err := pn.GetPositionOperator(positionId)
+	if err != nil {
+		panic(err)
+	}
+	return operator
 }
 
 // rewardPerSecondFromX128 returns the floored integer reward-per-second

--- a/contract/r/gnoswap/staker/v1/staker.gno
+++ b/contract/r/gnoswap/staker/v1/staker.gno
@@ -214,7 +214,10 @@ func (s *stakerV1) StakeToken(_ int, rlm realm, positionId uint64, referrer stri
 	caller := previousRealm.Address()
 	currentTime := time.Now().Unix()
 
-	owner := s.nftAccessor.MustOwnerOf(positionIdFrom(positionId))
+	owner, err := s.nftAccessor.OwnerOf(positionIdFrom(positionId))
+	if err != nil {
+		panic(err.Error())
+	}
 	assertIsPositionOwner(owner, caller)
 
 	actualReferrer := referral.TryRegister(cross(rlm), caller, referrer)
@@ -224,7 +227,10 @@ func (s *stakerV1) StakeToken(_ int, rlm realm, positionId uint64, referrer stri
 	}
 
 	// check pool path from positionId
-	poolPath := pn.GetPositionPoolKey(positionId)
+	poolPath, err := pn.GetPositionPoolKey(positionId)
+	if err != nil {
+		panic(err)
+	}
 	pools := s.getPools()
 
 	pool, ok := pools.Get(poolPath)
@@ -235,7 +241,7 @@ func (s *stakerV1) StakeToken(_ int, rlm realm, positionId uint64, referrer stri
 		))
 	}
 
-	err := s.poolHasIncentives(pool)
+	err = s.poolHasIncentives(pool)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -300,7 +306,11 @@ func (s *stakerV1) StakeToken(_ int, rlm realm, positionId uint64, referrer stri
 	poolResolver := NewPoolResolver(pool)
 
 	isInRange := false
-	if pn.IsInRange(positionId) {
+	inRange, err := pn.IsInRange(positionId)
+	if err != nil {
+		panic(err)
+	}
+	if inRange {
 		isInRange = true
 		poolResolver.modifyDeposit(signedLiquidity, currentTime, currentTick)
 	}
@@ -782,7 +792,11 @@ func (s *stakerV1) applyUnStake(positionId uint64) error {
 	currentTime := time.Now().Unix()
 	currentTick := s.poolAccessor.GetSlot0Tick(depositResolver.TargetPoolPath())
 	signedLiquidity := i256.Zero().Neg(i256.FromUint256(depositResolver.Liquidity()))
-	if pn.IsInRange(positionId) {
+	inRange, err := pn.IsInRange(positionId)
+	if err != nil {
+		return err
+	}
+	if inRange {
 		poolResolver.modifyDeposit(signedLiquidity, currentTime, currentTick)
 	}
 
@@ -828,12 +842,23 @@ func tokenHasLiquidity(positionId uint64) error {
 }
 
 func getLiquidity(positionId uint64) *u256.Uint {
-	return u256.MustFromDecimal(pn.GetPositionLiquidity(positionId))
+	liquidity, err := pn.GetPositionLiquidity(positionId)
+	if err != nil {
+		panic(err)
+	}
+
+	return u256.MustFromDecimal(liquidity)
 }
 
 func getTickOf(positionId uint64) (int32, int32) {
-	tickLower := pn.GetPositionTickLower(positionId)
-	tickUpper := pn.GetPositionTickUpper(positionId)
+	tickLower, err := pn.GetPositionTickLower(positionId)
+	if err != nil {
+		panic(err)
+	}
+	tickUpper, err := pn.GetPositionTickUpper(positionId)
+	if err != nil {
+		panic(err)
+	}
 	if tickUpper < tickLower {
 		panic(ufmt.Sprintf("tickUpper(%d) is less than tickLower(%d)", tickUpper, tickLower))
 	}

--- a/contract/r/gnoswap/test/fuzz/_helper_test.gno
+++ b/contract/r/gnoswap/test/fuzz/_helper_test.gno
@@ -256,9 +256,27 @@ func getTokenPathsFromPosition(tokenId uint64) (string, string) {
 	return token0, token1
 }
 
+func mustGetPositionPoolKey(positionId uint64) string {
+	poolKey, err := position.GetPositionPoolKey(positionId)
+	if err != nil {
+		panic(err)
+	}
+
+	return poolKey
+}
+
+func mustGetPositionLiquidity(positionId uint64) string {
+	liquidity, err := position.GetPositionLiquidity(positionId)
+	if err != nil {
+		panic(err)
+	}
+
+	return liquidity
+}
+
 // getPoolInfoFromPosition extracts token0Path, token1Path, and fee tier from a position
 func getPoolInfoFromPosition(tokenId uint64) (string, string, uint32) {
-	poolKey := position.GetPositionPoolKey(tokenId)
+	poolKey := mustGetPositionPoolKey(tokenId)
 	return parsePoolKey(poolKey)
 }
 

--- a/contract/r/gnoswap/test/fuzz/position_collect_fee_params_test.gno
+++ b/contract/r/gnoswap/test/fuzz/position_collect_fee_params_test.gno
@@ -25,7 +25,10 @@ func (p *positionCollectFeeParams) IsValid() bool {
 		return false
 	}
 
-	poolPath := position.GetPositionPoolKey(p.positionId)
+	poolPath, err := position.GetPositionPoolKey(p.positionId)
+	if err != nil {
+		return false
+	}
 	if poolPath == "" {
 		return false
 	}
@@ -76,7 +79,10 @@ func NewRandomizedPositionCollectFeeParams(t *fuzz.T, existingPositionId uint64)
 }
 
 func newExistingPositionCollectFeeParams(positionId uint64) *positionCollectFeeParams {
-	poolPath := position.GetPositionPoolKey(positionId)
+	poolPath, err := position.GetPositionPoolKey(positionId)
+	if err != nil {
+		panic(err)
+	}
 	return &positionCollectFeeParams{
 		positionId: positionId,
 		poolPath:   poolPath,

--- a/contract/r/gnoswap/test/fuzz/position_decrease_liquidity_params_test.gno
+++ b/contract/r/gnoswap/test/fuzz/position_decrease_liquidity_params_test.gno
@@ -33,7 +33,10 @@ func (p *positionDecreaseLiquidityParams) IsValid() bool {
 		return false
 	}
 
-	poolPath := position.GetPositionPoolKey(p.positionId)
+	poolPath, err := position.GetPositionPoolKey(p.positionId)
+	if err != nil {
+		return false
+	}
 	if poolPath == "" || !pool.ExistsPoolPath(poolPath) {
 		return false
 	}
@@ -52,7 +55,7 @@ func (p *positionDecreaseLiquidityParams) IsValid() bool {
 	}
 
 	// Liquidity must not exceed current position liquidity
-	currentLiquidity := u256.MustFromDecimal(position.GetPositionLiquidity(p.positionId))
+	currentLiquidity := u256.MustFromDecimal(mustGetPositionLiquidity(p.positionId))
 	if liq.Gt(currentLiquidity) {
 		return false
 	}
@@ -119,7 +122,7 @@ func NewRandomizedPositionDecreaseLiquidityParams(t *fuzz.T, existingPositionId 
 }
 
 func newValidPositionDecreaseLiquidityParams(t *fuzz.T, positionId uint64) *positionDecreaseLiquidityParams {
-	currentLiquidity := u256.MustFromDecimal(position.GetPositionLiquidity(positionId))
+	currentLiquidity := u256.MustFromDecimal(mustGetPositionLiquidity(positionId))
 	if currentLiquidity.IsZero() {
 		panic("position liquidity must be positive for valid decrease fuzz case")
 	}
@@ -138,6 +141,6 @@ func newValidPositionDecreaseLiquidityParams(t *fuzz.T, positionId uint64) *posi
 		amount0Min: "0",
 		amount1Min: "0",
 		deadline:   deadline,
-		poolPath:   position.GetPositionPoolKey(positionId),
+		poolPath:   mustGetPositionPoolKey(positionId),
 	}
 }

--- a/contract/r/gnoswap/test/fuzz/position_increase_liquidity_params_test.gno
+++ b/contract/r/gnoswap/test/fuzz/position_increase_liquidity_params_test.gno
@@ -35,7 +35,10 @@ func (p *positionIncreaseLiquidityParams) IsValid() bool {
 		return false
 	}
 
-	poolPath := position.GetPositionPoolKey(p.positionId)
+	poolPath, err := position.GetPositionPoolKey(p.positionId)
+	if err != nil {
+		return false
+	}
 	if poolPath == "" || !pool.ExistsPoolPath(poolPath) {
 		return false
 	}
@@ -134,7 +137,7 @@ func NewRandomizedPositionIncreaseLiquidityParams(t *fuzz.T, existingPositionId 
 }
 
 func newValidPositionIncreaseLiquidityParams(t *fuzz.T, positionId uint64) *positionIncreaseLiquidityParams {
-	poolPath := position.GetPositionPoolKey(positionId)
+	poolPath := mustGetPositionPoolKey(positionId)
 	if poolPath == "" {
 		panic("poolPath must exist for position")
 	}

--- a/contract/r/gnoswap/test/fuzz/position_increase_liquidity_test.gno
+++ b/contract/r/gnoswap/test/fuzz/position_increase_liquidity_test.gno
@@ -146,7 +146,7 @@ func TestFuzzPositionIncreaseLiquidity_ValidParams_Stateful(cur realm, t *testin
 		common.SafeGRC20Approve(cross(cur), token1Path, poolAddr, math.MaxInt64)
 
 		// Get current total liquidity before increase
-		prevTotalLiquidity := u256.MustFromDecimal(position.GetPositionLiquidity(tokenId))
+		prevTotalLiquidity := u256.MustFromDecimal(mustGetPositionLiquidity(tokenId))
 
 		// when - increase liquidity
 		_, liquidity, amount0, amount1, _ := position.IncreaseLiquidity(
@@ -165,7 +165,7 @@ func TestFuzzPositionIncreaseLiquidity_ValidParams_Stateful(cur realm, t *testin
 		}
 
 		// Get new total liquidity after increase
-		newTotalLiquidity := u256.MustFromDecimal(position.GetPositionLiquidity(tokenId))
+		newTotalLiquidity := u256.MustFromDecimal(mustGetPositionLiquidity(tokenId))
 
 		// Verify total liquidity increased
 		if newTotalLiquidity.Lte(prevTotalLiquidity) {
@@ -210,7 +210,7 @@ func TestFuzzPositionIncreaseLiquidity_RandomizedParams_Stateful(cur realm, t *t
 		// when - increase liquidity (may panic with invalid params)
 		//
 		// Get current total liquidity before increase
-		prevTotalLiquidity := u256.MustFromDecimal(position.GetPositionLiquidity(tokenId))
+		prevTotalLiquidity := u256.MustFromDecimal(mustGetPositionLiquidity(tokenId))
 
 		// when - increase liquidity
 		_, liquidity, amount0, amount1, _ := position.IncreaseLiquidity(
@@ -232,7 +232,7 @@ func TestFuzzPositionIncreaseLiquidity_RandomizedParams_Stateful(cur realm, t *t
 		}
 
 		// Get new total liquidity after increase
-		newTotalLiquidity := u256.MustFromDecimal(position.GetPositionLiquidity(tokenId))
+		newTotalLiquidity := u256.MustFromDecimal(mustGetPositionLiquidity(tokenId))
 
 		// Verify total liquidity increased
 		if newTotalLiquidity.Lte(prevTotalLiquidity) {

--- a/contract/r/gnoswap/test/fuzz/position_reposition_params_test.gno
+++ b/contract/r/gnoswap/test/fuzz/position_reposition_params_test.gno
@@ -36,7 +36,10 @@ func (p *positionRepositionParams) IsValid() bool {
 		return false
 	}
 
-	poolPath := position.GetPositionPoolKey(p.positionId)
+	poolPath, err := position.GetPositionPoolKey(p.positionId)
+	if err != nil {
+		return false
+	}
 	if poolPath == "" || !pool.ExistsPoolPath(poolPath) {
 		return false
 	}

--- a/contract/r/gnoswap/test/fuzz/position_reposition_test.gno
+++ b/contract/r/gnoswap/test/fuzz/position_reposition_test.gno
@@ -30,7 +30,7 @@ func TestFuzzPositionReposition_ValidParams_Stateless(cur realm, t *testing.T) {
 		tokenId := createTestPosition(cur, t, adminAddr, poolAddr)
 
 		// Get the actual liquidity from the position
-		liquidity := position.GetPositionLiquidity(tokenId)
+		liquidity := mustGetPositionLiquidity(tokenId)
 
 		// Clear the position first (Reposition requires position to be fully cleared)
 		deadline := randomFutureDeadline(ft)
@@ -110,7 +110,7 @@ func TestFuzzPositionReposition_RandomizedParams_Stateless(cur realm, t *testing
 		tokenId := createTestPosition(cur, t, adminAddr, poolAddr)
 
 		// Get the actual liquidity from the position
-		liquidity := position.GetPositionLiquidity(tokenId)
+		liquidity := mustGetPositionLiquidity(tokenId)
 
 		// Clear the position first (Reposition requires position to be fully cleared)
 		deadline := randomFutureDeadline(ft)
@@ -180,7 +180,7 @@ func TestFuzzPositionReposition_ValidParams_Stateful(cur realm, t *testing.T) {
 		testing.SetRealm(testing.NewUserRealm(adminAddr))
 
 		// Get the current position's liquidity
-		liquidity := position.GetPositionLiquidity(tokenId)
+		liquidity := mustGetPositionLiquidity(tokenId)
 
 		// Clear the position first (Reposition requires position to be fully cleared)
 		deadline := randomFutureDeadline(ft)
@@ -194,7 +194,7 @@ func TestFuzzPositionReposition_ValidParams_Stateful(cur realm, t *testing.T) {
 		)
 
 		// Verify position is now empty
-		liquidityAfterDecrease := position.GetPositionLiquidity(tokenId)
+		liquidityAfterDecrease := mustGetPositionLiquidity(tokenId)
 		if liquidityAfterDecrease != "0" {
 			panic(ufmt.Sprintf("Position should be empty after DecreaseLiquidity, but has %s", liquidityAfterDecrease))
 		}
@@ -277,7 +277,7 @@ func TestFuzzPositionReposition_RandomizedParams_Stateful(cur realm, t *testing.
 	fuzzutils.RunFuzzTest(t, FUZZ_ITERATIONS, func(ft *fuzz.T, fuzzResult *fuzzutils.Result, index int) {
 		testing.SetRealm(testing.NewUserRealm(adminAddr))
 
-		liquidity := position.GetPositionLiquidity(tokenId)
+		liquidity := mustGetPositionLiquidity(tokenId)
 		deadline := randomFutureDeadline(ft)
 		position.DecreaseLiquidity(
 			cross(cur),

--- a/contract/r/scenario/getter/position_getter_filetest.gno
+++ b/contract/r/scenario/getter/position_getter_filetest.gno
@@ -270,7 +270,10 @@ func isBurned(cur realm) {
 	println("[INFO] Check IsBurned method")
 	testing.SetRealm(adminRealm)
 
-	burned := pn.IsBurned(positionId)
+	burned, err := pn.IsBurned(positionId)
+	if err != nil {
+		panic(err)
+	}
 	ufmt.Printf("[EXPECTED] position %d is burned: %t\n", positionId, burned)
 }
 
@@ -278,7 +281,10 @@ func isInRange(cur realm) {
 	println("[INFO] Check IsInRange method")
 	testing.SetRealm(adminRealm)
 
-	inRange := pn.IsInRange(positionId)
+	inRange, err := pn.IsInRange(positionId)
+	if err != nil {
+		panic(err)
+	}
 	ufmt.Printf("[EXPECTED] position %d is in range: %t\n", positionId, inRange)
 }
 
@@ -286,8 +292,14 @@ func getPositionTokenBalances(cur realm) {
 	println("[INFO] Check GetPositionTokenBalances method")
 	testing.SetRealm(adminRealm)
 
-	balance0, balance1 := pn.GetPositionTokenBalances(positionId)
-	unclaimedFee0, unclaimedFee1 := pn.GetUnclaimedFee(positionId)
+	balance0, balance1, err := pn.GetPositionTokenBalances(positionId)
+	if err != nil {
+		panic(err)
+	}
+	unclaimedFee0, unclaimedFee1, err := pn.GetUnclaimedFee(positionId)
+	if err != nil {
+		panic(err)
+	}
 	println("[EXPECTED] position token0 balance:", balance0)
 	println("[EXPECTED] position token1 balance:", balance1)
 	println("[EXPECTED] pool token0 balance:", bar.BalanceOf(poolAddr))
@@ -300,7 +312,10 @@ func getPositionToken0Balance(cur realm) {
 	println("[INFO] Check GetPositionToken0Balance method")
 	testing.SetRealm(adminRealm)
 
-	balance0 := pn.GetPositionToken0Balance(positionId)
+	balance0, err := pn.GetPositionToken0Balance(positionId)
+	if err != nil {
+		panic(err)
+	}
 	println("[EXPECTED] position token0 balance:", balance0)
 }
 
@@ -308,7 +323,10 @@ func getPositionToken1Balance(cur realm) {
 	println("[INFO] Check GetPositionToken1Balance method")
 	testing.SetRealm(adminRealm)
 
-	balance1 := pn.GetPositionToken1Balance(positionId)
+	balance1, err := pn.GetPositionToken1Balance(positionId)
+	if err != nil {
+		panic(err)
+	}
 	println("[EXPECTED] position token1 balance:", balance1)
 }
 
@@ -316,7 +334,10 @@ func getPositionFeeGrowthInside0LastX128(cur realm) {
 	println("[INFO] Check GetPositionFeeGrowthInside0LastX128 method")
 	testing.SetRealm(adminRealm)
 
-	feeGrowth := pn.GetPositionFeeGrowthInside0LastX128(positionId)
+	feeGrowth, err := pn.GetPositionFeeGrowthInside0LastX128(positionId)
+	if err != nil {
+		panic(err)
+	}
 	println("[EXPECTED] position feeGrowthInside0LastX128:", feeGrowth)
 }
 
@@ -324,7 +345,10 @@ func getPositionFeeGrowthInside1LastX128(cur realm) {
 	println("[INFO] Check GetPositionFeeGrowthInside1LastX128 method")
 	testing.SetRealm(adminRealm)
 
-	feeGrowth := pn.GetPositionFeeGrowthInside1LastX128(positionId)
+	feeGrowth, err := pn.GetPositionFeeGrowthInside1LastX128(positionId)
+	if err != nil {
+		panic(err)
+	}
 	println("[EXPECTED] position feeGrowthInside1LastX128:", feeGrowth)
 }
 
@@ -332,7 +356,10 @@ func getPositionFeeGrowthInsideLastX128(cur realm) {
 	println("[INFO] Check GetPositionFeeGrowthInsideLastX128 method")
 	testing.SetRealm(adminRealm)
 
-	feeGrowth0, feeGrowth1 := pn.GetPositionFeeGrowthInsideLastX128(positionId)
+	feeGrowth0, feeGrowth1, err := pn.GetPositionFeeGrowthInsideLastX128(positionId)
+	if err != nil {
+		panic(err)
+	}
 	println("[EXPECTED] position feeGrowthInside0LastX128:", feeGrowth0)
 	println("[EXPECTED] position feeGrowthInside1LastX128:", feeGrowth1)
 }
@@ -341,7 +368,10 @@ func getPositionLiquidity(cur realm) {
 	println("[INFO] Check GetPositionLiquidity method")
 	testing.SetRealm(adminRealm)
 
-	liquidity := pn.GetPositionLiquidity(positionId)
+	liquidity, err := pn.GetPositionLiquidity(positionId)
+	if err != nil {
+		panic(err)
+	}
 	println("[EXPECTED] position liquidity:", liquidity)
 }
 
@@ -349,7 +379,10 @@ func getPositionOperator(cur realm) {
 	println("[INFO] Check GetPositionOperator method")
 	testing.SetRealm(adminRealm)
 
-	operator := pn.GetPositionOperator(positionId)
+	operator, err := pn.GetPositionOperator(positionId)
+	if err != nil {
+		panic(err)
+	}
 	println("[EXPECTED] position operator:", operator.String())
 }
 
@@ -357,7 +390,10 @@ func getPositionPoolKey(cur realm) {
 	println("[INFO] Check GetPositionPoolKey method")
 	testing.SetRealm(adminRealm)
 
-	poolKey := pn.GetPositionPoolKey(positionId)
+	poolKey, err := pn.GetPositionPoolKey(positionId)
+	if err != nil {
+		panic(err)
+	}
 	println("[EXPECTED] position poolKey:", poolKey)
 }
 
@@ -365,7 +401,10 @@ func getPositionTickLower(cur realm) {
 	println("[INFO] Check GetPositionTickLower method")
 	testing.SetRealm(adminRealm)
 
-	tickLower := pn.GetPositionTickLower(positionId)
+	tickLower, err := pn.GetPositionTickLower(positionId)
+	if err != nil {
+		panic(err)
+	}
 	ufmt.Printf("[EXPECTED] position tickLower: %d\n", tickLower)
 }
 
@@ -373,7 +412,10 @@ func getPositionTickUpper(cur realm) {
 	println("[INFO] Check GetPositionTickUpper method")
 	testing.SetRealm(adminRealm)
 
-	tickUpper := pn.GetPositionTickUpper(positionId)
+	tickUpper, err := pn.GetPositionTickUpper(positionId)
+	if err != nil {
+		panic(err)
+	}
 	ufmt.Printf("[EXPECTED] position tickUpper: %d\n", tickUpper)
 }
 
@@ -381,7 +423,10 @@ func getPositionTicks(cur realm) {
 	println("[INFO] Check GetPositionTicks method")
 	testing.SetRealm(adminRealm)
 
-	tickLower, tickUpper := pn.GetPositionTicks(positionId)
+	tickLower, tickUpper, err := pn.GetPositionTicks(positionId)
+	if err != nil {
+		panic(err)
+	}
 	ufmt.Printf("[EXPECTED] position tickLower: %d\n", tickLower)
 	ufmt.Printf("[EXPECTED] position tickUpper: %d\n", tickUpper)
 }
@@ -390,7 +435,10 @@ func getPositionTokensOwed0(cur realm) {
 	println("[INFO] Check GetPositionTokensOwed0 method")
 	testing.SetRealm(adminRealm)
 
-	tokensOwed0 := pn.GetPositionTokensOwed0(positionId)
+	tokensOwed0, err := pn.GetPositionTokensOwed0(positionId)
+	if err != nil {
+		panic(err)
+	}
 	println("[EXPECTED] position tokensOwed0:", tokensOwed0)
 }
 
@@ -398,7 +446,10 @@ func getPositionTokensOwed1(cur realm) {
 	println("[INFO] Check GetPositionTokensOwed1 method")
 	testing.SetRealm(adminRealm)
 
-	tokensOwed1 := pn.GetPositionTokensOwed1(positionId)
+	tokensOwed1, err := pn.GetPositionTokensOwed1(positionId)
+	if err != nil {
+		panic(err)
+	}
 	println("[EXPECTED] position tokensOwed1:", tokensOwed1)
 }
 
@@ -406,7 +457,10 @@ func getPositionTokensOwed(cur realm) {
 	println("[INFO] Check GetPositionTokensOwed method")
 	testing.SetRealm(adminRealm)
 
-	tokensOwed0, tokensOwed1 := pn.GetPositionTokensOwed(positionId)
+	tokensOwed0, tokensOwed1, err := pn.GetPositionTokensOwed(positionId)
+	if err != nil {
+		panic(err)
+	}
 	println("[EXPECTED] position tokensOwed0:", tokensOwed0)
 	println("[EXPECTED] position tokensOwed1:", tokensOwed1)
 }
@@ -415,7 +469,10 @@ func getUnclaimedFee(cur realm) {
 	println("[INFO] Check GetUnclaimedFee method")
 	testing.SetRealm(adminRealm)
 
-	unclaimedFee0, unclaimedFee1 := pn.GetUnclaimedFee(positionId)
+	unclaimedFee0, unclaimedFee1, err := pn.GetUnclaimedFee(positionId)
+	if err != nil {
+		panic(err)
+	}
 	println("[EXPECTED] position unclaimedFee0:", unclaimedFee0)
 	println("[EXPECTED] position unclaimedFee1:", unclaimedFee1)
 }
@@ -424,7 +481,10 @@ func getPositionOwner(cur realm) {
 	println("[INFO] Check GetPositionOwner method")
 	testing.SetRealm(adminRealm)
 
-	owner := pn.GetPositionOwner(positionId)
+	owner, err := pn.GetPositionOwner(positionId)
+	if err != nil {
+		panic(err)
+	}
 	println("[EXPECTED] position owner:", owner.String())
 }
 

--- a/contract/r/scenario/position/basic_position_management_filetest.gno
+++ b/contract/r/scenario/position/basic_position_management_filetest.gno
@@ -183,11 +183,11 @@ func testPositionCreationAndRetrieval(cur realm) {
 
 	println("[INFO] Retrieving position details")
 	testing.SetRealm(bobRealm)
-	poolKey := pn.GetPositionPoolKey(positionId)
-	tickLower := pn.GetPositionTickLower(positionId)
-	tickUpper := pn.GetPositionTickUpper(positionId)
-	positionLiquidity := pn.GetPositionLiquidity(positionId)
-	operator := pn.GetPositionOperator(positionId)
+	poolKey, _ := pn.GetPositionPoolKey(positionId)
+	tickLower, _ := pn.GetPositionTickLower(positionId)
+	tickUpper, _ := pn.GetPositionTickUpper(positionId)
+	positionLiquidity, _ := pn.GetPositionLiquidity(positionId)
+	operator, _ := pn.GetPositionOperator(positionId)
 
 	// then
 	println("[EXPECTED] Position created successfully with ID:", positionId)
@@ -196,8 +196,10 @@ func testPositionCreationAndRetrieval(cur realm) {
 	println("[EXPECTED] Position tick upper:", tickUpper)
 	println("[EXPECTED] Position liquidity:", positionLiquidity)
 	println("[EXPECTED] Position operator: zero address", operator)
-	println("[EXPECTED] Position is not burned:", !pn.IsBurned(positionId))
-	println("[EXPECTED] Position is in range:", pn.IsInRange(positionId))
+	burned, _ := pn.IsBurned(positionId)
+	inRange, _ := pn.IsInRange(positionId)
+	println("[EXPECTED] Position is not burned:", !burned)
+	println("[EXPECTED] Position is in range:", inRange)
 }
 
 func testPositionModification(cur realm) {
@@ -235,9 +237,9 @@ func testPositionModification(cur realm) {
 	)
 
 	println("[INFO] Retrieving modified position details")
-	modifiedLiquidity := pn.GetPositionLiquidity(positionId)
-	tokensOwed0 := pn.GetPositionTokensOwed0(positionId)
-	tokensOwed1 := pn.GetPositionTokensOwed1(positionId)
+	modifiedLiquidity, _ := pn.GetPositionLiquidity(positionId)
+	tokensOwed0, _ := pn.GetPositionTokensOwed0(positionId)
+	tokensOwed1, _ := pn.GetPositionTokensOwed1(positionId)
 
 	// then
 	println("[EXPECTED] Position modified successfully")
@@ -274,7 +276,7 @@ func testPositionDeletion(cur realm) {
 	)
 
 	println("[INFO] Verifying position exists before deletion")
-	existsBefore := pn.IsBurned(positionId)
+	existsBefore, _ := pn.IsBurned(positionId)
 
 	// need to add gnft approve
 	// by doing this, we can manage position
@@ -292,7 +294,7 @@ func testPositionDeletion(cur realm) {
 	)
 
 	println("[INFO] Verifying position is burned after deletion")
-	existsAfter := pn.IsBurned(positionId)
+	existsAfter, _ := pn.IsBurned(positionId)
 
 	// then
 	println("[EXPECTED] Position existed before deletion:", !existsBefore)

--- a/contract/r/scenario/position/contract_owned_position_lifecycle_filetest.gno
+++ b/contract/r/scenario/position/contract_owned_position_lifecycle_filetest.gno
@@ -128,7 +128,8 @@ func setupPoolAndFundVault(cur realm) {
 	foo.Transfer(cross(cur), vaultAddr, 150000000)
 
 	ufmt.Printf("[EXPECTED] pool path: %s\n", poolPath)
-	ufmt.Printf("[EXPECTED] pool tier after setup: %d\n", staker.GetPoolTier(poolPath))
+	tier := staker.GetPoolTier(poolPath)
+	ufmt.Printf("[EXPECTED] pool tier after setup: %d\n", tier)
 	ufmt.Printf("[EXPECTED] vault bar balance after funding: %d\n", bar.BalanceOf(vaultAddr))
 	ufmt.Printf("[EXPECTED] vault foo balance after funding: %d\n", foo.BalanceOf(vaultAddr))
 }
@@ -168,7 +169,7 @@ func vaultMintPosition(cur realm) {
 }
 
 func verifyVaultOwnership(cur realm) {
-	owner := position.GetPositionOwner(positionID)
+	owner, _ := position.GetPositionOwner(positionID)
 
 	ufmt.Printf("[EXPECTED] position owner: %s\n", owner.String())
 	ufmt.Printf("[EXPECTED] vault contract address: %s\n", vaultAddr.String())
@@ -207,12 +208,12 @@ func generateFees(cur realm) {
 	)
 
 	poolPath := pool.GetPoolPath(barPath, fooPath, fee)
-	poolTick, _ := pool.GetSlot0Tick(poolPath)
-	balance0, _ := pool.GetBalanceToken0(poolPath)
-	balance1, _ := pool.GetBalanceToken1(poolPath)
-	ufmt.Printf("[EXPECTED] pool tick after swaps: %d\n", poolTick)
-	ufmt.Printf("[EXPECTED] pool token0 balance after swaps: %d\n", balance0)
-	ufmt.Printf("[EXPECTED] pool token1 balance after swaps: %d\n", balance1)
+	currentTick, _ := pool.GetSlot0Tick(poolPath)
+	balanceToken0, _ := pool.GetBalanceToken0(poolPath)
+	balanceToken1, _ := pool.GetBalanceToken1(poolPath)
+	ufmt.Printf("[EXPECTED] pool tick after swaps: %d\n", currentTick)
+	ufmt.Printf("[EXPECTED] pool token0 balance after swaps: %d\n", balanceToken0)
+	ufmt.Printf("[EXPECTED] pool token1 balance after swaps: %d\n", balanceToken1)
 }
 
 func vaultCollectFees(cur realm) {
@@ -241,7 +242,7 @@ func vaultCollectFees(cur realm) {
 }
 
 func vaultIncreaseLiquidity(cur realm) {
-	liquidityBefore := position.GetPositionLiquidity(positionID)
+	liquidityBefore, _ := position.GetPositionLiquidity(positionID)
 
 	testing.SetRealm(vaultRealm)
 	bar.Approve(cross(cur), poolAddr, INT64_MAX)
@@ -263,15 +264,16 @@ func vaultIncreaseLiquidity(cur realm) {
 		)
 	}(cross(cur))
 
-	liquidityAfter := position.GetPositionLiquidity(positionID)
+	liquidityAfter, _ := position.GetPositionLiquidity(positionID)
 
 	ufmt.Printf("[EXPECTED] liquidity before increase: %s\n", liquidityBefore)
 	ufmt.Printf("[EXPECTED] liquidity after increase: %s\n", liquidityAfter)
-	ufmt.Printf("[EXPECTED] owner after increase: %s\n", position.GetPositionOwner(positionID).String())
+	owner, _ := position.GetPositionOwner(positionID)
+	ufmt.Printf("[EXPECTED] owner after increase: %s\n", owner.String())
 }
 
 func vaultDecreaseAllLiquidity(cur realm) {
-	liquidityBefore := position.GetPositionLiquidity(positionID)
+	liquidityBefore, _ := position.GetPositionLiquidity(positionID)
 
 	testing.SetRealm(originRealm)
 	testing.SetOriginCaller(originAddr)
@@ -289,12 +291,13 @@ func vaultDecreaseAllLiquidity(cur realm) {
 		)
 	}(cross(cur))
 
-	liquidityAfter := position.GetPositionLiquidity(positionID)
+	liquidityAfter, _ := position.GetPositionLiquidity(positionID)
 
 	ufmt.Printf("[EXPECTED] liquidity before decrease: %s\n", liquidityBefore)
 	ufmt.Printf("[EXPECTED] removed liquidity: %s\n", removedLiquidity)
 	ufmt.Printf("[EXPECTED] liquidity after decrease: %s\n", liquidityAfter)
-	ufmt.Printf("[EXPECTED] owner after decrease: %s\n", position.GetPositionOwner(positionID).String())
+	owner, _ := position.GetPositionOwner(positionID)
+	ufmt.Printf("[EXPECTED] owner after decrease: %s\n", owner.String())
 }
 
 func vaultReposition(cur realm) {
@@ -325,7 +328,8 @@ func vaultReposition(cur realm) {
 
 	ufmt.Printf("[EXPECTED] repositioned liquidity: %s\n", liquidity)
 	ufmt.Printf("[EXPECTED] repositioned tick range: [%d, %d]\n", tickLower, tickUpper)
-	ufmt.Printf("[EXPECTED] owner after reposition: %s\n", position.GetPositionOwner(positionID).String())
+	owner, _ := position.GetPositionOwner(positionID)
+	ufmt.Printf("[EXPECTED] owner after reposition: %s\n", owner.String())
 }
 
 func vaultStakePosition(cur realm) {
@@ -339,12 +343,13 @@ func vaultStakePosition(cur realm) {
 		poolPath = staker.StakeToken(cross(cur), positionID, "")
 	}(cross(cur))
 
-	owner := gnft.MustOwnerOf(positionIdToTokenId(cur, positionID))
+	owner := mustOwnerOf(positionIdToTokenId(cur, positionID))
 
 	ufmt.Printf("[EXPECTED] staked pool path: %s\n", poolPath)
 	ufmt.Printf("[EXPECTED] position owner after stake: %s\n", owner.String())
 	ufmt.Printf("[EXPECTED] staker contract address: %s\n", stakerAddr.String())
-	ufmt.Printf("[EXPECTED] deposit owner after stake: %s\n", staker.GetDepositOwner(positionID).String())
+	depositOwner := staker.GetDepositOwner(positionID)
+	ufmt.Printf("[EXPECTED] deposit owner after stake: %s\n", depositOwner.String())
 }
 
 func vaultCollectFeesWhileStaked(cur realm) {
@@ -389,7 +394,7 @@ func vaultUnstakePosition(cur realm) {
 		poolPath = staker.UnStakeToken(cross(cur), positionID)
 	}(cross(cur))
 
-	owner := gnft.MustOwnerOf(positionIdToTokenId(cur, positionID))
+	owner := mustOwnerOf(positionIdToTokenId(cur, positionID))
 
 	ufmt.Printf("[EXPECTED] unstaked pool path: %s\n", poolPath)
 	ufmt.Printf("[EXPECTED] position owner after unstake: %s\n", owner.String())
@@ -411,6 +416,14 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	}
 
 	return nil
+}
+
+func mustOwnerOf(tid grc721.TokenID) address {
+	owner, err := gnft.OwnerOf(tid)
+	if err != nil {
+		panic(err.Error())
+	}
+	return owner
 }
 
 // Output:

--- a/contract/r/scenario/position/liquidity_management_filetest.gno
+++ b/contract/r/scenario/position/liquidity_management_filetest.gno
@@ -38,10 +38,10 @@ const (
 
 // Variables for test addresses and realms
 var (
-	adminAddr, _         = access.GetAddress(prbac.ROLE_ADMIN.String())
-	adminRealm           = testing.NewUserRealm(adminAddr)
-	poolAddr, _         = access.GetAddress(prbac.ROLE_POOL.String())
-	positionAddr, _     = access.GetAddress(prbac.ROLE_POSITION.String())
+	adminAddr, _    = access.GetAddress(prbac.ROLE_ADMIN.String())
+	adminRealm      = testing.NewUserRealm(adminAddr)
+	poolAddr, _     = access.GetAddress(prbac.ROLE_POOL.String())
+	positionAddr, _ = access.GetAddress(prbac.ROLE_POSITION.String())
 
 	aliceAddr  = testutils.TestAddress("alice")
 	aliceRealm = testing.NewUserRealm(aliceAddr)
@@ -176,7 +176,8 @@ func testAddLiquiditySuccess(cur realm) {
 	println("[EXPECTED] Additional amount0:", amount0)
 	println("[EXPECTED] Additional amount1:", amount1)
 	println("[EXPECTED] Pool path:", poolPath)
-	println("[EXPECTED] Total liquidity after addition:", pn.GetPositionLiquidity(positionId))
+	liquidity, _ := pn.GetPositionLiquidity(positionId)
+	println("[EXPECTED] Total liquidity after addition:", liquidity)
 }
 
 func testAddLiquidityWithInvalidSlippage(cur realm) {
@@ -374,7 +375,7 @@ func testDecreaseLiquiditySuccess(cur realm) {
 	)
 
 	println("[INFO] Verifying position exists before decrease")
-	existsBefore := pn.IsBurned(positionId)
+	existsBefore, _ := pn.IsBurned(positionId)
 
 	// alice is position owner, so she can approve gnft
 	testing.SetRealm(aliceRealm)
@@ -392,7 +393,7 @@ func testDecreaseLiquiditySuccess(cur realm) {
 	)
 
 	println("[INFO] Verifying position after decrease")
-	existsAfter := pn.IsBurned(positionId)
+	existsAfter, _ := pn.IsBurned(positionId)
 
 	// then
 	println("[EXPECTED] Liquidity decreased successfully")
@@ -402,7 +403,8 @@ func testDecreaseLiquiditySuccess(cur realm) {
 	println("[EXPECTED] Collected fee1:", fee1)
 	println("[EXPECTED] Collected amount0:", amount0)
 	println("[EXPECTED] Collected amount1:", amount1)
-	println("[EXPECTED] Remaining liquidity:", pn.GetPositionLiquidity(positionId))
+	liquidity, _ := pn.GetPositionLiquidity(positionId)
+	println("[EXPECTED] Remaining liquidity:", liquidity)
 }
 
 func testDecreaseLiquidityWithOverRemoval(cur realm) {

--- a/contract/r/scenario/position/position_balance_decrease_liquidity_filetest.gno
+++ b/contract/r/scenario/position/position_balance_decrease_liquidity_filetest.gno
@@ -193,8 +193,10 @@ func testDecreaseLiquidityAndBalance(cur realm) {
 	ufmt.Printf("[EXPECTED] BAR balance increased by %d from decrease\n", barChange)
 	ufmt.Printf("[EXPECTED] FOO balance increased by %d from decrease\n", fooChange)
 
-	ufmt.Printf("[EXPECTED] Position token0 balance should be %d\n", position.GetPositionToken0Balance(1))
-	ufmt.Printf("[EXPECTED] Position token1 balance should be %d\n", position.GetPositionToken1Balance(1))
+	balance0, _ := position.GetPositionToken0Balance(1)
+	balance1, _ := position.GetPositionToken1Balance(1)
+	ufmt.Printf("[EXPECTED] Position token0 balance should be %d\n", balance0)
+	ufmt.Printf("[EXPECTED] Position token1 balance should be %d\n", balance1)
 
 	poolInfo, _ := pool.GetPools().Get(pool.GetPoolPath(barPath, fooPath, fee500)).(*pool.Pool)
 	ufmt.Printf("[EXPECTED] Pool token0 balance should be %d\n", poolInfo.BalanceToken0())

--- a/contract/r/scenario/position/position_balance_increase_liquidity_filetest.gno
+++ b/contract/r/scenario/position/position_balance_increase_liquidity_filetest.gno
@@ -142,8 +142,10 @@ func testIncreaseLiquidityAndBalance(cur realm) {
 	ufmt.Printf("[EXPECTED] BAR balance decreased by %d\n", barChange)
 	ufmt.Printf("[EXPECTED] FOO balance decreased by %d\n", fooChange)
 
-	ufmt.Printf("[EXPECTED] Position token0 balance should be %d\n", position.GetPositionToken0Balance(1))
-	ufmt.Printf("[EXPECTED] Position token1 balance should be %d\n", position.GetPositionToken1Balance(1))
+	balance0, _ := position.GetPositionToken0Balance(1)
+	balance1, _ := position.GetPositionToken1Balance(1)
+	ufmt.Printf("[EXPECTED] Position token0 balance should be %d\n", balance0)
+	ufmt.Printf("[EXPECTED] Position token1 balance should be %d\n", balance1)
 
 	poolInfo, _ := pool.GetPools().Get(pool.GetPoolPath(barPath, fooPath, fee500)).(*pool.Pool)
 	ufmt.Printf("[EXPECTED] Pool token0 balance should be %d\n", poolInfo.BalanceToken0())

--- a/contract/r/scenario/position/position_balance_mint_filetest.gno
+++ b/contract/r/scenario/position/position_balance_mint_filetest.gno
@@ -113,8 +113,10 @@ func testMintAndBalance(cur realm) {
 
 	pos, _ := position.GetPositions().Get(utils.Uint64ToString(positionId)).(position.Position)
 	ufmt.Printf("[EXPECTED] Position liquidity should be %s\n", pos.Liquidity())
-	ufmt.Printf("[EXPECTED] Position token0 balance should be %d\n", position.GetPositionToken0Balance(positionId))
-	ufmt.Printf("[EXPECTED] Position token1 balance should be %d\n", position.GetPositionToken1Balance(positionId))
+	balance0, _ := position.GetPositionToken0Balance(positionId)
+	balance1, _ := position.GetPositionToken1Balance(positionId)
+	ufmt.Printf("[EXPECTED] Position token0 balance should be %d\n", balance0)
+	ufmt.Printf("[EXPECTED] Position token1 balance should be %d\n", balance1)
 
 	poolInfo, _ := pool.GetPools().Get(pool.GetPoolPath(barPath, fooPath, fee500)).(*pool.Pool)
 	ufmt.Printf("[EXPECTED] Pool token0 balance should be %d\n", poolInfo.BalanceToken0())

--- a/contract/r/scenario/position/position_balance_reposition_filetest.gno
+++ b/contract/r/scenario/position/position_balance_reposition_filetest.gno
@@ -236,8 +236,10 @@ func testRepositionAndBalance(cur realm) {
 	pos, _ = position.GetPositions().Get(utils.Uint64ToString(1)).(position.Position)
 	ufmt.Printf("[EXPECTED] Final position liquidity should be %s\n", pos.Liquidity())
 	ufmt.Printf("[EXPECTED] Final position tick range should be [%d, %d]\n", pos.TickLower(), pos.TickUpper())
-	ufmt.Printf("[EXPECTED] Final position token0 balance should be %d\n", position.GetPositionToken0Balance(1))
-	ufmt.Printf("[EXPECTED] Final position token1 balance should be %d\n", position.GetPositionToken1Balance(1))
+	balance0, _ := position.GetPositionToken0Balance(1)
+	balance1, _ := position.GetPositionToken1Balance(1)
+	ufmt.Printf("[EXPECTED] Final position token0 balance should be %d\n", balance0)
+	ufmt.Printf("[EXPECTED] Final position token1 balance should be %d\n", balance1)
 	ufmt.Printf("[EXPECTED] Final pool balance change should be %d\n", afterToken0PoolBalance-beforeToken0PoolBalance)
 	ufmt.Printf("[EXPECTED] Final pool balance change should be %d\n", afterToken1PoolBalance-beforeToken1PoolBalance)
 

--- a/contract/r/scenario/position/position_collect_balance_revert_filetest.gno
+++ b/contract/r/scenario/position/position_collect_balance_revert_filetest.gno
@@ -145,7 +145,7 @@ func upgradePool(cur realm) {
 func decreaseLiquidityWithRevertingCollect(cur realm) {
 	testing.SetRealm(adminRealm)
 	barBefore := bar.BalanceOf(adminAddr)
-	owed0Before := position.GetPositionTokensOwed0(1)
+	owed0Before, _ := position.GetPositionTokensOwed0(1)
 
 	// Internal balance is desynced low (forced to 1 by the test implementation)
 	// while tokensOwed0 is larger. The underlying Collect cannot pay, so the
@@ -163,7 +163,7 @@ func decreaseLiquidityWithRevertingCollect(cur realm) {
 	})
 
 	barAfter := bar.BalanceOf(adminAddr)
-	owed0After := position.GetPositionTokensOwed0(1)
+	owed0After, _ := position.GetPositionTokensOwed0(1)
 	poolBalance0, _ := pool.GetBalanceToken0(poolKey)
 
 	if r != nil {

--- a/contract/r/scenario/position/position_decrease_increase_filetest.gno
+++ b/contract/r/scenario/position/position_decrease_increase_filetest.gno
@@ -125,8 +125,10 @@ func checkInitialPositionState(cur realm) {
 	ufmt.Printf("[EXPECTED] Initial position liquidity should be %s\n", pos.Liquidity())
 	ufmt.Printf("[EXPECTED] Initial position tickLower should be %d\n", pos.TickLower())
 	ufmt.Printf("[EXPECTED] Initial position tickUpper should be %d\n", pos.TickUpper())
-	ufmt.Printf("[EXPECTED] Position token0 balance should be %d\n", position.GetPositionToken0Balance(1))
-	ufmt.Printf("[EXPECTED] Position token1 balance should be %d\n", position.GetPositionToken1Balance(1))
+	balance0, _ := position.GetPositionToken0Balance(1)
+	balance1, _ := position.GetPositionToken1Balance(1)
+	ufmt.Printf("[EXPECTED] Position token0 balance should be %d\n", balance0)
+	ufmt.Printf("[EXPECTED] Position token1 balance should be %d\n", balance1)
 }
 
 func increasePositionLiquidity(cur realm) {
@@ -157,8 +159,10 @@ func checkDecreasedPositionState(cur realm) {
 	ufmt.Printf("[EXPECTED] Decreased position liquidity should be %s\n", pos.Liquidity())
 	ufmt.Printf("[EXPECTED] Position tickLower should be unchanged at %d\n", pos.TickLower())
 	ufmt.Printf("[EXPECTED] Position tickUpper should be unchanged at %d\n", pos.TickUpper())
-	ufmt.Printf("[EXPECTED] Position token0 balance should be %d\n", position.GetPositionToken0Balance(1))
-	ufmt.Printf("[EXPECTED] Position token1 balance should be %d\n", position.GetPositionToken1Balance(1))
+	balance0, _ := position.GetPositionToken0Balance(1)
+	balance1, _ := position.GetPositionToken1Balance(1)
+	ufmt.Printf("[EXPECTED] Position token0 balance should be %d\n", balance0)
+	ufmt.Printf("[EXPECTED] Position token1 balance should be %d\n", balance1)
 }
 
 func executeSwap(cur realm) {

--- a/contract/r/scenario/position/position_increase_decrease_filetest.gno
+++ b/contract/r/scenario/position/position_increase_decrease_filetest.gno
@@ -125,8 +125,10 @@ func checkInitialPositionState(cur realm) {
 	ufmt.Printf("[EXPECTED] Initial position liquidity should be %s\n", pos.Liquidity())
 	ufmt.Printf("[EXPECTED] Initial position tickLower should be %d\n", pos.TickLower())
 	ufmt.Printf("[EXPECTED] Initial position tickUpper should be %d\n", pos.TickUpper())
-	ufmt.Printf("[EXPECTED] Position token0 balance should be %d\n", position.GetPositionToken0Balance(1))
-	ufmt.Printf("[EXPECTED] Position token1 balance should be %d\n", position.GetPositionToken1Balance(1))
+	balance0, _ := position.GetPositionToken0Balance(1)
+	balance1, _ := position.GetPositionToken1Balance(1)
+	ufmt.Printf("[EXPECTED] Position token0 balance should be %d\n", balance0)
+	ufmt.Printf("[EXPECTED] Position token1 balance should be %d\n", balance1)
 }
 
 func increasePositionLiquidity(cur realm) {
@@ -157,8 +159,10 @@ func checkIncreasedPositionState(cur realm) {
 	ufmt.Printf("[EXPECTED] Increased position liquidity should be %s\n", pos.Liquidity())
 	ufmt.Printf("[EXPECTED] Position tickLower should be unchanged at %d\n", pos.TickLower())
 	ufmt.Printf("[EXPECTED] Position tickUpper should be unchanged at %d\n", pos.TickUpper())
-	ufmt.Printf("[EXPECTED] Position token0 balance should be %d\n", position.GetPositionToken0Balance(1))
-	ufmt.Printf("[EXPECTED] Position token1 balance should be %d\n", position.GetPositionToken1Balance(1))
+	balance0, _ := position.GetPositionToken0Balance(1)
+	balance1, _ := position.GetPositionToken1Balance(1)
+	ufmt.Printf("[EXPECTED] Position token0 balance should be %d\n", balance0)
+	ufmt.Printf("[EXPECTED] Position token1 balance should be %d\n", balance1)
 }
 
 func executeSwap(cur realm) {

--- a/contract/r/scenario/position/position_mint_and_balance_check_filetest.gno
+++ b/contract/r/scenario/position/position_mint_and_balance_check_filetest.gno
@@ -5,9 +5,9 @@
 package main
 
 import (
-	"gno.land/p/gnoswap/gnsmath"
 	"chain"
 	"chain/banker"
+	"gno.land/p/gnoswap/gnsmath"
 	"testing"
 	"time"
 
@@ -206,10 +206,14 @@ func comparePositionBalances(cur realm) {
 	testing.SetRealm(adminRealm)
 
 	ufmt.Println("[INFO] Comparing position balances")
-	ufmt.Printf("[EXPECTED] Position 1 token0 balance should be %d\n", position.GetPositionToken0Balance(1))
-	ufmt.Printf("[EXPECTED] Position 1 token1 balance should be %d\n", position.GetPositionToken1Balance(1))
-	ufmt.Printf("[EXPECTED] Position 2 token0 balance should be %d\n", position.GetPositionToken0Balance(2))
-	ufmt.Printf("[EXPECTED] Position 2 token1 balance should be %d\n", position.GetPositionToken1Balance(2))
+	balance10, _ := position.GetPositionToken0Balance(1)
+	balance11, _ := position.GetPositionToken1Balance(1)
+	balance20, _ := position.GetPositionToken0Balance(2)
+	balance21, _ := position.GetPositionToken1Balance(2)
+	ufmt.Printf("[EXPECTED] Position 1 token0 balance should be %d\n", balance10)
+	ufmt.Printf("[EXPECTED] Position 1 token1 balance should be %d\n", balance11)
+	ufmt.Printf("[EXPECTED] Position 2 token0 balance should be %d\n", balance20)
+	ufmt.Printf("[EXPECTED] Position 2 token1 balance should be %d\n", balance21)
 	ufmt.Printf("[EXPECTED] Sum of positions should stay close to pool balances\n")
 }
 

--- a/contract/r/scenario/position/position_mint_gnot_grc20_range_filetest.gno
+++ b/contract/r/scenario/position/position_mint_gnot_grc20_range_filetest.gno
@@ -174,8 +174,10 @@ func checkInRangePosition(cur realm) {
 
 	ufmt.Printf("[EXPECTED] Position liquidity should be %s\n", pos.Liquidity())
 	ufmt.Printf("[EXPECTED] Position should be in range\n")
-	ufmt.Printf("[EXPECTED] Token0 balance should be %d\n", position.GetPositionToken0Balance(1))
-	ufmt.Printf("[EXPECTED] Token1 balance should be %d\n", position.GetPositionToken1Balance(1))
+	balance0, _ := position.GetPositionToken0Balance(1)
+	balance1, _ := position.GetPositionToken1Balance(1)
+	ufmt.Printf("[EXPECTED] Token0 balance should be %d\n", balance0)
+	ufmt.Printf("[EXPECTED] Token1 balance should be %d\n", balance1)
 }
 
 func mintOutRangePosition(cur realm) {
@@ -212,8 +214,10 @@ func checkOutRangePosition(cur realm) {
 
 	ufmt.Printf("[EXPECTED] Position liquidity should be %s\n", pos.Liquidity())
 	ufmt.Printf("[EXPECTED] Position should be out of range\n")
-	ufmt.Printf("[EXPECTED] Token0 balance should be %d\n", position.GetPositionToken0Balance(2))
-	ufmt.Printf("[EXPECTED] Token1 balance should be %d\n", position.GetPositionToken1Balance(2))
+	balance0, _ := position.GetPositionToken0Balance(2)
+	balance1, _ := position.GetPositionToken1Balance(2)
+	ufmt.Printf("[EXPECTED] Token0 balance should be %d\n", balance0)
+	ufmt.Printf("[EXPECTED] Token1 balance should be %d\n", balance1)
 }
 
 func executeSwap(cur realm) {
@@ -245,8 +249,8 @@ func executeSwap(cur realm) {
 func verifyFinalPositions(cur realm) {
 	testing.SetRealm(adminRealm)
 
-	pos1fee0, pos1fee1 := position.GetUnclaimedFee(1)
-	pos2fee0, pos2fee1 := position.GetUnclaimedFee(2)
+	pos1fee0, pos1fee1, _ := position.GetUnclaimedFee(1)
+	pos2fee0, pos2fee1, _ := position.GetUnclaimedFee(2)
 
 	ufmt.Println("[INFO] Checking final position states")
 	ufmt.Printf("[EXPECTED] Position 1 should still be in range\n")

--- a/contract/r/scenario/position/position_mint_swap_burn_filetest.gno
+++ b/contract/r/scenario/position/position_mint_swap_burn_filetest.gno
@@ -148,8 +148,10 @@ func checkInitialState(cur realm) {
 	pos, _ := position.GetPositions().Get(utils.Uint64ToString(1)).(position.Position)
 
 	ufmt.Printf("[EXPECTED] Initial liquidity should be %s\n", pos.Liquidity())
-	ufmt.Printf("[EXPECTED] Initial token0 balance should be %d\n", position.GetPositionToken0Balance(1))
-	ufmt.Printf("[EXPECTED] Initial token1 balance should be %d\n", position.GetPositionToken1Balance(1))
+	balance0, _ := position.GetPositionToken0Balance(1)
+	balance1, _ := position.GetPositionToken1Balance(1)
+	ufmt.Printf("[EXPECTED] Initial token0 balance should be %d\n", balance0)
+	ufmt.Printf("[EXPECTED] Initial token1 balance should be %d\n", balance1)
 }
 
 func executeSwaps(cur realm) {
@@ -235,8 +237,10 @@ func verifyFinalState(cur realm) {
 
 	ufmt.Printf("[EXPECTED] Position should be burned\n")
 	ufmt.Printf("[EXPECTED] Final liquidity should be %s\n", pos.Liquidity())
-	ufmt.Printf("[EXPECTED] Final token0 balance should be %d\n", position.GetPositionToken0Balance(1))
-	ufmt.Printf("[EXPECTED] Final token1 balance should be %d\n", position.GetPositionToken1Balance(1))
+	balance0, _ := position.GetPositionToken0Balance(1)
+	balance1, _ := position.GetPositionToken1Balance(1)
+	ufmt.Printf("[EXPECTED] Final token0 balance should be %d\n", balance0)
+	ufmt.Printf("[EXPECTED] Final token1 balance should be %d\n", balance1)
 }
 
 func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0Delta int64, amount1Delta int64, zeroForOne bool) error {

--- a/contract/r/scenario/position/position_minting_filetest.gno
+++ b/contract/r/scenario/position/position_minting_filetest.gno
@@ -143,8 +143,10 @@ func testBasicPositionMinting(cur realm) {
 	println("[EXPECTED] Liquidity:", liquidity)
 	println("[EXPECTED] Amount0:", amount0)
 	println("[EXPECTED] Amount1:", amount1)
-	println("[EXPECTED] Position is not burned:", !pn.IsBurned(positionId))
-	println("[EXPECTED] Position is in range:", pn.IsInRange(positionId))
+	burned, _ := pn.IsBurned(positionId)
+	inRange, _ := pn.IsInRange(positionId)
+	println("[EXPECTED] Position is not burned:", !burned)
+	println("[EXPECTED] Position is in range:", inRange)
 }
 
 func testZeroLiquidityMintingFailure(cur realm) {

--- a/contract/r/scenario/position/position_native_token_filetest.gno
+++ b/contract/r/scenario/position/position_native_token_filetest.gno
@@ -133,7 +133,7 @@ func mintPosition(cur realm) {
 
 func checkUnclaimedFeesBeforeSwap(cur realm) {
 	testing.SetRealm(adminRealm)
-	amount0, amount1 := position.GetUnclaimedFee(1)
+	amount0, amount1, _ := position.GetUnclaimedFee(1)
 
 	ufmt.Printf("[EXPECTED] Unclaimed fee0 should be %s\n", amount0)
 	ufmt.Printf("[EXPECTED] Unclaimed fee1 should be %s\n", amount1)
@@ -169,7 +169,7 @@ func executeSwap(cur realm) {
 
 func checkUnclaimedFeesAfterSwap(cur realm) {
 	testing.SetRealm(adminRealm)
-	amount0, amount1 := position.GetUnclaimedFee(1)
+	amount0, amount1, _ := position.GetUnclaimedFee(1)
 
 	ufmt.Printf("[EXPECTED] Unclaimed fee0 should be %s\n", amount0)
 	ufmt.Printf("[EXPECTED] Unclaimed fee1 should be %s\n", amount1)

--- a/contract/r/scenario/position/position_transfer_equal_reward_filetest.gno
+++ b/contract/r/scenario/position/position_transfer_equal_reward_filetest.gno
@@ -177,7 +177,7 @@ func stakeBothInSameBlock(cur realm) {
 
 	// Transfer position 2 to Bob.
 	gnft.TransferFrom(cross(cur), aliceAddr, bobAddr, tokenIdOf(cur, positionId2))
-	bobOwns := gnft.MustOwnerOf(tokenIdOf(cur, positionId2))
+	bobOwns := mustOwnerOf(tokenIdOf(cur, positionId2))
 	println("[EXPECTED] Position 2 transferred to bob:", bobOwns == bobAddr)
 
 	// Bob stakes position 2 in the same block.
@@ -222,6 +222,14 @@ func verifyEqual(cur realm, aliceReward, bobReward int64) {
 
 func tokenIdOf(cur realm, id uint64) grc721.TokenID {
 	return grc721.TokenID(strconv.FormatUint(id, 10))
+}
+
+func mustOwnerOf(tid grc721.TokenID) address {
+	owner, err := gnft.OwnerOf(tid)
+	if err != nil {
+		panic(err.Error())
+	}
+	return owner
 }
 
 // Output:

--- a/contract/r/scenario/position/position_transfer_equal_reward_same_block_filetest.gno
+++ b/contract/r/scenario/position/position_transfer_equal_reward_same_block_filetest.gno
@@ -165,7 +165,7 @@ func mintTwoPositions(cur realm) {
 func transferToBob(cur realm) {
 	testing.SetRealm(aliceRealm)
 	gnft.TransferFrom(cross(cur), aliceAddr, bobAddr, tokenIdOf(cur, positionId2))
-	bobOwns := gnft.MustOwnerOf(tokenIdOf(cur, positionId2))
+	bobOwns := mustOwnerOf(tokenIdOf(cur, positionId2))
 	println("[EXPECTED] Position 2 transferred to bob:", bobOwns == bobAddr)
 }
 
@@ -218,6 +218,14 @@ func verifyEqual(cur realm, aliceReward, bobReward int64) {
 
 func tokenIdOf(cur realm, id uint64) grc721.TokenID {
 	return grc721.TokenID(strconv.FormatUint(id, 10))
+}
+
+func mustOwnerOf(tid grc721.TokenID) address {
+	owner, err := gnft.OwnerOf(tid)
+	if err != nil {
+		panic(err.Error())
+	}
+	return owner
 }
 
 // Output:

--- a/contract/r/scenario/position/position_transfer_staked_blocked_filetest.gno
+++ b/contract/r/scenario/position/position_transfer_staked_blocked_filetest.gno
@@ -122,7 +122,7 @@ func setup(cur realm) {
 	gnft.Approve(cross(cur), stakerAddr, tokenIdOf(cur, positionId))
 	staker.StakeToken(cross(cur), positionId, "")
 
-	owner := gnft.MustOwnerOf(tokenIdOf(cur, positionId))
+	owner := mustOwnerOf(tokenIdOf(cur, positionId))
 	println("[EXPECTED] Position ID:", positionId)
 	println("[EXPECTED] Owner after stake is staker:", owner == stakerAddr)
 }
@@ -183,16 +183,24 @@ func unstakeAndTransfer(cur realm) {
 	testing.SetRealm(aliceRealm)
 	staker.UnStakeToken(cross(cur), positionId)
 
-	owner := gnft.MustOwnerOf(tokenIdOf(cur, positionId))
+	owner := mustOwnerOf(tokenIdOf(cur, positionId))
 	println("[EXPECTED] Owner after unstake is alice:", owner == aliceAddr)
 
 	gnft.TransferFrom(cross(cur), aliceAddr, bobAddr, tokenIdOf(cur, positionId))
-	owner = gnft.MustOwnerOf(tokenIdOf(cur, positionId))
+	owner = mustOwnerOf(tokenIdOf(cur, positionId))
 	println("[EXPECTED] Owner after transfer is bob:", owner == bobAddr)
 }
 
 func tokenIdOf(cur realm, id uint64) grc721.TokenID {
 	return grc721.TokenID(strconv.FormatUint(id, 10))
+}
+
+func mustOwnerOf(tid grc721.TokenID) address {
+	owner, err := gnft.OwnerOf(tid)
+	if err != nil {
+		panic(err.Error())
+	}
+	return owner
 }
 
 // Output:

--- a/contract/r/scenario/position/position_transfer_then_liquidity_changes_filetest.gno
+++ b/contract/r/scenario/position/position_transfer_then_liquidity_changes_filetest.gno
@@ -121,7 +121,7 @@ func aliceTransfersToBob(cur realm) {
 	testing.SetRealm(aliceRealm)
 	gnft.TransferFrom(cross(cur), aliceAddr, bobAddr, tokenIdOf(cur, positionId))
 
-	owner := gnft.MustOwnerOf(tokenIdOf(cur, positionId))
+	owner := mustOwnerOf(tokenIdOf(cur, positionId))
 	println("[EXPECTED] Owner after transfer is bob:", owner == bobAddr)
 }
 
@@ -169,7 +169,7 @@ func bobIncreases(cur realm) {
 	bar.Approve(cross(cur), poolAddr, maxInt64)
 	foo.Approve(cross(cur), poolAddr, maxInt64)
 
-	liquidityBefore := position.GetPositionLiquidity(positionId)
+	liquidityBefore, _ := position.GetPositionLiquidity(positionId)
 	_, liquidityAdded, _, _, _ := position.IncreaseLiquidity(
 		cross(cur),
 		positionId,
@@ -177,7 +177,7 @@ func bobIncreases(cur realm) {
 		"0", "0",
 		maxTimeout,
 	)
-	liquidityAfter := position.GetPositionLiquidity(positionId)
+	liquidityAfter, _ := position.GetPositionLiquidity(positionId)
 
 	println("[EXPECTED] Liquidity before:", liquidityBefore)
 	println("[EXPECTED] Liquidity added:", liquidityAdded)
@@ -187,7 +187,7 @@ func bobIncreases(cur realm) {
 func bobDecreases(cur realm) {
 	testing.SetRealm(bobRealm)
 
-	liquidityBefore := position.GetPositionLiquidity(positionId)
+	liquidityBefore, _ := position.GetPositionLiquidity(positionId)
 	_, liquidityRemoved, _, _, _, _, _ := position.DecreaseLiquidity(
 		cross(cur),
 		positionId,
@@ -195,7 +195,7 @@ func bobDecreases(cur realm) {
 		"0", "0",
 		maxTimeout,
 	)
-	liquidityAfter := position.GetPositionLiquidity(positionId)
+	liquidityAfter, _ := position.GetPositionLiquidity(positionId)
 
 	println("[EXPECTED] Liquidity before:", liquidityBefore)
 	println("[EXPECTED] Liquidity removed:", liquidityRemoved)
@@ -204,6 +204,14 @@ func bobDecreases(cur realm) {
 
 func tokenIdOf(cur realm, id uint64) grc721.TokenID {
 	return grc721.TokenID(strconv.FormatUint(id, 10))
+}
+
+func mustOwnerOf(tid grc721.TokenID) address {
+	owner, err := gnft.OwnerOf(tid)
+	if err != nil {
+		panic(err.Error())
+	}
+	return owner
 }
 
 // Output:

--- a/contract/r/scenario/position/position_transfer_then_new_owner_stakes_filetest.gno
+++ b/contract/r/scenario/position/position_transfer_then_new_owner_stakes_filetest.gno
@@ -113,7 +113,7 @@ func setup(cur realm) {
 	)
 	positionId = id
 
-	owner := gnft.MustOwnerOf(tokenIdOf(cur, positionId))
+	owner := mustOwnerOf(tokenIdOf(cur, positionId))
 	println("[EXPECTED] Position ID:", positionId)
 	println("[EXPECTED] Owner after mint is alice:", owner == aliceAddr)
 }
@@ -126,7 +126,7 @@ func transferToBob(cur realm) {
 	println("[INFO] Alice approved staker on positionId")
 
 	gnft.TransferFrom(cross(cur), aliceAddr, bobAddr, tokenIdOf(cur, positionId))
-	owner := gnft.MustOwnerOf(tokenIdOf(cur, positionId))
+	owner := mustOwnerOf(tokenIdOf(cur, positionId))
 	println("[EXPECTED] Owner after transfer is bob:", owner == bobAddr)
 }
 
@@ -151,7 +151,7 @@ func bobStakes(cur realm) {
 	gnft.Approve(cross(cur), stakerAddr, tokenIdOf(cur, positionId))
 	staker.StakeToken(cross(cur), positionId, "")
 
-	owner := gnft.MustOwnerOf(tokenIdOf(cur, positionId))
+	owner := mustOwnerOf(tokenIdOf(cur, positionId))
 	println("[EXPECTED] Owner after stake is staker:", owner == stakerAddr)
 
 	depositOwner := staker.GetDepositOwner(positionId)
@@ -160,6 +160,14 @@ func bobStakes(cur realm) {
 
 func tokenIdOf(cur realm, id uint64) grc721.TokenID {
 	return grc721.TokenID(strconv.FormatUint(id, 10))
+}
+
+func mustOwnerOf(tid grc721.TokenID) address {
+	owner, err := gnft.OwnerOf(tid)
+	if err != nil {
+		panic(err.Error())
+	}
+	return owner
 }
 
 // Output:

--- a/contract/r/scenario/position/position_transfer_via_operator_filetest.gno
+++ b/contract/r/scenario/position/position_transfer_via_operator_filetest.gno
@@ -131,8 +131,8 @@ func operatorTransfersBoth(cur realm) {
 	gnft.TransferFrom(cross(cur), aliceAddr, bobAddr, tokenIdOf(cur, positionId1))
 	gnft.TransferFrom(cross(cur), aliceAddr, carolAddr, tokenIdOf(cur, positionId2))
 
-	owner1 := gnft.MustOwnerOf(tokenIdOf(cur, positionId1))
-	owner2 := gnft.MustOwnerOf(tokenIdOf(cur, positionId2))
+	owner1 := mustOwnerOf(tokenIdOf(cur, positionId1))
+	owner2 := mustOwnerOf(tokenIdOf(cur, positionId2))
 	println("[EXPECTED] Position 1 owner is bob:", owner1 == bobAddr)
 	println("[EXPECTED] Position 2 owner is carol:", owner2 == carolAddr)
 }
@@ -172,6 +172,14 @@ func revokeOperator(cur realm) {
 
 func tokenIdOf(cur realm, id uint64) grc721.TokenID {
 	return grc721.TokenID(strconv.FormatUint(id, 10))
+}
+
+func mustOwnerOf(tid grc721.TokenID) address {
+	owner, err := gnft.OwnerOf(tid)
+	if err != nil {
+		panic(err.Error())
+	}
+	return owner
 }
 
 // Output:

--- a/contract/r/scenario/position/position_unclaimed_fee_filetest.gno
+++ b/contract/r/scenario/position/position_unclaimed_fee_filetest.gno
@@ -183,7 +183,7 @@ func mintUpperRangePosition(cur realm) {
 
 func checkUnclaimedFeesBeforeSwap(cur realm) {
 	testing.SetRealm(adminRealm)
-	amount0, amount1 := position.GetUnclaimedFee(1)
+	amount0, amount1, _ := position.GetUnclaimedFee(1)
 
 	ufmt.Printf("[EXPECTED] Unclaimed fee0 should be %s\n", amount0)
 	ufmt.Printf("[EXPECTED] Unclaimed fee1 should be %s\n", amount1)
@@ -216,7 +216,7 @@ func executeFirstSwap(cur realm) {
 
 func checkUnclaimedFeesAfterFirstSwap(cur realm) {
 	testing.SetRealm(adminRealm)
-	amount0, amount1 := position.GetUnclaimedFee(1)
+	amount0, amount1, _ := position.GetUnclaimedFee(1)
 
 	ufmt.Printf("[EXPECTED] Unclaimed fee0 should be %s\n", amount0)
 	ufmt.Printf("[EXPECTED] Unclaimed fee1 should be %s\n", amount1)
@@ -249,7 +249,7 @@ func executeSecondSwap(cur realm) {
 
 func checkUnclaimedFeesAfterSecondSwap(cur realm) {
 	testing.SetRealm(adminRealm)
-	amount0, amount1 := position.GetUnclaimedFee(1)
+	amount0, amount1, _ := position.GetUnclaimedFee(1)
 
 	ufmt.Printf("[EXPECTED] Unclaimed fee0 should be %s\n", amount0)
 	ufmt.Printf("[EXPECTED] Unclaimed fee1 should be %s\n", amount1)
@@ -282,7 +282,7 @@ func executeThirdSwap(cur realm) {
 
 func checkFinalUnclaimedFees(cur realm) {
 	testing.SetRealm(adminRealm)
-	amount0, amount1 := position.GetUnclaimedFee(1)
+	amount0, amount1, _ := position.GetUnclaimedFee(1)
 
 	ufmt.Printf("[EXPECTED] Final unclaimed fee0 should be %s\n", amount0)
 	ufmt.Printf("[EXPECTED] Final unclaimed fee1 should be %s\n", amount1)

--- a/contract/r/scenario/position/staked_position_decrease_liquidity_blocked_filetest.gno
+++ b/contract/r/scenario/position/staked_position_decrease_liquidity_blocked_filetest.gno
@@ -136,7 +136,7 @@ func initPoolAndCreatePosition(cur realm) {
 	println("[EXPECTED] Amount0:", amount0)
 	println("[EXPECTED] Amount1:", amount1)
 
-	owner := gnft.MustOwnerOf(positionIdToTokenId(cur, positionId))
+	owner := mustOwnerOf(positionIdToTokenId(cur, positionId))
 	println("[EXPECTED] Position owner before staking:", owner.String())
 }
 
@@ -153,7 +153,7 @@ func stakePosition(cur realm) {
 }
 
 func verifyPositionIsStaked(cur realm) {
-	owner := gnft.MustOwnerOf(positionIdToTokenId(cur, positionId))
+	owner := mustOwnerOf(positionIdToTokenId(cur, positionId))
 
 	println("[EXPECTED] Position owner after staking:", owner.String())
 	println("[EXPECTED] Staker contract address:", stakerAddr.String())
@@ -202,6 +202,14 @@ func testCollectFeeOnStakedPosition(cur realm) {
 
 func positionIdToTokenId(cur realm, id uint64) grc721.TokenID {
 	return grc721.TokenID(strconv.Itoa(int(id)))
+}
+
+func mustOwnerOf(tid grc721.TokenID) address {
+	owner, err := gnft.OwnerOf(tid)
+	if err != nil {
+		panic(err.Error())
+	}
+	return owner
 }
 
 // Output:

--- a/contract/r/scenario/position/wugnot_gns_100_pool_burn_position_with_narrow_range_filetest.gno
+++ b/contract/r/scenario/position/wugnot_gns_100_pool_burn_position_with_narrow_range_filetest.gno
@@ -140,10 +140,10 @@ func removePosition(cur realm, positionId uint64) {
 	ufmt.Printf("[EXPECTED] decreased liquidity: %s\n", liquidity)
 	ufmt.Printf("[EXPECTED] decreased amount0: %s\n", amount0)
 	ufmt.Printf("[EXPECTED] decreased amount1: %s\n", amount1)
-	balance0, _ := pool.GetBalanceToken0(poolPath)
-	balance1, _ := pool.GetBalanceToken1(poolPath)
-	ufmt.Printf("[EXPECTED] pool token0 balance: %d\n", balance0)
-	ufmt.Printf("[EXPECTED] pool token1 balance: %d\n", balance1)
+	balanceToken0, _ := pool.GetBalanceToken0(poolPath)
+	balanceToken1, _ := pool.GetBalanceToken1(poolPath)
+	ufmt.Printf("[EXPECTED] pool token0 balance: %d\n", balanceToken0)
+	ufmt.Printf("[EXPECTED] pool token1 balance: %d\n", balanceToken1)
 }
 
 // Output:

--- a/contract/r/scenario/staker/full_internal_external_filetest.gno
+++ b/contract/r/scenario/staker/full_internal_external_filetest.gno
@@ -7,7 +7,6 @@ package main
 import (
 	"chain"
 	"chain/banker"
-	"gno.land/p/gnoswap/gnsmath"
 	"strconv"
 	"testing"
 	"time"

--- a/contract/r/scenario/staker/full_internal_external_filetest.gno
+++ b/contract/r/scenario/staker/full_internal_external_filetest.gno
@@ -7,6 +7,7 @@ package main
 import (
 	"chain"
 	"chain/banker"
+	"gno.land/p/gnoswap/gnsmath"
 	"strconv"
 	"testing"
 	"time"

--- a/contract/r/scenario/staker/staker_short_warmup_period_external_15_90d_filetest.gno
+++ b/contract/r/scenario/staker/staker_short_warmup_period_external_15_90d_filetest.gno
@@ -124,10 +124,26 @@ func mintBarBaz3000_1_4(cur realm) {
 	pn.Mint(cross(cur), barPath, bazPath, fee3000, int32(-1020), int32(1020), "7", "7", "0", "0", max_timeout, adminAddr, "")
 	testing.SkipHeights(1)
 
-	t1Liq := u256.MustFromDecimal(pn.GetPositionLiquidity(1))
-	t2Liq := u256.MustFromDecimal(pn.GetPositionLiquidity(2))
-	t3Liq := u256.MustFromDecimal(pn.GetPositionLiquidity(3))
-	t4Liq := u256.MustFromDecimal(pn.GetPositionLiquidity(4))
+	t1LiqStr, err := pn.GetPositionLiquidity(1)
+	if err != nil {
+		panic(err)
+	}
+	t2LiqStr, err := pn.GetPositionLiquidity(2)
+	if err != nil {
+		panic(err)
+	}
+	t3LiqStr, err := pn.GetPositionLiquidity(3)
+	if err != nil {
+		panic(err)
+	}
+	t4LiqStr, err := pn.GetPositionLiquidity(4)
+	if err != nil {
+		panic(err)
+	}
+	t1Liq := u256.MustFromDecimal(t1LiqStr)
+	t2Liq := u256.MustFromDecimal(t2LiqStr)
+	t3Liq := u256.MustFromDecimal(t3LiqStr)
+	t4Liq := u256.MustFromDecimal(t4LiqStr)
 
 	all := u256.Zero()
 	all.Add(all, t1Liq)

--- a/contract/r/scenario/staker/staker_short_warmup_period_external_16_180d_filetest.gno
+++ b/contract/r/scenario/staker/staker_short_warmup_period_external_16_180d_filetest.gno
@@ -124,10 +124,26 @@ func mintBarBaz3000_1_4(cur realm) {
 	pn.Mint(cross(cur), barPath, bazPath, fee3000, int32(-1020), int32(1020), "7", "7", "0", "0", max_timeout, adminAddr, "")
 	testing.SkipHeights(1)
 
-	t1Liq := u256.MustFromDecimal(pn.GetPositionLiquidity(1))
-	t2Liq := u256.MustFromDecimal(pn.GetPositionLiquidity(2))
-	t3Liq := u256.MustFromDecimal(pn.GetPositionLiquidity(3))
-	t4Liq := u256.MustFromDecimal(pn.GetPositionLiquidity(4))
+	t1LiqStr, err := pn.GetPositionLiquidity(1)
+	if err != nil {
+		panic(err)
+	}
+	t2LiqStr, err := pn.GetPositionLiquidity(2)
+	if err != nil {
+		panic(err)
+	}
+	t3LiqStr, err := pn.GetPositionLiquidity(3)
+	if err != nil {
+		panic(err)
+	}
+	t4LiqStr, err := pn.GetPositionLiquidity(4)
+	if err != nil {
+		panic(err)
+	}
+	t1Liq := u256.MustFromDecimal(t1LiqStr)
+	t2Liq := u256.MustFromDecimal(t2LiqStr)
+	t3Liq := u256.MustFromDecimal(t3LiqStr)
+	t4Liq := u256.MustFromDecimal(t4LiqStr)
 
 	all := u256.Zero()
 	all.Add(all, t1Liq)

--- a/contract/r/scenario/staker/staker_short_warmup_period_external_17_365d_filetest.gno
+++ b/contract/r/scenario/staker/staker_short_warmup_period_external_17_365d_filetest.gno
@@ -121,10 +121,26 @@ func mintBarBaz3000_1_4(cur realm) {
 	pn.Mint(cross(cur), barPath, bazPath, fee3000, int32(-1020), int32(1020), "7", "7", "0", "0", max_timeout, adminAddr, "")
 	testing.SkipHeights(1)
 
-	t1Liq := u256.MustFromDecimal(pn.GetPositionLiquidity(1))
-	t2Liq := u256.MustFromDecimal(pn.GetPositionLiquidity(2))
-	t3Liq := u256.MustFromDecimal(pn.GetPositionLiquidity(3))
-	t4Liq := u256.MustFromDecimal(pn.GetPositionLiquidity(4))
+	t1LiqStr, err := pn.GetPositionLiquidity(1)
+	if err != nil {
+		panic(err)
+	}
+	t2LiqStr, err := pn.GetPositionLiquidity(2)
+	if err != nil {
+		panic(err)
+	}
+	t3LiqStr, err := pn.GetPositionLiquidity(3)
+	if err != nil {
+		panic(err)
+	}
+	t4LiqStr, err := pn.GetPositionLiquidity(4)
+	if err != nil {
+		panic(err)
+	}
+	t1Liq := u256.MustFromDecimal(t1LiqStr)
+	t2Liq := u256.MustFromDecimal(t2LiqStr)
+	t3Liq := u256.MustFromDecimal(t3LiqStr)
+	t4Liq := u256.MustFromDecimal(t4LiqStr)
 
 	all := u256.Zero()
 	all.Add(all, t1Liq)

--- a/contract/r/scenario/staker/zero_net_tick_cross_internal_filetest.gno
+++ b/contract/r/scenario/staker/zero_net_tick_cross_internal_filetest.gno
@@ -115,8 +115,14 @@ func mintAdjacentPositions(cur realm) {
 	mintPosition(cur, 10, 20, "100000", "100000")
 	matchPositionLiquidity(cur, 1, 2)
 
-	liq1 := pn.GetPositionLiquidity(1)
-	liq2 := pn.GetPositionLiquidity(2)
+	liq1, err := pn.GetPositionLiquidity(1)
+	if err != nil {
+		panic(err)
+	}
+	liq2, err := pn.GetPositionLiquidity(2)
+	if err != nil {
+		panic(err)
+	}
 	ufmt.Printf("[INFO] position 1 liquidity: %s\n", liq1)
 	ufmt.Printf("[INFO] position 2 liquidity: %s\n", liq2)
 	if liq1 != liq2 {
@@ -127,11 +133,19 @@ func mintAdjacentPositions(cur realm) {
 }
 
 func matchPositionLiquidity(cur realm, positionId1 uint64, positionId2 uint64) {
-	liq1, err := strconv.Atoi(pn.GetPositionLiquidity(positionId1))
+	liq1Str, err := pn.GetPositionLiquidity(positionId1)
 	if err != nil {
 		panic(err)
 	}
-	liq2, err := strconv.Atoi(pn.GetPositionLiquidity(positionId2))
+	liq1, err := strconv.Atoi(liq1Str)
+	if err != nil {
+		panic(err)
+	}
+	liq2Str, err := pn.GetPositionLiquidity(positionId2)
+	if err != nil {
+		panic(err)
+	}
+	liq2, err := strconv.Atoi(liq2Str)
 	if err != nil {
 		panic(err)
 	}

--- a/contract/r/scenario/upgrade/full_lifecycle_v2_valid_upgrade_filetest.gno
+++ b/contract/r/scenario/upgrade/full_lifecycle_v2_valid_upgrade_filetest.gno
@@ -539,11 +539,35 @@ func positionLifecycle(cur realm) {
 	)
 	testing.SkipHeights(1)
 	println("[EXPECTED] minted position:", positionId, "liquidity:", liquidity, "amount0:", amount0, "amount1:", amount1)
-	println("[EXPECTED] position owner:", position.GetPositionOwner(positionId))
-	println("[EXPECTED] position pool key:", position.GetPositionPoolKey(positionId))
-	println("[EXPECTED] position ticks:", position.GetPositionTickLower(positionId), position.GetPositionTickUpper(positionId))
-	println("[EXPECTED] position in range:", position.IsInRange(positionId))
-	println("[EXPECTED] position burned:", position.IsBurned(positionId))
+	positionOwner, err := position.GetPositionOwner(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionPoolKey, err := position.GetPositionPoolKey(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionTickLower, err := position.GetPositionTickLower(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionTickUpper, err := position.GetPositionTickUpper(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionInRange, err := position.IsInRange(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionBurned, err := position.IsBurned(positionId)
+	if err != nil {
+		panic(err)
+	}
+	println("[EXPECTED] position owner:", positionOwner)
+	println("[EXPECTED] position pool key:", positionPoolKey)
+	println("[EXPECTED] position ticks:", positionTickLower, positionTickUpper)
+	println("[EXPECTED] position in range:", positionInRange)
+	println("[EXPECTED] position burned:", positionBurned)
 
 	// second position with a wider range, used for Reposition later
 	secondId, secondLiquidity, _, _ := position.Mint(
@@ -559,7 +583,11 @@ func positionLifecycle(cur realm) {
 	)
 	testing.SkipHeights(1)
 	println("[EXPECTED] increased liquidity:", increasedLiquidity, "amount0:", increased0, "amount1:", increased1)
-	println("[EXPECTED] position liquidity now:", position.GetPositionLiquidity(positionId))
+	positionLiquidity, err := position.GetPositionLiquidity(positionId)
+	if err != nil {
+		panic(err)
+	}
+	println("[EXPECTED] position liquidity now:", positionLiquidity)
 
 	// Trade both ways so the position actually accrues swap fees. Without this
 	// the DecreaseLiquidity below would collect a zero fee and the withdrawal
@@ -568,11 +596,17 @@ func positionLifecycle(cur realm) {
 
 	// DecreaseLiquidity collects the accrued fees first, so the gross fee is
 	// what the position holds right before the call.
-	grossFee0, grossFee1 := position.GetUnclaimedFee(positionId)
+	grossFee0, grossFee1, err := position.GetUnclaimedFee(positionId)
+	if err != nil {
+		panic(err)
+	}
 	println("[EXPECTED] fees accrued before decrease (gross):", grossFee0, grossFee1)
 
 	// decrease half of the liquidity; the withdrawal fee is routed to protocol fee
-	decreaseAmount := position.GetPositionLiquidity(positionId)
+	decreaseAmount, err := position.GetPositionLiquidity(positionId)
+	if err != nil {
+		panic(err)
+	}
 	beforeBarAccu := protocolFee.GetAccuTransferToGovStakerByTokenPath(barPath) +
 		protocolFee.GetAccuTransferToDevOpsByTokenPath(barPath)
 	beforeFooAccu := protocolFee.GetAccuTransferToGovStakerByTokenPath(fooPath) +
@@ -596,7 +630,11 @@ func positionLifecycle(cur realm) {
 	println("[EXPECTED] principal returned:", removed0, removed1)
 	println("[EXPECTED] fees returned with the principal (net):", fee0, fee1)
 	println("[EXPECTED] withdrawal fee accrued (BAR / FOO):", withdrawalFee0, withdrawalFee1)
-	println("[EXPECTED] position liquidity after decrease:", position.GetPositionLiquidity(positionId))
+	positionLiquidityAfterDecrease, err := position.GetPositionLiquidity(positionId)
+	if err != nil {
+		panic(err)
+	}
+	println("[EXPECTED] position liquidity after decrease:", positionLiquidityAfterDecrease)
 	println("[EXPECTED] position count:", position.GetPositions().Size())
 
 	// withdrawal fee is withdrawalFeeBPS of the gross fee, and the caller keeps
@@ -612,10 +650,26 @@ func positionLifecycle(cur realm) {
 	uassert.Equal(t, parseInt64(grossFee0)-expectedWithdrawalFee0, parseInt64(fee0))
 	uassert.Equal(t, parseInt64(grossFee1)-expectedWithdrawalFee1, parseInt64(fee1))
 
-	uassert.Equal(t, adminAddr, position.GetPositionOwner(positionId))
-	uassert.Equal(t, barFoo500PoolPath, position.GetPositionPoolKey(positionId))
-	uassert.True(t, position.IsInRange(positionId))
-	uassert.False(t, position.IsBurned(positionId))
+	positionOwner, err = position.GetPositionOwner(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionPoolKey, err = position.GetPositionPoolKey(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionInRange, err = position.IsInRange(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionBurned, err = position.IsBurned(positionId)
+	if err != nil {
+		panic(err)
+	}
+	uassert.Equal(t, adminAddr, positionOwner)
+	uassert.Equal(t, barFoo500PoolPath, positionPoolKey)
+	uassert.True(t, positionInRange)
+	uassert.False(t, positionBurned)
 	uassert.Equal(t, 2, position.GetPositions().Size())
 }
 
@@ -731,7 +785,10 @@ func routerSwaps(cur realm) {
 func collectPositionFee(cur realm, positionId uint64) {
 	testing.SetRealm(adminRealm)
 
-	unclaimed0, unclaimed1 := position.GetUnclaimedFee(positionId)
+	unclaimed0, unclaimed1, err := position.GetUnclaimedFee(positionId)
+	if err != nil {
+		panic(err)
+	}
 	println("[EXPECTED] unclaimed fee before collect:", unclaimed0, unclaimed1)
 
 	_, collected0, collected1, poolPath, token0, token1 := position.CollectFee(cross(cur), positionId)
@@ -739,7 +796,10 @@ func collectPositionFee(cur realm, positionId uint64) {
 	println("[EXPECTED] collected fee:", collected0, collected1, "pool:", poolPath)
 	println("[EXPECTED] fee tokens:", token0, token1)
 
-	after0, after1 := position.GetUnclaimedFee(positionId)
+	after0, after1, err := position.GetUnclaimedFee(positionId)
+	if err != nil {
+		panic(err)
+	}
 	println("[EXPECTED] unclaimed fee after collect:", after0, after1)
 
 	uassert.Equal(t, barFoo500PoolPath, poolPath)
@@ -748,12 +808,19 @@ func collectPositionFee(cur realm, positionId uint64) {
 func repositionPosition(cur realm, positionId uint64) {
 	testing.SetRealm(adminRealm)
 
-	liquidity := position.GetPositionLiquidity(positionId)
+	liquidity, err := position.GetPositionLiquidity(positionId)
+	if err != nil {
+		panic(err)
+	}
 	_, _, _, _, _, _, _ = position.DecreaseLiquidity(
 		cross(cur), positionId, liquidity, "0", "0", time.Now().Unix()+3600,
 	)
 	testing.SkipHeights(1)
-	println("[EXPECTED] liquidity before reposition:", position.GetPositionLiquidity(positionId))
+	positionLiquidity, err := position.GetPositionLiquidity(positionId)
+	if err != nil {
+		panic(err)
+	}
+	println("[EXPECTED] liquidity before reposition:", positionLiquidity)
 
 	_, newLiquidity, tickLower, tickUpper, used0, used1 := position.Reposition(
 		cross(cur), positionId, -600, 600, "20000000", "20000000", "0", "0", time.Now().Unix()+3600,
@@ -761,10 +828,18 @@ func repositionPosition(cur realm, positionId uint64) {
 	testing.SkipHeights(1)
 	println("[EXPECTED] repositioned liquidity:", newLiquidity, "ticks:", tickLower, tickUpper)
 	println("[EXPECTED] amounts used:", used0, used1)
-	println("[EXPECTED] position ticks from getter:", position.GetPositionTickLower(positionId), position.GetPositionTickUpper(positionId))
+	positionTickLower, err := position.GetPositionTickLower(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionTickUpper, err := position.GetPositionTickUpper(positionId)
+	if err != nil {
+		panic(err)
+	}
+	println("[EXPECTED] position ticks from getter:", positionTickLower, positionTickUpper)
 
-	uassert.Equal(t, int32(-600), position.GetPositionTickLower(positionId))
-	uassert.Equal(t, int32(600), position.GetPositionTickUpper(positionId))
+	uassert.Equal(t, int32(-600), positionTickLower)
+	uassert.Equal(t, int32(600), positionTickUpper)
 }
 
 // ---------------------------------------------------------------------------
@@ -808,13 +883,17 @@ func stakerSetup(cur realm) {
 	println("[EXPECTED] deposit target pool:", staker.GetDepositTargetPoolPath(1))
 	// StakeToken routes position.SetPositionOperator (staker-only entry point)
 	// and records the staking caller as the position operator.
-	println("[EXPECTED] position operator after stake is the staker caller:", position.GetPositionOperator(1) == adminAddr)
+	positionOperator, err := position.GetPositionOperator(1)
+	if err != nil {
+		panic(err)
+	}
+	println("[EXPECTED] position operator after stake is the staker caller:", positionOperator == adminAddr)
 	println("[EXPECTED] pool staked liquidity:", staker.GetPoolStakedLiquidity(barFoo500PoolPath))
 
 	uassert.Equal(t, uint64(1), staker.GetPoolTier(barFoo500PoolPath))
 	uassert.True(t, staker.IsStaked(1))
 	uassert.Equal(t, adminAddr, staker.GetDepositOwner(1))
-	uassert.Equal(t, adminAddr, position.GetPositionOperator(1))
+	uassert.Equal(t, adminAddr, positionOperator)
 	uassert.Equal(t, incentiveReward, staker.GetIncentiveTotalRewardAmount(barFoo500PoolPath, externalIncentiveId))
 }
 
@@ -1165,9 +1244,46 @@ func captureSnapshot() upgradeSnapshot {
 	if err != nil {
 		panic(err)
 	}
-	positionFeeGrowth0, positionFeeGrowth1 := position.GetPositionFeeGrowthInsideLastX128(1)
-	positionOwed0, positionOwed1 := position.GetPositionTokensOwed(1)
-	positionUnclaimed0, positionUnclaimed1 := position.GetUnclaimedFee(1)
+	positionFeeGrowth0, positionFeeGrowth1, err := position.GetPositionFeeGrowthInsideLastX128(1)
+	if err != nil {
+		panic(err)
+	}
+	positionOwed0, positionOwed1, err := position.GetPositionTokensOwed(1)
+	if err != nil {
+		panic(err)
+	}
+	positionUnclaimed0, positionUnclaimed1, err := position.GetUnclaimedFee(1)
+	if err != nil {
+		panic(err)
+	}
+	positionLiquidity, err := position.GetPositionLiquidity(1)
+	if err != nil {
+		panic(err)
+	}
+	positionTickLower, err := position.GetPositionTickLower(1)
+	if err != nil {
+		panic(err)
+	}
+	positionTickUpper, err := position.GetPositionTickUpper(1)
+	if err != nil {
+		panic(err)
+	}
+	positionOwner, err := position.GetPositionOwner(1)
+	if err != nil {
+		panic(err)
+	}
+	positionOperator, err := position.GetPositionOperator(1)
+	if err != nil {
+		panic(err)
+	}
+	positionBurned, err := position.IsBurned(1)
+	if err != nil {
+		panic(err)
+	}
+	positionInRange, err := position.IsInRange(1)
+	if err != nil {
+		panic(err)
+	}
 	paramStatus, _ := govGovernance.GetProposalStatusByProposalId(paramProposalId)
 	spendStatus, _ := govGovernance.GetProposalStatusByProposalId(spendProposalId)
 	textStatus, _ := govGovernance.GetProposalStatusByProposalId(textProposalId)
@@ -1191,19 +1307,19 @@ func captureSnapshot() upgradeSnapshot {
 		withdrawalFee:      pool.GetWithdrawalFee(),
 		swapFee:            router.GetSwapFee(),
 		positionCount:      position.GetPositions().Size(),
-		positionLiquidity:  position.GetPositionLiquidity(1),
-		positionTickLower:  position.GetPositionTickLower(1),
-		positionTickUpper:  position.GetPositionTickUpper(1),
-		positionOwner:      position.GetPositionOwner(1),
-		positionOperator:   position.GetPositionOperator(1),
+		positionLiquidity:  positionLiquidity,
+		positionTickLower:  positionTickLower,
+		positionTickUpper:  positionTickUpper,
+		positionOwner:      positionOwner,
+		positionOperator:   positionOperator,
 		positionFeeGrowth0: positionFeeGrowth0,
 		positionFeeGrowth1: positionFeeGrowth1,
 		positionOwed0:      positionOwed0,
 		positionOwed1:      positionOwed1,
 		positionUnclaimed0: positionUnclaimed0,
 		positionUnclaimed1: positionUnclaimed1,
-		positionBurned:     position.IsBurned(1),
-		positionInRange:    position.IsInRange(1),
+		positionBurned:     positionBurned,
+		positionInRange:    positionInRange,
 		stakerPoolTier:     staker.GetPoolTier(barFoo500PoolPath),
 		stakerPoolTierRat:  staker.GetPoolTierRatio(barFoo500PoolPath),
 		stakerUnstakingFee: staker.GetUnstakingFee(),
@@ -1505,8 +1621,16 @@ func windDown(cur realm) {
 	staker.UnStakeToken(cross(cur), 1)
 	testing.SkipHeights(1)
 	println("[EXPECTED] position 1 staked after unstake:", staker.IsStaked(1))
-	println("[EXPECTED] position 1 owner after unstake:", position.GetPositionOwner(1))
-	println("[EXPECTED] position 1 operator cleared:", position.GetPositionOperator(1) == zeroAddress)
+	positionOwner, err := position.GetPositionOwner(1)
+	if err != nil {
+		panic(err)
+	}
+	positionOperator, err := position.GetPositionOperator(1)
+	if err != nil {
+		panic(err)
+	}
+	println("[EXPECTED] position 1 owner after unstake:", positionOwner)
+	println("[EXPECTED] position 1 operator cleared:", positionOperator == zeroAddress)
 
 	staker.RemoveToken(cross(cur), barPath)
 	println("[EXPECTED] allowed token count after removal:", len(staker.GetAllowedTokens()))
@@ -1546,7 +1670,7 @@ func windDown(cur realm) {
 	println("[EXPECTED] launchpad leftover transferred:", left)
 
 	uassert.False(t, staker.IsStaked(1))
-	uassert.Equal(t, adminAddr, position.GetPositionOwner(1))
+	uassert.Equal(t, adminAddr, positionOwner)
 	uassert.Equal(t, uint64(0), staker.GetPoolTier(barFoo500PoolPath))
 	uassert.Equal(t, int64(0), after0)
 	uassert.Equal(t, int64(0), after1)

--- a/contract/r/scenario/upgrade/implements/mock/position/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/mock/position/test_impl.gno
@@ -167,122 +167,58 @@ func (t *TestPosition) GetPositions() *rotree.ReadOnlyTree {
 	).(*rotree.ReadOnlyTree)
 }
 
-func (t *TestPosition) IsBurned(positionId uint64) bool {
-	return t.ExecuteFn(
-		"IsBurned",
-		func(args ...any) any { return t.instance.IsBurned(args[0].(uint64)) },
-		positionId,
-	).(bool)
+func (t *TestPosition) IsBurned(positionId uint64) (bool, error) {
+	return t.instance.IsBurned(positionId)
 }
 
-func (t *TestPosition) IsInRange(positionId uint64) bool {
-	return t.ExecuteFn(
-		"IsInRange",
-		func(args ...any) any { return t.instance.IsInRange(args[0].(uint64)) },
-		positionId,
-	).(bool)
+func (t *TestPosition) IsInRange(positionId uint64) (bool, error) {
+	return t.instance.IsInRange(positionId)
 }
 
-func (t *TestPosition) GetPositionOperator(positionId uint64) address {
-	return t.ExecuteFn(
-		"GetPositionOperator",
-		func(args ...any) any { return t.instance.GetPositionOperator(args[0].(uint64)) },
-		positionId,
-	).(address)
+func (t *TestPosition) GetPositionOperator(positionId uint64) (address, error) {
+	return t.instance.GetPositionOperator(positionId)
 }
 
-func (t *TestPosition) GetPositionPoolKey(positionId uint64) string {
-	return t.ExecuteFn(
-		"GetPositionPoolKey",
-		func(args ...any) any { return t.instance.GetPositionPoolKey(args[0].(uint64)) },
-		positionId,
-	).(string)
+func (t *TestPosition) GetPositionPoolKey(positionId uint64) (string, error) {
+	return t.instance.GetPositionPoolKey(positionId)
 }
 
-func (t *TestPosition) GetPositionTickLower(positionId uint64) int32 {
-	return t.ExecuteFn(
-		"GetPositionTickLower",
-		func(args ...any) any { return t.instance.GetPositionTickLower(args[0].(uint64)) },
-		positionId,
-	).(int32)
+func (t *TestPosition) GetPositionTickLower(positionId uint64) (int32, error) {
+	return t.instance.GetPositionTickLower(positionId)
 }
 
-func (t *TestPosition) GetPositionTickUpper(positionId uint64) int32 {
-	return t.ExecuteFn(
-		"GetPositionTickUpper",
-		func(args ...any) any { return t.instance.GetPositionTickUpper(args[0].(uint64)) },
-		positionId,
-	).(int32)
+func (t *TestPosition) GetPositionTickUpper(positionId uint64) (int32, error) {
+	return t.instance.GetPositionTickUpper(positionId)
 }
 
-func (t *TestPosition) GetPositionLiquidity(positionId uint64) string {
-	return t.ExecuteFn(
-		"GetPositionLiquidity",
-		func(args ...any) any { return t.instance.GetPositionLiquidity(args[0].(uint64)) },
-		positionId,
-	).(string)
+func (t *TestPosition) GetPositionLiquidity(positionId uint64) (string, error) {
+	return t.instance.GetPositionLiquidity(positionId)
 }
 
-func (t *TestPosition) GetPositionTokenBalances(positionId uint64) (int64, int64) {
-	result := t.ExecuteFn(
-		"GetPositionTokenBalances",
-		func(args ...any) any {
-			r1, r2 := t.instance.GetPositionTokenBalances(args[0].(uint64))
-			return []any{r1, r2}
-		},
-		positionId,
-	).([]any)
-	return result[0].(int64), result[1].(int64)
+func (t *TestPosition) GetPositionTokenBalances(positionId uint64) (int64, int64, error) {
+	return t.instance.GetPositionTokenBalances(positionId)
 }
 
-func (t *TestPosition) GetPositionFeeGrowthInside0LastX128(positionId uint64) string {
-	return t.ExecuteFn(
-		"GetPositionFeeGrowthInside0LastX128",
-		func(args ...any) any { return t.instance.GetPositionFeeGrowthInside0LastX128(args[0].(uint64)) },
-		positionId,
-	).(string)
+func (t *TestPosition) GetPositionFeeGrowthInside0LastX128(positionId uint64) (string, error) {
+	return t.instance.GetPositionFeeGrowthInside0LastX128(positionId)
 }
 
-func (t *TestPosition) GetPositionFeeGrowthInside1LastX128(positionId uint64) string {
-	return t.ExecuteFn(
-		"GetPositionFeeGrowthInside1LastX128",
-		func(args ...any) any { return t.instance.GetPositionFeeGrowthInside1LastX128(args[0].(uint64)) },
-		positionId,
-	).(string)
+func (t *TestPosition) GetPositionFeeGrowthInside1LastX128(positionId uint64) (string, error) {
+	return t.instance.GetPositionFeeGrowthInside1LastX128(positionId)
 }
 
-func (t *TestPosition) GetPositionTokensOwed0(positionId uint64) int64 {
-	return t.ExecuteFn(
-		"GetPositionTokensOwed0",
-		func(args ...any) any { return t.instance.GetPositionTokensOwed0(args[0].(uint64)) },
-		positionId,
-	).(int64)
+func (t *TestPosition) GetPositionTokensOwed0(positionId uint64) (int64, error) {
+	return t.instance.GetPositionTokensOwed0(positionId)
 }
 
-func (t *TestPosition) GetPositionTokensOwed1(positionId uint64) int64 {
-	return t.ExecuteFn(
-		"GetPositionTokensOwed1",
-		func(args ...any) any { return t.instance.GetPositionTokensOwed1(args[0].(uint64)) },
-		positionId,
-	).(int64)
+func (t *TestPosition) GetPositionTokensOwed1(positionId uint64) (int64, error) {
+	return t.instance.GetPositionTokensOwed1(positionId)
 }
 
-func (t *TestPosition) GetUnclaimedFee(positionId uint64) (*u256.Uint, *u256.Uint) {
-	result := t.ExecuteFn(
-		"GetUnclaimedFee",
-		func(args ...any) any {
-			r1, r2 := t.instance.GetUnclaimedFee(args[0].(uint64))
-			return []any{r1, r2}
-		},
-		positionId,
-	).([]any)
-	return result[0].(*u256.Uint), result[1].(*u256.Uint)
+func (t *TestPosition) GetUnclaimedFee(positionId uint64) (*u256.Uint, *u256.Uint, error) {
+	return t.instance.GetUnclaimedFee(positionId)
 }
 
-func (t *TestPosition) GetPositionOwner(positionId uint64) address {
-	return t.ExecuteFn(
-		"GetPositionOwner",
-		func(args ...any) any { return t.instance.GetPositionOwner(args[0].(uint64)) },
-		positionId,
-	).(address)
+func (t *TestPosition) GetPositionOwner(positionId uint64) (address, error) {
+	return t.instance.GetPositionOwner(positionId)
 }

--- a/contract/r/scenario/upgrade/implements/mock/position/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/mock/position/test_impl.gno
@@ -207,12 +207,24 @@ func (t *TestPosition) GetPositionFeeGrowthInside1LastX128(positionId uint64) (s
 	return t.instance.GetPositionFeeGrowthInside1LastX128(positionId)
 }
 
+func (t *TestPosition) GetPositionFeeGrowthInsideLastX128(positionId uint64) (string, string, error) {
+	return t.instance.GetPositionFeeGrowthInsideLastX128(positionId)
+}
+
+func (t *TestPosition) GetPositionTicks(positionId uint64) (int32, int32, error) {
+	return t.instance.GetPositionTicks(positionId)
+}
+
 func (t *TestPosition) GetPositionTokensOwed0(positionId uint64) (int64, error) {
 	return t.instance.GetPositionTokensOwed0(positionId)
 }
 
 func (t *TestPosition) GetPositionTokensOwed1(positionId uint64) (int64, error) {
 	return t.instance.GetPositionTokensOwed1(positionId)
+}
+
+func (t *TestPosition) GetPositionTokensOwed(positionId uint64) (int64, int64, error) {
+	return t.instance.GetPositionTokensOwed(positionId)
 }
 
 func (t *TestPosition) GetUnclaimedFee(positionId uint64) (*u256.Uint, *u256.Uint, error) {

--- a/contract/r/scenario/upgrade/implements/v2_invalid/position/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v2_invalid/position/test_impl.gno
@@ -204,6 +204,20 @@ func (t *TestPosition) GetPositionFeeGrowthInside1LastX128(positionId uint64) (s
 	return t.instance.GetPositionFeeGrowthInside1LastX128(positionId)
 }
 
+func (t *TestPosition) GetPositionFeeGrowthInsideLastX128(positionId uint64) (string, string, error) {
+	if !t.isActive("GetPositionFeeGrowthInsideLastX128") {
+		panic("test implementation: GetPositionFeeGrowthInsideLastX128 not supported")
+	}
+	return t.instance.GetPositionFeeGrowthInsideLastX128(positionId)
+}
+
+func (t *TestPosition) GetPositionTicks(positionId uint64) (int32, int32, error) {
+	if !t.isActive("GetPositionTicks") {
+		panic("test implementation: GetPositionTicks not supported")
+	}
+	return t.instance.GetPositionTicks(positionId)
+}
+
 func (t *TestPosition) GetPositionTokensOwed0(positionId uint64) (int64, error) {
 	if !t.isActive("GetPositionTokensOwed0") {
 		panic("test implementation: GetPositionTokensOwed0 not supported")
@@ -216,6 +230,13 @@ func (t *TestPosition) GetPositionTokensOwed1(positionId uint64) (int64, error) 
 		panic("test implementation: GetPositionTokensOwed1 not supported")
 	}
 	return t.instance.GetPositionTokensOwed1(positionId)
+}
+
+func (t *TestPosition) GetPositionTokensOwed(positionId uint64) (int64, int64, error) {
+	if !t.isActive("GetPositionTokensOwed") {
+		panic("test implementation: GetPositionTokensOwed not supported")
+	}
+	return t.instance.GetPositionTokensOwed(positionId)
 }
 
 func (t *TestPosition) GetUnclaimedFee(positionId uint64) (*u256.Uint, *u256.Uint, error) {

--- a/contract/r/scenario/upgrade/implements/v2_invalid/position/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v2_invalid/position/test_impl.gno
@@ -134,98 +134,98 @@ func (t *TestPosition) GetPositions() *rotree.ReadOnlyTree {
 	return t.instance.GetPositions()
 }
 
-func (t *TestPosition) IsBurned(positionId uint64) bool {
+func (t *TestPosition) IsBurned(positionId uint64) (bool, error) {
 	if !t.isActive("IsBurned") {
 		panic("test implementation: IsBurned not supported")
 	}
 	return t.instance.IsBurned(positionId)
 }
 
-func (t *TestPosition) IsInRange(positionId uint64) bool {
+func (t *TestPosition) IsInRange(positionId uint64) (bool, error) {
 	if !t.isActive("IsInRange") {
 		panic("test implementation: IsInRange not supported")
 	}
 	return t.instance.IsInRange(positionId)
 }
 
-func (t *TestPosition) GetPositionOperator(positionId uint64) address {
+func (t *TestPosition) GetPositionOperator(positionId uint64) (address, error) {
 	if !t.isActive("GetPositionOperator") {
 		panic("test implementation: GetPositionOperator not supported")
 	}
 	return t.instance.GetPositionOperator(positionId)
 }
 
-func (t *TestPosition) GetPositionPoolKey(positionId uint64) string {
+func (t *TestPosition) GetPositionPoolKey(positionId uint64) (string, error) {
 	if !t.isActive("GetPositionPoolKey") {
 		panic("test implementation: GetPositionPoolKey not supported")
 	}
 	return t.instance.GetPositionPoolKey(positionId)
 }
 
-func (t *TestPosition) GetPositionTickLower(positionId uint64) int32 {
+func (t *TestPosition) GetPositionTickLower(positionId uint64) (int32, error) {
 	if !t.isActive("GetPositionTickLower") {
 		panic("test implementation: GetPositionTickLower not supported")
 	}
 	return t.instance.GetPositionTickLower(positionId)
 }
 
-func (t *TestPosition) GetPositionTickUpper(positionId uint64) int32 {
+func (t *TestPosition) GetPositionTickUpper(positionId uint64) (int32, error) {
 	if !t.isActive("GetPositionTickUpper") {
 		panic("test implementation: GetPositionTickUpper not supported")
 	}
 	return t.instance.GetPositionTickUpper(positionId)
 }
 
-func (t *TestPosition) GetPositionLiquidity(positionId uint64) string {
+func (t *TestPosition) GetPositionLiquidity(positionId uint64) (string, error) {
 	if !t.isActive("GetPositionLiquidity") {
 		panic("test implementation: GetPositionLiquidity not supported")
 	}
 	return t.instance.GetPositionLiquidity(positionId)
 }
 
-func (t *TestPosition) GetPositionTokenBalances(positionId uint64) (int64, int64) {
+func (t *TestPosition) GetPositionTokenBalances(positionId uint64) (int64, int64, error) {
 	if !t.isActive("GetPositionTokenBalances") {
 		panic("test implementation: GetPositionTokenBalances not supported")
 	}
 	return t.instance.GetPositionTokenBalances(positionId)
 }
 
-func (t *TestPosition) GetPositionFeeGrowthInside0LastX128(positionId uint64) string {
+func (t *TestPosition) GetPositionFeeGrowthInside0LastX128(positionId uint64) (string, error) {
 	if !t.isActive("GetPositionFeeGrowthInside0LastX128") {
 		panic("test implementation: GetPositionFeeGrowthInside0LastX128 not supported")
 	}
 	return t.instance.GetPositionFeeGrowthInside0LastX128(positionId)
 }
 
-func (t *TestPosition) GetPositionFeeGrowthInside1LastX128(positionId uint64) string {
+func (t *TestPosition) GetPositionFeeGrowthInside1LastX128(positionId uint64) (string, error) {
 	if !t.isActive("GetPositionFeeGrowthInside1LastX128") {
 		panic("test implementation: GetPositionFeeGrowthInside1LastX128 not supported")
 	}
 	return t.instance.GetPositionFeeGrowthInside1LastX128(positionId)
 }
 
-func (t *TestPosition) GetPositionTokensOwed0(positionId uint64) int64 {
+func (t *TestPosition) GetPositionTokensOwed0(positionId uint64) (int64, error) {
 	if !t.isActive("GetPositionTokensOwed0") {
 		panic("test implementation: GetPositionTokensOwed0 not supported")
 	}
 	return t.instance.GetPositionTokensOwed0(positionId)
 }
 
-func (t *TestPosition) GetPositionTokensOwed1(positionId uint64) int64 {
+func (t *TestPosition) GetPositionTokensOwed1(positionId uint64) (int64, error) {
 	if !t.isActive("GetPositionTokensOwed1") {
 		panic("test implementation: GetPositionTokensOwed1 not supported")
 	}
 	return t.instance.GetPositionTokensOwed1(positionId)
 }
 
-func (t *TestPosition) GetUnclaimedFee(positionId uint64) (*u256.Uint, *u256.Uint) {
+func (t *TestPosition) GetUnclaimedFee(positionId uint64) (*u256.Uint, *u256.Uint, error) {
 	if !t.isActive("GetUnclaimedFee") {
 		panic("test implementation: GetUnclaimedFee not supported")
 	}
 	return t.instance.GetUnclaimedFee(positionId)
 }
 
-func (t *TestPosition) GetPositionOwner(positionId uint64) address {
+func (t *TestPosition) GetPositionOwner(positionId uint64) (address, error) {
 	if !t.isActive("GetPositionOwner") {
 		panic("test implementation: GetPositionOwner not supported")
 	}

--- a/contract/r/scenario/upgrade/implements/v3_valid/position/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/position/test_impl.gno
@@ -100,58 +100,58 @@ func (t *TestPosition) GetPositions() *rotree.ReadOnlyTree {
 	return t.instance.GetPositions()
 }
 
-func (t *TestPosition) IsBurned(positionId uint64) bool {
+func (t *TestPosition) IsBurned(positionId uint64) (bool, error) {
 	return t.instance.IsBurned(positionId)
 }
 
-func (t *TestPosition) IsInRange(positionId uint64) bool {
+func (t *TestPosition) IsInRange(positionId uint64) (bool, error) {
 	return t.instance.IsInRange(positionId)
 }
 
-func (t *TestPosition) GetPositionOperator(positionId uint64) address {
+func (t *TestPosition) GetPositionOperator(positionId uint64) (address, error) {
 	return t.instance.GetPositionOperator(positionId)
 }
 
-func (t *TestPosition) GetPositionPoolKey(positionId uint64) string {
+func (t *TestPosition) GetPositionPoolKey(positionId uint64) (string, error) {
 	return t.instance.GetPositionPoolKey(positionId)
 }
 
-func (t *TestPosition) GetPositionTickLower(positionId uint64) int32 {
+func (t *TestPosition) GetPositionTickLower(positionId uint64) (int32, error) {
 	return t.instance.GetPositionTickLower(positionId)
 }
 
-func (t *TestPosition) GetPositionTickUpper(positionId uint64) int32 {
+func (t *TestPosition) GetPositionTickUpper(positionId uint64) (int32, error) {
 	return t.instance.GetPositionTickUpper(positionId)
 }
 
-func (t *TestPosition) GetPositionLiquidity(positionId uint64) string {
+func (t *TestPosition) GetPositionLiquidity(positionId uint64) (string, error) {
 	return t.instance.GetPositionLiquidity(positionId)
 }
 
-func (t *TestPosition) GetPositionTokenBalances(positionId uint64) (int64, int64) {
+func (t *TestPosition) GetPositionTokenBalances(positionId uint64) (int64, int64, error) {
 	return t.instance.GetPositionTokenBalances(positionId)
 }
 
-func (t *TestPosition) GetPositionFeeGrowthInside0LastX128(positionId uint64) string {
+func (t *TestPosition) GetPositionFeeGrowthInside0LastX128(positionId uint64) (string, error) {
 	return t.instance.GetPositionFeeGrowthInside0LastX128(positionId)
 }
 
-func (t *TestPosition) GetPositionFeeGrowthInside1LastX128(positionId uint64) string {
+func (t *TestPosition) GetPositionFeeGrowthInside1LastX128(positionId uint64) (string, error) {
 	return t.instance.GetPositionFeeGrowthInside1LastX128(positionId)
 }
 
-func (t *TestPosition) GetPositionTokensOwed0(positionId uint64) int64 {
+func (t *TestPosition) GetPositionTokensOwed0(positionId uint64) (int64, error) {
 	return t.instance.GetPositionTokensOwed0(positionId)
 }
 
-func (t *TestPosition) GetPositionTokensOwed1(positionId uint64) int64 {
+func (t *TestPosition) GetPositionTokensOwed1(positionId uint64) (int64, error) {
 	return t.instance.GetPositionTokensOwed1(positionId)
 }
 
-func (t *TestPosition) GetUnclaimedFee(positionId uint64) (*u256.Uint, *u256.Uint) {
+func (t *TestPosition) GetUnclaimedFee(positionId uint64) (*u256.Uint, *u256.Uint, error) {
 	return t.instance.GetUnclaimedFee(positionId)
 }
 
-func (t *TestPosition) GetPositionOwner(positionId uint64) address {
+func (t *TestPosition) GetPositionOwner(positionId uint64) (address, error) {
 	return t.instance.GetPositionOwner(positionId)
 }

--- a/contract/r/scenario/upgrade/implements/v3_valid/position/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/position/test_impl.gno
@@ -140,12 +140,24 @@ func (t *TestPosition) GetPositionFeeGrowthInside1LastX128(positionId uint64) (s
 	return t.instance.GetPositionFeeGrowthInside1LastX128(positionId)
 }
 
+func (t *TestPosition) GetPositionFeeGrowthInsideLastX128(positionId uint64) (string, string, error) {
+	return t.instance.GetPositionFeeGrowthInsideLastX128(positionId)
+}
+
+func (t *TestPosition) GetPositionTicks(positionId uint64) (int32, int32, error) {
+	return t.instance.GetPositionTicks(positionId)
+}
+
 func (t *TestPosition) GetPositionTokensOwed0(positionId uint64) (int64, error) {
 	return t.instance.GetPositionTokensOwed0(positionId)
 }
 
 func (t *TestPosition) GetPositionTokensOwed1(positionId uint64) (int64, error) {
 	return t.instance.GetPositionTokensOwed1(positionId)
+}
+
+func (t *TestPosition) GetPositionTokensOwed(positionId uint64) (int64, int64, error) {
+	return t.instance.GetPositionTokensOwed(positionId)
 }
 
 func (t *TestPosition) GetUnclaimedFee(positionId uint64) (*u256.Uint, *u256.Uint, error) {

--- a/contract/r/scenario/upgrade/pool_upgrade_with_validate_data_filetest.gno
+++ b/contract/r/scenario/upgrade/pool_upgrade_with_validate_data_filetest.gno
@@ -239,14 +239,38 @@ func captureV1Snapshot() {
 	v1WithdrawalFee = pool.GetWithdrawalFee()
 
 	v1PositionCount = position.GetPositions().Size()
-	v1PositionLiquidity = position.GetPositionLiquidity(positionId)
-	v1PositionOwner = position.GetPositionOwner(positionId)
-	v1PositionTickLower = position.GetPositionTickLower(positionId)
-	v1PositionTickUpper = position.GetPositionTickUpper(positionId)
-	v1PositionPoolKey = position.GetPositionPoolKey(positionId)
-	v1PositionIsBurned = position.IsBurned(positionId)
-	v1PositionIsInRange = position.IsInRange(positionId)
-	v1PositionTokensOwed = position.GetPositionTokensOwed0(positionId)
+	v1PositionLiquidity, err = position.GetPositionLiquidity(positionId)
+	if err != nil {
+		panic(err)
+	}
+	v1PositionOwner, err = position.GetPositionOwner(positionId)
+	if err != nil {
+		panic(err)
+	}
+	v1PositionTickLower, err = position.GetPositionTickLower(positionId)
+	if err != nil {
+		panic(err)
+	}
+	v1PositionTickUpper, err = position.GetPositionTickUpper(positionId)
+	if err != nil {
+		panic(err)
+	}
+	v1PositionPoolKey, err = position.GetPositionPoolKey(positionId)
+	if err != nil {
+		panic(err)
+	}
+	v1PositionIsBurned, err = position.IsBurned(positionId)
+	if err != nil {
+		panic(err)
+	}
+	v1PositionIsInRange, err = position.IsInRange(positionId)
+	if err != nil {
+		panic(err)
+	}
+	v1PositionTokensOwed, err = position.GetPositionTokensOwed0(positionId)
+	if err != nil {
+		panic(err)
+	}
 
 	println("[EXPECTED] pool liquidity:", v1PoolLiquidity)
 	println("[EXPECTED] pool balances:", v1PoolBalance0, v1PoolBalance1)
@@ -330,6 +354,38 @@ func validateV1Snapshot() {
 	if err != nil {
 		panic(err)
 	}
+	positionLiquidity, err := position.GetPositionLiquidity(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionOwner, err := position.GetPositionOwner(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionTickLower, err := position.GetPositionTickLower(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionTickUpper, err := position.GetPositionTickUpper(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionPoolKey, err := position.GetPositionPoolKey(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionIsBurned, err := position.IsBurned(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionIsInRange, err := position.IsInRange(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionTokensOwed, err := position.GetPositionTokensOwed0(positionId)
+	if err != nil {
+		panic(err)
+	}
 
 	uassert.Equal(t, v1PoolLiquidity, poolLiquidity)
 	uassert.Equal(t, v1PoolSqrtPriceX96, poolSqrtPriceX96)
@@ -355,14 +411,14 @@ func validateV1Snapshot() {
 	uassert.Equal(t, v1WithdrawalFee, pool.GetWithdrawalFee())
 
 	uassert.Equal(t, v1PositionCount, position.GetPositions().Size())
-	uassert.Equal(t, v1PositionLiquidity, position.GetPositionLiquidity(positionId))
-	uassert.Equal(t, v1PositionOwner, position.GetPositionOwner(positionId))
-	uassert.Equal(t, v1PositionTickLower, position.GetPositionTickLower(positionId))
-	uassert.Equal(t, v1PositionTickUpper, position.GetPositionTickUpper(positionId))
-	uassert.Equal(t, v1PositionPoolKey, position.GetPositionPoolKey(positionId))
-	uassert.Equal(t, v1PositionIsBurned, position.IsBurned(positionId))
-	uassert.Equal(t, v1PositionIsInRange, position.IsInRange(positionId))
-	uassert.Equal(t, v1PositionTokensOwed, position.GetPositionTokensOwed0(positionId))
+	uassert.Equal(t, v1PositionLiquidity, positionLiquidity)
+	uassert.Equal(t, v1PositionOwner, positionOwner)
+	uassert.Equal(t, v1PositionTickLower, positionTickLower)
+	uassert.Equal(t, v1PositionTickUpper, positionTickUpper)
+	uassert.Equal(t, v1PositionPoolKey, positionPoolKey)
+	uassert.Equal(t, v1PositionIsBurned, positionIsBurned)
+	uassert.Equal(t, v1PositionIsInRange, positionIsInRange)
+	uassert.Equal(t, v1PositionTokensOwed, positionTokensOwed)
 	uassert.True(t, pool.ExistsPoolPath(barFoo500PoolPath))
 
 	println("[EXPECTED] every pool and position getter still returns the v1 value")
@@ -382,6 +438,10 @@ func validateAfterSecondMint(cur realm) {
 	if err != nil {
 		panic(err)
 	}
+	positionLiquidity, err := position.GetPositionLiquidity(positionId)
+	if err != nil {
+		panic(err)
+	}
 
 	println("[EXPECTED] pool liquidity after the second mint:", poolLiquidity)
 	println("[EXPECTED] pool-side position liquidity:", poolPositionLiquidity)
@@ -392,7 +452,7 @@ func validateAfterSecondMint(cur realm) {
 	// the two positions share the same tick range, so the pool-side position
 	// entry is the sum of both and the first position is untouched
 	uassert.Equal(t, v1PositionCount+1, position.GetPositions().Size())
-	uassert.Equal(t, v1PositionLiquidity, position.GetPositionLiquidity(positionId))
+	uassert.Equal(t, v1PositionLiquidity, positionLiquidity)
 	uassert.Equal(t, poolLiquidity, poolPositionLiquidity)
 	uassert.Equal(t, poolLiquidity, tickLowerGross)
 }

--- a/contract/r/scenario/upgrade/position_collectfee_upgrade_with_validate_data_filetest.gno
+++ b/contract/r/scenario/upgrade/position_collectfee_upgrade_with_validate_data_filetest.gno
@@ -136,14 +136,38 @@ func main(cur realm) {
 
 func captureV1Snapshot() {
 	var err error
-	v1PositionLiquidity = position.GetPositionLiquidity(positionId)
-	v1PositionPoolKey = position.GetPositionPoolKey(positionId)
-	v1PositionOwner = position.GetPositionOwner(positionId)
-	v1PositionTickLower = position.GetPositionTickLower(positionId)
-	v1PositionTickUpper = position.GetPositionTickUpper(positionId)
-	v1PositionFeeGrowth0, v1PositionFeeGrowth1 = position.GetPositionFeeGrowthInsideLastX128(positionId)
-	v1PositionTokensOwed0, v1PositionTokensOwed1 = position.GetPositionTokensOwed(positionId)
-	v1PositionUnclaimed0, v1PositionUnclaimed1 = position.GetUnclaimedFee(positionId)
+	v1PositionLiquidity, err = position.GetPositionLiquidity(positionId)
+	if err != nil {
+		panic(err)
+	}
+	v1PositionPoolKey, err = position.GetPositionPoolKey(positionId)
+	if err != nil {
+		panic(err)
+	}
+	v1PositionOwner, err = position.GetPositionOwner(positionId)
+	if err != nil {
+		panic(err)
+	}
+	v1PositionTickLower, err = position.GetPositionTickLower(positionId)
+	if err != nil {
+		panic(err)
+	}
+	v1PositionTickUpper, err = position.GetPositionTickUpper(positionId)
+	if err != nil {
+		panic(err)
+	}
+	v1PositionFeeGrowth0, v1PositionFeeGrowth1, err = position.GetPositionFeeGrowthInsideLastX128(positionId)
+	if err != nil {
+		panic(err)
+	}
+	v1PositionTokensOwed0, v1PositionTokensOwed1, err = position.GetPositionTokensOwed(positionId)
+	if err != nil {
+		panic(err)
+	}
+	v1PositionUnclaimed0, v1PositionUnclaimed1, err = position.GetUnclaimedFee(positionId)
+	if err != nil {
+		panic(err)
+	}
 	v1PoolFeeGrowth0, v1PoolFeeGrowth1, err = pool.GetFeeGrowthGlobalX128(barFoo500PoolPath)
 	if err != nil {
 		panic(err)
@@ -197,15 +221,48 @@ func validateExactAfterUpgrade() {
 	if err != nil {
 		panic(err)
 	}
-	positionFeeGrowth0, positionFeeGrowth1 := position.GetPositionFeeGrowthInsideLastX128(positionId)
-	tokensOwed0, tokensOwed1 := position.GetPositionTokensOwed(positionId)
-	unclaimed0, unclaimed1 := position.GetUnclaimedFee(positionId)
+	positionFeeGrowth0, positionFeeGrowth1, err := position.GetPositionFeeGrowthInsideLastX128(positionId)
+	if err != nil {
+		panic(err)
+	}
+	tokensOwed0, tokensOwed1, err := position.GetPositionTokensOwed(positionId)
+	if err != nil {
+		panic(err)
+	}
+	unclaimed0, unclaimed1, err := position.GetUnclaimedFee(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionLiquidity, err := position.GetPositionLiquidity(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionPoolKey, err := position.GetPositionPoolKey(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionOwner, err := position.GetPositionOwner(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionTickLower, err := position.GetPositionTickLower(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionTickUpper, err := position.GetPositionTickUpper(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionBurned, err := position.IsBurned(positionId)
+	if err != nil {
+		panic(err)
+	}
 
-	uassert.Equal(t, v1PositionLiquidity, position.GetPositionLiquidity(positionId))
-	uassert.Equal(t, v1PositionPoolKey, position.GetPositionPoolKey(positionId))
-	uassert.Equal(t, v1PositionOwner, position.GetPositionOwner(positionId))
-	uassert.Equal(t, v1PositionTickLower, position.GetPositionTickLower(positionId))
-	uassert.Equal(t, v1PositionTickUpper, position.GetPositionTickUpper(positionId))
+	uassert.Equal(t, v1PositionLiquidity, positionLiquidity)
+	uassert.Equal(t, v1PositionPoolKey, positionPoolKey)
+	uassert.Equal(t, v1PositionOwner, positionOwner)
+	uassert.Equal(t, v1PositionTickLower, positionTickLower)
+	uassert.Equal(t, v1PositionTickUpper, positionTickUpper)
 	uassert.Equal(t, v1PositionFeeGrowth0, positionFeeGrowth0)
 	uassert.Equal(t, v1PositionFeeGrowth1, positionFeeGrowth1)
 	uassert.Equal(t, v1PositionTokensOwed0, tokensOwed0)
@@ -218,7 +275,7 @@ func validateExactAfterUpgrade() {
 	uassert.Equal(t, v1PoolProtocolFee1, protocolFee1)
 	uassert.Equal(t, v1PoolLiquidity, poolLiquidity)
 	uassert.Equal(t, v1PoolTick, poolTick)
-	uassert.False(t, position.IsBurned(positionId))
+	uassert.False(t, positionBurned)
 
 	println("[EXPECTED] Every snapshot field matches exactly right after the upgrade")
 	println("[EXPECTED] Position fee growth inside last:", positionFeeGrowth0, positionFeeGrowth1)
@@ -245,15 +302,34 @@ func validateAccrualAfterUpgrade() {
 	if err != nil {
 		panic(err)
 	}
-	unclaimed0, unclaimed1 := position.GetUnclaimedFee(positionId)
+	unclaimed0, unclaimed1, err := position.GetUnclaimedFee(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionLiquidity, err := position.GetPositionLiquidity(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionPoolKey, err := position.GetPositionPoolKey(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionOwner, err := position.GetPositionOwner(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionBurned, err := position.IsBurned(positionId)
+	if err != nil {
+		panic(err)
+	}
 
-	uassert.Equal(t, v1PositionLiquidity, position.GetPositionLiquidity(positionId))
-	uassert.Equal(t, v1PositionPoolKey, position.GetPositionPoolKey(positionId))
-	uassert.Equal(t, v1PositionOwner, position.GetPositionOwner(positionId))
+	uassert.Equal(t, v1PositionLiquidity, positionLiquidity)
+	uassert.Equal(t, v1PositionPoolKey, positionPoolKey)
+	uassert.Equal(t, v1PositionOwner, positionOwner)
 	// no mint / burn happened, so the in-range liquidity is unchanged; the tick
 	// may have moved because of the post-upgrade swap
 	uassert.Equal(t, v1PoolLiquidity, poolLiquidity)
-	uassert.False(t, position.IsBurned(positionId))
+	uassert.False(t, positionBurned)
 
 	uassert.True(t, feeGrowth0 >= v1PoolFeeGrowth0)
 	uassert.True(t, feeGrowth1 >= v1PoolFeeGrowth1)

--- a/contract/r/scenario/upgrade/position_v2_valid_upgrade_filetest.gno
+++ b/contract/r/scenario/upgrade/position_v2_valid_upgrade_filetest.gno
@@ -210,7 +210,11 @@ func mintPositionV2Valid(cur realm) {
 func setPositionOperatorV2Valid(cur realm) {
 	testing.SetRealm(stakerRealm)
 	position.SetPositionOperator(cross(cur), positionId, operatorAddr)
-	ufmt.Printf("[EXPECTED] v2_valid set operator id=%d operator=%s\n", positionId, position.GetPositionOperator(positionId))
+	operator, err := position.GetPositionOperator(positionId)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[EXPECTED] v2_valid set operator id=%d operator=%s\n", positionId, operator)
 }
 
 // clearV1PositionForReposition fully drains the v1 position so it satisfies the
@@ -219,13 +223,20 @@ func setPositionOperatorV2Valid(cur realm) {
 // v2_valid and then collects fees to zero out tokensOwed.
 func clearV1PositionForReposition(cur realm) {
 	testing.SetRealm(adminRealm)
-	remaining := position.GetPositionLiquidity(positionId)
+	remaining, err := position.GetPositionLiquidity(positionId)
+	if err != nil {
+		panic(err)
+	}
 	id, liq, _, _, _, _, _ := position.DecreaseLiquidity(cross(cur), positionId, remaining, "0", "0", time.Now().Unix()+3600)
 	ufmt.Printf("[EXPECTED] v2_valid drained position id=%d removedLiquidity=%s\n", id, liq)
 
 	cid, amount0, amount1, _, _, _ := position.CollectFee(cross(cur), positionId)
+	liquidity, err := position.GetPositionLiquidity(positionId)
+	if err != nil {
+		panic(err)
+	}
 	ufmt.Printf("[EXPECTED] v2_valid cleared owed id=%d amount0=%s amount1=%s liquidity=%s\n",
-		cid, amount0, amount1, position.GetPositionLiquidity(positionId))
+		cid, amount0, amount1, liquidity)
 }
 
 // repositionV2Valid repositions the now-cleared v1 position into a new tick
@@ -242,17 +253,35 @@ func repositionV2Valid(cur realm) {
 }
 
 func printPositionData(cur realm) {
-	liquidity := position.GetPositionLiquidity(positionId)
-	tickLower, tickUpper := position.GetPositionTicks(positionId)
-	poolKey := position.GetPositionPoolKey(positionId)
+	liquidity, err := position.GetPositionLiquidity(positionId)
+	if err != nil {
+		panic(err)
+	}
+	tickLower, tickUpper, err := position.GetPositionTicks(positionId)
+	if err != nil {
+		panic(err)
+	}
+	poolKey, err := position.GetPositionPoolKey(positionId)
+	if err != nil {
+		panic(err)
+	}
 	ufmt.Printf("[EXPECTED] position id=%d liquidity=%s tickLower=%d tickUpper=%d pool=%s\n",
 		positionId, liquidity, tickLower, tickUpper, poolKey)
 }
 
 func printNewPositionData(cur realm) {
-	liquidity := position.GetPositionLiquidity(newPositionId)
-	tickLower, tickUpper := position.GetPositionTicks(newPositionId)
-	poolKey := position.GetPositionPoolKey(newPositionId)
+	liquidity, err := position.GetPositionLiquidity(newPositionId)
+	if err != nil {
+		panic(err)
+	}
+	tickLower, tickUpper, err := position.GetPositionTicks(newPositionId)
+	if err != nil {
+		panic(err)
+	}
+	poolKey, err := position.GetPositionPoolKey(newPositionId)
+	if err != nil {
+		panic(err)
+	}
 	ufmt.Printf("[EXPECTED] position id=%d liquidity=%s tickLower=%d tickUpper=%d pool=%s\n",
 		newPositionId, liquidity, tickLower, tickUpper, poolKey)
 }

--- a/contract/r/scenario/upgrade/router_swap_upgrade_with_validate_data_filetest.gno
+++ b/contract/r/scenario/upgrade/router_swap_upgrade_with_validate_data_filetest.gno
@@ -143,11 +143,26 @@ func captureV1Snapshot() {
 	if err != nil {
 		panic(err)
 	}
-	v1PositionLiquidity = position.GetPositionLiquidity(positionId)
-	v1PositionPoolKey = position.GetPositionPoolKey(positionId)
-	v1PositionTickLower = position.GetPositionTickLower(positionId)
-	v1PositionTickUpper = position.GetPositionTickUpper(positionId)
-	v1PositionUnclaimed0, v1PositionUnclaimed1 = position.GetUnclaimedFee(positionId)
+	v1PositionLiquidity, err = position.GetPositionLiquidity(positionId)
+	if err != nil {
+		panic(err)
+	}
+	v1PositionPoolKey, err = position.GetPositionPoolKey(positionId)
+	if err != nil {
+		panic(err)
+	}
+	v1PositionTickLower, err = position.GetPositionTickLower(positionId)
+	if err != nil {
+		panic(err)
+	}
+	v1PositionTickUpper, err = position.GetPositionTickUpper(positionId)
+	if err != nil {
+		panic(err)
+	}
+	v1PositionUnclaimed0, v1PositionUnclaimed1, err = position.GetUnclaimedFee(positionId)
+	if err != nil {
+		panic(err)
+	}
 
 	println("[EXPECTED] Router swap fee:", v1SwapFee)
 	println("[EXPECTED] Pool tick after the v1 swap:", v1PoolTick)
@@ -187,7 +202,26 @@ func validateExactAfterUpgrade() {
 	if err != nil {
 		panic(err)
 	}
-	unclaimed0, unclaimed1 := position.GetUnclaimedFee(positionId)
+	unclaimed0, unclaimed1, err := position.GetUnclaimedFee(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionLiquidity, err := position.GetPositionLiquidity(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionPoolKey, err := position.GetPositionPoolKey(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionTickLower, err := position.GetPositionTickLower(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionTickUpper, err := position.GetPositionTickUpper(positionId)
+	if err != nil {
+		panic(err)
+	}
 
 	uassert.Equal(t, v1SwapFee, router.GetSwapFee())
 	uassert.Equal(t, v1PoolLiquidity, poolLiquidity)
@@ -198,10 +232,10 @@ func validateExactAfterUpgrade() {
 	uassert.Equal(t, v1PoolProtocolFee1, protocolFee1)
 	uassert.Equal(t, v1PoolBalance0, balance0)
 	uassert.Equal(t, v1PoolBalance1, balance1)
-	uassert.Equal(t, v1PositionLiquidity, position.GetPositionLiquidity(positionId))
-	uassert.Equal(t, v1PositionPoolKey, position.GetPositionPoolKey(positionId))
-	uassert.Equal(t, v1PositionTickLower, position.GetPositionTickLower(positionId))
-	uassert.Equal(t, v1PositionTickUpper, position.GetPositionTickUpper(positionId))
+	uassert.Equal(t, v1PositionLiquidity, positionLiquidity)
+	uassert.Equal(t, v1PositionPoolKey, positionPoolKey)
+	uassert.Equal(t, v1PositionTickLower, positionTickLower)
+	uassert.Equal(t, v1PositionTickUpper, positionTickUpper)
 	uassert.Equal(t, v1PositionUnclaimed0, unclaimed0)
 	uassert.Equal(t, v1PositionUnclaimed1, unclaimed1)
 
@@ -223,16 +257,39 @@ func validateAccrualAfterUpgrade() {
 	if err != nil {
 		panic(err)
 	}
-	unclaimed0, unclaimed1 := position.GetUnclaimedFee(positionId)
+	unclaimed0, unclaimed1, err := position.GetUnclaimedFee(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionLiquidity, err := position.GetPositionLiquidity(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionPoolKey, err := position.GetPositionPoolKey(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionTickLower, err := position.GetPositionTickLower(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionTickUpper, err := position.GetPositionTickUpper(positionId)
+	if err != nil {
+		panic(err)
+	}
+	positionBurned, err := position.IsBurned(positionId)
+	if err != nil {
+		panic(err)
+	}
 
 	// the router upgrade must not move liquidity or reshape the position
 	uassert.Equal(t, v1SwapFee, router.GetSwapFee())
 	uassert.Equal(t, v1PoolLiquidity, poolLiquidity)
-	uassert.Equal(t, v1PositionLiquidity, position.GetPositionLiquidity(positionId))
-	uassert.Equal(t, v1PositionPoolKey, position.GetPositionPoolKey(positionId))
-	uassert.Equal(t, v1PositionTickLower, position.GetPositionTickLower(positionId))
-	uassert.Equal(t, v1PositionTickUpper, position.GetPositionTickUpper(positionId))
-	uassert.False(t, position.IsBurned(positionId))
+	uassert.Equal(t, v1PositionLiquidity, positionLiquidity)
+	uassert.Equal(t, v1PositionPoolKey, positionPoolKey)
+	uassert.Equal(t, v1PositionTickLower, positionTickLower)
+	uassert.Equal(t, v1PositionTickUpper, positionTickUpper)
+	uassert.False(t, positionBurned)
 
 	// the swap routed through the upgraded router keeps accruing on top of the
 	// v1 values instead of resetting them


### PR DESCRIPTION
## Summary

- Return errors from position getters when requested pool or position data is unavailable.
- Propagate those errors through position lifecycle callers and dependent pool/staker integrations.
- Update mocks, upgrade fixtures, tests, and position scenarios for the error-returning getter API.

## Validation

- `make test PKG=gno.land/r/gnoswap/pool/v1`
- `make test PKG=gno.land/r/gnoswap/position/v1`
- `make test PKG=gno.land/r/gnoswap/staker/v1`
- `make test PKG=gno.land/r/gnoswap/scenario/position`
- `git diff --check origin/main..HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added queries for pool positions, including liquidity, fee growth, ticks, token balances, and tokens owed.
  * Added accessors for detailed tick state and initialization status.
  * Added combined position queries for fee growth, tick ranges, and owed tokens.

* **Bug Fixes**
  * Position and pool lookups now return actionable errors instead of silently returning empty values or panicking.
  * Improved error propagation for balance, ownership, range, and unclaimed-fee queries.

* **Tests**
  * Expanded coverage for successful, missing, invalid, and upgrade-related position and tick queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->