### PR TITLE
refactor(staker): return errors in getters

### DIFF
--- a/contract/r/gnoswap/staker/_mock_test.gno
+++ b/contract/r/gnoswap/staker/_mock_test.gno
@@ -142,116 +142,130 @@ func (m *MockStaker) GetPendingProtocolFees() map[string]int64 {
 }
 
 // Getter methods
-func (m *MockStaker) GetPool(poolPath string) *Pool {
+func (m *MockStaker) GetPool(poolPath string) (*Pool, error) {
 	res, ok := m.Response.Get("GetPool")
 	if !ok {
-		return nil
+		return nil, nil
 	}
-	return res[0].(*Pool)
+
+	return res[0].(*Pool), nil
 }
 
-func (m *MockStaker) GetDeposit(lpTokenId uint64) *Deposit {
+func (m *MockStaker) GetDeposit(lpTokenId uint64) (*Deposit, error) {
 	res, ok := m.Response.Get("GetDeposit")
 	if !ok {
-		return nil
+		return nil, nil
 	}
-	return res[0].(*Deposit)
+
+	return res[0].(*Deposit), nil
 }
 
-func (m *MockStaker) CollectableEmissionReward(positionId uint64) int64 {
+func (m *MockStaker) CollectableEmissionReward(positionId uint64) (int64, error) {
 	res, ok := m.Response.Get("CollectableEmissionReward")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
-func (m *MockStaker) CollectableExternalIncentiveReward(positionId uint64, incentiveId string) int64 {
+func (m *MockStaker) CollectableExternalIncentiveReward(positionId uint64, incentiveId string) (int64, error) {
 	res, ok := m.Response.Get("CollectableExternalIncentiveReward")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
-func (m *MockStaker) GetCreatedHeightOfIncentive(poolPath string, incentiveId string) int64 {
+func (m *MockStaker) GetCreatedHeightOfIncentive(poolPath string, incentiveId string) (int64, error) {
 	res, ok := m.Response.Get("GetCreatedHeightOfIncentive")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
-func (m *MockStaker) GetIncentiveCreatedTimestamp(poolPath string, incentiveId string) int64 {
+func (m *MockStaker) GetIncentiveCreatedTimestamp(poolPath string, incentiveId string) (int64, error) {
 	res, ok := m.Response.Get("GetIncentiveCreatedTimestamp")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
-func (m *MockStaker) GetIncentiveTotalRewardAmount(poolPath string, incentiveId string) int64 {
+func (m *MockStaker) GetIncentiveTotalRewardAmount(poolPath string, incentiveId string) (int64, error) {
 	res, ok := m.Response.Get("GetIncentiveTotalRewardAmount")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
-func (m *MockStaker) GetIncentiveDistributedRewardAmount(poolPath string, incentiveId string) int64 {
+func (m *MockStaker) GetIncentiveDistributedRewardAmount(poolPath string, incentiveId string) (int64, error) {
 	res, ok := m.Response.Get("GetIncentiveDistributedRewardAmount")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
-func (m *MockStaker) GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) int64 {
+func (m *MockStaker) GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) (int64, error) {
 	res, ok := m.Response.Get("GetIncentiveRemainingRewardAmount")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
-func (m *MockStaker) GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) int64 {
+func (m *MockStaker) GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) (int64, error) {
 	res, ok := m.Response.Get("GetIncentiveAccumulatedPenaltyAmount")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
-func (m *MockStaker) GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) int64 {
+func (m *MockStaker) GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) (int64, error) {
 	res, ok := m.Response.Get("GetIncentiveDepositGnsAmount")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
-func (m *MockStaker) GetIncentiveRefunded(poolPath string, incentiveId string) bool {
+func (m *MockStaker) GetIncentiveRefunded(poolPath string, incentiveId string) (bool, error) {
 	res, ok := m.Response.Get("GetIncentiveRefunded")
 	if !ok {
-		return false
+		return false, nil
 	}
-	return res[0].(bool)
+
+	return res[0].(bool), nil
 }
 
-func (m *MockStaker) IsIncentiveActive(poolPath string, incentiveId string) bool {
+func (m *MockStaker) IsIncentiveActive(poolPath string, incentiveId string) (bool, error) {
 	res, ok := m.Response.Get("IsIncentiveActive")
 	if !ok {
-		return false
+		return false, nil
 	}
-	return res[0].(bool)
+
+	return res[0].(bool), nil
 }
 
-func (m *MockStaker) GetDepositExternalRewardLastCollectTimestamp(lpTokenId uint64, incentiveId string) int64 {
+func (m *MockStaker) GetDepositExternalRewardLastCollectTimestamp(lpTokenId uint64, incentiveId string) (int64, error) {
 	res, ok := m.Response.Get("GetDepositExternalRewardLastCollectTimestamp")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
 func (m *MockStaker) GetDepositGnsAmount() int64 {
@@ -259,167 +273,188 @@ func (m *MockStaker) GetDepositGnsAmount() int64 {
 	if !ok {
 		return 0
 	}
+
 	return res[0].(int64)
 }
 
-func (m *MockStaker) GetDepositInternalRewardLastCollectTimestamp(lpTokenId uint64) int64 {
+func (m *MockStaker) GetDepositInternalRewardLastCollectTimestamp(lpTokenId uint64) (int64, error) {
 	res, ok := m.Response.Get("GetDepositInternalRewardLastCollectTimestamp")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
-func (m *MockStaker) GetDepositCollectedInternalReward(lpTokenId uint64) int64 {
+func (m *MockStaker) GetDepositCollectedInternalReward(lpTokenId uint64) (int64, error) {
 	res, ok := m.Response.Get("GetDepositCollectedInternalReward")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
-func (m *MockStaker) GetDepositCollectedExternalReward(lpTokenId uint64, incentiveId string) int64 {
+func (m *MockStaker) GetDepositCollectedExternalReward(lpTokenId uint64, incentiveId string) (int64, error) {
 	res, ok := m.Response.Get("GetDepositCollectedExternalReward")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
-func (m *MockStaker) GetDepositLiquidity(lpTokenId uint64) *u256.Uint {
+func (m *MockStaker) GetDepositLiquidity(lpTokenId uint64) (*u256.Uint, error) {
 	res, ok := m.Response.Get("GetDepositLiquidity")
 	if !ok {
-		return u256.Zero()
+		return u256.Zero(), nil
 	}
-	return res[0].(*u256.Uint)
+
+	return res[0].(*u256.Uint), nil
 }
 
-func (m *MockStaker) GetDepositLiquidityAsString(lpTokenId uint64) string {
+func (m *MockStaker) GetDepositLiquidityAsString(lpTokenId uint64) (string, error) {
 	res, ok := m.Response.Get("GetDepositLiquidityAsString")
 	if !ok {
-		return "0"
+		return "0", nil
 	}
-	return res[0].(string)
+
+	return res[0].(string), nil
 }
 
-func (m *MockStaker) GetDepositOwner(lpTokenId uint64) address {
+func (m *MockStaker) GetDepositOwner(lpTokenId uint64) (address, error) {
 	res, ok := m.Response.Get("GetDepositOwner")
 	if !ok {
-		return address("")
+		return address(""), nil
 	}
-	return res[0].(address)
+
+	return res[0].(address), nil
 }
 
-func (m *MockStaker) GetDepositStakeTime(lpTokenId uint64) int64 {
+func (m *MockStaker) GetDepositStakeTime(lpTokenId uint64) (int64, error) {
 	res, ok := m.Response.Get("GetDepositStakeTime")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
-func (m *MockStaker) GetDepositTargetPoolPath(lpTokenId uint64) string {
+func (m *MockStaker) GetDepositTargetPoolPath(lpTokenId uint64) (string, error) {
 	res, ok := m.Response.Get("GetDepositTargetPoolPath")
 	if !ok {
-		return ""
+		return "", nil
 	}
-	return res[0].(string)
+
+	return res[0].(string), nil
 }
 
-func (m *MockStaker) GetDepositTickLower(lpTokenId uint64) int32 {
+func (m *MockStaker) GetDepositTickLower(lpTokenId uint64) (int32, error) {
 	res, ok := m.Response.Get("GetDepositTickLower")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int32)
+
+	return res[0].(int32), nil
 }
 
-func (m *MockStaker) GetDepositTickUpper(lpTokenId uint64) int32 {
+func (m *MockStaker) GetDepositTickUpper(lpTokenId uint64) (int32, error) {
 	res, ok := m.Response.Get("GetDepositTickUpper")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int32)
+
+	return res[0].(int32), nil
 }
 
-func (m *MockStaker) GetDepositWarmUp(lpTokenId uint64) []Warmup {
+func (m *MockStaker) GetDepositWarmUp(lpTokenId uint64) ([]Warmup, error) {
 	res, ok := m.Response.Get("GetDepositWarmUp")
 	if !ok {
-		return nil
+		return nil, nil
 	}
-	return res[0].([]Warmup)
+
+	return res[0].([]Warmup), nil
 }
 
-func (m *MockStaker) GetDepositExternalIncentiveIdList(lpTokenId uint64) []string {
+func (m *MockStaker) GetDepositExternalIncentiveIdList(lpTokenId uint64) ([]string, error) {
 	res, ok := m.Response.Get("GetDepositExternalIncentiveIdList")
 	if !ok {
-		return nil
+		return nil, nil
 	}
-	return res[0].([]string)
+
+	return res[0].([]string), nil
 }
 
-func (m *MockStaker) GetExternalIncentiveByPoolPath(poolPath string) []ExternalIncentive {
+func (m *MockStaker) GetExternalIncentiveByPoolPath(poolPath string) ([]ExternalIncentive, error) {
 	res, ok := m.Response.Get("GetExternalIncentiveByPoolPath")
 	if !ok {
-		return nil
+		return nil, nil
 	}
-	return res[0].([]ExternalIncentive)
+
+	return res[0].([]ExternalIncentive), nil
 }
 
-func (m *MockStaker) GetIncentiveEndTimestamp(poolPath string, incentiveId string) int64 {
+func (m *MockStaker) GetIncentiveEndTimestamp(poolPath string, incentiveId string) (int64, error) {
 	res, ok := m.Response.Get("GetIncentiveEndTimestamp")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
-func (m *MockStaker) GetIncentiveCreator(poolPath string, incentiveId string) address {
+func (m *MockStaker) GetIncentiveCreator(poolPath string, incentiveId string) (address, error) {
 	res, ok := m.Response.Get("GetIncentiveCreator")
 	if !ok {
-		return address("")
+		return address(""), nil
 	}
-	return res[0].(address)
+
+	return res[0].(address), nil
 }
 
-func (m *MockStaker) GetIncentiveRewardAmount(poolPath string, incentiveId string) *u256.Uint {
+func (m *MockStaker) GetIncentiveRewardAmount(poolPath string, incentiveId string) (*u256.Uint, error) {
 	res, ok := m.Response.Get("GetIncentiveRewardAmount")
 	if !ok {
-		return u256.Zero()
+		return u256.Zero(), nil
 	}
-	return res[0].(*u256.Uint)
+
+	return res[0].(*u256.Uint), nil
 }
 
-func (m *MockStaker) GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) string {
+func (m *MockStaker) GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) (string, error) {
 	res, ok := m.Response.Get("GetIncentiveRewardAmountAsString")
 	if !ok {
-		return "0"
+		return "0", nil
 	}
-	return res[0].(string)
+
+	return res[0].(string), nil
 }
 
-func (m *MockStaker) GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) *u256.Uint {
+func (m *MockStaker) GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) (*u256.Uint, error) {
 	res, ok := m.Response.Get("GetIncentiveRewardPerSecondX128")
 	if !ok {
-		return u256.Zero()
+		return u256.Zero(), nil
 	}
-	return res[0].(*u256.Uint)
+
+	return res[0].(*u256.Uint), nil
 }
 
-func (m *MockStaker) GetIncentiveRewardToken(poolPath string, incentiveId string) string {
+func (m *MockStaker) GetIncentiveRewardToken(poolPath string, incentiveId string) (string, error) {
 	res, ok := m.Response.Get("GetIncentiveRewardToken")
 	if !ok {
-		return ""
+		return "", nil
 	}
-	return res[0].(string)
+
+	return res[0].(string), nil
 }
 
-func (m *MockStaker) GetIncentiveStartTimestamp(poolPath string, incentiveId string) int64 {
+func (m *MockStaker) GetIncentiveStartTimestamp(poolPath string, incentiveId string) (int64, error) {
 	res, ok := m.Response.Get("GetIncentiveStartTimestamp")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
 func (m *MockStaker) GetMinimumRewardAmount() int64 {
@@ -427,6 +462,7 @@ func (m *MockStaker) GetMinimumRewardAmount() int64 {
 	if !ok {
 		return 0
 	}
+
 	return res[0].(int64)
 }
 
@@ -435,31 +471,35 @@ func (m *MockStaker) GetMinimumRewardAmountForToken(tokenPath string) int64 {
 	if !ok {
 		return 0
 	}
+
 	return res[0].(int64)
 }
 
-func (m *MockStaker) GetPoolStakedLiquidity(poolPath string) string {
+func (m *MockStaker) GetPoolStakedLiquidity(poolPath string) (string, error) {
 	res, ok := m.Response.Get("GetPoolStakedLiquidity")
 	if !ok {
-		return ""
+		return "", nil
 	}
-	return res[0].(string)
+
+	return res[0].(string), nil
 }
 
-func (m *MockStaker) GetPoolsByTier(tier uint64) []string {
+func (m *MockStaker) GetPoolsByTier(tier uint64) ([]string, error) {
 	res, ok := m.Response.Get("GetPoolsByTier")
 	if !ok {
-		return []string{}
+		return []string{}, nil
 	}
-	return res[0].([]string)
+
+	return res[0].([]string), nil
 }
 
-func (m *MockStaker) GetPoolReward(tier uint64) int64 {
+func (m *MockStaker) GetPoolReward(tier uint64) (int64, error) {
 	res, ok := m.Response.Get("GetPoolReward")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
 func (m *MockStaker) GetPoolTier(poolPath string) uint64 {
@@ -467,6 +507,7 @@ func (m *MockStaker) GetPoolTier(poolPath string) uint64 {
 	if !ok {
 		return 0
 	}
+
 	return res[0].(uint64)
 }
 
@@ -475,15 +516,17 @@ func (m *MockStaker) GetPoolTierCount(tier uint64) uint64 {
 	if !ok {
 		return 0
 	}
+
 	return res[0].(uint64)
 }
 
-func (m *MockStaker) GetPoolTierRatio(poolPath string) uint64 {
+func (m *MockStaker) GetPoolTierRatio(poolPath string) (uint64, error) {
 	res, ok := m.Response.Get("GetPoolTierRatio")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(uint64)
+
+	return res[0].(uint64), nil
 }
 
 func (m *MockStaker) GetSpecificTokenMinimumRewardAmount(tokenPath string) (int64, bool) {
@@ -494,12 +537,13 @@ func (m *MockStaker) GetSpecificTokenMinimumRewardAmount(tokenPath string) (int6
 	return res[0].(int64), res[1].(bool)
 }
 
-func (m *MockStaker) GetTargetPoolPathByIncentiveId(poolPath string, incentiveId string) string {
+func (m *MockStaker) GetTargetPoolPathByIncentiveId(poolPath string, incentiveId string) (string, error) {
 	res, ok := m.Response.Get("GetTargetPoolPathByIncentiveId")
 	if !ok {
-		return ""
+		return "", nil
 	}
-	return res[0].(string)
+
+	return res[0].(string), nil
 }
 
 func (m *MockStaker) GetUnstakingFee() uint64 {
@@ -507,14 +551,16 @@ func (m *MockStaker) GetUnstakingFee() uint64 {
 	if !ok {
 		return 0
 	}
+
 	return res[0].(uint64)
 }
 
-func (m *MockStaker) IsStaked(positionId uint64) bool {
+func (m *MockStaker) IsStaked(lpTokenId uint64) bool {
 	res, ok := m.Response.Get("IsStaked")
 	if !ok {
 		return false
 	}
+
 	return res[0].(bool)
 }
 
@@ -523,6 +569,7 @@ func (m *MockStaker) GetTotalEmissionSent() int64 {
 	if !ok {
 		return 0
 	}
+
 	return res[0].(int64)
 }
 
@@ -531,6 +578,7 @@ func (m *MockStaker) GetAllowedTokens() []string {
 	if !ok {
 		return nil
 	}
+
 	return res[0].([]string)
 }
 
@@ -539,6 +587,7 @@ func (m *MockStaker) GetWarmupTemplate() []Warmup {
 	if !ok {
 		return nil
 	}
+
 	return res[0].([]Warmup)
 }
 

--- a/contract/r/gnoswap/staker/_mock_test.gno
+++ b/contract/r/gnoswap/staker/_mock_test.gno
@@ -138,116 +138,130 @@ func (m *MockStaker) GetPendingProtocolFees() map[string]int64 {
 }
 
 // Getter methods
-func (m *MockStaker) GetPool(poolPath string) *Pool {
+func (m *MockStaker) GetPool(poolPath string) (*Pool, error) {
 	res, ok := m.Response.Get("GetPool")
 	if !ok {
-		return nil
+		return nil, nil
 	}
-	return res[0].(*Pool)
+
+	return res[0].(*Pool), nil
 }
 
-func (m *MockStaker) GetDeposit(lpTokenId uint64) *Deposit {
+func (m *MockStaker) GetDeposit(lpTokenId uint64) (*Deposit, error) {
 	res, ok := m.Response.Get("GetDeposit")
 	if !ok {
-		return nil
+		return nil, nil
 	}
-	return res[0].(*Deposit)
+
+	return res[0].(*Deposit), nil
 }
 
-func (m *MockStaker) CollectableEmissionReward(positionId uint64) int64 {
+func (m *MockStaker) CollectableEmissionReward(positionId uint64) (int64, error) {
 	res, ok := m.Response.Get("CollectableEmissionReward")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
-func (m *MockStaker) CollectableExternalIncentiveReward(positionId uint64, incentiveId string) int64 {
+func (m *MockStaker) CollectableExternalIncentiveReward(positionId uint64, incentiveId string) (int64, error) {
 	res, ok := m.Response.Get("CollectableExternalIncentiveReward")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
-func (m *MockStaker) GetCreatedHeightOfIncentive(poolPath string, incentiveId string) int64 {
+func (m *MockStaker) GetCreatedHeightOfIncentive(poolPath string, incentiveId string) (int64, error) {
 	res, ok := m.Response.Get("GetCreatedHeightOfIncentive")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
-func (m *MockStaker) GetIncentiveCreatedTimestamp(poolPath string, incentiveId string) int64 {
+func (m *MockStaker) GetIncentiveCreatedTimestamp(poolPath string, incentiveId string) (int64, error) {
 	res, ok := m.Response.Get("GetIncentiveCreatedTimestamp")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
-func (m *MockStaker) GetIncentiveTotalRewardAmount(poolPath string, incentiveId string) int64 {
+func (m *MockStaker) GetIncentiveTotalRewardAmount(poolPath string, incentiveId string) (int64, error) {
 	res, ok := m.Response.Get("GetIncentiveTotalRewardAmount")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
-func (m *MockStaker) GetIncentiveDistributedRewardAmount(poolPath string, incentiveId string) int64 {
+func (m *MockStaker) GetIncentiveDistributedRewardAmount(poolPath string, incentiveId string) (int64, error) {
 	res, ok := m.Response.Get("GetIncentiveDistributedRewardAmount")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
-func (m *MockStaker) GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) int64 {
+func (m *MockStaker) GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) (int64, error) {
 	res, ok := m.Response.Get("GetIncentiveRemainingRewardAmount")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
-func (m *MockStaker) GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) int64 {
+func (m *MockStaker) GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) (int64, error) {
 	res, ok := m.Response.Get("GetIncentiveAccumulatedPenaltyAmount")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
-func (m *MockStaker) GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) int64 {
+func (m *MockStaker) GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) (int64, error) {
 	res, ok := m.Response.Get("GetIncentiveDepositGnsAmount")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
-func (m *MockStaker) GetIncentiveRefunded(poolPath string, incentiveId string) bool {
+func (m *MockStaker) GetIncentiveRefunded(poolPath string, incentiveId string) (bool, error) {
 	res, ok := m.Response.Get("GetIncentiveRefunded")
 	if !ok {
-		return false
+		return false, nil
 	}
-	return res[0].(bool)
+
+	return res[0].(bool), nil
 }
 
-func (m *MockStaker) IsIncentiveActive(poolPath string, incentiveId string) bool {
+func (m *MockStaker) IsIncentiveActive(poolPath string, incentiveId string) (bool, error) {
 	res, ok := m.Response.Get("IsIncentiveActive")
 	if !ok {
-		return false
+		return false, nil
 	}
-	return res[0].(bool)
+
+	return res[0].(bool), nil
 }
 
-func (m *MockStaker) GetDepositExternalRewardLastCollectTimestamp(lpTokenId uint64, incentiveId string) int64 {
+func (m *MockStaker) GetDepositExternalRewardLastCollectTimestamp(lpTokenId uint64, incentiveId string) (int64, error) {
 	res, ok := m.Response.Get("GetDepositExternalRewardLastCollectTimestamp")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
 func (m *MockStaker) GetDepositGnsAmount() int64 {
@@ -255,167 +269,188 @@ func (m *MockStaker) GetDepositGnsAmount() int64 {
 	if !ok {
 		return 0
 	}
+
 	return res[0].(int64)
 }
 
-func (m *MockStaker) GetDepositInternalRewardLastCollectTimestamp(lpTokenId uint64) int64 {
+func (m *MockStaker) GetDepositInternalRewardLastCollectTimestamp(lpTokenId uint64) (int64, error) {
 	res, ok := m.Response.Get("GetDepositInternalRewardLastCollectTimestamp")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
-func (m *MockStaker) GetDepositCollectedInternalReward(lpTokenId uint64) int64 {
+func (m *MockStaker) GetDepositCollectedInternalReward(lpTokenId uint64) (int64, error) {
 	res, ok := m.Response.Get("GetDepositCollectedInternalReward")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
-func (m *MockStaker) GetDepositCollectedExternalReward(lpTokenId uint64, incentiveId string) int64 {
+func (m *MockStaker) GetDepositCollectedExternalReward(lpTokenId uint64, incentiveId string) (int64, error) {
 	res, ok := m.Response.Get("GetDepositCollectedExternalReward")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
-func (m *MockStaker) GetDepositLiquidity(lpTokenId uint64) *u256.Uint {
+func (m *MockStaker) GetDepositLiquidity(lpTokenId uint64) (*u256.Uint, error) {
 	res, ok := m.Response.Get("GetDepositLiquidity")
 	if !ok {
-		return u256.Zero()
+		return u256.Zero(), nil
 	}
-	return res[0].(*u256.Uint)
+
+	return res[0].(*u256.Uint), nil
 }
 
-func (m *MockStaker) GetDepositLiquidityAsString(lpTokenId uint64) string {
+func (m *MockStaker) GetDepositLiquidityAsString(lpTokenId uint64) (string, error) {
 	res, ok := m.Response.Get("GetDepositLiquidityAsString")
 	if !ok {
-		return "0"
+		return "0", nil
 	}
-	return res[0].(string)
+
+	return res[0].(string), nil
 }
 
-func (m *MockStaker) GetDepositOwner(lpTokenId uint64) address {
+func (m *MockStaker) GetDepositOwner(lpTokenId uint64) (address, error) {
 	res, ok := m.Response.Get("GetDepositOwner")
 	if !ok {
-		return address("")
+		return address(""), nil
 	}
-	return res[0].(address)
+
+	return res[0].(address), nil
 }
 
-func (m *MockStaker) GetDepositStakeTime(lpTokenId uint64) int64 {
+func (m *MockStaker) GetDepositStakeTime(lpTokenId uint64) (int64, error) {
 	res, ok := m.Response.Get("GetDepositStakeTime")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
-func (m *MockStaker) GetDepositTargetPoolPath(lpTokenId uint64) string {
+func (m *MockStaker) GetDepositTargetPoolPath(lpTokenId uint64) (string, error) {
 	res, ok := m.Response.Get("GetDepositTargetPoolPath")
 	if !ok {
-		return ""
+		return "", nil
 	}
-	return res[0].(string)
+
+	return res[0].(string), nil
 }
 
-func (m *MockStaker) GetDepositTickLower(lpTokenId uint64) int32 {
+func (m *MockStaker) GetDepositTickLower(lpTokenId uint64) (int32, error) {
 	res, ok := m.Response.Get("GetDepositTickLower")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int32)
+
+	return res[0].(int32), nil
 }
 
-func (m *MockStaker) GetDepositTickUpper(lpTokenId uint64) int32 {
+func (m *MockStaker) GetDepositTickUpper(lpTokenId uint64) (int32, error) {
 	res, ok := m.Response.Get("GetDepositTickUpper")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int32)
+
+	return res[0].(int32), nil
 }
 
-func (m *MockStaker) GetDepositWarmUp(lpTokenId uint64) []Warmup {
+func (m *MockStaker) GetDepositWarmUp(lpTokenId uint64) ([]Warmup, error) {
 	res, ok := m.Response.Get("GetDepositWarmUp")
 	if !ok {
-		return nil
+		return nil, nil
 	}
-	return res[0].([]Warmup)
+
+	return res[0].([]Warmup), nil
 }
 
-func (m *MockStaker) GetDepositExternalIncentiveIdList(lpTokenId uint64) []string {
+func (m *MockStaker) GetDepositExternalIncentiveIdList(lpTokenId uint64) ([]string, error) {
 	res, ok := m.Response.Get("GetDepositExternalIncentiveIdList")
 	if !ok {
-		return nil
+		return nil, nil
 	}
-	return res[0].([]string)
+
+	return res[0].([]string), nil
 }
 
-func (m *MockStaker) GetExternalIncentiveByPoolPath(poolPath string) []ExternalIncentive {
+func (m *MockStaker) GetExternalIncentiveByPoolPath(poolPath string) ([]ExternalIncentive, error) {
 	res, ok := m.Response.Get("GetExternalIncentiveByPoolPath")
 	if !ok {
-		return nil
+		return nil, nil
 	}
-	return res[0].([]ExternalIncentive)
+
+	return res[0].([]ExternalIncentive), nil
 }
 
-func (m *MockStaker) GetIncentiveEndTimestamp(poolPath string, incentiveId string) int64 {
+func (m *MockStaker) GetIncentiveEndTimestamp(poolPath string, incentiveId string) (int64, error) {
 	res, ok := m.Response.Get("GetIncentiveEndTimestamp")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
-func (m *MockStaker) GetIncentiveCreator(poolPath string, incentiveId string) address {
+func (m *MockStaker) GetIncentiveCreator(poolPath string, incentiveId string) (address, error) {
 	res, ok := m.Response.Get("GetIncentiveCreator")
 	if !ok {
-		return address("")
+		return address(""), nil
 	}
-	return res[0].(address)
+
+	return res[0].(address), nil
 }
 
-func (m *MockStaker) GetIncentiveRewardAmount(poolPath string, incentiveId string) *u256.Uint {
+func (m *MockStaker) GetIncentiveRewardAmount(poolPath string, incentiveId string) (*u256.Uint, error) {
 	res, ok := m.Response.Get("GetIncentiveRewardAmount")
 	if !ok {
-		return u256.Zero()
+		return u256.Zero(), nil
 	}
-	return res[0].(*u256.Uint)
+
+	return res[0].(*u256.Uint), nil
 }
 
-func (m *MockStaker) GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) string {
+func (m *MockStaker) GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) (string, error) {
 	res, ok := m.Response.Get("GetIncentiveRewardAmountAsString")
 	if !ok {
-		return "0"
+		return "0", nil
 	}
-	return res[0].(string)
+
+	return res[0].(string), nil
 }
 
-func (m *MockStaker) GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) *u256.Uint {
+func (m *MockStaker) GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) (*u256.Uint, error) {
 	res, ok := m.Response.Get("GetIncentiveRewardPerSecondX128")
 	if !ok {
-		return u256.Zero()
+		return u256.Zero(), nil
 	}
-	return res[0].(*u256.Uint)
+
+	return res[0].(*u256.Uint), nil
 }
 
-func (m *MockStaker) GetIncentiveRewardToken(poolPath string, incentiveId string) string {
+func (m *MockStaker) GetIncentiveRewardToken(poolPath string, incentiveId string) (string, error) {
 	res, ok := m.Response.Get("GetIncentiveRewardToken")
 	if !ok {
-		return ""
+		return "", nil
 	}
-	return res[0].(string)
+
+	return res[0].(string), nil
 }
 
-func (m *MockStaker) GetIncentiveStartTimestamp(poolPath string, incentiveId string) int64 {
+func (m *MockStaker) GetIncentiveStartTimestamp(poolPath string, incentiveId string) (int64, error) {
 	res, ok := m.Response.Get("GetIncentiveStartTimestamp")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
 func (m *MockStaker) GetMinimumRewardAmount() int64 {
@@ -423,6 +458,7 @@ func (m *MockStaker) GetMinimumRewardAmount() int64 {
 	if !ok {
 		return 0
 	}
+
 	return res[0].(int64)
 }
 
@@ -431,31 +467,35 @@ func (m *MockStaker) GetMinimumRewardAmountForToken(tokenPath string) int64 {
 	if !ok {
 		return 0
 	}
+
 	return res[0].(int64)
 }
 
-func (m *MockStaker) GetPoolStakedLiquidity(poolPath string) string {
+func (m *MockStaker) GetPoolStakedLiquidity(poolPath string) (string, error) {
 	res, ok := m.Response.Get("GetPoolStakedLiquidity")
 	if !ok {
-		return ""
+		return "", nil
 	}
-	return res[0].(string)
+
+	return res[0].(string), nil
 }
 
-func (m *MockStaker) GetPoolsByTier(tier uint64) []string {
+func (m *MockStaker) GetPoolsByTier(tier uint64) ([]string, error) {
 	res, ok := m.Response.Get("GetPoolsByTier")
 	if !ok {
-		return []string{}
+		return []string{}, nil
 	}
-	return res[0].([]string)
+
+	return res[0].([]string), nil
 }
 
-func (m *MockStaker) GetPoolReward(tier uint64) int64 {
+func (m *MockStaker) GetPoolReward(tier uint64) (int64, error) {
 	res, ok := m.Response.Get("GetPoolReward")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(int64)
+
+	return res[0].(int64), nil
 }
 
 func (m *MockStaker) GetPoolTier(poolPath string) uint64 {
@@ -463,6 +503,7 @@ func (m *MockStaker) GetPoolTier(poolPath string) uint64 {
 	if !ok {
 		return 0
 	}
+
 	return res[0].(uint64)
 }
 
@@ -471,15 +512,17 @@ func (m *MockStaker) GetPoolTierCount(tier uint64) uint64 {
 	if !ok {
 		return 0
 	}
+
 	return res[0].(uint64)
 }
 
-func (m *MockStaker) GetPoolTierRatio(poolPath string) uint64 {
+func (m *MockStaker) GetPoolTierRatio(poolPath string) (uint64, error) {
 	res, ok := m.Response.Get("GetPoolTierRatio")
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return res[0].(uint64)
+
+	return res[0].(uint64), nil
 }
 
 func (m *MockStaker) GetSpecificTokenMinimumRewardAmount(tokenPath string) (int64, bool) {
@@ -490,12 +533,13 @@ func (m *MockStaker) GetSpecificTokenMinimumRewardAmount(tokenPath string) (int6
 	return res[0].(int64), res[1].(bool)
 }
 
-func (m *MockStaker) GetTargetPoolPathByIncentiveId(poolPath string, incentiveId string) string {
+func (m *MockStaker) GetTargetPoolPathByIncentiveId(poolPath string, incentiveId string) (string, error) {
 	res, ok := m.Response.Get("GetTargetPoolPathByIncentiveId")
 	if !ok {
-		return ""
+		return "", nil
 	}
-	return res[0].(string)
+
+	return res[0].(string), nil
 }
 
 func (m *MockStaker) GetUnstakingFee() uint64 {
@@ -503,14 +547,16 @@ func (m *MockStaker) GetUnstakingFee() uint64 {
 	if !ok {
 		return 0
 	}
+
 	return res[0].(uint64)
 }
 
-func (m *MockStaker) IsStaked(positionId uint64) bool {
+func (m *MockStaker) IsStaked(lpTokenId uint64) bool {
 	res, ok := m.Response.Get("IsStaked")
 	if !ok {
 		return false
 	}
+
 	return res[0].(bool)
 }
 
@@ -519,6 +565,7 @@ func (m *MockStaker) GetTotalEmissionSent() int64 {
 	if !ok {
 		return 0
 	}
+
 	return res[0].(int64)
 }
 
@@ -527,6 +574,7 @@ func (m *MockStaker) GetAllowedTokens() []string {
 	if !ok {
 		return nil
 	}
+
 	return res[0].([]string)
 }
 
@@ -535,6 +583,7 @@ func (m *MockStaker) GetWarmupTemplate() []Warmup {
 	if !ok {
 		return nil
 	}
+
 	return res[0].([]Warmup)
 }
 

--- a/contract/r/gnoswap/staker/getter.gno
+++ b/contract/r/gnoswap/staker/getter.gno
@@ -8,80 +8,86 @@ import (
 // IStakerGetter functions
 
 // GetPool returns a copy of the pool for the given path.
-func GetPool(poolPath string) *Pool {
-	pool := getImplementation().GetPool(poolPath)
-	if pool == nil {
-		return nil
+func GetPool(poolPath string) (*Pool, error) {
+	pool, err := getImplementation().GetPool(poolPath)
+	if err != nil {
+		return nil, err
 	}
-	return pool.Clone()
+	if pool == nil {
+		return nil, nil
+	}
+	return pool.Clone(), nil
 }
 
 // GetDeposit returns a copy of the deposit for the given position ID.
-func GetDeposit(lpTokenId uint64) *Deposit {
-	deposit := getImplementation().GetDeposit(lpTokenId)
-	if deposit == nil {
-		return nil
+func GetDeposit(lpTokenId uint64) (*Deposit, error) {
+	deposit, err := getImplementation().GetDeposit(lpTokenId)
+	if err != nil {
+		return nil, err
 	}
-	return deposit.Clone()
+	if deposit == nil {
+		return nil, nil
+	}
+	return deposit.Clone(), nil
 }
 
 // CollectableEmissionReward returns the claimable internal reward amount.
-func CollectableEmissionReward(positionId uint64) int64 {
+func CollectableEmissionReward(positionId uint64) (int64, error) {
 	return getImplementation().CollectableEmissionReward(positionId)
 }
 
 // CollectableExternalIncentiveReward returns the claimable external reward amount.
-func CollectableExternalIncentiveReward(positionId uint64, incentiveId string) int64 {
+func CollectableExternalIncentiveReward(positionId uint64, incentiveId string) (int64, error) {
 	return getImplementation().CollectableExternalIncentiveReward(positionId, incentiveId)
 }
 
 // GetCreatedHeightOfIncentive returns the block height when an incentive was created.
-func GetCreatedHeightOfIncentive(poolPath string, incentiveId string) int64 {
+func GetCreatedHeightOfIncentive(poolPath string, incentiveId string) (int64, error) {
 	return getImplementation().GetCreatedHeightOfIncentive(poolPath, incentiveId)
 }
 
 // GetIncentiveCreatedTimestamp returns the creation timestamp of an incentive.
-func GetIncentiveCreatedTimestamp(poolPath string, incentiveId string) int64 {
+func GetIncentiveCreatedTimestamp(poolPath string, incentiveId string) (int64, error) {
 	return getImplementation().GetIncentiveCreatedTimestamp(poolPath, incentiveId)
 }
 
 // GetIncentiveTotalRewardAmount returns the total reward amount of an incentive.
-func GetIncentiveTotalRewardAmount(poolPath string, incentiveId string) int64 {
+func GetIncentiveTotalRewardAmount(poolPath string, incentiveId string) (int64, error) {
 	return getImplementation().GetIncentiveTotalRewardAmount(poolPath, incentiveId)
 }
 
 // GetIncentiveDistributedRewardAmount returns the distributed reward amount of an incentive.
-func GetIncentiveDistributedRewardAmount(poolPath string, incentiveId string) int64 {
+func GetIncentiveDistributedRewardAmount(poolPath string, incentiveId string) (int64, error) {
 	return getImplementation().GetIncentiveDistributedRewardAmount(poolPath, incentiveId)
 }
 
 // GetIncentiveRemainingRewardAmount returns the remaining reward amount of an incentive.
-func GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) int64 {
+func GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) (int64, error) {
 	return getImplementation().GetIncentiveRemainingRewardAmount(poolPath, incentiveId)
 }
 
 // GetIncentiveAccumulatedPenaltyAmount returns the accumulated warmup penalty amount of an incentive.
-func GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) int64 {
+func GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) (int64, error) {
 	return getImplementation().GetIncentiveAccumulatedPenaltyAmount(poolPath, incentiveId)
 }
 
 // GetIncentiveDepositGnsAmount returns the deposited GNS amount of an incentive.
-func GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) int64 {
+func GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) (int64, error) {
 	return getImplementation().GetIncentiveDepositGnsAmount(poolPath, incentiveId)
 }
 
 // GetIncentiveRefunded returns whether an incentive has been refunded.
-func GetIncentiveRefunded(poolPath string, incentiveId string) bool {
+func GetIncentiveRefunded(poolPath string, incentiveId string) (bool, error) {
 	return getImplementation().GetIncentiveRefunded(poolPath, incentiveId)
 }
 
 // IsIncentiveActive returns whether an incentive is active.
-func IsIncentiveActive(poolPath string, incentiveId string) bool {
+func IsIncentiveActive(poolPath string, incentiveId string) (bool, error) {
 	return getImplementation().IsIncentiveActive(poolPath, incentiveId)
 }
 
 // GetDepositExternalRewardLastCollectTimestamp returns the last external reward collection time for a position.
-func GetDepositExternalRewardLastCollectTimestamp(lpTokenId uint64, incentiveId string) int64 {
+func GetDepositExternalRewardLastCollectTimestamp(lpTokenId uint64, incentiveId string) (int64, error) {
 	return getImplementation().GetDepositExternalRewardLastCollectTimestamp(lpTokenId, incentiveId)
 }
 
@@ -91,87 +97,107 @@ func GetDepositGnsAmount() int64 {
 }
 
 // GetDepositInternalRewardLastCollectTimestamp returns the last internal reward collection time for a position.
-func GetDepositInternalRewardLastCollectTimestamp(lpTokenId uint64) int64 {
+func GetDepositInternalRewardLastCollectTimestamp(lpTokenId uint64) (int64, error) {
 	return getImplementation().GetDepositInternalRewardLastCollectTimestamp(lpTokenId)
 }
 
 // GetDepositCollectedInternalReward returns the collected internal reward amount of a position.
-func GetDepositCollectedInternalReward(lpTokenId uint64) int64 {
+func GetDepositCollectedInternalReward(lpTokenId uint64) (int64, error) {
 	return getImplementation().GetDepositCollectedInternalReward(lpTokenId)
 }
 
 // GetDepositCollectedExternalReward returns the collected external reward amount of a position.
-func GetDepositCollectedExternalReward(lpTokenId uint64, incentiveId string) int64 {
+func GetDepositCollectedExternalReward(lpTokenId uint64, incentiveId string) (int64, error) {
 	return getImplementation().GetDepositCollectedExternalReward(lpTokenId, incentiveId)
 }
 
 // GetDepositLiquidity returns the liquidity amount of a staked position.
-func GetDepositLiquidity(lpTokenId uint64) *u256.Uint {
-	return getImplementation().GetDepositLiquidity(lpTokenId).Clone()
+func GetDepositLiquidity(lpTokenId uint64) (*u256.Uint, error) {
+	liquidity, err := getImplementation().GetDepositLiquidity(lpTokenId)
+	if err != nil {
+		return nil, err
+	}
+	return liquidity.Clone(), nil
 }
 
 // GetDepositLiquidityAsString returns the liquidity amount of a staked position as string.
-func GetDepositLiquidityAsString(lpTokenId uint64) string {
+func GetDepositLiquidityAsString(lpTokenId uint64) (string, error) {
 	return getImplementation().GetDepositLiquidityAsString(lpTokenId)
 }
 
 // GetDepositOwner returns the owner of a staked position.
-func GetDepositOwner(lpTokenId uint64) address {
+func GetDepositOwner(lpTokenId uint64) (address, error) {
 	return getImplementation().GetDepositOwner(lpTokenId)
 }
 
 // GetDepositStakeTime returns the staking duration of a position.
-func GetDepositStakeTime(lpTokenId uint64) int64 {
+func GetDepositStakeTime(lpTokenId uint64) (int64, error) {
 	return getImplementation().GetDepositStakeTime(lpTokenId)
 }
 
 // GetDepositTargetPoolPath returns the pool path of a staked position.
-func GetDepositTargetPoolPath(lpTokenId uint64) string {
+func GetDepositTargetPoolPath(lpTokenId uint64) (string, error) {
 	return getImplementation().GetDepositTargetPoolPath(lpTokenId)
 }
 
 // GetDepositTickLower returns the lower tick of a staked position.
-func GetDepositTickLower(lpTokenId uint64) int32 {
+func GetDepositTickLower(lpTokenId uint64) (int32, error) {
 	return getImplementation().GetDepositTickLower(lpTokenId)
 }
 
 // GetDepositTickUpper returns the upper tick of a staked position.
-func GetDepositTickUpper(lpTokenId uint64) int32 {
+func GetDepositTickUpper(lpTokenId uint64) (int32, error) {
 	return getImplementation().GetDepositTickUpper(lpTokenId)
 }
 
 // GetDepositWarmUp returns the warmup records of a staked position.
-func GetDepositWarmUp(lpTokenId uint64) []Warmup {
-	return cloneWarmups(getImplementation().GetDepositWarmUp(lpTokenId))
+func GetDepositWarmUp(lpTokenId uint64) ([]Warmup, error) {
+	warmups, err := getImplementation().GetDepositWarmUp(lpTokenId)
+	if err != nil {
+		return nil, err
+	}
+	return cloneWarmups(warmups), nil
 }
 
 // GetDepositExternalIncentiveIdList returns external incentive IDs for a deposit.
-func GetDepositExternalIncentiveIdList(lpTokenId uint64) []string {
-	return cloneStringSlice(getImplementation().GetDepositExternalIncentiveIdList(lpTokenId))
+func GetDepositExternalIncentiveIdList(lpTokenId uint64) ([]string, error) {
+	ids, err := getImplementation().GetDepositExternalIncentiveIdList(lpTokenId)
+	if err != nil {
+		return nil, err
+	}
+	return cloneStringSlice(ids), nil
 }
 
 // GetExternalIncentiveByPoolPath returns all external incentives for a pool.
-func GetExternalIncentiveByPoolPath(poolPath string) []ExternalIncentive {
-	return cloneExternalIncentives(getImplementation().GetExternalIncentiveByPoolPath(poolPath))
+func GetExternalIncentiveByPoolPath(poolPath string) ([]ExternalIncentive, error) {
+	incentives, err := getImplementation().GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		return nil, err
+	}
+	return cloneExternalIncentives(incentives), nil
 }
 
 // GetIncentiveEndTimestamp returns the end timestamp of an incentive.
-func GetIncentiveEndTimestamp(poolPath string, incentiveId string) int64 {
+func GetIncentiveEndTimestamp(poolPath string, incentiveId string) (int64, error) {
 	return getImplementation().GetIncentiveEndTimestamp(poolPath, incentiveId)
 }
 
 // GetIncentiveCreator returns the creator address of an incentive.
-func GetIncentiveCreator(poolPath string, incentiveId string) address {
+func GetIncentiveCreator(poolPath string, incentiveId string) (address, error) {
 	return getImplementation().GetIncentiveCreator(poolPath, incentiveId)
 }
 
 // GetIncentiveRewardAmount returns the total reward amount of an incentive.
-func GetIncentiveRewardAmount(poolPath string, incentiveId string) *u256.Uint {
-	return getImplementation().GetIncentiveRewardAmount(poolPath, incentiveId).Clone()
+func GetIncentiveRewardAmount(poolPath string, incentiveId string) (*u256.Uint, error) {
+	amount, err := getImplementation().GetIncentiveRewardAmount(poolPath, incentiveId)
+	if err != nil {
+		return nil, err
+	}
+	return amount.Clone(), nil
 }
 
 // GetIncentiveRewardAmountAsString returns the total reward amount of an incentive as string.
-func GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) string {
+func GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) (string, error) {
 	return getImplementation().GetIncentiveRewardAmountAsString(poolPath, incentiveId)
 }
 
@@ -179,17 +205,21 @@ func GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) strin
 // incentive, expressed as a Q128 fixed-point number (i.e. actual rate =
 // value / 2^128). Callers needing an integer rate can right-shift the result
 // by 128.
-func GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) *u256.Uint {
-	return getImplementation().GetIncentiveRewardPerSecondX128(poolPath, incentiveId).Clone()
+func GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) (*u256.Uint, error) {
+	amount, err := getImplementation().GetIncentiveRewardPerSecondX128(poolPath, incentiveId)
+	if err != nil {
+		return nil, err
+	}
+	return amount.Clone(), nil
 }
 
 // GetIncentiveRewardToken returns the reward token of an incentive.
-func GetIncentiveRewardToken(poolPath string, incentiveId string) string {
+func GetIncentiveRewardToken(poolPath string, incentiveId string) (string, error) {
 	return getImplementation().GetIncentiveRewardToken(poolPath, incentiveId)
 }
 
 // GetIncentiveStartTimestamp returns the start timestamp of an incentive.
-func GetIncentiveStartTimestamp(poolPath string, incentiveId string) int64 {
+func GetIncentiveStartTimestamp(poolPath string, incentiveId string) (int64, error) {
 	return getImplementation().GetIncentiveStartTimestamp(poolPath, incentiveId)
 }
 
@@ -204,17 +234,21 @@ func GetMinimumRewardAmountForToken(tokenPath string) int64 {
 }
 
 // GetPoolStakedLiquidity returns the current total staked liquidity of a pool.
-func GetPoolStakedLiquidity(poolPath string) string {
+func GetPoolStakedLiquidity(poolPath string) (string, error) {
 	return getImplementation().GetPoolStakedLiquidity(poolPath)
 }
 
 // GetPoolsByTier returns the pool list for a tier.
-func GetPoolsByTier(tier uint64) []string {
-	return cloneStringSlice(getImplementation().GetPoolsByTier(tier))
+func GetPoolsByTier(tier uint64) ([]string, error) {
+	pools, err := getImplementation().GetPoolsByTier(tier)
+	if err != nil {
+		return nil, err
+	}
+	return cloneStringSlice(pools), nil
 }
 
 // GetPoolReward returns the reward amount for a tier.
-func GetPoolReward(tier uint64) int64 {
+func GetPoolReward(tier uint64) (int64, error) {
 	return getImplementation().GetPoolReward(tier)
 }
 
@@ -229,7 +263,7 @@ func GetPoolTierCount(tier uint64) uint64 {
 }
 
 // GetPoolTierRatio returns the reward ratio of a pool.
-func GetPoolTierRatio(poolPath string) uint64 {
+func GetPoolTierRatio(poolPath string) (uint64, error) {
 	return getImplementation().GetPoolTierRatio(poolPath)
 }
 
@@ -239,7 +273,7 @@ func GetSpecificTokenMinimumRewardAmount(tokenPath string) (int64, bool) {
 }
 
 // GetTargetPoolPathByIncentiveId returns the pool path for an incentive ID.
-func GetTargetPoolPathByIncentiveId(poolPath string, incentiveId string) string {
+func GetTargetPoolPathByIncentiveId(poolPath string, incentiveId string) (string, error) {
 	return getImplementation().GetTargetPoolPathByIncentiveId(poolPath, incentiveId)
 }
 

--- a/contract/r/gnoswap/staker/getter_test.gno
+++ b/contract/r/gnoswap/staker/getter_test.gno
@@ -39,7 +39,7 @@ func TestMutableStakerGetterIsolation(t *testing.T) {
 		{
 			name:   "GetPool",
 			setup:  func(m *MockStaker) { m.Response.Set("GetPool", newStakerPool()) },
-			getter: func() any { return GetPool("foo:bar:500") },
+			getter: func() any { value, err := GetPool("foo:bar:500"); uassert.NoError(t, err); return value },
 			mutate: func(result any) {
 				pool := result.(*Pool)
 				pool.SetPoolPath("mutated:pool")
@@ -56,7 +56,7 @@ func TestMutableStakerGetterIsolation(t *testing.T) {
 		{
 			name:   "GetDeposit",
 			setup:  func(m *MockStaker) { m.Response.Set("GetDeposit", newStakerDeposit()) },
-			getter: func() any { return GetDeposit(1) },
+			getter: func() any { value, err := GetDeposit(1); uassert.NoError(t, err); return value },
 			mutate: func(result any) {
 				deposit := result.(*Deposit)
 				deposit.SetTargetPoolPath("mutated:pool")
@@ -85,7 +85,7 @@ func TestMutableStakerGetterIsolation(t *testing.T) {
 		{
 			name:   "GetDepositLiquidity",
 			setup:  func(m *MockStaker) { m.Response.Set("GetDepositLiquidity", u256.MustFromDecimal("1000")) },
-			getter: func() any { return GetDepositLiquidity(1) },
+			getter: func() any { value, err := GetDepositLiquidity(1); uassert.NoError(t, err); return value },
 			mutate: func(result any) { result.(*u256.Uint).Set(u256.MustFromDecimal("2000")) },
 			assertRaw: func(t *testing.T, m *MockStaker) {
 				value := m.Response.data["GetDepositLiquidity"][0].(*u256.Uint)
@@ -97,7 +97,7 @@ func TestMutableStakerGetterIsolation(t *testing.T) {
 			setup: func(m *MockStaker) {
 				m.Response.Set("GetDepositWarmUp", []Warmup{{TimeDuration: 10, NextWarmupTime: 20, WarmupRatio: 30}})
 			},
-			getter: func() any { return GetDepositWarmUp(1) },
+			getter: func() any { value, err := GetDepositWarmUp(1); uassert.NoError(t, err); return value },
 			mutate: func(result any) {
 				warmups := result.([]Warmup)
 				warmups[0].TimeDuration = 99
@@ -114,7 +114,7 @@ func TestMutableStakerGetterIsolation(t *testing.T) {
 		{
 			name:   "GetDepositExternalIncentiveIdList",
 			setup:  func(m *MockStaker) { m.Response.Set("GetDepositExternalIncentiveIdList", []string{"a", "b"}) },
-			getter: func() any { return GetDepositExternalIncentiveIdList(1) },
+			getter: func() any { value, err := GetDepositExternalIncentiveIdList(1); uassert.NoError(t, err); return value },
 			mutate: func(result any) {
 				values := result.([]string)
 				values[0] = "mutated"
@@ -131,7 +131,11 @@ func TestMutableStakerGetterIsolation(t *testing.T) {
 			setup: func(m *MockStaker) {
 				m.Response.Set("GetExternalIncentiveByPoolPath", []ExternalIncentive{newExternalIncentive()})
 			},
-			getter: func() any { return GetExternalIncentiveByPoolPath("foo:bar:500") },
+			getter: func() any {
+				value, err := GetExternalIncentiveByPoolPath("foo:bar:500")
+				uassert.NoError(t, err)
+				return value
+			},
 			mutate: func(result any) {
 				values := result.([]ExternalIncentive)
 				values[0].SetRewardToken("mutated")
@@ -151,9 +155,13 @@ func TestMutableStakerGetterIsolation(t *testing.T) {
 			},
 		},
 		{
-			name:   "GetIncentiveRewardAmount",
-			setup:  func(m *MockStaker) { m.Response.Set("GetIncentiveRewardAmount", u256.MustFromDecimal("3000")) },
-			getter: func() any { return GetIncentiveRewardAmount("foo:bar:500", "incentive-1") },
+			name:  "GetIncentiveRewardAmount",
+			setup: func(m *MockStaker) { m.Response.Set("GetIncentiveRewardAmount", u256.MustFromDecimal("3000")) },
+			getter: func() any {
+				value, err := GetIncentiveRewardAmount("foo:bar:500", "incentive-1")
+				uassert.NoError(t, err)
+				return value
+			},
 			mutate: func(result any) { result.(*u256.Uint).Set(u256.MustFromDecimal("4000")) },
 			assertRaw: func(t *testing.T, m *MockStaker) {
 				value := m.Response.data["GetIncentiveRewardAmount"][0].(*u256.Uint)
@@ -163,7 +171,7 @@ func TestMutableStakerGetterIsolation(t *testing.T) {
 		{
 			name:   "GetPoolsByTier",
 			setup:  func(m *MockStaker) { m.Response.Set("GetPoolsByTier", []string{"foo:bar:500", "baz:qux:3000"}) },
-			getter: func() any { return GetPoolsByTier(1) },
+			getter: func() any { value, err := GetPoolsByTier(1); uassert.NoError(t, err); return value },
 			mutate: func(result any) {
 				values := result.([]string)
 				values[0] = "mutated"

--- a/contract/r/gnoswap/staker/types.gno
+++ b/contract/r/gnoswap/staker/types.gno
@@ -42,55 +42,55 @@ type IStakerManager interface {
 }
 
 type IStakerGetter interface {
-	GetPool(poolPath string) *Pool
+	GetPool(poolPath string) (*Pool, error)
 	GetPoolRewardCaches(poolPath string) *rotree.ReadOnlyTree
 	GetPoolIncentives(poolPath string) *rotree.ReadOnlyTree
 	GetPoolGlobalRewardRatioAccumulations(poolPath string) *rotree.ReadOnlyTree
 	GetPoolHistoricalTicks(poolPath string) *rotree.ReadOnlyTree
-	GetDeposit(lpTokenId uint64) *Deposit
-	CollectableEmissionReward(positionId uint64) int64
-	CollectableExternalIncentiveReward(positionId uint64, incentiveId string) int64
-	GetCreatedHeightOfIncentive(poolPath string, incentiveId string) int64
-	GetIncentiveCreatedTimestamp(poolPath string, incentiveId string) int64
-	GetIncentiveTotalRewardAmount(poolPath string, incentiveId string) int64
-	GetIncentiveDistributedRewardAmount(poolPath string, incentiveId string) int64
-	GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) int64
-	GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) int64
-	GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) int64
-	GetIncentiveRefunded(poolPath string, incentiveId string) bool
-	IsIncentiveActive(poolPath string, incentiveId string) bool
-	GetDepositExternalRewardLastCollectTimestamp(lpTokenId uint64, incentiveId string) int64
+	GetDeposit(lpTokenId uint64) (*Deposit, error)
+	CollectableEmissionReward(positionId uint64) (int64, error)
+	CollectableExternalIncentiveReward(positionId uint64, incentiveId string) (int64, error)
+	GetCreatedHeightOfIncentive(poolPath string, incentiveId string) (int64, error)
+	GetIncentiveCreatedTimestamp(poolPath string, incentiveId string) (int64, error)
+	GetIncentiveTotalRewardAmount(poolPath string, incentiveId string) (int64, error)
+	GetIncentiveDistributedRewardAmount(poolPath string, incentiveId string) (int64, error)
+	GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) (int64, error)
+	GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) (int64, error)
+	GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) (int64, error)
+	GetIncentiveRefunded(poolPath string, incentiveId string) (bool, error)
+	IsIncentiveActive(poolPath string, incentiveId string) (bool, error)
+	GetDepositExternalRewardLastCollectTimestamp(lpTokenId uint64, incentiveId string) (int64, error)
 	GetDepositGnsAmount() int64
-	GetDepositInternalRewardLastCollectTimestamp(lpTokenId uint64) int64
-	GetDepositCollectedInternalReward(lpTokenId uint64) int64
-	GetDepositCollectedExternalReward(lpTokenId uint64, incentiveId string) int64
-	GetDepositLiquidity(lpTokenId uint64) *u256.Uint
-	GetDepositLiquidityAsString(lpTokenId uint64) string
-	GetDepositOwner(lpTokenId uint64) address
-	GetDepositStakeTime(lpTokenId uint64) int64
-	GetDepositTargetPoolPath(lpTokenId uint64) string
-	GetDepositTickLower(lpTokenId uint64) int32
-	GetDepositTickUpper(lpTokenId uint64) int32
-	GetDepositWarmUp(lpTokenId uint64) []Warmup
-	GetDepositExternalIncentiveIdList(lpTokenId uint64) []string
-	GetExternalIncentiveByPoolPath(poolPath string) []ExternalIncentive
-	GetIncentiveEndTimestamp(poolPath string, incentiveId string) int64
-	GetIncentiveCreator(poolPath string, incentiveId string) address
-	GetIncentiveRewardAmount(poolPath string, incentiveId string) *u256.Uint
-	GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) string
-	GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) *u256.Uint
-	GetIncentiveRewardToken(poolPath string, incentiveId string) string
-	GetIncentiveStartTimestamp(poolPath string, incentiveId string) int64
+	GetDepositInternalRewardLastCollectTimestamp(lpTokenId uint64) (int64, error)
+	GetDepositCollectedInternalReward(lpTokenId uint64) (int64, error)
+	GetDepositCollectedExternalReward(lpTokenId uint64, incentiveId string) (int64, error)
+	GetDepositLiquidity(lpTokenId uint64) (*u256.Uint, error)
+	GetDepositLiquidityAsString(lpTokenId uint64) (string, error)
+	GetDepositOwner(lpTokenId uint64) (address, error)
+	GetDepositStakeTime(lpTokenId uint64) (int64, error)
+	GetDepositTargetPoolPath(lpTokenId uint64) (string, error)
+	GetDepositTickLower(lpTokenId uint64) (int32, error)
+	GetDepositTickUpper(lpTokenId uint64) (int32, error)
+	GetDepositWarmUp(lpTokenId uint64) ([]Warmup, error)
+	GetDepositExternalIncentiveIdList(lpTokenId uint64) ([]string, error)
+	GetExternalIncentiveByPoolPath(poolPath string) ([]ExternalIncentive, error)
+	GetIncentiveEndTimestamp(poolPath string, incentiveId string) (int64, error)
+	GetIncentiveCreator(poolPath string, incentiveId string) (address, error)
+	GetIncentiveRewardAmount(poolPath string, incentiveId string) (*u256.Uint, error)
+	GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) (string, error)
+	GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) (*u256.Uint, error)
+	GetIncentiveRewardToken(poolPath string, incentiveId string) (string, error)
+	GetIncentiveStartTimestamp(poolPath string, incentiveId string) (int64, error)
 	GetMinimumRewardAmount() int64
 	GetMinimumRewardAmountForToken(tokenPath string) int64
-	GetPoolStakedLiquidity(poolPath string) string
-	GetPoolsByTier(tier uint64) []string
-	GetPoolReward(tier uint64) int64
+	GetPoolStakedLiquidity(poolPath string) (string, error)
+	GetPoolsByTier(tier uint64) ([]string, error)
+	GetPoolReward(tier uint64) (int64, error)
 	GetPoolTier(poolPath string) uint64
 	GetPoolTierCount(tier uint64) uint64
-	GetPoolTierRatio(poolPath string) uint64
+	GetPoolTierRatio(poolPath string) (uint64, error)
 	GetSpecificTokenMinimumRewardAmount(tokenPath string) (int64, bool)
-	GetTargetPoolPathByIncentiveId(poolPath string, incentiveId string) string
+	GetTargetPoolPathByIncentiveId(poolPath string, incentiveId string) (string, error)
 	GetUnstakingFee() uint64
 	GetPendingProtocolFees() map[string]int64
 	IsStaked(positionId uint64) bool

--- a/contract/r/gnoswap/staker/types.gno
+++ b/contract/r/gnoswap/staker/types.gno
@@ -43,55 +43,55 @@ type IStakerManager interface {
 }
 
 type IStakerGetter interface {
-	GetPool(poolPath string) *Pool
+	GetPool(poolPath string) (*Pool, error)
 	GetPoolRewardCaches(poolPath string) *rotree.ReadOnlyTree
 	GetPoolIncentives(poolPath string) *rotree.ReadOnlyTree
 	GetPoolGlobalRewardRatioAccumulations(poolPath string) *rotree.ReadOnlyTree
 	GetPoolHistoricalTicks(poolPath string) *rotree.ReadOnlyTree
-	GetDeposit(lpTokenId uint64) *Deposit
-	CollectableEmissionReward(positionId uint64) int64
-	CollectableExternalIncentiveReward(positionId uint64, incentiveId string) int64
-	GetCreatedHeightOfIncentive(poolPath string, incentiveId string) int64
-	GetIncentiveCreatedTimestamp(poolPath string, incentiveId string) int64
-	GetIncentiveTotalRewardAmount(poolPath string, incentiveId string) int64
-	GetIncentiveDistributedRewardAmount(poolPath string, incentiveId string) int64
-	GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) int64
-	GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) int64
-	GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) int64
-	GetIncentiveRefunded(poolPath string, incentiveId string) bool
-	IsIncentiveActive(poolPath string, incentiveId string) bool
-	GetDepositExternalRewardLastCollectTimestamp(lpTokenId uint64, incentiveId string) int64
+	GetDeposit(lpTokenId uint64) (*Deposit, error)
+	CollectableEmissionReward(positionId uint64) (int64, error)
+	CollectableExternalIncentiveReward(positionId uint64, incentiveId string) (int64, error)
+	GetCreatedHeightOfIncentive(poolPath string, incentiveId string) (int64, error)
+	GetIncentiveCreatedTimestamp(poolPath string, incentiveId string) (int64, error)
+	GetIncentiveTotalRewardAmount(poolPath string, incentiveId string) (int64, error)
+	GetIncentiveDistributedRewardAmount(poolPath string, incentiveId string) (int64, error)
+	GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) (int64, error)
+	GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) (int64, error)
+	GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) (int64, error)
+	GetIncentiveRefunded(poolPath string, incentiveId string) (bool, error)
+	IsIncentiveActive(poolPath string, incentiveId string) (bool, error)
+	GetDepositExternalRewardLastCollectTimestamp(lpTokenId uint64, incentiveId string) (int64, error)
 	GetDepositGnsAmount() int64
-	GetDepositInternalRewardLastCollectTimestamp(lpTokenId uint64) int64
-	GetDepositCollectedInternalReward(lpTokenId uint64) int64
-	GetDepositCollectedExternalReward(lpTokenId uint64, incentiveId string) int64
-	GetDepositLiquidity(lpTokenId uint64) *u256.Uint
-	GetDepositLiquidityAsString(lpTokenId uint64) string
-	GetDepositOwner(lpTokenId uint64) address
-	GetDepositStakeTime(lpTokenId uint64) int64
-	GetDepositTargetPoolPath(lpTokenId uint64) string
-	GetDepositTickLower(lpTokenId uint64) int32
-	GetDepositTickUpper(lpTokenId uint64) int32
-	GetDepositWarmUp(lpTokenId uint64) []Warmup
-	GetDepositExternalIncentiveIdList(lpTokenId uint64) []string
-	GetExternalIncentiveByPoolPath(poolPath string) []ExternalIncentive
-	GetIncentiveEndTimestamp(poolPath string, incentiveId string) int64
-	GetIncentiveCreator(poolPath string, incentiveId string) address
-	GetIncentiveRewardAmount(poolPath string, incentiveId string) *u256.Uint
-	GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) string
-	GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) *u256.Uint
-	GetIncentiveRewardToken(poolPath string, incentiveId string) string
-	GetIncentiveStartTimestamp(poolPath string, incentiveId string) int64
+	GetDepositInternalRewardLastCollectTimestamp(lpTokenId uint64) (int64, error)
+	GetDepositCollectedInternalReward(lpTokenId uint64) (int64, error)
+	GetDepositCollectedExternalReward(lpTokenId uint64, incentiveId string) (int64, error)
+	GetDepositLiquidity(lpTokenId uint64) (*u256.Uint, error)
+	GetDepositLiquidityAsString(lpTokenId uint64) (string, error)
+	GetDepositOwner(lpTokenId uint64) (address, error)
+	GetDepositStakeTime(lpTokenId uint64) (int64, error)
+	GetDepositTargetPoolPath(lpTokenId uint64) (string, error)
+	GetDepositTickLower(lpTokenId uint64) (int32, error)
+	GetDepositTickUpper(lpTokenId uint64) (int32, error)
+	GetDepositWarmUp(lpTokenId uint64) ([]Warmup, error)
+	GetDepositExternalIncentiveIdList(lpTokenId uint64) ([]string, error)
+	GetExternalIncentiveByPoolPath(poolPath string) ([]ExternalIncentive, error)
+	GetIncentiveEndTimestamp(poolPath string, incentiveId string) (int64, error)
+	GetIncentiveCreator(poolPath string, incentiveId string) (address, error)
+	GetIncentiveRewardAmount(poolPath string, incentiveId string) (*u256.Uint, error)
+	GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) (string, error)
+	GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) (*u256.Uint, error)
+	GetIncentiveRewardToken(poolPath string, incentiveId string) (string, error)
+	GetIncentiveStartTimestamp(poolPath string, incentiveId string) (int64, error)
 	GetMinimumRewardAmount() int64
 	GetMinimumRewardAmountForToken(tokenPath string) int64
-	GetPoolStakedLiquidity(poolPath string) string
-	GetPoolsByTier(tier uint64) []string
-	GetPoolReward(tier uint64) int64
+	GetPoolStakedLiquidity(poolPath string) (string, error)
+	GetPoolsByTier(tier uint64) ([]string, error)
+	GetPoolReward(tier uint64) (int64, error)
 	GetPoolTier(poolPath string) uint64
 	GetPoolTierCount(tier uint64) uint64
-	GetPoolTierRatio(poolPath string) uint64
+	GetPoolTierRatio(poolPath string) (uint64, error)
 	GetSpecificTokenMinimumRewardAmount(tokenPath string) (int64, bool)
-	GetTargetPoolPathByIncentiveId(poolPath string, incentiveId string) string
+	GetTargetPoolPathByIncentiveId(poolPath string, incentiveId string) (string, error)
 	GetUnstakingFee() uint64
 	GetPendingProtocolFees() map[string]int64
 	IsStaked(positionId uint64) bool

--- a/contract/r/gnoswap/staker/v1/external_deposit_fee.gno
+++ b/contract/r/gnoswap/staker/v1/external_deposit_fee.gno
@@ -54,7 +54,7 @@ func (s *stakerV1) SetDepositGnsAmount(_ int, rlm realm, amount int64) {
 
 	assertIsValidAmount(amount)
 
-	prevDepositGnsAmount := s.GetDepositGnsAmount()
+	prevDepositGnsAmount := s.store.GetDepositGnsAmount()
 	s.setDepositGnsAmount(0, rlm, amount)
 
 	chain.Emit(
@@ -116,7 +116,7 @@ func (s *stakerV1) SetTokenMinimumRewardAmount(_ int, rlm realm, paramsStr strin
 		))
 	}
 
-	prevAmount, found := s.GetSpecificTokenMinimumRewardAmount(tokenPath)
+	prevAmount, found := s.store.GetTokenSpecificMinimumRewards()[tokenPath]
 
 	// If amount is 0, remove the entry; otherwise, set it.
 	if amount64 == 0 {

--- a/contract/r/gnoswap/staker/v1/external_deposit_fee_test.gno
+++ b/contract/r/gnoswap/staker/v1/external_deposit_fee_test.gno
@@ -72,7 +72,8 @@ func TestSetDepositGnsAmount(cur realm, t *testing.T) {
 		},
 	}, mockInstanceSetDepositGnsAmount, func() int64 {
 		testing.SetRealm(adminRealm)
-		return getMockInstance().GetDepositGnsAmount()
+		amount := getMockInstance().GetDepositGnsAmount()
+		return amount
 	})
 }
 
@@ -103,7 +104,8 @@ func TestSetMinimumRewardAmount(cur realm, t *testing.T) {
 		},
 	}, mockInstanceSetMinimumRewardAmount, func() int64 {
 		testing.SetRealm(adminRealm)
-		return getMockInstance().GetMinimumRewardAmount()
+		amount := getMockInstance().GetMinimumRewardAmount()
+		return amount
 	})
 }
 

--- a/contract/r/gnoswap/staker/v1/external_incentive_test.gno
+++ b/contract/r/gnoswap/staker/v1/external_incentive_test.gno
@@ -2142,7 +2142,8 @@ func TestEndExternalIncentive_RewardAmountInvariantAfterRefund(cur realm, t *tes
 
 	// GetIncentiveRemainingRewardAmount must reflect the post-refund value, not the stale
 	// pre-refund one.
-	remaining := s.GetIncentiveRemainingRewardAmount(poolPath, incentiveId)
+	remaining, err := s.GetIncentiveRemainingRewardAmount(poolPath, incentiveId)
+	uassert.NoError(t, err)
 	uassert.Equal(t, updated.RewardAmount(), remaining)
 }
 

--- a/contract/r/gnoswap/staker/v1/external_incentive_test.gno
+++ b/contract/r/gnoswap/staker/v1/external_incentive_test.gno
@@ -2342,7 +2342,8 @@ func TestEndExternalIncentive_RewardAmountInvariantAfterRefund(cur realm, t *tes
 
 	// GetIncentiveRemainingRewardAmount must reflect the post-refund value, not the stale
 	// pre-refund one.
-	remaining := s.GetIncentiveRemainingRewardAmount(poolPath, incentiveId)
+	remaining, err := s.GetIncentiveRemainingRewardAmount(poolPath, incentiveId)
+	uassert.NoError(t, err)
 	uassert.Equal(t, updated.RewardAmount(), remaining)
 }
 

--- a/contract/r/gnoswap/staker/v1/getter.gno
+++ b/contract/r/gnoswap/staker/v1/getter.gno
@@ -30,298 +30,401 @@ func (s *stakerV1) findPoolByPoolPath(poolPath string) *sr.Pool {
 }
 
 // getPoolByPoolPath retrieves the pool by its path.
-func (s *stakerV1) getPoolByPoolPath(poolPath string) *sr.Pool {
+func (s *stakerV1) getPoolByPoolPath(poolPath string) (*sr.Pool, error) {
 	result := s.store.GetPools().Get(poolPath)
 	if result == nil {
-		panic(makeErrorWithDetails(
+		return nil, makeErrorWithDetails(
 			errDataNotFound,
-			ufmt.Sprintf("poolPath(%s) pool does not exist", poolPath)),
+			ufmt.Sprintf("poolPath(%s) pool does not exist", poolPath),
 		)
 	}
 
 	pool, ok := result.(*sr.Pool)
 	if !ok {
-		panic(makeErrorWithDetails(
+		return nil, makeErrorWithDetails(
 			errDataNotFound,
-			ufmt.Sprintf("poolPath(%s) pool does not exist", poolPath)),
+			ufmt.Sprintf("poolPath(%s) pool does not exist", poolPath),
 		)
 	}
 
-	return pool
+	return pool, nil
 }
 
 // GetPool returns the pool for the given path.
-func (s *stakerV1) GetPool(poolPath string) *sr.Pool {
-	return s.getPoolByPoolPath(poolPath)
+func (s *stakerV1) GetPool(poolPath string) (*sr.Pool, error) {
+	pool, err := s.getPoolByPoolPath(poolPath)
+	if err != nil {
+		return nil, err
+	}
+	return pool, nil
 }
 
 // getIncentive retrieves an external incentive by ID.
-func (s *stakerV1) getIncentive(poolPath string, incentiveId string) *sr.ExternalIncentive {
-	pool := s.getPoolByPoolPath(poolPath)
+func (s *stakerV1) getIncentive(poolPath string, incentiveId string) (*sr.ExternalIncentive, error) {
+	pool, err := s.getPoolByPoolPath(poolPath)
+	if err != nil {
+		return nil, err
+	}
 
 	incentives := pool.Incentives()
 	incentive := incentives.IncentiveTrees().Get(incentiveId)
 	if incentive == nil {
-		panic(ufmt.Sprintf("incentiveId(%s) incentive does not exist", incentiveId))
+		return nil, ufmt.Errorf("incentiveId(%s) incentive does not exist", incentiveId)
 	}
 
 	ictv, ok := incentive.(*sr.ExternalIncentive)
 	if !ok {
-		panic(ufmt.Sprintf("failed to cast incentive to *ExternalIncentive: %T", incentive))
+		return nil, ufmt.Errorf("failed to cast incentive to *ExternalIncentive: %T", incentive)
 	}
-	return ictv
+	return ictv, nil
 }
 
 // GetIncentiveStartTimestamp returns the start timestamp of an incentive.
-func (s *stakerV1) GetIncentiveStartTimestamp(poolPath string, incentiveId string) int64 {
-	incentive := s.getIncentive(poolPath, incentiveId)
+func (s *stakerV1) GetIncentiveStartTimestamp(poolPath string, incentiveId string) (int64, error) {
+	incentive, err := s.getIncentive(poolPath, incentiveId)
+	if err != nil {
+		return 0, err
+	}
 
-	return incentive.StartTimestamp()
+	return incentive.StartTimestamp(), nil
 }
 
 // GetIncentiveEndTimestamp returns the end timestamp of an incentive.
-func (s *stakerV1) GetIncentiveEndTimestamp(poolPath string, incentiveId string) int64 {
-	incentive := s.getIncentive(poolPath, incentiveId)
+func (s *stakerV1) GetIncentiveEndTimestamp(poolPath string, incentiveId string) (int64, error) {
+	incentive, err := s.getIncentive(poolPath, incentiveId)
+	if err != nil {
+		return 0, err
+	}
 
-	return incentive.EndTimestamp()
+	return incentive.EndTimestamp(), nil
 }
 
 // GetTargetPoolPathByIncentiveId returns the target pool path of an incentive.
-func (s *stakerV1) GetTargetPoolPathByIncentiveId(poolPath string, incentiveId string) string {
-	incentive := s.getIncentive(poolPath, incentiveId)
+func (s *stakerV1) GetTargetPoolPathByIncentiveId(poolPath string, incentiveId string) (string, error) {
+	incentive, err := s.getIncentive(poolPath, incentiveId)
+	if err != nil {
+		return "", err
+	}
 
-	return incentive.TargetPoolPath()
+	return incentive.TargetPoolPath(), nil
 }
 
 // GetCreatedHeightOfIncentive returns the creation height of an incentive.
-func (s *stakerV1) GetCreatedHeightOfIncentive(poolPath string, incentiveId string) int64 {
-	incentive := s.getIncentive(poolPath, incentiveId)
+func (s *stakerV1) GetCreatedHeightOfIncentive(poolPath string, incentiveId string) (int64, error) {
+	incentive, err := s.getIncentive(poolPath, incentiveId)
+	if err != nil {
+		return 0, err
+	}
 
-	return incentive.CreatedHeight()
+	return incentive.CreatedHeight(), nil
 }
 
 // GetIncentiveCreatedTimestamp returns the creation timestamp of an incentive.
-func (s *stakerV1) GetIncentiveCreatedTimestamp(poolPath string, incentiveId string) int64 {
-	incentive := s.getIncentive(poolPath, incentiveId)
+func (s *stakerV1) GetIncentiveCreatedTimestamp(poolPath string, incentiveId string) (int64, error) {
+	incentive, err := s.getIncentive(poolPath, incentiveId)
+	if err != nil {
+		return 0, err
+	}
 
-	return incentive.CreatedTimestamp()
+	return incentive.CreatedTimestamp(), nil
 }
 
 // GetIncentiveTotalRewardAmount returns the total reward amount of an incentive.
-func (s *stakerV1) GetIncentiveTotalRewardAmount(poolPath string, incentiveId string) int64 {
-	incentive := s.getIncentive(poolPath, incentiveId)
+func (s *stakerV1) GetIncentiveTotalRewardAmount(poolPath string, incentiveId string) (int64, error) {
+	incentive, err := s.getIncentive(poolPath, incentiveId)
+	if err != nil {
+		return 0, err
+	}
 
-	return incentive.TotalRewardAmount()
+	return incentive.TotalRewardAmount(), nil
 }
 
 // GetIncentiveDistributedRewardAmount returns the distributed reward amount of an incentive.
-func (s *stakerV1) GetIncentiveDistributedRewardAmount(poolPath string, incentiveId string) int64 {
-	incentive := s.getIncentive(poolPath, incentiveId)
+func (s *stakerV1) GetIncentiveDistributedRewardAmount(poolPath string, incentiveId string) (int64, error) {
+	incentive, err := s.getIncentive(poolPath, incentiveId)
+	if err != nil {
+		return 0, err
+	}
 
-	return incentive.DistributedRewardAmount()
+	return incentive.DistributedRewardAmount(), nil
 }
 
 // GetIncentiveRemainingRewardAmount returns the remaining reward amount of an incentive.
-func (s *stakerV1) GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) int64 {
-	incentive := s.getIncentive(poolPath, incentiveId)
+func (s *stakerV1) GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) (int64, error) {
+	incentive, err := s.getIncentive(poolPath, incentiveId)
+	if err != nil {
+		return 0, err
+	}
 
-	return incentive.RewardAmount()
+	return incentive.RewardAmount(), nil
 }
 
 // GetIncentiveAccumulatedPenaltyAmount returns the accumulated warmup penalty amount of an incentive.
-func (s *stakerV1) GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) int64 {
-	incentive := s.getIncentive(poolPath, incentiveId)
+func (s *stakerV1) GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) (int64, error) {
+	incentive, err := s.getIncentive(poolPath, incentiveId)
+	if err != nil {
+		return 0, err
+	}
 
-	return incentive.AccumulatedPenaltyAmount()
+	return incentive.AccumulatedPenaltyAmount(), nil
 }
 
 // GetIncentiveDepositGnsAmount returns the deposit GNS amount of an incentive.
-func (s *stakerV1) GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) int64 {
-	incentive := s.getIncentive(poolPath, incentiveId)
+func (s *stakerV1) GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) (int64, error) {
+	incentive, err := s.getIncentive(poolPath, incentiveId)
+	if err != nil {
+		return 0, err
+	}
 
-	return incentive.DepositGnsAmount()
+	return incentive.DepositGnsAmount(), nil
 }
 
 // GetIncentiveRefunded returns whether an incentive has been refunded.
-func (s *stakerV1) GetIncentiveRefunded(poolPath string, incentiveId string) bool {
-	incentive := s.getIncentive(poolPath, incentiveId)
+func (s *stakerV1) GetIncentiveRefunded(poolPath string, incentiveId string) (bool, error) {
+	incentive, err := s.getIncentive(poolPath, incentiveId)
+	if err != nil {
+		return false, err
+	}
 
-	return incentive.Refunded()
+	return incentive.Refunded(), nil
 }
 
 // IsIncentiveActive returns whether an incentive is currently active.
-func (s *stakerV1) IsIncentiveActive(poolPath string, incentiveId string) bool {
-	incentive := s.getIncentive(poolPath, incentiveId)
+func (s *stakerV1) IsIncentiveActive(poolPath string, incentiveId string) (bool, error) {
+	incentive, err := s.getIncentive(poolPath, incentiveId)
+	if err != nil {
+		return false, err
+	}
 	currentTime := time.Now().Unix()
 
 	resolver := NewExternalIncentiveResolver(incentive)
-	return resolver.isActive(currentTime) && !resolver.Refunded()
+	return resolver.isActive(currentTime) && !resolver.Refunded(), nil
 }
 
 // GetIncentiveRewardToken returns the reward token of an incentive.
-func (s *stakerV1) GetIncentiveRewardToken(poolPath string, incentiveId string) string {
-	incentive := s.getIncentive(poolPath, incentiveId)
+func (s *stakerV1) GetIncentiveRewardToken(poolPath string, incentiveId string) (string, error) {
+	incentive, err := s.getIncentive(poolPath, incentiveId)
+	if err != nil {
+		return "", err
+	}
 
-	return incentive.RewardToken()
+	return incentive.RewardToken(), nil
 }
 
 // GetIncentiveRewardAmount returns the reward amount of an incentive.
-func (s *stakerV1) GetIncentiveRewardAmount(poolPath string, incentiveId string) *u256.Uint {
-	incentive := s.getIncentive(poolPath, incentiveId)
+func (s *stakerV1) GetIncentiveRewardAmount(poolPath string, incentiveId string) (*u256.Uint, error) {
+	incentive, err := s.getIncentive(poolPath, incentiveId)
+	if err != nil {
+		return nil, err
+	}
 
-	return u256.NewUintFromInt64(incentive.RewardAmount())
+	return u256.NewUintFromInt64(incentive.RewardAmount()), nil
 }
 
 // GetIncentiveRewardAmountAsString returns the reward amount of an incentive as string.
-func (s *stakerV1) GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) string {
-	rewardAmount := s.GetIncentiveRewardAmount(poolPath, incentiveId)
+func (s *stakerV1) GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) (string, error) {
+	rewardAmount, err := s.GetIncentiveRewardAmount(poolPath, incentiveId)
+	if err != nil {
+		return "", err
+	}
 
-	return rewardAmount.ToString()
+	return rewardAmount.ToString(), nil
 }
 
 // GetIncentiveRewardPerSecondX128 returns the Q128-scaled reward per second of
 // an incentive (i.e. actual rate = value / 2^128). The Q128 form preserves
 // sub-second precision that would otherwise be lost to int64 truncation.
-func (s *stakerV1) GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) *u256.Uint {
-	incentive := s.getIncentive(poolPath, incentiveId)
+func (s *stakerV1) GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) (*u256.Uint, error) {
+	incentive, err := s.getIncentive(poolPath, incentiveId)
+	if err != nil {
+		return nil, err
+	}
 
-	return incentive.RewardPerSecondX128()
+	return incentive.RewardPerSecondX128(), nil
 }
 
 // GetIncentiveCreator returns the creator address of an incentive.
-func (s *stakerV1) GetIncentiveCreator(poolPath string, incentiveId string) address {
-	incentive := s.getIncentive(poolPath, incentiveId)
+func (s *stakerV1) GetIncentiveCreator(poolPath string, incentiveId string) (address, error) {
+	incentive, err := s.getIncentive(poolPath, incentiveId)
+	if err != nil {
+		return address(""), err
+	}
 
-	return incentive.Creator()
+	return incentive.Creator(), nil
 }
 
 // getDeposit retrieves a deposit by LP token ID.
-func (s *stakerV1) getDeposit(lpTokenId uint64) *sr.Deposit {
-	deposit := s.getDeposits().get(lpTokenId)
-	if deposit == nil {
-		panic(
-			makeErrorWithDetails(
-				errDataNotFound,
-				ufmt.Sprintf("lpTokenId(%d) deposit does not exist", lpTokenId),
-			),
+func (s *stakerV1) getDeposit(lpTokenId uint64) (*sr.Deposit, error) {
+	deposits := s.getDeposits()
+	if !deposits.Has(lpTokenId) {
+		return nil, makeErrorWithDetails(
+			errDataNotFound,
+			ufmt.Sprintf("lpTokenId(%d) deposit does not exist", lpTokenId),
 		)
 	}
 
-	return deposit
+	return deposits.get(lpTokenId), nil
 }
 
 // GetDeposit returns the deposit for the given LP token ID.
-func (s *stakerV1) GetDeposit(lpTokenId uint64) *sr.Deposit {
+func (s *stakerV1) GetDeposit(lpTokenId uint64) (*sr.Deposit, error) {
 	return s.getDeposit(lpTokenId)
 }
 
 // CollectableEmissionReward returns the claimable internal reward amount for a position.
 // calculateCollectablePositionReward is read-only, so querying a collectable amount never mutates state.
-func (s *stakerV1) CollectableEmissionReward(positionId uint64) int64 {
+func (s *stakerV1) CollectableEmissionReward(positionId uint64) (int64, error) {
 	currentTime := time.Now().Unix()
 	currentHeight := runtime.ChainHeight()
+	if _, err := s.getDeposit(positionId); err != nil {
+		return 0, err
+	}
 	reward := s.calculateCollectablePositionReward(currentHeight, currentTime, positionId)
-	return reward.Internal
+	return reward.Internal, nil
 }
 
 // CollectableExternalIncentiveReward returns the claimable external reward amount for an incentive.
 // calculateCollectablePositionReward is read-only, so querying a collectable amount never mutates state.
-func (s *stakerV1) CollectableExternalIncentiveReward(positionId uint64, incentiveId string) int64 {
+func (s *stakerV1) CollectableExternalIncentiveReward(positionId uint64, incentiveId string) (int64, error) {
 	currentTime := time.Now().Unix()
 	currentHeight := runtime.ChainHeight()
+	if _, err := s.getDeposit(positionId); err != nil {
+		return 0, err
+	}
 	reward := s.calculateCollectablePositionReward(currentHeight, currentTime, positionId)
 	amount, ok := reward.External[incentiveId]
 	if !ok {
-		return 0
+		return 0, nil
 	}
-	return amount
+	return amount, nil
 }
 
 // GetDepositOwner returns the owner of a deposit.
-func (s *stakerV1) GetDepositOwner(lpTokenId uint64) address {
-	deposit := s.getDeposit(lpTokenId)
+func (s *stakerV1) GetDepositOwner(lpTokenId uint64) (address, error) {
+	deposit, err := s.getDeposit(lpTokenId)
+	if err != nil {
+		return address(""), err
+	}
 
-	return deposit.Owner()
+	return deposit.Owner(), nil
 }
 
 // GetDepositStakeTime returns the stake time of a deposit.
-func (s *stakerV1) GetDepositStakeTime(lpTokenId uint64) int64 {
-	deposit := s.getDeposit(lpTokenId)
+func (s *stakerV1) GetDepositStakeTime(lpTokenId uint64) (int64, error) {
+	deposit, err := s.getDeposit(lpTokenId)
+	if err != nil {
+		return 0, err
+	}
 
-	return deposit.StakeTime()
+	return deposit.StakeTime(), nil
 }
 
 // GetDepositTargetPoolPath returns the target pool path of a deposit.
-func (s *stakerV1) GetDepositTargetPoolPath(lpTokenId uint64) string {
-	deposit := s.getDeposit(lpTokenId)
+func (s *stakerV1) GetDepositTargetPoolPath(lpTokenId uint64) (string, error) {
+	deposit, err := s.getDeposit(lpTokenId)
+	if err != nil {
+		return "", err
+	}
 
-	return deposit.TargetPoolPath()
+	return deposit.TargetPoolPath(), nil
 }
 
 // GetDepositTickLower returns the lower tick of a deposit.
-func (s *stakerV1) GetDepositTickLower(lpTokenId uint64) int32 {
-	deposit := s.getDeposit(lpTokenId)
+func (s *stakerV1) GetDepositTickLower(lpTokenId uint64) (int32, error) {
+	deposit, err := s.getDeposit(lpTokenId)
+	if err != nil {
+		return 0, err
+	}
 
-	return deposit.TickLower()
+	return deposit.TickLower(), nil
 }
 
 // GetDepositTickUpper returns the upper tick of a deposit.
-func (s *stakerV1) GetDepositTickUpper(lpTokenId uint64) int32 {
-	deposit := s.getDeposit(lpTokenId)
+func (s *stakerV1) GetDepositTickUpper(lpTokenId uint64) (int32, error) {
+	deposit, err := s.getDeposit(lpTokenId)
+	if err != nil {
+		return 0, err
+	}
 
-	return deposit.TickUpper()
+	return deposit.TickUpper(), nil
 }
 
 // GetDepositLiquidity returns the liquidity of a deposit.
-func (s *stakerV1) GetDepositLiquidity(lpTokenId uint64) *u256.Uint {
-	deposit := s.getDeposit(lpTokenId)
+func (s *stakerV1) GetDepositLiquidity(lpTokenId uint64) (*u256.Uint, error) {
+	deposit, err := s.getDeposit(lpTokenId)
+	if err != nil {
+		return nil, err
+	}
 
-	return deposit.Liquidity()
+	return deposit.Liquidity(), nil
 }
 
 // GetDepositLiquidityAsString returns the liquidity of a deposit as string.
-func (s *stakerV1) GetDepositLiquidityAsString(lpTokenId uint64) string {
-	liquidity := s.GetDepositLiquidity(lpTokenId)
+func (s *stakerV1) GetDepositLiquidityAsString(lpTokenId uint64) (string, error) {
+	liquidity, err := s.GetDepositLiquidity(lpTokenId)
+	if err != nil {
+		return "", err
+	}
 
-	return liquidity.ToString()
+	return liquidity.ToString(), nil
 }
 
 // GetDepositInternalRewardLastCollectTimestamp returns the last collect timestamp of a deposit.
-func (s *stakerV1) GetDepositInternalRewardLastCollectTimestamp(lpTokenId uint64) int64 {
-	deposit := s.getDeposit(lpTokenId)
+func (s *stakerV1) GetDepositInternalRewardLastCollectTimestamp(lpTokenId uint64) (int64, error) {
+	deposit, err := s.getDeposit(lpTokenId)
+	if err != nil {
+		return 0, err
+	}
 
-	return deposit.InternalRewardLastCollectTime()
+	return deposit.InternalRewardLastCollectTime(), nil
 }
 
 // GetDepositCollectedInternalReward returns the collected internal reward amount.
-func (s *stakerV1) GetDepositCollectedInternalReward(lpTokenId uint64) int64 {
-	deposit := s.getDeposit(lpTokenId)
+func (s *stakerV1) GetDepositCollectedInternalReward(lpTokenId uint64) (int64, error) {
+	deposit, err := s.getDeposit(lpTokenId)
+	if err != nil {
+		return 0, err
+	}
 
-	return deposit.CollectedInternalReward()
+	return deposit.CollectedInternalReward(), nil
 }
 
 // GetDepositCollectedExternalReward returns the collected external reward amount for an incentive.
-func (s *stakerV1) GetDepositCollectedExternalReward(lpTokenId uint64, incentiveId string) int64 {
-	return s.getDepositResolver(lpTokenId).CollectedExternalReward(incentiveId)
+func (s *stakerV1) GetDepositCollectedExternalReward(lpTokenId uint64, incentiveId string) (int64, error) {
+	depositResolver, err := s.getDepositResolver(lpTokenId)
+	if err != nil {
+		return 0, err
+	}
+	return depositResolver.CollectedExternalReward(incentiveId), nil
 }
 
 // GetDepositExternalRewardLastCollectTimestamp returns the last collect timestamp of a deposit.
-func (s *stakerV1) GetDepositExternalRewardLastCollectTimestamp(lpTokenId uint64, incentiveId string) int64 {
-	return s.getDepositResolver(lpTokenId).ExternalRewardLastCollectTime(incentiveId)
+func (s *stakerV1) GetDepositExternalRewardLastCollectTimestamp(lpTokenId uint64, incentiveId string) (int64, error) {
+	depositResolver, err := s.getDepositResolver(lpTokenId)
+	if err != nil {
+		return 0, err
+	}
+	return depositResolver.ExternalRewardLastCollectTime(incentiveId), nil
 }
 
 // GetDepositWarmUp returns the warm-up records of a deposit.
-func (s *stakerV1) GetDepositWarmUp(lpTokenId uint64) []sr.Warmup {
-	deposit := s.getDeposit(lpTokenId)
+func (s *stakerV1) GetDepositWarmUp(lpTokenId uint64) ([]sr.Warmup, error) {
+	deposit, err := s.getDeposit(lpTokenId)
+	if err != nil {
+		return nil, err
+	}
 
-	return deposit.Warmups()
+	return deposit.Warmups(), nil
 }
 
 // GetDepositExternalIncentiveIdList returns external incentive IDs for a deposit.
-func (s *stakerV1) GetDepositExternalIncentiveIdList(lpTokenId uint64) []string {
-	deposit := s.getDeposit(lpTokenId)
+func (s *stakerV1) GetDepositExternalIncentiveIdList(lpTokenId uint64) ([]string, error) {
+	deposit, err := s.getDeposit(lpTokenId)
+	if err != nil {
+		return nil, err
+	}
 
-	return deposit.GetExternalIncentiveIdList()
+	return deposit.GetExternalIncentiveIdList(), nil
 }
 
 // GetPoolTier returns the tier of a pool.
@@ -330,14 +433,14 @@ func (s *stakerV1) GetPoolTier(poolPath string) uint64 {
 }
 
 // GetPoolTierRatio returns the current reward ratio for a pool's tier.
-func (s *stakerV1) GetPoolTierRatio(poolPath string) uint64 {
+func (s *stakerV1) GetPoolTierRatio(poolPath string) (uint64, error) {
 	tier := s.GetPoolTier(poolPath)
 	ratio, err := s.getPoolTier().tierRatio.Get(tier)
 	if err != nil {
-		panic(makeErrorWithDetails(errInvalidPoolTier, err.Error()))
+		return 0, makeErrorWithDetails(errInvalidPoolTier, err.Error())
 	}
 
-	return ratio
+	return ratio, nil
 }
 
 // GetPoolTierCount returns the number of pools in a tier.
@@ -349,40 +452,54 @@ func (s *stakerV1) GetPoolTierCount(tier uint64) uint64 {
 }
 
 // GetPoolReward returns the current reward amount for a tier.
-func (s *stakerV1) GetPoolReward(tier uint64) int64 {
-	return s.getPoolTier().CurrentReward(tier)
+func (s *stakerV1) GetPoolReward(tier uint64) (int64, error) {
+	if tier == 0 || tier >= AllTierCount {
+		return 0, makeErrorWithDetails(
+			errInvalidPoolTier,
+			ufmt.Sprintf("tier(%d) must be between 1 and %d", tier, AllTierCount-1),
+		)
+	}
+	return s.getPoolTier().CurrentReward(tier), nil
 }
 
 // GetPoolStakedLiquidity returns the current total staked liquidity of a pool.
-func (s *stakerV1) GetPoolStakedLiquidity(poolPath string) string {
-	pool := s.getPoolByPoolPath(poolPath)
+func (s *stakerV1) GetPoolStakedLiquidity(poolPath string) (string, error) {
+	pool, err := s.getPoolByPoolPath(poolPath)
+	if err != nil {
+		return "", err
+	}
 	liquidity := NewPoolResolver(pool).CurrentStakedLiquidity(time.Now().Unix())
 	if liquidity == nil {
-		return u256.Zero().ToString()
+		return u256.Zero().ToString(), nil
 	}
 
-	return liquidity.ToString()
+	return liquidity.ToString(), nil
 }
 
 // GetPoolsByTier returns the list of pools in a tier.
-func (s *stakerV1) GetPoolsByTier(tier uint64) []string {
+func (s *stakerV1) GetPoolsByTier(tier uint64) ([]string, error) {
 	if tier == 0 {
-		return []string{}
+		return []string{}, nil
 	}
 
 	pools := make([]string, 0)
+	var iterErr error
 	s.getPoolTier().membership.Iterate("", "", func(poolPath string, value any) bool {
 		currentTier, ok := value.(uint64)
 		if !ok {
-			panic("failed to cast tier to uint64")
+			iterErr = ufmt.Errorf("failed to cast tier to uint64")
+			return true
 		}
 		if currentTier == tier {
 			pools = append(pools, poolPath)
 		}
 		return false
 	})
+	if iterErr != nil {
+		return nil, iterErr
+	}
 
-	return pools
+	return pools, nil
 }
 
 // GetTotalEmissionSent returns the total GNS emission sent.
@@ -406,21 +523,26 @@ func (s *stakerV1) IsStaked(positionId uint64) bool {
 }
 
 // GetExternalIncentiveByPoolPath returns all external incentives for a pool.
-func (s *stakerV1) GetExternalIncentiveByPoolPath(poolPath string) []sr.ExternalIncentive {
+func (s *stakerV1) GetExternalIncentiveByPoolPath(poolPath string) ([]sr.ExternalIncentive, error) {
 	incentives := make([]sr.ExternalIncentive, 0)
+	var iterErr error
 
 	s.store.GetExternalIncentives().Iterate("", "", func(_ string, value any) bool {
 		incentive, ok := value.(*sr.ExternalIncentive)
 		if !ok {
-			panic("failed to cast value to *ExternalIncentive")
+			iterErr = ufmt.Errorf("failed to cast value to *ExternalIncentive")
+			return true
 		}
 		if incentive.TargetPoolPath() == poolPath {
 			incentives = append(incentives, *incentive)
 		}
 		return false
 	})
+	if iterErr != nil {
+		return nil, iterErr
+	}
 
-	return incentives
+	return incentives, nil
 }
 
 // GetPoolRewardCaches returns a read-only view of a pool's reward cache, keyed

--- a/contract/r/gnoswap/staker/v1/getter.gno
+++ b/contract/r/gnoswap/staker/v1/getter.gno
@@ -2,6 +2,7 @@ package staker
 
 import (
 	"chain/runtime"
+	"errors"
 	"time"
 
 	rotree "gno.land/p/nt/bptree/v0/rotree"
@@ -487,7 +488,7 @@ func (s *stakerV1) GetPoolsByTier(tier uint64) ([]string, error) {
 	s.getPoolTier().membership.Iterate("", "", func(poolPath string, value any) bool {
 		currentTier, ok := value.(uint64)
 		if !ok {
-			iterErr = ufmt.Errorf("failed to cast tier to uint64")
+			iterErr = errors.New("failed to cast tier to uint64")
 			return true
 		}
 		if currentTier == tier {
@@ -530,7 +531,7 @@ func (s *stakerV1) GetExternalIncentiveByPoolPath(poolPath string) ([]sr.Externa
 	s.store.GetExternalIncentives().Iterate("", "", func(_ string, value any) bool {
 		incentive, ok := value.(*sr.ExternalIncentive)
 		if !ok {
-			iterErr = ufmt.Errorf("failed to cast value to *ExternalIncentive")
+			iterErr = errors.New("failed to cast value to *ExternalIncentive")
 			return true
 		}
 		if incentive.TargetPoolPath() == poolPath {

--- a/contract/r/gnoswap/staker/v1/getter_test.gno
+++ b/contract/r/gnoswap/staker/v1/getter_test.gno
@@ -120,48 +120,84 @@ func TestGetterIncentiveBasicProperties(cur realm, t *testing.T) {
 		expected any
 	}{
 		{
-			name:     "GetIncentiveStartTimestamp",
-			getter:   func() any { return state.instance.GetIncentiveStartTimestamp(state.poolPath, state.incentiveId) },
+			name: "GetIncentiveStartTimestamp",
+			getter: func() any {
+				v, err := state.instance.GetIncentiveStartTimestamp(state.poolPath, state.incentiveId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: state.fixedTimestamp,
 		},
 		{
-			name:     "GetIncentiveEndTimestamp",
-			getter:   func() any { return state.instance.GetIncentiveEndTimestamp(state.poolPath, state.incentiveId) },
+			name: "GetIncentiveEndTimestamp",
+			getter: func() any {
+				v, err := state.instance.GetIncentiveEndTimestamp(state.poolPath, state.incentiveId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: state.fixedTimestamp + 3600,
 		},
 		{
-			name:     "GetTargetPoolPathByIncentiveId",
-			getter:   func() any { return state.instance.GetTargetPoolPathByIncentiveId(state.poolPath, state.incentiveId) },
+			name: "GetTargetPoolPathByIncentiveId",
+			getter: func() any {
+				v, err := state.instance.GetTargetPoolPathByIncentiveId(state.poolPath, state.incentiveId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: state.poolPath,
 		},
 		{
-			name:     "GetCreatedHeightOfIncentive",
-			getter:   func() any { return state.instance.GetCreatedHeightOfIncentive(state.poolPath, state.incentiveId) },
+			name: "GetCreatedHeightOfIncentive",
+			getter: func() any {
+				v, err := state.instance.GetCreatedHeightOfIncentive(state.poolPath, state.incentiveId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: state.fixedBlockHeight,
 		},
 		{
-			name:     "GetIncentiveCreatedTimestamp",
-			getter:   func() any { return state.instance.GetIncentiveCreatedTimestamp(state.poolPath, state.incentiveId) },
+			name: "GetIncentiveCreatedTimestamp",
+			getter: func() any {
+				v, err := state.instance.GetIncentiveCreatedTimestamp(state.poolPath, state.incentiveId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: state.fixedTimestamp,
 		},
 		{
-			name:     "GetIncentiveDepositGnsAmount",
-			getter:   func() any { return state.instance.GetIncentiveDepositGnsAmount(state.poolPath, state.incentiveId) },
+			name: "GetIncentiveDepositGnsAmount",
+			getter: func() any {
+				v, err := state.instance.GetIncentiveDepositGnsAmount(state.poolPath, state.incentiveId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: int64(1_000_000_000),
 		},
 		{
-			name:     "GetIncentiveRefunded",
-			getter:   func() any { return state.instance.GetIncentiveRefunded(state.poolPath, state.incentiveId) },
+			name: "GetIncentiveRefunded",
+			getter: func() any {
+				v, err := state.instance.GetIncentiveRefunded(state.poolPath, state.incentiveId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: false,
 		},
 		{
-			name:     "GetIncentiveRewardToken",
-			getter:   func() any { return state.instance.GetIncentiveRewardToken(state.poolPath, state.incentiveId) },
+			name: "GetIncentiveRewardToken",
+			getter: func() any {
+				v, err := state.instance.GetIncentiveRewardToken(state.poolPath, state.incentiveId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: barPath,
 		},
 		{
-			name:     "GetIncentiveCreator",
-			getter:   func() any { return state.instance.GetIncentiveCreator(state.poolPath, state.incentiveId) },
+			name: "GetIncentiveCreator",
+			getter: func() any {
+				v, err := state.instance.GetIncentiveCreator(state.poolPath, state.incentiveId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: state.owner,
 		},
 	}
@@ -182,9 +218,13 @@ func TestGetterIncentiveRewardAmounts(cur realm, t *testing.T) {
 	// Set distributed amount to create derived relationship
 	state.incentive.SetDistributedRewardAmount(3_000_000)
 
-	totalReward := state.instance.GetIncentiveTotalRewardAmount(state.poolPath, state.incentiveId)
-	distributedReward := state.instance.GetIncentiveDistributedRewardAmount(state.poolPath, state.incentiveId)
-	remainingReward := state.instance.GetIncentiveRemainingRewardAmount(state.poolPath, state.incentiveId)
+	totalReward, err := state.instance.GetIncentiveTotalRewardAmount(state.poolPath, state.incentiveId)
+
+	uassert.NoError(t, err)
+	distributedReward, err := state.instance.GetIncentiveDistributedRewardAmount(state.poolPath, state.incentiveId)
+	uassert.NoError(t, err)
+	remainingReward, err := state.instance.GetIncentiveRemainingRewardAmount(state.poolPath, state.incentiveId)
+	uassert.NoError(t, err)
 
 	// Verify individual values
 	uassert.Equal(t, int64(10_000_000), totalReward)
@@ -200,13 +240,16 @@ func TestGetterIncentiveRewardAmounts(cur realm, t *testing.T) {
 	// sub-integer rates (here 10_000_000 / 3600 = 2777.77...) survive without
 	// the truncation that the previous int64 representation forced. Floor of
 	// rewardPerSecondX128 >> 128 should still equal the legacy value 2777.
-	rewardPerSecondX128 := state.instance.GetIncentiveRewardPerSecondX128(state.poolPath, state.incentiveId)
+	rewardPerSecondX128, err := state.instance.GetIncentiveRewardPerSecondX128(state.poolPath, state.incentiveId)
+	uassert.NoError(t, err)
 	floor := u256.Zero().Rsh(rewardPerSecondX128, 128)
 	uassert.Equal(t, "2777", floor.ToString())
 
 	// Test u256 variants
-	rewardAmount := state.instance.GetIncentiveRewardAmount(state.poolPath, state.incentiveId)
-	rewardAmountStr := state.instance.GetIncentiveRewardAmountAsString(state.poolPath, state.incentiveId)
+	rewardAmount, err := state.instance.GetIncentiveRewardAmount(state.poolPath, state.incentiveId)
+	uassert.NoError(t, err)
+	rewardAmountStr, err := state.instance.GetIncentiveRewardAmountAsString(state.poolPath, state.incentiveId)
+	uassert.NoError(t, err)
 	uassert.Equal(t, "10000000", rewardAmount.ToString())
 	uassert.Equal(t, "10000000", rewardAmountStr)
 }
@@ -214,7 +257,9 @@ func TestGetterIncentiveRewardAmounts(cur realm, t *testing.T) {
 func TestGetterPoolIncentiveDepositObjects(cur realm, t *testing.T) {
 	state := setupBasicTestState(cur, t)
 
-	pool := state.instance.GetPool(state.poolPath)
+	pool, err := state.instance.GetPool(state.poolPath)
+
+	uassert.NoError(t, err)
 	uassert.Equal(t, state.poolPath, pool.PoolPath())
 
 	incentive, ok := state.instance.GetPoolIncentives(state.poolPath).Get(state.incentiveId).(*sr.ExternalIncentive)
@@ -222,7 +267,9 @@ func TestGetterPoolIncentiveDepositObjects(cur realm, t *testing.T) {
 	uassert.Equal(t, state.incentiveId, incentive.IncentiveId())
 	uassert.Equal(t, barPath, incentive.RewardToken())
 
-	deposit := state.instance.GetDeposit(state.positionId)
+	deposit, err := state.instance.GetDeposit(state.positionId)
+
+	uassert.NoError(t, err)
 	uassert.Equal(t, state.owner, deposit.Owner())
 	uassert.Equal(t, state.poolPath, deposit.TargetPoolPath())
 }
@@ -230,10 +277,14 @@ func TestGetterPoolIncentiveDepositObjects(cur realm, t *testing.T) {
 func TestGetterCollectableRewards(cur realm, t *testing.T) {
 	state := setupBasicTestState(cur, t)
 
-	internal := state.instance.CollectableEmissionReward(state.positionId)
+	internal, err := state.instance.CollectableEmissionReward(state.positionId)
+
+	uassert.NoError(t, err)
 	uassert.Equal(t, int64(0), internal)
 
-	external := state.instance.CollectableExternalIncentiveReward(state.positionId, state.incentiveId)
+	external, err := state.instance.CollectableExternalIncentiveReward(state.positionId, state.incentiveId)
+
+	uassert.NoError(t, err)
 	uassert.Equal(t, int64(0), external)
 }
 
@@ -261,7 +312,9 @@ func TestGetterPoolIncentiveIdList(cur realm, t *testing.T) {
 func TestGetterExternalIncentiveByPoolPath(cur realm, t *testing.T) {
 	state := setupBasicTestState(cur, t)
 
-	incentives := state.instance.GetExternalIncentiveByPoolPath(state.poolPath)
+	incentives, err := state.instance.GetExternalIncentiveByPoolPath(state.poolPath)
+
+	uassert.NoError(t, err)
 
 	uassert.Equal(t, 1, len(incentives))
 	uassert.Equal(t, state.incentiveId, incentives[0].IncentiveId())
@@ -276,38 +329,66 @@ func TestGetterDepositBasicProperties(cur realm, t *testing.T) {
 		expected any
 	}{
 		{
-			name:     "GetDepositOwner",
-			getter:   func() any { return state.instance.GetDepositOwner(state.positionId) },
+			name: "GetDepositOwner",
+			getter: func() any {
+				v, err := state.instance.GetDepositOwner(state.positionId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: state.owner,
 		},
 		{
-			name:     "GetDepositStakeTime",
-			getter:   func() any { return state.instance.GetDepositStakeTime(state.positionId) },
+			name: "GetDepositStakeTime",
+			getter: func() any {
+				v, err := state.instance.GetDepositStakeTime(state.positionId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: state.fixedTimestamp,
 		},
 		{
-			name:     "GetDepositTargetPoolPath",
-			getter:   func() any { return state.instance.GetDepositTargetPoolPath(state.positionId) },
+			name: "GetDepositTargetPoolPath",
+			getter: func() any {
+				v, err := state.instance.GetDepositTargetPoolPath(state.positionId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: state.poolPath,
 		},
 		{
-			name:     "GetDepositTickLower",
-			getter:   func() any { return state.instance.GetDepositTickLower(state.positionId) },
+			name: "GetDepositTickLower",
+			getter: func() any {
+				v, err := state.instance.GetDepositTickLower(state.positionId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: int32(-100),
 		},
 		{
-			name:     "GetDepositTickUpper",
-			getter:   func() any { return state.instance.GetDepositTickUpper(state.positionId) },
+			name: "GetDepositTickUpper",
+			getter: func() any {
+				v, err := state.instance.GetDepositTickUpper(state.positionId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: int32(100),
 		},
 		{
-			name:     "GetDepositInternalRewardLastCollectTimestamp",
-			getter:   func() any { return state.instance.GetDepositInternalRewardLastCollectTimestamp(state.positionId) },
+			name: "GetDepositInternalRewardLastCollectTimestamp",
+			getter: func() any {
+				v, err := state.instance.GetDepositInternalRewardLastCollectTimestamp(state.positionId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: state.fixedTimestamp,
 		},
 		{
-			name:     "GetDepositCollectedInternalReward",
-			getter:   func() any { return state.instance.GetDepositCollectedInternalReward(state.positionId) },
+			name: "GetDepositCollectedInternalReward",
+			getter: func() any {
+				v, err := state.instance.GetDepositCollectedInternalReward(state.positionId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: int64(5000),
 		},
 	}
@@ -323,8 +404,11 @@ func TestGetterDepositBasicProperties(cur realm, t *testing.T) {
 func TestGetterDepositLiquidity(cur realm, t *testing.T) {
 	state := setupBasicTestState(cur, t)
 
-	liquidity := state.instance.GetDepositLiquidity(state.positionId)
-	liquidityStr := state.instance.GetDepositLiquidityAsString(state.positionId)
+	liquidity, err := state.instance.GetDepositLiquidity(state.positionId)
+
+	uassert.NoError(t, err)
+	liquidityStr, err := state.instance.GetDepositLiquidityAsString(state.positionId)
+	uassert.NoError(t, err)
 
 	uassert.Equal(t, "1000000", liquidity.ToString())
 	uassert.Equal(t, "1000000", liquidityStr)
@@ -334,15 +418,18 @@ func TestGetterDepositExternalRewards(cur realm, t *testing.T) {
 	state := setupBasicTestState(cur, t)
 
 	// Test collected external reward
-	collectedReward := state.instance.GetDepositCollectedExternalReward(state.positionId, state.incentiveId)
+	collectedReward, err := state.instance.GetDepositCollectedExternalReward(state.positionId, state.incentiveId)
+	uassert.NoError(t, err)
 	uassert.Equal(t, int64(2500), collectedReward)
 
 	// Test last collect timestamp
-	lastCollectTime := state.instance.GetDepositExternalRewardLastCollectTimestamp(state.positionId, state.incentiveId)
+	lastCollectTime, err := state.instance.GetDepositExternalRewardLastCollectTimestamp(state.positionId, state.incentiveId)
+	uassert.NoError(t, err)
 	uassert.Equal(t, state.fixedTimestamp+100, lastCollectTime)
 
 	// Test external incentive id list
-	incentiveIds := state.instance.GetDepositExternalIncentiveIdList(state.positionId)
+	incentiveIds, err := state.instance.GetDepositExternalIncentiveIdList(state.positionId)
+	uassert.NoError(t, err)
 	uassert.Equal(t, 1, len(incentiveIds))
 	uassert.Equal(t, state.incentiveId, incentiveIds[0])
 }
@@ -350,7 +437,9 @@ func TestGetterDepositExternalRewards(cur realm, t *testing.T) {
 func TestGetterDepositWarmUp(cur realm, t *testing.T) {
 	state := setupBasicTestState(cur, t)
 
-	warmups := state.instance.GetDepositWarmUp(state.positionId)
+	warmups, err := state.instance.GetDepositWarmUp(state.positionId)
+
+	uassert.NoError(t, err)
 
 	uassert.Equal(t, 3, len(warmups))
 	uassert.Equal(t, uint64(30), warmups[0].WarmupRatio)
@@ -394,7 +483,8 @@ func TestGetterPoolTierProperties(cur realm, t *testing.T) {
 	uassert.Equal(t, uint64(1), tier)
 
 	// Test pool tier ratio
-	ratio := state.instance.GetPoolTierRatio(state.poolPath)
+	ratio, err := state.instance.GetPoolTierRatio(state.poolPath)
+	uassert.NoError(t, err)
 	uassert.Equal(t, uint64(50), ratio)
 
 	// Test pool tier count
@@ -413,15 +503,19 @@ func TestGetterPoolsByTier(cur realm, t *testing.T) {
 	pool2Path := "gno.land/r/onbloc/foo.FOO:gno.land/r/onbloc/qux.QUX:500"
 	state.instance.setPoolTier(0, cur, pool2Path, 1, state.fixedTimestamp)
 
-	pools := state.instance.GetPoolsByTier(1)
+	pools, err := state.instance.GetPoolsByTier(1)
+
+	uassert.NoError(t, err)
 	uassert.Equal(t, 2, len(pools))
 
 	// Test tier 0 returns empty
-	poolsTier0 := state.instance.GetPoolsByTier(0)
+	poolsTier0, err := state.instance.GetPoolsByTier(0)
+	uassert.NoError(t, err)
 	uassert.Equal(t, 0, len(poolsTier0))
 
 	// Test non-existent tier
-	poolsTier99 := state.instance.GetPoolsByTier(99)
+	poolsTier99, err := state.instance.GetPoolsByTier(99)
+	uassert.NoError(t, err)
 	uassert.Equal(t, 0, len(poolsTier99))
 }
 
@@ -496,17 +590,15 @@ func TestGetterWarmupTemplate(cur realm, t *testing.T) {
 func TestGetterNonExistentIncentive(cur realm, t *testing.T) {
 	state := setupBasicTestState(cur, t)
 
-	uassert.PanicsContains(t, cur, "incentive does not exist", func() {
-		state.instance.GetIncentiveStartTimestamp(state.poolPath, "non-existent-incentive")
-	})
+	_, err := state.instance.GetIncentiveStartTimestamp(state.poolPath, "non-existent-incentive")
+	uassert.ErrorContains(t, err, "incentive does not exist")
 }
 
 func TestGetterNonExistentDeposit(cur realm, t *testing.T) {
 	state := setupBasicTestState(cur, t)
 
-	uassert.PanicsContains(t, cur, "not found", func() {
-		state.instance.GetDepositOwner(uint64(999))
-	})
+	_, err := state.instance.GetDepositOwner(uint64(999))
+	uassert.ErrorContains(t, err, "not found")
 }
 
 func TestGetterNonExistentPool(cur realm, t *testing.T) {
@@ -548,8 +640,11 @@ func TestGetterMultipleDepositsForSameOwner(cur realm, t *testing.T) {
 	positionId2 := uint64(2)
 	state.instance.getDeposits().set(positionId2, deposit2)
 
-	owner1 := state.instance.GetDepositOwner(state.positionId)
-	owner2 := state.instance.GetDepositOwner(positionId2)
+	owner1, err := state.instance.GetDepositOwner(state.positionId)
+
+	uassert.NoError(t, err)
+	owner2, err := state.instance.GetDepositOwner(positionId2)
+	uassert.NoError(t, err)
 	uassert.Equal(t, state.owner, owner1)
 	uassert.Equal(t, state.owner, owner2)
 }
@@ -614,8 +709,9 @@ func TestGetterIncentiveActiveStatus(cur realm, t *testing.T) {
 			}
 			pool.Incentives().SetIncentive(tt.incentiveId, incentive)
 
-			// IsIncentiveActive uses time.Now(), so we just verify it doesn't panic
-			_ = instance.IsIncentiveActive(poolPath, tt.incentiveId)
+			// IsIncentiveActive uses time.Now(), so we just verify it doesn't error
+			_, err := instance.IsIncentiveActive(poolPath, tt.incentiveId)
+			uassert.NoError(t, err)
 		})
 	}
 }

--- a/contract/r/gnoswap/staker/v1/getter_test.gno
+++ b/contract/r/gnoswap/staker/v1/getter_test.gno
@@ -119,48 +119,84 @@ func TestGetterIncentiveBasicProperties(cur realm, t *testing.T) {
 		expected any
 	}{
 		{
-			name:     "GetIncentiveStartTimestamp",
-			getter:   func() any { return state.instance.GetIncentiveStartTimestamp(state.poolPath, state.incentiveId) },
+			name: "GetIncentiveStartTimestamp",
+			getter: func() any {
+				v, err := state.instance.GetIncentiveStartTimestamp(state.poolPath, state.incentiveId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: state.fixedTimestamp,
 		},
 		{
-			name:     "GetIncentiveEndTimestamp",
-			getter:   func() any { return state.instance.GetIncentiveEndTimestamp(state.poolPath, state.incentiveId) },
+			name: "GetIncentiveEndTimestamp",
+			getter: func() any {
+				v, err := state.instance.GetIncentiveEndTimestamp(state.poolPath, state.incentiveId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: state.fixedTimestamp + 3600,
 		},
 		{
-			name:     "GetTargetPoolPathByIncentiveId",
-			getter:   func() any { return state.instance.GetTargetPoolPathByIncentiveId(state.poolPath, state.incentiveId) },
+			name: "GetTargetPoolPathByIncentiveId",
+			getter: func() any {
+				v, err := state.instance.GetTargetPoolPathByIncentiveId(state.poolPath, state.incentiveId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: state.poolPath,
 		},
 		{
-			name:     "GetCreatedHeightOfIncentive",
-			getter:   func() any { return state.instance.GetCreatedHeightOfIncentive(state.poolPath, state.incentiveId) },
+			name: "GetCreatedHeightOfIncentive",
+			getter: func() any {
+				v, err := state.instance.GetCreatedHeightOfIncentive(state.poolPath, state.incentiveId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: state.fixedBlockHeight,
 		},
 		{
-			name:     "GetIncentiveCreatedTimestamp",
-			getter:   func() any { return state.instance.GetIncentiveCreatedTimestamp(state.poolPath, state.incentiveId) },
+			name: "GetIncentiveCreatedTimestamp",
+			getter: func() any {
+				v, err := state.instance.GetIncentiveCreatedTimestamp(state.poolPath, state.incentiveId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: state.fixedTimestamp,
 		},
 		{
-			name:     "GetIncentiveDepositGnsAmount",
-			getter:   func() any { return state.instance.GetIncentiveDepositGnsAmount(state.poolPath, state.incentiveId) },
+			name: "GetIncentiveDepositGnsAmount",
+			getter: func() any {
+				v, err := state.instance.GetIncentiveDepositGnsAmount(state.poolPath, state.incentiveId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: int64(1_000_000_000),
 		},
 		{
-			name:     "GetIncentiveRefunded",
-			getter:   func() any { return state.instance.GetIncentiveRefunded(state.poolPath, state.incentiveId) },
+			name: "GetIncentiveRefunded",
+			getter: func() any {
+				v, err := state.instance.GetIncentiveRefunded(state.poolPath, state.incentiveId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: false,
 		},
 		{
-			name:     "GetIncentiveRewardToken",
-			getter:   func() any { return state.instance.GetIncentiveRewardToken(state.poolPath, state.incentiveId) },
+			name: "GetIncentiveRewardToken",
+			getter: func() any {
+				v, err := state.instance.GetIncentiveRewardToken(state.poolPath, state.incentiveId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: barPath,
 		},
 		{
-			name:     "GetIncentiveCreator",
-			getter:   func() any { return state.instance.GetIncentiveCreator(state.poolPath, state.incentiveId) },
+			name: "GetIncentiveCreator",
+			getter: func() any {
+				v, err := state.instance.GetIncentiveCreator(state.poolPath, state.incentiveId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: state.owner,
 		},
 	}
@@ -181,9 +217,13 @@ func TestGetterIncentiveRewardAmounts(cur realm, t *testing.T) {
 	// Set distributed amount to create derived relationship
 	state.incentive.SetDistributedRewardAmount(3_000_000)
 
-	totalReward := state.instance.GetIncentiveTotalRewardAmount(state.poolPath, state.incentiveId)
-	distributedReward := state.instance.GetIncentiveDistributedRewardAmount(state.poolPath, state.incentiveId)
-	remainingReward := state.instance.GetIncentiveRemainingRewardAmount(state.poolPath, state.incentiveId)
+	totalReward, err := state.instance.GetIncentiveTotalRewardAmount(state.poolPath, state.incentiveId)
+
+	uassert.NoError(t, err)
+	distributedReward, err := state.instance.GetIncentiveDistributedRewardAmount(state.poolPath, state.incentiveId)
+	uassert.NoError(t, err)
+	remainingReward, err := state.instance.GetIncentiveRemainingRewardAmount(state.poolPath, state.incentiveId)
+	uassert.NoError(t, err)
 
 	// Verify individual values
 	uassert.Equal(t, int64(10_000_000), totalReward)
@@ -199,13 +239,16 @@ func TestGetterIncentiveRewardAmounts(cur realm, t *testing.T) {
 	// sub-integer rates (here 10_000_000 / 3600 = 2777.77...) survive without
 	// the truncation that the previous int64 representation forced. Floor of
 	// rewardPerSecondX128 >> 128 should still equal the legacy value 2777.
-	rewardPerSecondX128 := state.instance.GetIncentiveRewardPerSecondX128(state.poolPath, state.incentiveId)
+	rewardPerSecondX128, err := state.instance.GetIncentiveRewardPerSecondX128(state.poolPath, state.incentiveId)
+	uassert.NoError(t, err)
 	floor := u256.Zero().Rsh(rewardPerSecondX128, 128)
 	uassert.Equal(t, "2777", floor.ToString())
 
 	// Test u256 variants
-	rewardAmount := state.instance.GetIncentiveRewardAmount(state.poolPath, state.incentiveId)
-	rewardAmountStr := state.instance.GetIncentiveRewardAmountAsString(state.poolPath, state.incentiveId)
+	rewardAmount, err := state.instance.GetIncentiveRewardAmount(state.poolPath, state.incentiveId)
+	uassert.NoError(t, err)
+	rewardAmountStr, err := state.instance.GetIncentiveRewardAmountAsString(state.poolPath, state.incentiveId)
+	uassert.NoError(t, err)
 	uassert.Equal(t, "10000000", rewardAmount.ToString())
 	uassert.Equal(t, "10000000", rewardAmountStr)
 }
@@ -213,7 +256,9 @@ func TestGetterIncentiveRewardAmounts(cur realm, t *testing.T) {
 func TestGetterPoolIncentiveDepositObjects(cur realm, t *testing.T) {
 	state := setupBasicTestState(cur, t)
 
-	pool := state.instance.GetPool(state.poolPath)
+	pool, err := state.instance.GetPool(state.poolPath)
+
+	uassert.NoError(t, err)
 	uassert.Equal(t, state.poolPath, pool.PoolPath())
 
 	incentive, ok := state.instance.GetPoolIncentives(state.poolPath).Get(state.incentiveId).(*sr.ExternalIncentive)
@@ -221,7 +266,9 @@ func TestGetterPoolIncentiveDepositObjects(cur realm, t *testing.T) {
 	uassert.Equal(t, state.incentiveId, incentive.IncentiveId())
 	uassert.Equal(t, barPath, incentive.RewardToken())
 
-	deposit := state.instance.GetDeposit(state.positionId)
+	deposit, err := state.instance.GetDeposit(state.positionId)
+
+	uassert.NoError(t, err)
 	uassert.Equal(t, state.owner, deposit.Owner())
 	uassert.Equal(t, state.poolPath, deposit.TargetPoolPath())
 }
@@ -229,10 +276,14 @@ func TestGetterPoolIncentiveDepositObjects(cur realm, t *testing.T) {
 func TestGetterCollectableRewards(cur realm, t *testing.T) {
 	state := setupBasicTestState(cur, t)
 
-	internal := state.instance.CollectableEmissionReward(state.positionId)
+	internal, err := state.instance.CollectableEmissionReward(state.positionId)
+
+	uassert.NoError(t, err)
 	uassert.Equal(t, int64(0), internal)
 
-	external := state.instance.CollectableExternalIncentiveReward(state.positionId, state.incentiveId)
+	external, err := state.instance.CollectableExternalIncentiveReward(state.positionId, state.incentiveId)
+
+	uassert.NoError(t, err)
 	uassert.Equal(t, int64(0), external)
 }
 
@@ -260,7 +311,9 @@ func TestGetterPoolIncentiveIdList(cur realm, t *testing.T) {
 func TestGetterExternalIncentiveByPoolPath(cur realm, t *testing.T) {
 	state := setupBasicTestState(cur, t)
 
-	incentives := state.instance.GetExternalIncentiveByPoolPath(state.poolPath)
+	incentives, err := state.instance.GetExternalIncentiveByPoolPath(state.poolPath)
+
+	uassert.NoError(t, err)
 
 	uassert.Equal(t, 1, len(incentives))
 	uassert.Equal(t, state.incentiveId, incentives[0].IncentiveId())
@@ -275,38 +328,66 @@ func TestGetterDepositBasicProperties(cur realm, t *testing.T) {
 		expected any
 	}{
 		{
-			name:     "GetDepositOwner",
-			getter:   func() any { return state.instance.GetDepositOwner(state.positionId) },
+			name: "GetDepositOwner",
+			getter: func() any {
+				v, err := state.instance.GetDepositOwner(state.positionId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: state.owner,
 		},
 		{
-			name:     "GetDepositStakeTime",
-			getter:   func() any { return state.instance.GetDepositStakeTime(state.positionId) },
+			name: "GetDepositStakeTime",
+			getter: func() any {
+				v, err := state.instance.GetDepositStakeTime(state.positionId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: state.fixedTimestamp,
 		},
 		{
-			name:     "GetDepositTargetPoolPath",
-			getter:   func() any { return state.instance.GetDepositTargetPoolPath(state.positionId) },
+			name: "GetDepositTargetPoolPath",
+			getter: func() any {
+				v, err := state.instance.GetDepositTargetPoolPath(state.positionId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: state.poolPath,
 		},
 		{
-			name:     "GetDepositTickLower",
-			getter:   func() any { return state.instance.GetDepositTickLower(state.positionId) },
+			name: "GetDepositTickLower",
+			getter: func() any {
+				v, err := state.instance.GetDepositTickLower(state.positionId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: int32(-100),
 		},
 		{
-			name:     "GetDepositTickUpper",
-			getter:   func() any { return state.instance.GetDepositTickUpper(state.positionId) },
+			name: "GetDepositTickUpper",
+			getter: func() any {
+				v, err := state.instance.GetDepositTickUpper(state.positionId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: int32(100),
 		},
 		{
-			name:     "GetDepositInternalRewardLastCollectTimestamp",
-			getter:   func() any { return state.instance.GetDepositInternalRewardLastCollectTimestamp(state.positionId) },
+			name: "GetDepositInternalRewardLastCollectTimestamp",
+			getter: func() any {
+				v, err := state.instance.GetDepositInternalRewardLastCollectTimestamp(state.positionId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: state.fixedTimestamp,
 		},
 		{
-			name:     "GetDepositCollectedInternalReward",
-			getter:   func() any { return state.instance.GetDepositCollectedInternalReward(state.positionId) },
+			name: "GetDepositCollectedInternalReward",
+			getter: func() any {
+				v, err := state.instance.GetDepositCollectedInternalReward(state.positionId)
+				uassert.NoError(t, err)
+				return v
+			},
 			expected: int64(5000),
 		},
 	}
@@ -322,8 +403,11 @@ func TestGetterDepositBasicProperties(cur realm, t *testing.T) {
 func TestGetterDepositLiquidity(cur realm, t *testing.T) {
 	state := setupBasicTestState(cur, t)
 
-	liquidity := state.instance.GetDepositLiquidity(state.positionId)
-	liquidityStr := state.instance.GetDepositLiquidityAsString(state.positionId)
+	liquidity, err := state.instance.GetDepositLiquidity(state.positionId)
+
+	uassert.NoError(t, err)
+	liquidityStr, err := state.instance.GetDepositLiquidityAsString(state.positionId)
+	uassert.NoError(t, err)
 
 	uassert.Equal(t, "1000000", liquidity.ToString())
 	uassert.Equal(t, "1000000", liquidityStr)
@@ -333,15 +417,18 @@ func TestGetterDepositExternalRewards(cur realm, t *testing.T) {
 	state := setupBasicTestState(cur, t)
 
 	// Test collected external reward
-	collectedReward := state.instance.GetDepositCollectedExternalReward(state.positionId, state.incentiveId)
+	collectedReward, err := state.instance.GetDepositCollectedExternalReward(state.positionId, state.incentiveId)
+	uassert.NoError(t, err)
 	uassert.Equal(t, int64(2500), collectedReward)
 
 	// Test last collect timestamp
-	lastCollectTime := state.instance.GetDepositExternalRewardLastCollectTimestamp(state.positionId, state.incentiveId)
+	lastCollectTime, err := state.instance.GetDepositExternalRewardLastCollectTimestamp(state.positionId, state.incentiveId)
+	uassert.NoError(t, err)
 	uassert.Equal(t, state.fixedTimestamp+100, lastCollectTime)
 
 	// Test external incentive id list
-	incentiveIds := state.instance.GetDepositExternalIncentiveIdList(state.positionId)
+	incentiveIds, err := state.instance.GetDepositExternalIncentiveIdList(state.positionId)
+	uassert.NoError(t, err)
 	uassert.Equal(t, 1, len(incentiveIds))
 	uassert.Equal(t, state.incentiveId, incentiveIds[0])
 }
@@ -349,7 +436,9 @@ func TestGetterDepositExternalRewards(cur realm, t *testing.T) {
 func TestGetterDepositWarmUp(cur realm, t *testing.T) {
 	state := setupBasicTestState(cur, t)
 
-	warmups := state.instance.GetDepositWarmUp(state.positionId)
+	warmups, err := state.instance.GetDepositWarmUp(state.positionId)
+
+	uassert.NoError(t, err)
 
 	uassert.Equal(t, 3, len(warmups))
 	uassert.Equal(t, uint64(30), warmups[0].WarmupRatio)
@@ -393,7 +482,8 @@ func TestGetterPoolTierProperties(cur realm, t *testing.T) {
 	uassert.Equal(t, uint64(1), tier)
 
 	// Test pool tier ratio
-	ratio := state.instance.GetPoolTierRatio(state.poolPath)
+	ratio, err := state.instance.GetPoolTierRatio(state.poolPath)
+	uassert.NoError(t, err)
 	uassert.Equal(t, uint64(50), ratio)
 
 	// Test pool tier count
@@ -412,15 +502,19 @@ func TestGetterPoolsByTier(cur realm, t *testing.T) {
 	pool2Path := "gno.land/r/onbloc/foo.FOO:gno.land/r/onbloc/qux.QUX:500"
 	state.instance.setPoolTier(0, cur, pool2Path, 1, state.fixedTimestamp)
 
-	pools := state.instance.GetPoolsByTier(1)
+	pools, err := state.instance.GetPoolsByTier(1)
+
+	uassert.NoError(t, err)
 	uassert.Equal(t, 2, len(pools))
 
 	// Test tier 0 returns empty
-	poolsTier0 := state.instance.GetPoolsByTier(0)
+	poolsTier0, err := state.instance.GetPoolsByTier(0)
+	uassert.NoError(t, err)
 	uassert.Equal(t, 0, len(poolsTier0))
 
 	// Test non-existent tier
-	poolsTier99 := state.instance.GetPoolsByTier(99)
+	poolsTier99, err := state.instance.GetPoolsByTier(99)
+	uassert.NoError(t, err)
 	uassert.Equal(t, 0, len(poolsTier99))
 }
 
@@ -495,17 +589,15 @@ func TestGetterWarmupTemplate(cur realm, t *testing.T) {
 func TestGetterNonExistentIncentive(cur realm, t *testing.T) {
 	state := setupBasicTestState(cur, t)
 
-	uassert.PanicsContains(t, cur, "incentive does not exist", func() {
-		state.instance.GetIncentiveStartTimestamp(state.poolPath, "non-existent-incentive")
-	})
+	_, err := state.instance.GetIncentiveStartTimestamp(state.poolPath, "non-existent-incentive")
+	uassert.ErrorContains(t, err, "incentive does not exist")
 }
 
 func TestGetterNonExistentDeposit(cur realm, t *testing.T) {
 	state := setupBasicTestState(cur, t)
 
-	uassert.PanicsContains(t, cur, "not found", func() {
-		state.instance.GetDepositOwner(uint64(999))
-	})
+	_, err := state.instance.GetDepositOwner(uint64(999))
+	uassert.ErrorContains(t, err, "not found")
 }
 
 func TestGetterNonExistentPool(cur realm, t *testing.T) {
@@ -547,8 +639,11 @@ func TestGetterMultipleDepositsForSameOwner(cur realm, t *testing.T) {
 	positionId2 := uint64(2)
 	state.instance.getDeposits().set(positionId2, deposit2)
 
-	owner1 := state.instance.GetDepositOwner(state.positionId)
-	owner2 := state.instance.GetDepositOwner(positionId2)
+	owner1, err := state.instance.GetDepositOwner(state.positionId)
+
+	uassert.NoError(t, err)
+	owner2, err := state.instance.GetDepositOwner(positionId2)
+	uassert.NoError(t, err)
 	uassert.Equal(t, state.owner, owner1)
 	uassert.Equal(t, state.owner, owner2)
 }
@@ -613,8 +708,9 @@ func TestGetterIncentiveActiveStatus(cur realm, t *testing.T) {
 			}
 			pool.Incentives().SetIncentive(tt.incentiveId, incentive)
 
-			// IsIncentiveActive uses time.Now(), so we just verify it doesn't panic
-			_ = instance.IsIncentiveActive(poolPath, tt.incentiveId)
+			// IsIncentiveActive uses time.Now(), so we just verify it doesn't error
+			_, err := instance.IsIncentiveActive(poolPath, tt.incentiveId)
+			uassert.NoError(t, err)
 		})
 	}
 }

--- a/contract/r/gnoswap/staker/v1/instance.gno
+++ b/contract/r/gnoswap/staker/v1/instance.gno
@@ -76,8 +76,12 @@ func (s *stakerV1) getExternalIncentives() *ExternalIncentives {
 	}
 }
 
-func (s *stakerV1) getDepositResolver(lpTokenId uint64) *DepositResolver {
-	return NewDepositResolver(s.getDeposit(lpTokenId))
+func (s *stakerV1) getDepositResolver(lpTokenId uint64) (*DepositResolver, error) {
+	deposit, err := s.getDeposit(lpTokenId)
+	if err != nil {
+		return nil, err
+	}
+	return NewDepositResolver(deposit), nil
 }
 
 func NewStakerV1(stakerStore sr.IStakerStore, poolAccessor sr.PoolAccessor, emissionAccessor sr.EmissionAccessor, nftAccessor sr.NFTAccessor) *stakerV1 {

--- a/contract/r/gnoswap/staker/v1/staker_test.gno
+++ b/contract/r/gnoswap/staker/v1/staker_test.gno
@@ -351,12 +351,14 @@ func TestCollectReward_ExternalPenaltyNotDoubleCountedWhenIncentiveMissing(cur r
 	// First collect should skip external processing because rewardAmount is zero.
 	testing.SetRealm(testing.NewUserRealm(addr01))
 	communityPoolBefore := TokenBalance(t, barPath, communityPoolAddr)
-	resolver := getMockInstance().getDepositResolver(positionId)
+	resolver, err := getMockInstance().getDepositResolver(positionId)
+	uassert.NoError(t, err)
 	firstLastCollect := resolver.ExternalRewardLastCollectTime(incentiveId)
 
 	sr.CollectReward(cross(cur), positionId)
 
-	resolver = getMockInstance().getDepositResolver(positionId)
+	resolver, err = getMockInstance().getDepositResolver(positionId)
+	uassert.NoError(t, err)
 	uassert.Equal(t, firstLastCollect, resolver.ExternalRewardLastCollectTime(incentiveId))
 	uassert.Equal(t, int64(0), resolver.CollectedExternalReward(incentiveId))
 	uassert.Equal(t, communityPoolBefore, TokenBalance(t, barPath, communityPoolAddr))
@@ -368,7 +370,8 @@ func TestCollectReward_ExternalPenaltyNotDoubleCountedWhenIncentiveMissing(cur r
 	communityPoolBefore = TokenBalance(t, barPath, communityPoolAddr)
 	sr.CollectReward(cross(cur), positionId)
 
-	resolver = getMockInstance().getDepositResolver(positionId)
+	resolver, err = getMockInstance().getDepositResolver(positionId)
+	uassert.NoError(t, err)
 	communityPoolAfter := TokenBalance(t, barPath, communityPoolAddr)
 	communityPoolChanges := communityPoolAfter - communityPoolBefore
 	if communityPoolChanges != 0 {
@@ -382,7 +385,8 @@ func TestCollectReward_ExternalPenaltyNotDoubleCountedWhenIncentiveMissing(cur r
 
 	// Subsequent collect in the same second should not apply the penalty again.
 	sr.CollectReward(cross(cur), positionId)
-	resolver = getMockInstance().getDepositResolver(positionId)
+	resolver, err = getMockInstance().getDepositResolver(positionId)
+	uassert.NoError(t, err)
 	uassert.Equal(t, communityPoolAfter, TokenBalance(t, barPath, communityPoolAddr))
 	uassert.Equal(t, collectedAfter, resolver.CollectedExternalReward(incentiveId))
 	uassert.Equal(t, lastCollectAfter, resolver.ExternalRewardLastCollectTime(incentiveId))
@@ -486,7 +490,8 @@ func TestCollectReward_SkipsWhenPenaltyInclusiveDebitExceedsAvailableReward(cur 
 	incentive.SetRewardAmount(totalRewardAmount - 1)
 	incentives.set(incentiveId, incentive)
 
-	depositResolver := getMockInstance().getDepositResolver(positionId)
+	depositResolver, err := getMockInstance().getDepositResolver(positionId)
+	uassert.NoError(t, err)
 	beforeLastCollect := depositResolver.ExternalRewardLastCollectTime(incentiveId)
 	beforeCollected := depositResolver.CollectedExternalReward(incentiveId)
 	beforeUserBar := bar.BalanceOf(addr01)
@@ -496,7 +501,8 @@ func TestCollectReward_SkipsWhenPenaltyInclusiveDebitExceedsAvailableReward(cur 
 	testing.SetRealm(testing.NewUserRealm(addr01))
 	sr.CollectReward(cross(cur), positionId)
 
-	depositResolver = getMockInstance().getDepositResolver(positionId)
+	depositResolver, err = getMockInstance().getDepositResolver(positionId)
+	uassert.NoError(t, err)
 	incentiveAfter := getMockInstance().getExternalIncentives().get(incentiveId)
 	afterUserBar := bar.BalanceOf(addr01)
 	afterCommunityBar := bar.BalanceOf(communityPoolAddr)
@@ -573,7 +579,8 @@ func TestCollectReward_ZeroNetRewardWithPenalty(cur realm, t *testing.T) {
 	communityGnsBefore := gns.BalanceOf(communityPoolAddr)
 
 	// Get deposit info to check internal state
-	depositResolver := getMockInstance().getDepositResolver(positionId)
+	depositResolver, err := getMockInstance().getDepositResolver(positionId)
+	uassert.NoError(t, err)
 
 	// Collect reward - should process penalty even if net reward is 0
 	sr.CollectReward(cross(cur), positionId)

--- a/contract/r/gnoswap/staker/v1/staker_test.gno
+++ b/contract/r/gnoswap/staker/v1/staker_test.gno
@@ -346,12 +346,14 @@ func TestCollectReward_ExternalPenaltyNotDoubleCountedWhenIncentiveMissing(cur r
 	// First collect should skip external processing because rewardAmount is zero.
 	testing.SetRealm(testing.NewUserRealm(addr01))
 	communityPoolBefore := TokenBalance(t, barPath, communityPoolAddr)
-	resolver := getMockInstance().getDepositResolver(positionId)
+	resolver, err := getMockInstance().getDepositResolver(positionId)
+	uassert.NoError(t, err)
 	firstLastCollect := resolver.ExternalRewardLastCollectTime(incentiveId)
 
 	sr.CollectReward(cross(cur), positionId)
 
-	resolver = getMockInstance().getDepositResolver(positionId)
+	resolver, err = getMockInstance().getDepositResolver(positionId)
+	uassert.NoError(t, err)
 	uassert.Equal(t, firstLastCollect, resolver.ExternalRewardLastCollectTime(incentiveId))
 	uassert.Equal(t, int64(0), resolver.CollectedExternalReward(incentiveId))
 	uassert.Equal(t, communityPoolBefore, TokenBalance(t, barPath, communityPoolAddr))
@@ -363,7 +365,8 @@ func TestCollectReward_ExternalPenaltyNotDoubleCountedWhenIncentiveMissing(cur r
 	communityPoolBefore = TokenBalance(t, barPath, communityPoolAddr)
 	sr.CollectReward(cross(cur), positionId)
 
-	resolver = getMockInstance().getDepositResolver(positionId)
+	resolver, err = getMockInstance().getDepositResolver(positionId)
+	uassert.NoError(t, err)
 	communityPoolAfter := TokenBalance(t, barPath, communityPoolAddr)
 	communityPoolChanges := communityPoolAfter - communityPoolBefore
 	if communityPoolChanges != 0 {
@@ -377,7 +380,8 @@ func TestCollectReward_ExternalPenaltyNotDoubleCountedWhenIncentiveMissing(cur r
 
 	// Subsequent collect in the same second should not apply the penalty again.
 	sr.CollectReward(cross(cur), positionId)
-	resolver = getMockInstance().getDepositResolver(positionId)
+	resolver, err = getMockInstance().getDepositResolver(positionId)
+	uassert.NoError(t, err)
 	uassert.Equal(t, communityPoolAfter, TokenBalance(t, barPath, communityPoolAddr))
 	uassert.Equal(t, collectedAfter, resolver.CollectedExternalReward(incentiveId))
 	uassert.Equal(t, lastCollectAfter, resolver.ExternalRewardLastCollectTime(incentiveId))
@@ -467,7 +471,8 @@ func TestCollectReward_SkipsWhenPenaltyInclusiveDebitExceedsAvailableReward(cur 
 	incentive.SetRewardAmount(totalRewardAmount - 1)
 	incentives.set(incentiveId, incentive)
 
-	depositResolver := getMockInstance().getDepositResolver(positionId)
+	depositResolver, err := getMockInstance().getDepositResolver(positionId)
+	uassert.NoError(t, err)
 	beforeLastCollect := depositResolver.ExternalRewardLastCollectTime(incentiveId)
 	beforeCollected := depositResolver.CollectedExternalReward(incentiveId)
 	beforeUserBar := bar.BalanceOf(addr01)
@@ -477,7 +482,8 @@ func TestCollectReward_SkipsWhenPenaltyInclusiveDebitExceedsAvailableReward(cur 
 	testing.SetRealm(testing.NewUserRealm(addr01))
 	sr.CollectReward(cross(cur), positionId)
 
-	depositResolver = getMockInstance().getDepositResolver(positionId)
+	depositResolver, err = getMockInstance().getDepositResolver(positionId)
+	uassert.NoError(t, err)
 	incentiveAfter := getMockInstance().getExternalIncentives().get(incentiveId)
 	afterUserBar := bar.BalanceOf(addr01)
 	afterCommunityBar := bar.BalanceOf(communityPoolAddr)
@@ -554,7 +560,8 @@ func TestCollectReward_ZeroNetRewardWithPenalty(cur realm, t *testing.T) {
 	communityGnsBefore := gns.BalanceOf(communityPoolAddr)
 
 	// Get deposit info to check internal state
-	depositResolver := getMockInstance().getDepositResolver(positionId)
+	depositResolver, err := getMockInstance().getDepositResolver(positionId)
+	uassert.NoError(t, err)
 
 	// Collect reward - should process penalty even if net reward is 0
 	sr.CollectReward(cross(cur), positionId)

--- a/contract/r/gnoswap/test/fuzz/collect_reward_test.gno
+++ b/contract/r/gnoswap/test/fuzz/collect_reward_test.gno
@@ -53,7 +53,10 @@ func TestFuzzCollectReward_ExternalIncentive_Stateless(cur realm, t *testing.T) 
 		poolPath, incentiveID, positionID := setupExternalRewardPoolAndPosition(cur, ft)
 		setupStakePosition(cur, ft, positionID)
 
-		incentiveTimestamp := staker.GetIncentiveStartTimestamp(poolPath, incentiveID)
+		incentiveTimestamp, err := staker.GetIncentiveStartTimestamp(poolPath, incentiveID)
+		if err != nil {
+			t.Fatal(err)
+		}
 		params := NewValidCollectRewardParams(ft, positionID, true, incentiveTimestamp)
 		testing.SkipHeights(params.skipBlocks)
 		params.updatePreviousBalances(oblPath)

--- a/contract/r/scenario/gov/governance/governance_proposal_execute_staker_cancel_external_incentive_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_proposal_execute_staker_cancel_external_incentive_filetest.gno
@@ -148,7 +148,11 @@ func createPoolAndIncentive(cur realm) {
 	incentiveID = ufmt.Sprintf("%s:%d:%d", adminAddr, createTimestamp, 1)
 	sr.CreateExternalIncentive(cross(cur), poolPath, barPath, REWARD_AMOUNT, startTimestamp, endTimestamp)
 
-	ufmt.Printf("[INFO] pending incentives for pool: %d\n", len(sr.GetExternalIncentiveByPoolPath(poolPath)))
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[INFO] pending incentives for pool: %d\n", len(incentives))
 }
 
 func proposeShortVotingSchedule(cur realm) int64 {
@@ -206,7 +210,11 @@ func voteAndExecute(cur realm, proposalID int64, config governance.Config) {
 func verifyCancelled(cur realm) {
 	ufmt.Printf("[EXPECTED] creator BAR refund delta: %d\n", bar.BalanceOf(adminAddr)-creatorBarBeforeExecute)
 	ufmt.Printf("[EXPECTED] creator GNS refund delta: %d\n", gns.BalanceOf(adminAddr)-creatorGnsBeforeExecute)
-	ufmt.Printf("[EXPECTED] remaining incentives for pool: %d\n", len(sr.GetExternalIncentiveByPoolPath(poolPath)))
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[EXPECTED] remaining incentives for pool: %d\n", len(incentives))
 }
 
 // Output:

--- a/contract/r/scenario/position/contract_owned_position_lifecycle_filetest.gno
+++ b/contract/r/scenario/position/contract_owned_position_lifecycle_filetest.gno
@@ -348,7 +348,7 @@ func vaultStakePosition(cur realm) {
 	ufmt.Printf("[EXPECTED] staked pool path: %s\n", poolPath)
 	ufmt.Printf("[EXPECTED] position owner after stake: %s\n", owner.String())
 	ufmt.Printf("[EXPECTED] staker contract address: %s\n", stakerAddr.String())
-	depositOwner := staker.GetDepositOwner(positionID)
+	depositOwner, _ := staker.GetDepositOwner(positionID)
 	ufmt.Printf("[EXPECTED] deposit owner after stake: %s\n", depositOwner.String())
 }
 

--- a/contract/r/scenario/position/position_transfer_equal_reward_filetest.gno
+++ b/contract/r/scenario/position/position_transfer_equal_reward_filetest.gno
@@ -172,7 +172,7 @@ func stakeBothInSameBlock(cur realm) {
 	// Stake position 1 as Alice (no transfer).
 	gnft.Approve(cross(cur), stakerAddr, tokenIdOf(cur, positionId1))
 	staker.StakeToken(cross(cur), positionId1, "")
-	owner1 := staker.GetDepositOwner(positionId1)
+	owner1, _ := staker.GetDepositOwner(positionId1)
 	println("[EXPECTED] Deposit 1 owner is alice:", owner1 == aliceAddr)
 
 	// Transfer position 2 to Bob.
@@ -184,7 +184,7 @@ func stakeBothInSameBlock(cur realm) {
 	testing.SetRealm(bobRealm)
 	gnft.Approve(cross(cur), stakerAddr, tokenIdOf(cur, positionId2))
 	staker.StakeToken(cross(cur), positionId2, "")
-	owner2 := staker.GetDepositOwner(positionId2)
+	owner2, _ := staker.GetDepositOwner(positionId2)
 	println("[EXPECTED] Deposit 2 owner is bob:", owner2 == bobAddr)
 }
 

--- a/contract/r/scenario/position/position_transfer_equal_reward_same_block_filetest.gno
+++ b/contract/r/scenario/position/position_transfer_equal_reward_same_block_filetest.gno
@@ -179,14 +179,14 @@ func stakeBothInSameBlock(cur realm) {
 	// Stake position 1 as Alice (no transfer).
 	gnft.Approve(cross(cur), stakerAddr, tokenIdOf(cur, positionId1))
 	staker.StakeToken(cross(cur), positionId1, "")
-	owner1 := staker.GetDepositOwner(positionId1)
+	owner1, _ := staker.GetDepositOwner(positionId1)
 	println("[EXPECTED] Deposit 1 owner is alice:", owner1 == aliceAddr)
 
 	// Bob stakes position 2 in the same block.
 	testing.SetRealm(bobRealm)
 	gnft.Approve(cross(cur), stakerAddr, tokenIdOf(cur, positionId2))
 	staker.StakeToken(cross(cur), positionId2, "")
-	owner2 := staker.GetDepositOwner(positionId2)
+	owner2, _ := staker.GetDepositOwner(positionId2)
 	println("[EXPECTED] Deposit 2 owner is bob:", owner2 == bobAddr)
 }
 

--- a/contract/r/scenario/position/position_transfer_then_new_owner_stakes_filetest.gno
+++ b/contract/r/scenario/position/position_transfer_then_new_owner_stakes_filetest.gno
@@ -154,7 +154,7 @@ func bobStakes(cur realm) {
 	owner := mustOwnerOf(tokenIdOf(cur, positionId))
 	println("[EXPECTED] Owner after stake is staker:", owner == stakerAddr)
 
-	depositOwner := staker.GetDepositOwner(positionId)
+	depositOwner, _ := staker.GetDepositOwner(positionId)
 	println("[EXPECTED] Deposit owner is bob:", depositOwner == bobAddr)
 }
 

--- a/contract/r/scenario/staker/callback_stake_tick_cross_accounting_filetest.gno
+++ b/contract/r/scenario/staker/callback_stake_tick_cross_accounting_filetest.gno
@@ -89,7 +89,11 @@ func setup(cur realm) {
 
 	stake(cur, referencePositionID)
 	stake(cur, honestPositionID)
-	if got := sr.GetPoolStakedLiquidity(poolPath); got != referenceLiquidity {
+	got, err := sr.GetPoolStakedLiquidity(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	if got != referenceLiquidity {
 		panic(ufmt.Sprintf("expected initial CurrentStakedLiquidity %s, got %s", referenceLiquidity, got))
 	}
 	println("[EXPECTED] Initial staked liquidity matches the [0, 10] reference position")
@@ -117,12 +121,20 @@ func stakeAndSettleSwap(cur realm, amount0Delta, amount1Delta int64, _ *pl.Callb
 	if currentTick != 100 {
 		return ufmt.Errorf("expected pool tick 100 before callback stake, got %d", currentTick)
 	}
-	if got := sr.GetPoolStakedLiquidity(poolPath); got != honestLiquidity {
+	got, err := sr.GetPoolStakedLiquidity(poolPath)
+	if err != nil {
+		return err
+	}
+	if got != honestLiquidity {
 		return ufmt.Errorf("expected CurrentStakedLiquidity %s at tick 100, got %s", honestLiquidity, got)
 	}
 
 	stake(cur, callbackPositionID)
-	if got := sr.GetPoolStakedLiquidity(poolPath); got != honestLiquidity {
+	got, err = sr.GetPoolStakedLiquidity(poolPath)
+	if err != nil {
+		return err
+	}
+	if got != honestLiquidity {
 		return ufmt.Errorf("expected out-of-range callback position to stay excluded from CurrentStakedLiquidity %s, got %s", honestLiquidity, got)
 	}
 	println("[EXPECTED] Callback position remains excluded from CurrentStakedLiquidity at tick 100")
@@ -149,13 +161,21 @@ func verifyFinalAccounting(cur realm) {
 	if !sr.IsStaked(callbackPositionID) {
 		panic("callback position must be staked")
 	}
-	if got := sr.GetPoolStakedLiquidity(poolPath); got != honestLiquidity {
+	got, err := sr.GetPoolStakedLiquidity(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	if got != honestLiquidity {
 		panic(ufmt.Sprintf("expected final CurrentStakedLiquidity %s, got %s", honestLiquidity, got))
 	}
 	println("[EXPECTED] Historical tick and CurrentStakedLiquidity match tick 100")
 
 	testing.SkipHeights(10)
-	if reward := sr.CollectableEmissionReward(callbackPositionID); reward != 0 {
+	reward, err := sr.CollectableEmissionReward(callbackPositionID)
+	if err != nil {
+		panic(err)
+	}
+	if reward != 0 {
 		panic(ufmt.Sprintf("out-of-range callback position must have zero collectable reward, got %d", reward))
 	}
 	before := gns.BalanceOf(adminAddr)

--- a/contract/r/scenario/staker/cancel_external_incentive_after_stake_filetest.gno
+++ b/contract/r/scenario/staker/cancel_external_incentive_after_stake_filetest.gno
@@ -148,7 +148,11 @@ func createPendingIncentive(cur realm) {
 	incentiveID = ufmt.Sprintf("%s:%d:%d", adminAddr, createTimestamp, 1)
 	sr.CreateExternalIncentive(cross(cur), poolPath, barPath, REWARD_AMOUNT, startTimestamp, endTimestamp)
 
-	ufmt.Printf("[INFO] pending incentives for pool: %d\n", len(sr.GetExternalIncentiveByPoolPath(poolPath)))
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[INFO] pending incentives for pool: %d\n", len(incentives))
 }
 
 func stakeWhilePending(cur realm) {
@@ -160,7 +164,10 @@ func stakeWhilePending(cur realm) {
 
 	// The incentive is still pending (start > now), so StakeToken does not add it
 	// to the deposit's incentive-id list.
-	ids := sr.GetDepositExternalIncentiveIdList(stakedPosition)
+	ids, err := sr.GetDepositExternalIncentiveIdList(stakedPosition)
+	if err != nil {
+		panic(err)
+	}
 	ufmt.Printf("[INFO] staked position %d\n", stakedPosition)
 	ufmt.Printf("[EXPECTED] deposit references the pending incentive: %t\n", len(ids) != 0)
 }
@@ -169,7 +176,11 @@ func cancelIncentive(cur realm) {
 	testing.SetRealm(adminRealm)
 	sr.CancelExternalIncentive(cross(cur), poolPath, incentiveID)
 
-	ufmt.Printf("[EXPECTED] remaining incentives for pool: %d\n", len(sr.GetExternalIncentiveByPoolPath(poolPath)))
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[EXPECTED] remaining incentives for pool: %d\n", len(incentives))
 }
 
 func collectAfterCancel(cur realm) {
@@ -178,7 +189,10 @@ func collectAfterCancel(cur realm) {
 
 	// The deposit never referenced the pending incentive, so collecting is a
 	// clean no-op and must not panic on a removed incentive id.
-	ids := sr.GetDepositExternalIncentiveIdList(stakedPosition)
+	ids, err := sr.GetDepositExternalIncentiveIdList(stakedPosition)
+	if err != nil {
+		panic(err)
+	}
 	ufmt.Printf("[EXPECTED] deposit incentive-id count after cancel: %d\n", len(ids))
 
 	testing.SetRealm(userRealm)

--- a/contract/r/scenario/staker/cancel_external_incentive_after_start_rejected_filetest.gno
+++ b/contract/r/scenario/staker/cancel_external_incentive_after_start_rejected_filetest.gno
@@ -135,7 +135,11 @@ func createPendingIncentives(cur realm) {
 	sr.CreateExternalIncentive(cross(cur), poolPath, barPath, REWARD_AMOUNT, startTimestamp, endTimestamp)
 	sr.CreateExternalIncentive(cross(cur), poolPath, quxPath, REWARD_AMOUNT, startTimestamp, endTimestamp)
 
-	ufmt.Printf("[INFO] pending incentives for pool: %d\n", len(sr.GetExternalIncentiveByPoolPath(poolPath)))
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[INFO] pending incentives for pool: %d\n", len(incentives))
 }
 
 func cancelJustBeforeStart(cur realm) {
@@ -150,7 +154,11 @@ func cancelJustBeforeStart(cur realm) {
 	sr.CancelExternalIncentive(cross(cur), poolPath, spareIncentiveID)
 
 	ufmt.Printf("[EXPECTED] creator QUX delta: %d\n", qux.BalanceOf(adminAddr)-quxBefore)
-	ufmt.Printf("[EXPECTED] remaining incentives for pool: %d\n", len(sr.GetExternalIncentiveByPoolPath(poolPath)))
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[EXPECTED] remaining incentives for pool: %d\n", len(incentives))
 }
 
 func checkCancelRejectedAfterStart(cur realm) {
@@ -185,8 +193,16 @@ func endStartedIncentive(cur realm) {
 
 	ufmt.Printf("[EXPECTED] refundee BAR delta: %d\n", bar.BalanceOf(refundeeAddr)-barBefore)
 	ufmt.Printf("[EXPECTED] refundee GNS delta: %d\n", gns.BalanceOf(refundeeAddr)-gnsBefore)
-	ufmt.Printf("[EXPECTED] ended incentive refunded flag: %t\n", sr.GetIncentiveRefunded(poolPath, liveIncentiveID))
-	ufmt.Printf("[EXPECTED] ended incentive still recorded: %d\n", len(sr.GetExternalIncentiveByPoolPath(poolPath)))
+	refunded, err := sr.GetIncentiveRefunded(poolPath, liveIncentiveID)
+	if err != nil {
+		panic(err)
+	}
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[EXPECTED] ended incentive refunded flag: %t\n", refunded)
+	ufmt.Printf("[EXPECTED] ended incentive still recorded: %d\n", len(incentives))
 }
 
 // skipToTimestamp advances the chain to the last block at or before the given

--- a/contract/r/scenario/staker/cancel_external_incentive_before_start_filetest.gno
+++ b/contract/r/scenario/staker/cancel_external_incentive_before_start_filetest.gno
@@ -172,7 +172,10 @@ func createPendingIncentive(cur realm) {
 		endTime,
 	)
 
-	incentives := sr.GetExternalIncentiveByPoolPath(poolPath)
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
 	ufmt.Printf("[INFO] pending incentives for pool: %d\n", len(incentives))
 	ufmt.Printf("[INFO] incentive starts in %d seconds\n", startTime-time.Now().Unix())
 }
@@ -221,14 +224,16 @@ func cancelIncentive(cur realm) {
 }
 
 func checkPoolNotIncentivized(cur realm) {
-	incentives := sr.GetExternalIncentiveByPoolPath(poolPath)
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
 	ufmt.Printf("[EXPECTED] remaining incentives for pool: %d\n", len(incentives))
 
 	// Getters resolve the incentive by id, so a cancelled incentive reads as if
 	// it had never been created.
-	uassert.AbortsContains(t, cur, "does not exist", func() {
-		sr.GetIncentiveEndTimestamp(poolPath, incentiveID)
-	})
+	_, err = sr.GetIncentiveEndTimestamp(poolPath, incentiveID)
+	uassert.ErrorContains(t, err, "does not exist")
 	println("[EXPECTED] incentive getters no longer resolve the cancelled id")
 
 	testing.SetRealm(userRealm)

--- a/contract/r/scenario/staker/cancel_external_incentive_creator_permission_filetest.gno
+++ b/contract/r/scenario/staker/cancel_external_incentive_creator_permission_filetest.gno
@@ -84,7 +84,11 @@ func main(cur realm) {
 	println("[SCENARIO] 1. A non-admin user creates a pending incentive")
 	initialize(cur)
 	firstIncentiveID = createIncentiveAs(cur, creatorAddr, 1)
-	ufmt.Printf("[EXPECTED] incentives for pool: %d\n", len(sr.GetExternalIncentiveByPoolPath(poolPath)))
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[EXPECTED] incentives for pool: %d\n", len(incentives))
 	println()
 
 	println("[SCENARIO] 2. An unrelated stranger cannot cancel it")
@@ -148,7 +152,11 @@ func strangerCannotCancel(cur realm) {
 		sr.CancelExternalIncentive(cross(cur), poolPath, firstIncentiveID)
 	})
 	println("[EXPECTED] stranger rejected: not admin, governance, or creator")
-	ufmt.Printf("[EXPECTED] incentive untouched: %d\n", len(sr.GetExternalIncentiveByPoolPath(poolPath)))
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[EXPECTED] incentive untouched: %d\n", len(incentives))
 }
 
 func creatorCancelsOwn(cur realm) {
@@ -160,7 +168,11 @@ func creatorCancelsOwn(cur realm) {
 
 	ufmt.Printf("[EXPECTED] creator BAR refund delta: %d\n", bar.BalanceOf(creatorAddr)-barBefore)
 	ufmt.Printf("[EXPECTED] creator GNS refund delta: %d\n", gns.BalanceOf(creatorAddr)-gnsBefore)
-	ufmt.Printf("[EXPECTED] incentives for pool: %d\n", len(sr.GetExternalIncentiveByPoolPath(poolPath)))
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[EXPECTED] incentives for pool: %d\n", len(incentives))
 }
 
 func adminCancelsRefundsCreator(cur realm) {
@@ -174,7 +186,11 @@ func adminCancelsRefundsCreator(cur realm) {
 	ufmt.Printf("[EXPECTED] user2 (creator) BAR refund delta: %d\n", bar.BalanceOf(user2Addr)-creatorBarBefore)
 	ufmt.Printf("[EXPECTED] user2 (creator) GNS refund delta: %d\n", gns.BalanceOf(user2Addr)-creatorGnsBefore)
 	ufmt.Printf("[EXPECTED] admin BAR delta (receives nothing): %d\n", bar.BalanceOf(adminAddr)-adminBarBefore)
-	ufmt.Printf("[EXPECTED] incentives for pool: %d\n", len(sr.GetExternalIncentiveByPoolPath(poolPath)))
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[EXPECTED] incentives for pool: %d\n", len(incentives))
 }
 
 // Output:

--- a/contract/r/scenario/staker/cancel_external_incentive_permission_and_halt_filetest.gno
+++ b/contract/r/scenario/staker/cancel_external_incentive_permission_and_halt_filetest.gno
@@ -116,7 +116,11 @@ func initialize(cur realm) {
 	incentiveID = ufmt.Sprintf("%s:%d:%d", adminAddr, createTimestamp, 1)
 	sr.CreateExternalIncentive(cross(cur), poolPath, barPath, REWARD_AMOUNT, startTimestamp, endTimestamp)
 
-	ufmt.Printf("[INFO] pending incentives for pool: %d\n", len(sr.GetExternalIncentiveByPoolPath(poolPath)))
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[INFO] pending incentives for pool: %d\n", len(incentives))
 }
 
 func checkStrangerBlocked(cur realm) {
@@ -127,7 +131,11 @@ func checkStrangerBlocked(cur realm) {
 	})
 	println("[EXPECTED] stranger rejected: caller is not admin, governance, or creator")
 
-	ufmt.Printf("[EXPECTED] incentive untouched: %d\n", len(sr.GetExternalIncentiveByPoolPath(poolPath)))
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[EXPECTED] incentive untouched: %d\n", len(incentives))
 }
 
 func checkSafeModeBlocked(cur realm) {
@@ -154,7 +162,11 @@ func cancelInEmergencyMode(cur realm) {
 
 	ufmt.Printf("[EXPECTED] creator BAR delta: %d\n", bar.BalanceOf(adminAddr)-barBefore)
 	ufmt.Printf("[EXPECTED] creator GNS delta: %d\n", gns.BalanceOf(adminAddr)-gnsBefore)
-	ufmt.Printf("[EXPECTED] remaining incentives for pool: %d\n", len(sr.GetExternalIncentiveByPoolPath(poolPath)))
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[EXPECTED] remaining incentives for pool: %d\n", len(incentives))
 }
 
 // Output:

--- a/contract/r/scenario/staker/cancel_external_incentive_recreate_filetest.gno
+++ b/contract/r/scenario/staker/cancel_external_incentive_recreate_filetest.gno
@@ -137,7 +137,11 @@ func createWrongIncentive(cur realm) {
 	wrongIncentiveID = ufmt.Sprintf("%s:%d:%d", adminAddr, createTimestamp, 1)
 	sr.CreateExternalIncentive(cross(cur), poolPath, barPath, REWARD_AMOUNT, startTimestamp, endTimestamp)
 
-	ufmt.Printf("[INFO] reward token: %s\n", sr.GetIncentiveRewardToken(poolPath, wrongIncentiveID))
+	rewardToken, err := sr.GetIncentiveRewardToken(poolPath, wrongIncentiveID)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[INFO] reward token: %s\n", rewardToken)
 }
 
 func cancelWrongIncentive(cur realm) {
@@ -150,7 +154,11 @@ func cancelWrongIncentive(cur realm) {
 
 	ufmt.Printf("[EXPECTED] creator BAR delta: %d\n", bar.BalanceOf(adminAddr)-barBefore)
 	ufmt.Printf("[EXPECTED] creator GNS delta: %d\n", gns.BalanceOf(adminAddr)-gnsBefore)
-	ufmt.Printf("[EXPECTED] incentives for pool: %d\n", len(sr.GetExternalIncentiveByPoolPath(poolPath)))
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[EXPECTED] incentives for pool: %d\n", len(incentives))
 }
 
 func createCorrectIncentive(cur realm) {
@@ -161,8 +169,16 @@ func createCorrectIncentive(cur realm) {
 	sr.CreateExternalIncentive(cross(cur), poolPath, quxPath, REWARD_AMOUNT, startTimestamp, endTimestamp)
 
 	ufmt.Printf("[EXPECTED] replacement id differs from the cancelled one: %t\n", correctIncentiveID != wrongIncentiveID)
-	ufmt.Printf("[EXPECTED] reward token: %s\n", sr.GetIncentiveRewardToken(poolPath, correctIncentiveID))
-	ufmt.Printf("[EXPECTED] incentives for pool: %d\n", len(sr.GetExternalIncentiveByPoolPath(poolPath)))
+	rewardToken, err := sr.GetIncentiveRewardToken(poolPath, correctIncentiveID)
+	if err != nil {
+		panic(err)
+	}
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[EXPECTED] reward token: %s\n", rewardToken)
+	ufmt.Printf("[EXPECTED] incentives for pool: %d\n", len(incentives))
 }
 
 func stakeAndCollect(cur realm) {

--- a/contract/r/scenario/staker/cancel_external_incentive_reward_isolation_filetest.gno
+++ b/contract/r/scenario/staker/cancel_external_incentive_reward_isolation_filetest.gno
@@ -145,7 +145,11 @@ func createPendingIncentives(cur realm) {
 	sr.CreateExternalIncentive(cross(cur), poolPath, barPath, REWARD_AMOUNT, startTimestamp, endTimestamp)
 	sr.CreateExternalIncentive(cross(cur), poolPath, quxPath, REWARD_AMOUNT, startTimestamp, endTimestamp)
 
-	ufmt.Printf("[INFO] pending incentives for pool: %d\n", len(sr.GetExternalIncentiveByPoolPath(poolPath)))
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[INFO] pending incentives for pool: %d\n", len(incentives))
 }
 
 func userMintThenStake(cur realm) {
@@ -182,8 +186,16 @@ func cancelBarIncentive(cur realm) {
 	testing.SetRealm(adminRealm)
 	sr.CancelExternalIncentive(cross(cur), poolPath, cancelledIncentiveID)
 
-	ufmt.Printf("[INFO] remaining incentives for pool: %d\n", len(sr.GetExternalIncentiveByPoolPath(poolPath)))
-	ufmt.Printf("[INFO] surviving incentive reward token: %s\n", sr.GetIncentiveRewardToken(poolPath, activeIncentiveID))
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	rewardToken, err := sr.GetIncentiveRewardToken(poolPath, activeIncentiveID)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[INFO] remaining incentives for pool: %d\n", len(incentives))
+	ufmt.Printf("[INFO] surviving incentive reward token: %s\n", rewardToken)
 }
 
 func skipPastStart(cur realm) {
@@ -195,8 +207,14 @@ func skipPastStart(cur realm) {
 func collectAndVerify(cur realm) {
 	// Collectable is read at the same block as the collect, so with the
 	// unstaking fee set to 0 the user receives exactly this amount.
-	collectableQux := sr.CollectableExternalIncentiveReward(positionId, activeIncentiveID)
-	collectableBar := sr.CollectableExternalIncentiveReward(positionId, cancelledIncentiveID)
+	collectableQux, err := sr.CollectableExternalIncentiveReward(positionId, activeIncentiveID)
+	if err != nil {
+		panic(err)
+	}
+	collectableBar, err := sr.CollectableExternalIncentiveReward(positionId, cancelledIncentiveID)
+	if err != nil {
+		panic(err)
+	}
 
 	ufmt.Printf("[EXPECTED] collectable from active (QUX) incentive > 0: %t\n", collectableQux > 0)
 	ufmt.Printf("[EXPECTED] collectable from cancelled (BAR) incentive: %d\n", collectableBar)
@@ -222,7 +240,10 @@ func collectAndVerify(cur realm) {
 	// The surviving incentive is what got drained: its distributed amount tracks
 	// exactly the reward handed to the user (the remaining amount also drops by
 	// the warmup penalty, so distributed is the clean invariant here).
-	distributed := sr.GetIncentiveDistributedRewardAmount(poolPath, activeIncentiveID)
+	distributed, err := sr.GetIncentiveDistributedRewardAmount(poolPath, activeIncentiveID)
+	if err != nil {
+		panic(err)
+	}
 	uassert.Equal(t, quxDelta, distributed)
 	ufmt.Printf("[EXPECTED] active incentive distributed == QUX received: %t\n", distributed == quxDelta)
 }

--- a/contract/r/scenario/staker/cancel_external_incentive_then_unstake_filetest.gno
+++ b/contract/r/scenario/staker/cancel_external_incentive_then_unstake_filetest.gno
@@ -139,7 +139,11 @@ func createPendingIncentive(cur realm) {
 	incentiveID = ufmt.Sprintf("%s:%d:%d", adminAddr, createTimestamp, 1)
 	sr.CreateExternalIncentive(cross(cur), poolPath, barPath, REWARD_AMOUNT, startTimestamp, endTimestamp)
 
-	ufmt.Printf("[INFO] pending incentives for pool: %d\n", len(sr.GetExternalIncentiveByPoolPath(poolPath)))
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[INFO] pending incentives for pool: %d\n", len(incentives))
 }
 
 func stakeWhilePending(cur realm) {
@@ -162,7 +166,11 @@ func cancelIncentive(cur realm) {
 	testing.SetRealm(adminRealm)
 	sr.CancelExternalIncentive(cross(cur), poolPath, incentiveID)
 
-	ufmt.Printf("[EXPECTED] remaining incentives for pool: %d\n", len(sr.GetExternalIncentiveByPoolPath(poolPath)))
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[EXPECTED] remaining incentives for pool: %d\n", len(incentives))
 	ufmt.Printf("[EXPECTED] creator BAR (reward) refunded: %d\n", bar.BalanceOf(adminAddr)-creatorBarBefore)
 	ufmt.Printf("[EXPECTED] creator GNS (deposit) refunded: %d\n", gns.BalanceOf(adminAddr)-creatorGnsBefore)
 }

--- a/contract/r/scenario/staker/cancel_external_incentive_with_multiple_incentives_filetest.gno
+++ b/contract/r/scenario/staker/cancel_external_incentive_with_multiple_incentives_filetest.gno
@@ -144,9 +144,20 @@ func createPendingIncentives(cur realm) {
 	sr.CreateExternalIncentive(cross(cur), poolPath, barPath, REWARD_AMOUNT, startTimestamp, endTimestamp)
 	sr.CreateExternalIncentive(cross(cur), poolPath, quxPath, REWARD_AMOUNT, startTimestamp, endTimestamp)
 
-	ufmt.Printf("[INFO] pending incentives for pool: %d\n", len(sr.GetExternalIncentiveByPoolPath(poolPath)))
-	ufmt.Printf("[INFO] both start at the same timestamp: %t\n",
-		sr.GetIncentiveStartTimestamp(poolPath, cancelledIncentiveID) == sr.GetIncentiveStartTimestamp(poolPath, survivingIncentiveID))
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	cancelledStart, err := sr.GetIncentiveStartTimestamp(poolPath, cancelledIncentiveID)
+	if err != nil {
+		panic(err)
+	}
+	survivingStart, err := sr.GetIncentiveStartTimestamp(poolPath, survivingIncentiveID)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[INFO] pending incentives for pool: %d\n", len(incentives))
+	ufmt.Printf("[INFO] both start at the same timestamp: %t\n", cancelledStart == survivingStart)
 }
 
 func userMintThenStake(cur realm) {
@@ -169,18 +180,32 @@ func cancelBarIncentive(cur realm) {
 
 	ufmt.Printf("[EXPECTED] creator BAR delta: %d\n", bar.BalanceOf(adminAddr)-barBefore)
 	ufmt.Printf("[EXPECTED] creator GNS delta: %d\n", gns.BalanceOf(adminAddr)-gnsBefore)
-	ufmt.Printf("[EXPECTED] remaining incentives for pool: %d\n", len(sr.GetExternalIncentiveByPoolPath(poolPath)))
-	ufmt.Printf("[EXPECTED] surviving incentive reward token: %s\n", sr.GetIncentiveRewardToken(poolPath, survivingIncentiveID))
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	rewardToken, err := sr.GetIncentiveRewardToken(poolPath, survivingIncentiveID)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[EXPECTED] remaining incentives for pool: %d\n", len(incentives))
+	ufmt.Printf("[EXPECTED] surviving incentive reward token: %s\n", rewardToken)
 }
 
 func collectAfterStart(cur realm) {
 	// Run one third of the incentive window so a non-trivial reward accrues.
 	skipToTimestamp(startTimestamp + INCENTIVE_DURATION/3)
 
-	ufmt.Printf("[EXPECTED] collectable from surviving incentive > 0: %t\n",
-		sr.CollectableExternalIncentiveReward(1, survivingIncentiveID) > 0)
-	ufmt.Printf("[EXPECTED] collectable from cancelled incentive: %d\n",
-		sr.CollectableExternalIncentiveReward(1, cancelledIncentiveID))
+	collectableSurviving, err := sr.CollectableExternalIncentiveReward(1, survivingIncentiveID)
+	if err != nil {
+		panic(err)
+	}
+	collectableCancelled, err := sr.CollectableExternalIncentiveReward(1, cancelledIncentiveID)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[EXPECTED] collectable from surviving incentive > 0: %t\n", collectableSurviving > 0)
+	ufmt.Printf("[EXPECTED] collectable from cancelled incentive: %d\n", collectableCancelled)
 
 	testing.SetRealm(userRealm)
 	barBefore := bar.BalanceOf(userAddr)

--- a/contract/r/scenario/staker/check_external_incentive_end_filetest.gno
+++ b/contract/r/scenario/staker/check_external_incentive_end_filetest.gno
@@ -236,14 +236,14 @@ func endExternalIncentive(cur realm) {
 func checkCollectableExternalIncentive(cur realm, positionId uint64) {
 	testing.SetRealm(userRealm)
 
-	endTime := sr.GetIncentiveEndTimestamp("gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/qux.QUX:100", actualIncentiveID)
+	endTime, _ := sr.GetIncentiveEndTimestamp("gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/qux.QUX:100", actualIncentiveID)
 	currentTime := time.Now().Unix()
 	isEnded := currentTime > endTime
 	if !isEnded {
 		panic("incentive is not ended")
 	}
 
-	collectableExternalIncentive := sr.CollectableExternalIncentiveReward(positionId, actualIncentiveID)
+	collectableExternalIncentive, _ := sr.CollectableExternalIncentiveReward(positionId, actualIncentiveID)
 	ufmt.Printf("[INFO] position %d collectable external incentive: %d GNS\n", positionId, collectableExternalIncentive)
 }
 

--- a/contract/r/scenario/staker/collect_external_incentive_penalty_filetest.gno
+++ b/contract/r/scenario/staker/collect_external_incentive_penalty_filetest.gno
@@ -213,8 +213,8 @@ func collectRewards(cur realm) {
 	testing.SetRealm(adminRealm)
 	sr.CollectReward(cross(cur), 1)
 
-	penaltyAfterCollect := sr.GetIncentiveAccumulatedPenaltyAmount("gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/qux.QUX:100", actualIncentiveID)
-	distributedAfterCollect := sr.GetIncentiveDistributedRewardAmount("gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/qux.QUX:100", actualIncentiveID)
+	penaltyAfterCollect, _ := sr.GetIncentiveAccumulatedPenaltyAmount("gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/qux.QUX:100", actualIncentiveID)
+	distributedAfterCollect, _ := sr.GetIncentiveDistributedRewardAmount("gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/qux.QUX:100", actualIncentiveID)
 
 	ufmt.Printf("[INFO] after CollectReward:\n")
 	ufmt.Printf("  - accumulatedPenaltyAmount: %d\n", penaltyAfterCollect)
@@ -245,7 +245,7 @@ func endIncentive(cur realm) {
 
 func collectPenalty(cur realm) {
 	creatorQuxBefore := qux.BalanceOf(externalCreatorUser)
-	penaltyBefore := sr.GetIncentiveAccumulatedPenaltyAmount("gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/qux.QUX:100", actualIncentiveID)
+	penaltyBefore, _ := sr.GetIncentiveAccumulatedPenaltyAmount("gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/qux.QUX:100", actualIncentiveID)
 
 	testing.SetRealm(adminRealm)
 	collected := sr.CollectExternalIncentivePenalty(
@@ -256,7 +256,7 @@ func collectPenalty(cur realm) {
 	)
 
 	creatorQuxAfter := qux.BalanceOf(externalCreatorUser)
-	penaltyAfter := sr.GetIncentiveAccumulatedPenaltyAmount("gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/qux.QUX:100", actualIncentiveID)
+	penaltyAfter, _ := sr.GetIncentiveAccumulatedPenaltyAmount("gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/qux.QUX:100", actualIncentiveID)
 
 	ufmt.Printf("[INFO] penalty before collection: %d\n", penaltyBefore)
 	ufmt.Printf("[INFO] penalty collected: %d\n", collected)

--- a/contract/r/scenario/staker/collect_external_incentive_penalty_with_multi_staking_filetest.gno
+++ b/contract/r/scenario/staker/collect_external_incentive_penalty_with_multi_staking_filetest.gno
@@ -223,8 +223,8 @@ func collectRewards(cur realm, positionId uint64) {
 	quxBeforeCollect := qux.BalanceOf(adminAddr)
 	sr.CollectReward(cross(cur), positionId)
 
-	penaltyAfterCollect := sr.GetIncentiveAccumulatedPenaltyAmount("gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/qux.QUX:100", actualIncentiveID)
-	distributedAfterCollect := sr.GetIncentiveDistributedRewardAmount("gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/qux.QUX:100", actualIncentiveID)
+	penaltyAfterCollect, _ := sr.GetIncentiveAccumulatedPenaltyAmount("gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/qux.QUX:100", actualIncentiveID)
+	distributedAfterCollect, _ := sr.GetIncentiveDistributedRewardAmount("gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/qux.QUX:100", actualIncentiveID)
 	quxAfterCollect := qux.BalanceOf(adminAddr)
 	quxCollected := quxAfterCollect - quxBeforeCollect
 
@@ -252,7 +252,7 @@ func endIncentive(cur realm) {
 
 func collectPenalty(cur realm) {
 	creatorQuxBefore := qux.BalanceOf(externalCreatorUser)
-	penaltyBefore := sr.GetIncentiveAccumulatedPenaltyAmount("gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/qux.QUX:100", actualIncentiveID)
+	penaltyBefore, _ := sr.GetIncentiveAccumulatedPenaltyAmount("gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/qux.QUX:100", actualIncentiveID)
 
 	testing.SetRealm(adminRealm)
 	collected := sr.CollectExternalIncentivePenalty(
@@ -263,7 +263,7 @@ func collectPenalty(cur realm) {
 	)
 
 	creatorQuxAfter := qux.BalanceOf(externalCreatorUser)
-	penaltyAfter := sr.GetIncentiveAccumulatedPenaltyAmount("gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/qux.QUX:100", actualIncentiveID)
+	penaltyAfter, _ := sr.GetIncentiveAccumulatedPenaltyAmount("gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/qux.QUX:100", actualIncentiveID)
 
 	ufmt.Printf("[INFO] penalty before collection: %d\n", penaltyBefore)
 	ufmt.Printf("[INFO] penalty collected: %d\n", collected)

--- a/contract/r/scenario/staker/create_external_incentive_allowed_token_filetest.gno
+++ b/contract/r/scenario/staker/create_external_incentive_allowed_token_filetest.gno
@@ -131,7 +131,11 @@ func rejectNonAllowedToken(cur realm) {
 		sr.CreateExternalIncentive(cross(cur), poolPath, bazPath, REWARD_AMOUNT, startTimestamp, endTimestamp)
 	})
 	println("[EXPECTED] baz rejected: not allowed for external reward")
-	ufmt.Printf("[EXPECTED] incentives for pool: %d\n", len(sr.GetExternalIncentiveByPoolPath(poolPath)))
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[EXPECTED] incentives for pool: %d\n", len(incentives))
 }
 
 func acceptPoolToken(cur realm) {
@@ -139,7 +143,11 @@ func acceptPoolToken(cur realm) {
 
 	// bar is token0 of the pool, so it is allowed even though it is not whitelisted.
 	sr.CreateExternalIncentive(cross(cur), poolPath, barPath, REWARD_AMOUNT, startTimestamp, endTimestamp)
-	ufmt.Printf("[EXPECTED] bar (pool token) accepted; incentives for pool: %d\n", len(sr.GetExternalIncentiveByPoolPath(poolPath)))
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[EXPECTED] bar (pool token) accepted; incentives for pool: %d\n", len(incentives))
 }
 
 func acceptWhitelistedToken(cur realm) {
@@ -147,7 +155,11 @@ func acceptWhitelistedToken(cur realm) {
 
 	// gns is not a token of bar:qux, but it is on the default whitelist.
 	sr.CreateExternalIncentive(cross(cur), poolPath, gnsPath, REWARD_AMOUNT, startTimestamp, endTimestamp)
-	ufmt.Printf("[EXPECTED] gns (whitelisted token) accepted; incentives for pool: %d\n", len(sr.GetExternalIncentiveByPoolPath(poolPath)))
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[EXPECTED] gns (whitelisted token) accepted; incentives for pool: %d\n", len(incentives))
 }
 
 func acceptAfterWhitelisting(cur realm) {
@@ -155,7 +167,11 @@ func acceptAfterWhitelisting(cur realm) {
 
 	sr.AddToken(cross(cur), bazPath)
 	sr.CreateExternalIncentive(cross(cur), poolPath, bazPath, REWARD_AMOUNT, startTimestamp, endTimestamp)
-	ufmt.Printf("[EXPECTED] baz accepted after AddToken; incentives for pool: %d\n", len(sr.GetExternalIncentiveByPoolPath(poolPath)))
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[EXPECTED] baz accepted after AddToken; incentives for pool: %d\n", len(incentives))
 }
 
 // Output:

--- a/contract/r/scenario/staker/create_external_incentive_single_active_per_token_filetest.gno
+++ b/contract/r/scenario/staker/create_external_incentive_single_active_per_token_filetest.gno
@@ -122,7 +122,11 @@ func createFirstBar(cur realm) {
 	firstBarEnd = firstBarStart + INCENTIVE_DURATION
 
 	sr.CreateExternalIncentive(cross(cur), poolPath, barPath, REWARD_AMOUNT, firstBarStart, firstBarEnd)
-	ufmt.Printf("[EXPECTED] bar incentive created; incentives for pool: %d\n", len(sr.GetExternalIncentiveByPoolPath(poolPath)))
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[EXPECTED] bar incentive created; incentives for pool: %d\n", len(incentives))
 }
 
 func rejectSecondBarWhilePending(cur realm) {
@@ -134,7 +138,11 @@ func rejectSecondBarWhilePending(cur realm) {
 		sr.CreateExternalIncentive(cross(cur), poolPath, barPath, REWARD_AMOUNT, start, start+INCENTIVE_DURATION)
 	})
 	println("[EXPECTED] second bar rejected while first is pending")
-	ufmt.Printf("[EXPECTED] incentives for pool: %d\n", len(sr.GetExternalIncentiveByPoolPath(poolPath)))
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[EXPECTED] incentives for pool: %d\n", len(incentives))
 }
 
 func acceptDifferentToken(cur realm) {
@@ -142,7 +150,11 @@ func acceptDifferentToken(cur realm) {
 
 	start := nextValidStart()
 	sr.CreateExternalIncentive(cross(cur), poolPath, quxPath, REWARD_AMOUNT, start, start+INCENTIVE_DURATION)
-	ufmt.Printf("[EXPECTED] qux (different token) accepted; incentives for pool: %d\n", len(sr.GetExternalIncentiveByPoolPath(poolPath)))
+	incentives, err := sr.GetExternalIncentiveByPoolPath(poolPath)
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[EXPECTED] qux (different token) accepted; incentives for pool: %d\n", len(incentives))
 }
 
 func rejectSecondBarWhileActive(cur realm) {

--- a/contract/r/scenario/staker/end_external_incentive_reward_amount_invariant_filetest.gno
+++ b/contract/r/scenario/staker/end_external_incentive_reward_amount_invariant_filetest.gno
@@ -246,10 +246,10 @@ func endExternalIncentive(cur realm) {
 }
 
 func verifyAccountingInvariant(cur realm) {
-	total := sr.GetIncentiveTotalRewardAmount(targetPoolPath, actualIncentiveID)
-	remaining := sr.GetIncentiveRemainingRewardAmount(targetPoolPath, actualIncentiveID)
-	distributed := sr.GetIncentiveDistributedRewardAmount(targetPoolPath, actualIncentiveID)
-	penalty := sr.GetIncentiveAccumulatedPenaltyAmount(targetPoolPath, actualIncentiveID)
+	total, _ := sr.GetIncentiveTotalRewardAmount(targetPoolPath, actualIncentiveID)
+	remaining, _ := sr.GetIncentiveRemainingRewardAmount(targetPoolPath, actualIncentiveID)
+	distributed, _ := sr.GetIncentiveDistributedRewardAmount(targetPoolPath, actualIncentiveID)
+	penalty, _ := sr.GetIncentiveAccumulatedPenaltyAmount(targetPoolPath, actualIncentiveID)
 
 	sum := remaining + distributed + penalty
 

--- a/contract/r/scenario/staker/external_incentive_complete_distribution_filetest.gno
+++ b/contract/r/scenario/staker/external_incentive_complete_distribution_filetest.gno
@@ -278,7 +278,7 @@ func stakePosition(cur realm) {
 	println("[INFO] stake position")
 	sr.StakeToken(cross(cur), 1, "")
 
-	owner := gnft.MustOwnerOf(positionIdFrom(cur, 1))
+	owner := mustOwnerOf(positionIdFrom(cur, 1))
 	ufmt.Printf("[INFO] position owner after staking: %s\n", owner)
 }
 
@@ -352,7 +352,7 @@ func unstakePosition(cur realm) {
 	ufmt.Printf("[INFO] total rewards collected so far: %d QUX\n", totalRewardsCollected)
 
 	// Verify NFT ownership returned
-	owner := gnft.MustOwnerOf(positionIdFrom(cur, 1))
+	owner := mustOwnerOf(positionIdFrom(cur, 1))
 	ufmt.Printf("[INFO] position owner after unstaking: %s\n", owner)
 }
 
@@ -422,6 +422,14 @@ func endExternalIncentiveAndVerifyNoDust(cur realm) {
 
 func positionIdFrom(cur realm, positionId int) grc721.TokenID {
 	return grc721.TokenID(strconv.Itoa(positionId))
+}
+
+func mustOwnerOf(tid grc721.TokenID) address {
+	owner, err := gnft.OwnerOf(tid)
+	if err != nil {
+		panic(err.Error())
+	}
+	return owner
 }
 
 // Output:

--- a/contract/r/scenario/staker/external_incentive_refund_with_multiple_unclaimable_periods_filetest.gno
+++ b/contract/r/scenario/staker/external_incentive_refund_with_multiple_unclaimable_periods_filetest.gno
@@ -298,10 +298,10 @@ func endExternalIncentive(cur realm) {
 }
 
 func verifyRefundAccounting(cur realm) {
-	total := sr.GetIncentiveTotalRewardAmount(targetPoolPath, actualIncentiveID)
-	remaining := sr.GetIncentiveRemainingRewardAmount(targetPoolPath, actualIncentiveID)
-	distributed := sr.GetIncentiveDistributedRewardAmount(targetPoolPath, actualIncentiveID)
-	penalty := sr.GetIncentiveAccumulatedPenaltyAmount(targetPoolPath, actualIncentiveID)
+	total, _ := sr.GetIncentiveTotalRewardAmount(targetPoolPath, actualIncentiveID)
+	remaining, _ := sr.GetIncentiveRemainingRewardAmount(targetPoolPath, actualIncentiveID)
+	distributed, _ := sr.GetIncentiveDistributedRewardAmount(targetPoolPath, actualIncentiveID)
+	penalty, _ := sr.GetIncentiveAccumulatedPenaltyAmount(targetPoolPath, actualIncentiveID)
 
 	sum := remaining + distributed + penalty
 

--- a/contract/r/scenario/staker/full_internal_external_filetest.gno
+++ b/contract/r/scenario/staker/full_internal_external_filetest.gno
@@ -7,11 +7,11 @@ package main
 import (
 	"chain"
 	"chain/banker"
+	"gno.land/p/gnoswap/gnsmath"
 	"strconv"
 	"testing"
 	"time"
 
-	"gno.land/p/gnoswap/gnsmath"
 	"gno.land/r/gnoswap/scenarioutils"
 
 	"gno.land/p/demo/tokens/grc721"

--- a/contract/r/scenario/staker/initial_tier_unclaimable_period_filetest.gno
+++ b/contract/r/scenario/staker/initial_tier_unclaimable_period_filetest.gno
@@ -106,7 +106,7 @@ func testInitialTierInternalRewards(cur realm) {
 
 	// Verify tier assignment
 	tier := sr.GetPoolTier(poolPath1)
-	rewardPerSecond := sr.GetPoolReward(tier)
+	rewardPerSecond, _ := sr.GetPoolReward(tier)
 	ufmt.Printf("[VERIFY] tier assigned: %d, reward per second: %d\n", tier, rewardPerSecond)
 
 	// Verify pool has zero liquidity after tier assignment

--- a/contract/r/scenario/staker/no_position_to_give_reward_filetest.gno
+++ b/contract/r/scenario/staker/no_position_to_give_reward_filetest.gno
@@ -183,7 +183,7 @@ func mintPositionButDontStake(cur realm) {
 	ufmt.Printf("[EXPECTED] liquidity: %s\n", liquidity)
 	ufmt.Printf("[EXPECTED] amount0: %s, amount1: %s\n", amount0, amount1)
 
-	owner := gnft.MustOwnerOf(positionIdFrom(cur, positionId))
+	owner := mustOwnerOf(positionIdFrom(cur, positionId))
 	ufmt.Printf("[EXPECTED] position owner: %s (not staked)\n", owner)
 
 	if owner != adminAddr {
@@ -234,7 +234,7 @@ func stakePositionAndVerifyEmission(cur realm) {
 	gnft.Approve(cross(cur), stakerAddr, positionIdFrom(cur, 1))
 	sr.StakeToken(cross(cur), 1, "")
 
-	ownerAfterStake := gnft.MustOwnerOf(positionIdFrom(cur, 1))
+	ownerAfterStake := mustOwnerOf(positionIdFrom(cur, 1))
 	ufmt.Printf("[EXPECTED] position owner after staking: %s\n", ownerAfterStake)
 
 	if ownerAfterStake != stakerAddr {
@@ -277,6 +277,14 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 	default:
 		panic("unsupported positionId type")
 	}
+}
+
+func mustOwnerOf(tid grc721.TokenID) address {
+	owner, err := gnft.OwnerOf(tid)
+	if err != nil {
+		panic(err.Error())
+	}
+	return owner
 }
 
 // Output:

--- a/contract/r/scenario/staker/pool_tier_removal_readd_check_rewards_filetest.gno
+++ b/contract/r/scenario/staker/pool_tier_removal_readd_check_rewards_filetest.gno
@@ -11,11 +11,11 @@ package main
 
 import (
 	"chain/runtime"
+	"gno.land/p/gnoswap/gnsmath"
 	"strconv"
 	"testing"
 	"time"
 
-	"gno.land/p/gnoswap/gnsmath"
 	"gno.land/r/gnoswap/scenarioutils"
 
 	"gno.land/p/demo/tokens/grc721"
@@ -204,7 +204,7 @@ func setPoolTier(cur realm, tier int) {
 	beforePoolTier := sr.GetPoolTier(barBazPoolPath)
 	beforePoolEmissionReward := int64(0)
 	if beforePoolTier != 0 {
-		beforePoolEmissionReward = sr.GetPoolReward(beforePoolTier)
+		beforePoolEmissionReward, _ = sr.GetPoolReward(beforePoolTier)
 	}
 
 	sr.SetPoolTier(cross(cur), barBazPoolPath, uint64(tier))
@@ -212,7 +212,7 @@ func setPoolTier(cur realm, tier int) {
 	afterPoolTier := sr.GetPoolTier(barBazPoolPath)
 	afterPoolEmissionReward := int64(0)
 	if afterPoolTier != 0 {
-		afterPoolEmissionReward = sr.GetPoolReward(afterPoolTier)
+		afterPoolEmissionReward, _ = sr.GetPoolReward(afterPoolTier)
 	}
 
 	ufmt.Printf("[EXPECTED] %s pool's tier changed: %d -> %d\n", barBazPoolPath, beforePoolTier, afterPoolTier)

--- a/contract/r/scenario/staker/short_warmup_internal_gnot_gns_3000_filetest.gno
+++ b/contract/r/scenario/staker/short_warmup_internal_gnot_gns_3000_filetest.gno
@@ -8,12 +8,12 @@ import (
 	"chain"
 	"chain/banker"
 	"chain/runtime"
+	"gno.land/p/gnoswap/gnsmath"
 	"math"
 	"strconv"
 	"testing"
 	"time"
 
-	"gno.land/p/gnoswap/gnsmath"
 	"gno.land/r/gnoswap/scenarioutils"
 
 	"gno.land/p/demo/tokens/grc721"
@@ -173,7 +173,7 @@ func mintWugnotGnsPos01(cur realm) {
 	ufmt.Printf("[EXPECTED] liquidity: %s\n", liquidity)
 	ufmt.Printf("[EXPECTED] amount0: %s, amount1: %s\n", amount0, amount1)
 
-	owner := gnft.MustOwnerOf(positionIdFrom(cur, positionId))
+	owner := mustOwnerOf(positionIdFrom(cur, positionId))
 	ufmt.Printf("[EXPECTED] position owner: %s\n", owner)
 
 	testing.SkipHeights(1)
@@ -238,6 +238,14 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 	default:
 		panic("unsupported positionId type")
 	}
+}
+
+func mustOwnerOf(tid grc721.TokenID) address {
+	owner, err := gnft.OwnerOf(tid)
+	if err != nil {
+		panic(err.Error())
+	}
+	return owner
 }
 
 // Output:

--- a/contract/r/scenario/staker/single_position_stake_unstake_restake_filetest.gno
+++ b/contract/r/scenario/staker/single_position_stake_unstake_restake_filetest.gno
@@ -152,7 +152,7 @@ func mintPosition01(cur realm) {
 	ufmt.Printf("[EXPECTED] liquidity: %s\n", liquidity)
 	ufmt.Printf("[EXPECTED] amount0: %s, amount1: %s\n", amount0, amount1)
 
-	owner := gnft.MustOwnerOf(positionIdFrom(cur, positionId))
+	owner := mustOwnerOf(positionIdFrom(cur, positionId))
 	ufmt.Printf("[EXPECTED] position owner: %s\n", owner)
 
 	testing.SkipHeights(1)
@@ -167,7 +167,7 @@ func firstStakeOperation(cur realm) {
 	println("[INFO] stake position 01 for the first time")
 	sr.StakeToken(cross(cur), 1, "")
 
-	ownerAfterStake := gnft.MustOwnerOf(positionIdFrom(cur, 1))
+	ownerAfterStake := mustOwnerOf(positionIdFrom(cur, 1))
 	ufmt.Printf("[EXPECTED] position owner after first stake: %s\n", ownerAfterStake)
 
 	if ownerAfterStake != stakerAddr {
@@ -202,7 +202,7 @@ func unstakeOperation(cur realm) {
 	println("[INFO] unstake position 01")
 	sr.UnStakeToken(cross(cur), 1)
 
-	ownerAfterUnstake := gnft.MustOwnerOf(positionIdFrom(cur, 1))
+	ownerAfterUnstake := mustOwnerOf(positionIdFrom(cur, 1))
 	ufmt.Printf("[EXPECTED] position owner after unstake: %s\n", ownerAfterUnstake)
 
 	if ownerAfterUnstake != adminAddr {
@@ -221,7 +221,7 @@ func restakeOperation(cur realm) {
 	println("[INFO] restake position 01")
 	sr.StakeToken(cross(cur), 1, "")
 
-	ownerAfterRestake := gnft.MustOwnerOf(positionIdFrom(cur, 1))
+	ownerAfterRestake := mustOwnerOf(positionIdFrom(cur, 1))
 	ufmt.Printf("[EXPECTED] position owner after restake: %s\n", ownerAfterRestake)
 
 	if ownerAfterRestake != stakerAddr {
@@ -259,7 +259,7 @@ func finalUnstakeOperation(cur realm) {
 	println("[INFO] final unstake operation")
 	sr.UnStakeToken(cross(cur), 1)
 
-	ownerAfterFinalUnstake := gnft.MustOwnerOf(positionIdFrom(cur, 1))
+	ownerAfterFinalUnstake := mustOwnerOf(positionIdFrom(cur, 1))
 	ufmt.Printf("[EXPECTED] position owner after final unstake: %s\n", ownerAfterFinalUnstake)
 
 	if ownerAfterFinalUnstake != adminAddr {
@@ -286,6 +286,14 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 	default:
 		panic("unsupported positionId type")
 	}
+}
+
+func mustOwnerOf(tid grc721.TokenID) address {
+	owner, err := gnft.OwnerOf(tid)
+	if err != nil {
+		panic(err.Error())
+	}
+	return owner
 }
 
 // Output:

--- a/contract/r/scenario/staker/single_position_stake_unstake_same_block_filetest.gno
+++ b/contract/r/scenario/staker/single_position_stake_unstake_same_block_filetest.gno
@@ -135,7 +135,7 @@ func mintPosition01(cur realm) {
 	ufmt.Printf("[EXPECTED] liquidity: %s\n", liquidity)
 	ufmt.Printf("[EXPECTED] amount0: %s, amount1: %s\n", amount0, amount1)
 
-	owner := gnft.MustOwnerOf(positionIdFrom(cur, positionId))
+	owner := mustOwnerOf(positionIdFrom(cur, positionId))
 	ufmt.Printf("[EXPECTED] initial position owner: %s\n", owner)
 
 	testing.SkipHeights(1)
@@ -145,7 +145,7 @@ func stakeAndUnstakeInSameBlock(cur realm) {
 	testing.SetRealm(adminRealm)
 
 	println("[INFO] check initial state before staking")
-	initialOwner := gnft.MustOwnerOf(positionIdFrom(cur, 1))
+	initialOwner := mustOwnerOf(positionIdFrom(cur, 1))
 	initialGnsBalance := gns.BalanceOf(adminUser)
 
 	ufmt.Printf("[INFO] initial owner: %s\n", initialOwner)
@@ -157,7 +157,7 @@ func stakeAndUnstakeInSameBlock(cur realm) {
 	println("[INFO] stake position 01")
 	sr.StakeToken(cross(cur), 1, "")
 
-	ownerAfterStake := gnft.MustOwnerOf(positionIdFrom(cur, 1))
+	ownerAfterStake := mustOwnerOf(positionIdFrom(cur, 1))
 
 	ufmt.Printf("[EXPECTED] owner after stake: %s\n", ownerAfterStake)
 
@@ -168,7 +168,7 @@ func stakeAndUnstakeInSameBlock(cur realm) {
 	println("[INFO] immediately unstake position 01 (same block)")
 	sr.UnStakeToken(cross(cur), 1)
 
-	ownerAfterUnstake := gnft.MustOwnerOf(positionIdFrom(cur, 1))
+	ownerAfterUnstake := mustOwnerOf(positionIdFrom(cur, 1))
 	gnsAfterUnstake := gns.BalanceOf(adminUser)
 
 	ufmt.Printf("[EXPECTED] owner after unstake: %s\n", ownerAfterUnstake)
@@ -196,7 +196,7 @@ func verifyFinalState(cur realm) {
 
 	println("[INFO] verify final state after same block operations")
 
-	finalOwner := gnft.MustOwnerOf(positionIdFrom(cur, 1))
+	finalOwner := mustOwnerOf(positionIdFrom(cur, 1))
 
 	ufmt.Printf("[EXPECTED] final position owner: %s\n", finalOwner)
 
@@ -213,7 +213,7 @@ func verifyFinalState(cur realm) {
 
 	testing.SkipHeights(1)
 
-	verifyOwner := gnft.MustOwnerOf(positionIdFrom(cur, 1))
+	verifyOwner := mustOwnerOf(positionIdFrom(cur, 1))
 
 	ufmt.Printf("[EXPECTED] verification - owner after normal stake: %s\n", verifyOwner)
 
@@ -241,6 +241,14 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 	default:
 		panic("unsupported positionId type")
 	}
+}
+
+func mustOwnerOf(tid grc721.TokenID) address {
+	owner, err := gnft.OwnerOf(tid)
+	if err != nil {
+		panic(err.Error())
+	}
+	return owner
 }
 
 // Output:

--- a/contract/r/scenario/staker/staked_liquidity_change_by_staking_unstaking_external_filetest.gno
+++ b/contract/r/scenario/staker/staked_liquidity_change_by_staking_unstaking_external_filetest.gno
@@ -5,14 +5,13 @@
 package main
 
 import (
-	"gno.land/p/gnoswap/gnsmath"
 	"chain/runtime"
+	"gno.land/p/gnoswap/gnsmath"
 	"strconv"
 	"testing"
 
 	"gno.land/p/demo/tokens/grc721"
 	ufmt "gno.land/p/nt/ufmt/v0"
-
 
 	"gno.land/r/gnoswap/access"
 
@@ -259,7 +258,7 @@ func unstakePosition02(cur realm) {
 	println("[INFO] unstake position 02")
 	sr.UnStakeToken(cross(cur), 2)
 
-	owner := gnft.MustOwnerOf(positionIdFrom(cur, 2))
+	owner := mustOwnerOf(positionIdFrom(cur, 2))
 	ufmt.Printf("[EXPECTED] position 02 owner after unstaking: %s\n", owner)
 
 	if owner != adminAddr {
@@ -322,6 +321,14 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 	default:
 		panic("unsupported positionId type")
 	}
+}
+
+func mustOwnerOf(tid grc721.TokenID) address {
+	owner, err := gnft.OwnerOf(tid)
+	if err != nil {
+		panic(err.Error())
+	}
+	return owner
 }
 
 // Output:

--- a/contract/r/scenario/staker/staked_liquidity_change_by_staking_unstaking_internal_filetest.gno
+++ b/contract/r/scenario/staker/staked_liquidity_change_by_staking_unstaking_internal_filetest.gno
@@ -7,11 +7,11 @@ package main
 import (
 	"chain"
 	"chain/banker"
+	"gno.land/p/gnoswap/gnsmath"
 	"strconv"
 	"testing"
 	"time"
 
-	"gno.land/p/gnoswap/gnsmath"
 	"gno.land/r/gnoswap/scenarioutils"
 
 	"gno.land/p/demo/tokens/grc721"
@@ -248,7 +248,7 @@ func unstakePosition02(cur realm) {
 	println("[INFO] unstake position 02")
 	sr.UnStakeToken(cross(cur), 2)
 
-	owner := gnft.MustOwnerOf(positionIdFrom(cur, 2))
+	owner := mustOwnerOf(positionIdFrom(cur, 2))
 	ufmt.Printf("[EXPECTED] position 02 owner after unstaking: %s\n", owner)
 
 	if owner != adminAddr {
@@ -310,6 +310,14 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 	default:
 		panic("unsupported positionId type")
 	}
+}
+
+func mustOwnerOf(tid grc721.TokenID) address {
+	owner, err := gnft.OwnerOf(tid)
+	if err != nil {
+		panic(err.Error())
+	}
+	return owner
 }
 
 // Output:

--- a/contract/r/scenario/staker/staker_halving_lazy_pool_cache_filetest.gno
+++ b/contract/r/scenario/staker/staker_halving_lazy_pool_cache_filetest.gno
@@ -149,7 +149,7 @@ func collectAndAssertLatestCache(cur realm, label string) int64 {
 
 func assertLatestPoolRewardCacheMatchesCurrentPoolReward(label string) int64 {
 	latestCache := latestPoolRewardCache()
-	currentPoolReward := sr.GetPoolReward(1)
+	currentPoolReward, _ := sr.GetPoolReward(1)
 	println("[INFO]", label, "pool reward cache:", latestCache)
 	println("[INFO]", label, "current pool reward:", currentPoolReward)
 	if latestCache != currentPoolReward {

--- a/contract/r/scenario/staker/staker_native_create_collect_unstake_filetest.gno
+++ b/contract/r/scenario/staker/staker_native_create_collect_unstake_filetest.gno
@@ -8,12 +8,12 @@ import (
 	"chain"
 	"chain/banker"
 	"fmt"
+	"gno.land/p/gnoswap/gnsmath"
 	"math"
 	"strconv"
 	"testing"
 	"time"
 
-	"gno.land/p/gnoswap/gnsmath"
 	"gno.land/r/gnoswap/scenarioutils"
 
 	"gno.land/p/demo/tokens/grc721"
@@ -244,7 +244,7 @@ func mintNativePosition01Post(cur realm) {
 	ufmt.Printf("[EXPECTED] liquidity: %s\n", liquidity)
 	ufmt.Printf("[EXPECTED] amount0: %s, amount1: %s\n", amount0, amount1)
 
-	owner := gnft.MustOwnerOf(positionIdFrom(cur, lpTokenId))
+	owner := mustOwnerOf(positionIdFrom(cur, lpTokenId))
 	ufmt.Printf("[EXPECTED] position owner: %s\n", owner)
 
 	testing.SkipHeights(1)
@@ -294,7 +294,7 @@ func mintNativePosition02Post(cur realm) {
 	ufmt.Printf("[EXPECTED] liquidity: %s\n", liquidity)
 	ufmt.Printf("[EXPECTED] amount0: %s, amount1: %s\n", amount0, amount1)
 
-	owner := gnft.MustOwnerOf(positionIdFrom(cur, lpTokenId))
+	owner := mustOwnerOf(positionIdFrom(cur, lpTokenId))
 	ufmt.Printf("[EXPECTED] position owner: %s\n", owner)
 
 	testing.SkipHeights(1)
@@ -351,7 +351,7 @@ func stakeToken01(cur realm) {
 
 	testing.SkipHeights(1)
 
-	owner := gnft.MustOwnerOf(positionIdFrom(cur, 1))
+	owner := mustOwnerOf(positionIdFrom(cur, 1))
 	ufmt.Printf("[EXPECTED] NFT owner after staking: %s\n", owner)
 }
 
@@ -367,7 +367,7 @@ func stakeToken02(cur realm) {
 
 	testing.SkipHeights(1)
 
-	owner := gnft.MustOwnerOf(positionIdFrom(cur, 2))
+	owner := mustOwnerOf(positionIdFrom(cur, 2))
 	ufmt.Printf("[EXPECTED] NFT owner after staking: %s\n", owner)
 }
 
@@ -416,7 +416,7 @@ func unstakeToken02(cur realm) {
 	sr.UnStakeToken(cross(cur), 2)
 	testing.SkipHeights(1)
 
-	owner := gnft.MustOwnerOf(positionIdFrom(cur, 2))
+	owner := mustOwnerOf(positionIdFrom(cur, 2))
 	ufmt.Printf("[EXPECTED] NFT owner after unstaking: %s\n", owner)
 
 	wugnotBalanceAfter := wugnot.BalanceOf(adminUser)
@@ -484,7 +484,7 @@ func unstakeToken01(cur realm) {
 	sr.UnStakeToken(cross(cur), 1)
 	testing.SkipHeights(1)
 
-	owner := gnft.MustOwnerOf(positionIdFrom(cur, 1))
+	owner := mustOwnerOf(positionIdFrom(cur, 1))
 	ufmt.Printf("[EXPECTED] NFT owner after unstaking: %s\n", owner)
 
 	wugnotBalanceAfter := wugnot.BalanceOf(adminUser)
@@ -522,6 +522,14 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 	default:
 		panic("unsupported positionId type")
 	}
+}
+
+func mustOwnerOf(tid grc721.TokenID) address {
+	owner, err := gnft.OwnerOf(tid)
+	if err != nil {
+		panic(err.Error())
+	}
+	return owner
 }
 
 // Output:

--- a/contract/r/scenario/staker/staker_native_create_collect_unstake_with_finish_filetest.gno
+++ b/contract/r/scenario/staker/staker_native_create_collect_unstake_with_finish_filetest.gno
@@ -8,12 +8,12 @@ import (
 	"chain"
 	"chain/banker"
 	"fmt"
+	"gno.land/p/gnoswap/gnsmath"
 	"math"
 	"strconv"
 	"testing"
 	"time"
 
-	"gno.land/p/gnoswap/gnsmath"
 	"gno.land/r/gnoswap/scenarioutils"
 
 	"gno.land/p/demo/tokens/grc721"
@@ -243,7 +243,7 @@ func mintNativePosition01Post(cur realm) {
 	ufmt.Printf("[EXPECTED] liquidity: %s\n", liquidity)
 	ufmt.Printf("[EXPECTED] amount0: %s, amount1: %s\n", amount0, amount1)
 
-	owner := gnft.MustOwnerOf(positionIdFrom(cur, lpTokenId))
+	owner := mustOwnerOf(positionIdFrom(cur, lpTokenId))
 	ufmt.Printf("[EXPECTED] position owner: %s\n", owner)
 
 	testing.SkipHeights(1)
@@ -293,7 +293,7 @@ func mintNativePosition02Post(cur realm) {
 	ufmt.Printf("[EXPECTED] liquidity: %s\n", liquidity)
 	ufmt.Printf("[EXPECTED] amount0: %s, amount1: %s\n", amount0, amount1)
 
-	owner := gnft.MustOwnerOf(positionIdFrom(cur, lpTokenId))
+	owner := mustOwnerOf(positionIdFrom(cur, lpTokenId))
 	ufmt.Printf("[EXPECTED] position owner: %s\n", owner)
 
 	testing.SkipHeights(1)
@@ -350,7 +350,7 @@ func stakeToken01(cur realm) {
 
 	testing.SkipHeights(1)
 
-	owner := gnft.MustOwnerOf(positionIdFrom(cur, 1))
+	owner := mustOwnerOf(positionIdFrom(cur, 1))
 	ufmt.Printf("[EXPECTED] NFT owner after staking: %s\n", owner)
 }
 
@@ -366,7 +366,7 @@ func stakeToken02(cur realm) {
 
 	testing.SkipHeights(1)
 
-	owner := gnft.MustOwnerOf(positionIdFrom(cur, 2))
+	owner := mustOwnerOf(positionIdFrom(cur, 2))
 	ufmt.Printf("[EXPECTED] NFT owner after staking: %s\n", owner)
 }
 
@@ -415,7 +415,7 @@ func unstakeToken(cur realm, tokenId uint64) {
 	sr.UnStakeToken(cross(cur), tokenId)
 	testing.SkipHeights(1)
 
-	owner := gnft.MustOwnerOf(positionIdFrom(cur, tokenId))
+	owner := mustOwnerOf(positionIdFrom(cur, tokenId))
 	ufmt.Printf("[EXPECTED] NFT owner after unstaking: %s\n", owner)
 
 	wugnotBalanceAfter := wugnot.BalanceOf(adminUser)
@@ -490,6 +490,14 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 	default:
 		panic("unsupported positionId type")
 	}
+}
+
+func mustOwnerOf(tid grc721.TokenID) address {
+	owner, err := gnft.OwnerOf(tid)
+	if err != nil {
+		panic(err.Error())
+	}
+	return owner
 }
 
 // Output:

--- a/contract/r/scenario/staker/staker_nft_transfer_01_filetest.gno
+++ b/contract/r/scenario/staker/staker_nft_transfer_01_filetest.gno
@@ -143,7 +143,7 @@ func mintPosition01(cur realm) {
 	ufmt.Printf("[EXPECTED] liquidity: %s\n", liquidity)
 	ufmt.Printf("[EXPECTED] amount0: %s, amount1: %s\n", amount0, amount1)
 
-	owner := gnft.MustOwnerOf(positionIdFrom(cur, positionId))
+	owner := mustOwnerOf(positionIdFrom(cur, positionId))
 	ufmt.Printf("[EXPECTED] position owner: %s\n", owner)
 
 	testing.SkipHeights(1)
@@ -160,7 +160,7 @@ func stakePosition01(cur realm) {
 	sr.StakeToken(cross(cur), 1, "")
 	testing.SkipHeights(1)
 
-	owner := gnft.MustOwnerOf(positionIdFrom(cur, 1))
+	owner := mustOwnerOf(positionIdFrom(cur, 1))
 	ufmt.Printf("[EXPECTED] NFT owner after staking: %s\n", owner)
 
 	if owner != stakerAddr {
@@ -204,6 +204,14 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 	default:
 		panic("unsupported positionId type")
 	}
+}
+
+func mustOwnerOf(tid grc721.TokenID) address {
+	owner, err := gnft.OwnerOf(tid)
+	if err != nil {
+		panic(err.Error())
+	}
+	return owner
 }
 
 // Output:

--- a/contract/r/scenario/staker/staker_nft_transfer_03_filetest.gno
+++ b/contract/r/scenario/staker/staker_nft_transfer_03_filetest.gno
@@ -144,7 +144,7 @@ func mintPositionsForUsers(cur realm) {
 	ufmt.Printf("[EXPECTED] admin position ID: %d, liquidity: %s\n", positionId1, liquidity1)
 	ufmt.Printf("[EXPECTED] amounts - 0: %s, 1: %s\n", amount0_1, amount1_1)
 
-	owner1 := gnft.MustOwnerOf(positionIdFrom(cur, 1))
+	owner1 := mustOwnerOf(positionIdFrom(cur, 1))
 	ufmt.Printf("[EXPECTED] position 01 owner: %s\n", owner1)
 
 	bar.Transfer(cross(cur), user2Addr, 1000)
@@ -178,7 +178,7 @@ func mintPositionsForUsers(cur realm) {
 	ufmt.Printf("[EXPECTED] user2 position ID: %d, liquidity: %s\n", positionId2, liquidity2)
 	ufmt.Printf("[EXPECTED] amounts - 0: %s, 1: %s\n", amount0_2, amount1_2)
 
-	owner2 := gnft.MustOwnerOf(positionIdFrom(cur, 2))
+	owner2 := mustOwnerOf(positionIdFrom(cur, 2))
 	ufmt.Printf("[EXPECTED] position 02 owner: %s\n", owner2)
 
 	testing.SkipHeights(1)
@@ -192,7 +192,7 @@ func stakePositionsForUsers(cur realm) {
 	gnft.Approve(cross(cur), stakerAddr, positionIdFrom(cur, 1))
 	sr.StakeToken(cross(cur), 1, "")
 
-	ownerAfterStake1 := gnft.MustOwnerOf(positionIdFrom(cur, 1))
+	ownerAfterStake1 := mustOwnerOf(positionIdFrom(cur, 1))
 	ufmt.Printf("[EXPECTED] position 01 owner after staking: %s\n", ownerAfterStake1)
 
 	// User2 stakes position 2
@@ -202,7 +202,7 @@ func stakePositionsForUsers(cur realm) {
 	gnft.Approve(cross(cur), stakerAddr, positionIdFrom(cur, 2))
 	sr.StakeToken(cross(cur), 2, "")
 
-	ownerAfterStake2 := gnft.MustOwnerOf(positionIdFrom(cur, 2))
+	ownerAfterStake2 := mustOwnerOf(positionIdFrom(cur, 2))
 	ufmt.Printf("[EXPECTED] position 02 owner after staking: %s\n", ownerAfterStake2)
 
 	testing.SkipHeights(1)
@@ -251,7 +251,7 @@ func unstakeAndVerifyOwnership(cur realm) {
 	println("[INFO] admin: unstake position 01")
 	sr.UnStakeToken(cross(cur), 1)
 
-	ownerAfterUnstake1 := gnft.MustOwnerOf(positionIdFrom(cur, 1))
+	ownerAfterUnstake1 := mustOwnerOf(positionIdFrom(cur, 1))
 	ufmt.Printf("[EXPECTED] position 01 owner after unstaking: %s\n", ownerAfterUnstake1)
 
 	if ownerAfterUnstake1 != adminAddr {
@@ -264,7 +264,7 @@ func unstakeAndVerifyOwnership(cur realm) {
 	println("[INFO] user2: unstake position 02")
 	sr.UnStakeToken(cross(cur), 2)
 
-	ownerAfterUnstake2 := gnft.MustOwnerOf(positionIdFrom(cur, 2))
+	ownerAfterUnstake2 := mustOwnerOf(positionIdFrom(cur, 2))
 	ufmt.Printf("[EXPECTED] position 02 owner after unstaking: %s\n", ownerAfterUnstake2)
 
 	if ownerAfterUnstake2 != user2Addr {
@@ -291,6 +291,14 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 	default:
 		panic("unsupported positionId type")
 	}
+}
+
+func mustOwnerOf(tid grc721.TokenID) address {
+	owner, err := gnft.OwnerOf(tid)
+	if err != nil {
+		panic(err.Error())
+	}
+	return owner
 }
 
 // Output:

--- a/contract/r/scenario/staker/staker_short_warmup_period_external_10_filetest.gno
+++ b/contract/r/scenario/staker/staker_short_warmup_period_external_10_filetest.gno
@@ -159,7 +159,7 @@ func mintBarQux100Position1(cur realm) {
 		panic("position ID should be 1")
 	}
 
-	owner := gnft.MustOwnerOf(positionIdFrom(cur, positionId))
+	owner := mustOwnerOf(positionIdFrom(cur, positionId))
 	if owner != adminAddr {
 		panic("position should be owned by admin")
 	}
@@ -268,7 +268,7 @@ func mintAndStakePosition2(cur realm) {
 		panic("position ID should be 2")
 	}
 
-	owner := gnft.MustOwnerOf(positionIdFrom(cur, positionId))
+	owner := mustOwnerOf(positionIdFrom(cur, positionId))
 	if owner != adminAddr {
 		panic("position should be owned by admin")
 	}
@@ -334,6 +334,14 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 	default:
 		panic("unsupported positionId type")
 	}
+}
+
+func mustOwnerOf(tid grc721.TokenID) address {
+	owner, err := gnft.OwnerOf(tid)
+	if err != nil {
+		panic(err.Error())
+	}
+	return owner
 }
 
 // Output:

--- a/contract/r/scenario/staker/staker_short_warmup_period_external_12_filetest.gno
+++ b/contract/r/scenario/staker/staker_short_warmup_period_external_12_filetest.gno
@@ -157,7 +157,7 @@ func mintBarQux100Position1(cur realm) {
 		panic("position ID should be 1")
 	}
 
-	owner := gnft.MustOwnerOf(positionIdFrom(cur, positionId))
+	owner := mustOwnerOf(positionIdFrom(cur, positionId))
 	if owner != adminAddr {
 		panic("position should be owned by admin")
 	}
@@ -294,6 +294,14 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 
 func milliToSec(cur realm, ms int64) int64 {
 	return ms / int64(1000)
+}
+
+func mustOwnerOf(tid grc721.TokenID) address {
+	owner, err := gnft.OwnerOf(tid)
+	if err != nil {
+		panic(err.Error())
+	}
+	return owner
 }
 
 // Output:

--- a/contract/r/scenario/staker/staker_short_warmup_period_external_13_gns_external_filetest.gno
+++ b/contract/r/scenario/staker/staker_short_warmup_period_external_13_gns_external_filetest.gno
@@ -156,7 +156,7 @@ func mintBarQux100Position1(cur realm) {
 		panic("position ID should be 1")
 	}
 
-	owner := gnft.MustOwnerOf(positionIdFrom(cur, positionId))
+	owner := mustOwnerOf(positionIdFrom(cur, positionId))
 	if owner != adminAddr {
 		panic("position should be owned by admin")
 	}
@@ -280,6 +280,14 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 	default:
 		panic("unsupported positionId type")
 	}
+}
+
+func mustOwnerOf(tid grc721.TokenID) address {
+	owner, err := gnft.OwnerOf(tid)
+	if err != nil {
+		panic(err.Error())
+	}
+	return owner
 }
 
 // Output:

--- a/contract/r/scenario/staker/staker_short_warmup_period_internal_01_filetest.gno
+++ b/contract/r/scenario/staker/staker_short_warmup_period_internal_01_filetest.gno
@@ -181,7 +181,7 @@ func mintBarQux100Position1(cur realm) {
 		panic("position ID should be 1")
 	}
 
-	owner := gnft.MustOwnerOf(positionIdFrom(cur, positionId))
+	owner := mustOwnerOf(positionIdFrom(cur, positionId))
 	if owner != adminAddr {
 		panic("position should be owned by admin")
 	}
@@ -219,7 +219,7 @@ func mintBarBaz3000Position2(cur realm) {
 		panic("position ID should be 2")
 	}
 
-	owner := gnft.MustOwnerOf(positionIdFrom(cur, positionId))
+	owner := mustOwnerOf(positionIdFrom(cur, positionId))
 	if owner != adminAddr {
 		panic("position should be owned by admin")
 	}
@@ -331,6 +331,14 @@ func isInErrorRange(cur realm, expected, actual uint64) bool {
 
 	errorRate := float64(diff) / float64(expected)
 	return errorRate <= 0.05 // 5% error tolerance
+}
+
+func mustOwnerOf(tid grc721.TokenID) address {
+	owner, err := gnft.OwnerOf(tid)
+	if err != nil {
+		panic(err.Error())
+	}
+	return owner
 }
 
 // Output:

--- a/contract/r/scenario/staker/warmup_period_penalty_scenario_filetest.gno
+++ b/contract/r/scenario/staker/warmup_period_penalty_scenario_filetest.gno
@@ -155,7 +155,7 @@ func mintLargePosition(cur realm) uint64 {
 	ufmt.Printf("[EXPECTED] position minted: ID=%d, liquidity=%s\n", positionId, liquidity)
 
 	// Verify ownership
-	owner := gnft.MustOwnerOf(positionIdFrom(cur, positionId))
+	owner := mustOwnerOf(positionIdFrom(cur, positionId))
 	if owner != adminAddr {
 		panic("position should be owned by admin")
 	}
@@ -277,6 +277,14 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 	default:
 		panic("unsupported positionId type")
 	}
+}
+
+func mustOwnerOf(tid grc721.TokenID) address {
+	owner, err := gnft.OwnerOf(tid)
+	if err != nil {
+		panic(err.Error())
+	}
+	return owner
 }
 
 // Output:

--- a/contract/r/scenario/upgrade/full_lifecycle_v2_valid_upgrade_filetest.gno
+++ b/contract/r/scenario/upgrade/full_lifecycle_v2_valid_upgrade_filetest.gno
@@ -865,22 +865,50 @@ func stakerSetup(cur realm) {
 	staker.CreateExternalIncentive(cross(cur), barFoo500PoolPath, gnsPath, incentiveReward, startTime, endTime)
 	testing.SkipHeights(1)
 
+	incentiveRewardToken, err := staker.GetIncentiveRewardToken(barFoo500PoolPath, externalIncentiveId)
+	if err != nil {
+		panic(err)
+	}
+	incentiveTotalReward, err := staker.GetIncentiveTotalRewardAmount(barFoo500PoolPath, externalIncentiveId)
+	if err != nil {
+		panic(err)
+	}
+	incentiveCreator, err := staker.GetIncentiveCreator(barFoo500PoolPath, externalIncentiveId)
+	if err != nil {
+		panic(err)
+	}
+	incentiveDepositGns, err := staker.GetIncentiveDepositGnsAmount(barFoo500PoolPath, externalIncentiveId)
+	if err != nil {
+		panic(err)
+	}
 	println("[EXPECTED] incentive id:", externalIncentiveId)
-	println("[EXPECTED] incentive reward token:", staker.GetIncentiveRewardToken(barFoo500PoolPath, externalIncentiveId))
-	println("[EXPECTED] incentive total reward:", staker.GetIncentiveTotalRewardAmount(barFoo500PoolPath, externalIncentiveId))
-	println("[EXPECTED] incentive creator:", staker.GetIncentiveCreator(barFoo500PoolPath, externalIncentiveId))
-	println("[EXPECTED] incentive deposit gns:", staker.GetIncentiveDepositGnsAmount(barFoo500PoolPath, externalIncentiveId))
+	println("[EXPECTED] incentive reward token:", incentiveRewardToken)
+	println("[EXPECTED] incentive total reward:", incentiveTotalReward)
+	println("[EXPECTED] incentive creator:", incentiveCreator)
+	println("[EXPECTED] incentive deposit gns:", incentiveDepositGns)
 
 	// stake position 1; staker takes NFT custody and becomes the position operator
 	gnft.Approve(cross(cur), stakerAddr, grc721.TokenID("1"))
 	lpTokenId := staker.StakeToken(cross(cur), 1, "")
 	testing.SkipHeights(1)
 
+	depositOwner, err := staker.GetDepositOwner(1)
+	if err != nil {
+		panic(err)
+	}
+	depositLiquidity, err := staker.GetDepositLiquidityAsString(1)
+	if err != nil {
+		panic(err)
+	}
+	depositTargetPool, err := staker.GetDepositTargetPoolPath(1)
+	if err != nil {
+		panic(err)
+	}
 	println("[EXPECTED] staked position 1 into:", lpTokenId)
 	println("[EXPECTED] is staked:", staker.IsStaked(1))
-	println("[EXPECTED] deposit owner:", staker.GetDepositOwner(1))
-	println("[EXPECTED] deposit liquidity:", staker.GetDepositLiquidityAsString(1))
-	println("[EXPECTED] deposit target pool:", staker.GetDepositTargetPoolPath(1))
+	println("[EXPECTED] deposit owner:", depositOwner)
+	println("[EXPECTED] deposit liquidity:", depositLiquidity)
+	println("[EXPECTED] deposit target pool:", depositTargetPool)
 	// StakeToken routes position.SetPositionOperator (staker-only entry point)
 	// and records the staking caller as the position operator.
 	positionOperator, err := position.GetPositionOperator(1)
@@ -888,13 +916,17 @@ func stakerSetup(cur realm) {
 		panic(err)
 	}
 	println("[EXPECTED] position operator after stake is the staker caller:", positionOperator == adminAddr)
-	println("[EXPECTED] pool staked liquidity:", staker.GetPoolStakedLiquidity(barFoo500PoolPath))
+	poolStakedLiquidity, err := staker.GetPoolStakedLiquidity(barFoo500PoolPath)
+	if err != nil {
+		panic(err)
+	}
+	println("[EXPECTED] pool staked liquidity:", poolStakedLiquidity)
 
 	uassert.Equal(t, uint64(1), staker.GetPoolTier(barFoo500PoolPath))
 	uassert.True(t, staker.IsStaked(1))
-	uassert.Equal(t, adminAddr, staker.GetDepositOwner(1))
+	uassert.Equal(t, adminAddr, depositOwner)
 	uassert.Equal(t, adminAddr, positionOperator)
-	uassert.Equal(t, incentiveReward, staker.GetIncentiveTotalRewardAmount(barFoo500PoolPath, externalIncentiveId))
+	uassert.Equal(t, incentiveReward, incentiveTotalReward)
 }
 
 func accumulateAndCollectStakingReward(cur realm) {
@@ -902,8 +934,14 @@ func accumulateAndCollectStakingReward(cur realm) {
 	// amount reflects two different warm-up ratios.
 	testing.SkipHeights(10 * secondsPerDay / blockTimeSeconds)
 
-	collectableEmission := staker.CollectableEmissionReward(1)
-	collectableExternal := staker.CollectableExternalIncentiveReward(1, externalIncentiveId)
+	collectableEmission, err := staker.CollectableEmissionReward(1)
+	if err != nil {
+		panic(err)
+	}
+	collectableExternal, err := staker.CollectableExternalIncentiveReward(1, externalIncentiveId)
+	if err != nil {
+		panic(err)
+	}
 	println("[EXPECTED] collectable emission reward:", collectableEmission)
 	println("[EXPECTED] collectable external reward:", collectableExternal)
 
@@ -918,7 +956,11 @@ func accumulateAndCollectStakingReward(cur realm) {
 	for tokenPath, amount := range externalPenalty {
 		println("[EXPECTED] external reward penalty:", tokenPath, amount)
 	}
-	println("[EXPECTED] collected internal reward total:", staker.GetDepositCollectedInternalReward(1))
+	collectedInternalReward, err := staker.GetDepositCollectedInternalReward(1)
+	if err != nil {
+		panic(err)
+	}
+	println("[EXPECTED] collected internal reward total:", collectedInternalReward)
 	println("[EXPECTED] total emission sent:", staker.GetTotalEmissionSent())
 
 	toUser, _ := strconv.ParseInt(rewardToUser, 10, 64)
@@ -927,7 +969,7 @@ func accumulateAndCollectStakingReward(cur realm) {
 	uassert.True(t, penalty > 0)
 	// the collected-reward ledger also accounts for the penalty share and for
 	// the block mined between the getter read and the collect transaction
-	uassert.True(t, staker.GetDepositCollectedInternalReward(1) >= toUser)
+	uassert.True(t, collectedInternalReward >= toUser)
 }
 
 // ---------------------------------------------------------------------------
@@ -1284,6 +1326,46 @@ func captureSnapshot() upgradeSnapshot {
 	if err != nil {
 		panic(err)
 	}
+	stakerPoolTierRatio, err := staker.GetPoolTierRatio(barFoo500PoolPath)
+	if err != nil {
+		panic(err)
+	}
+	depositLiquidity, err := staker.GetDepositLiquidityAsString(1)
+	if err != nil {
+		panic(err)
+	}
+	depositStakeTime, err := staker.GetDepositStakeTime(1)
+	if err != nil {
+		panic(err)
+	}
+	depositTickLower, err := staker.GetDepositTickLower(1)
+	if err != nil {
+		panic(err)
+	}
+	depositTickUpper, err := staker.GetDepositTickUpper(1)
+	if err != nil {
+		panic(err)
+	}
+	depositWarmups, err := staker.GetDepositWarmUp(1)
+	if err != nil {
+		panic(err)
+	}
+	depositCollected, err := staker.GetDepositCollectedInternalReward(1)
+	if err != nil {
+		panic(err)
+	}
+	incentiveTotal, err := staker.GetIncentiveTotalRewardAmount(barFoo500PoolPath, externalIncentiveId)
+	if err != nil {
+		panic(err)
+	}
+	incentiveDistributed, err := staker.GetIncentiveDistributedRewardAmount(barFoo500PoolPath, externalIncentiveId)
+	if err != nil {
+		panic(err)
+	}
+	incentiveRefunded, err := staker.GetIncentiveRefunded(barFoo500PoolPath, externalIncentiveId)
+	if err != nil {
+		panic(err)
+	}
 	paramStatus, _ := govGovernance.GetProposalStatusByProposalId(paramProposalId)
 	spendStatus, _ := govGovernance.GetProposalStatusByProposalId(spendProposalId)
 	textStatus, _ := govGovernance.GetProposalStatusByProposalId(textProposalId)
@@ -1321,22 +1403,22 @@ func captureSnapshot() upgradeSnapshot {
 		positionBurned:     positionBurned,
 		positionInRange:    positionInRange,
 		stakerPoolTier:     staker.GetPoolTier(barFoo500PoolPath),
-		stakerPoolTierRat:  staker.GetPoolTierRatio(barFoo500PoolPath),
+		stakerPoolTierRat:  stakerPoolTierRatio,
 		stakerUnstakingFee: staker.GetUnstakingFee(),
 		stakerDepositGns:   staker.GetDepositGnsAmount(),
 		stakerAllowedToken: len(staker.GetAllowedTokens()),
 		stakerAllowedList:  staker.GetAllowedTokens(),
-		depositLiquidity:   staker.GetDepositLiquidityAsString(1),
-		depositStakeTime:   staker.GetDepositStakeTime(1),
-		depositTickLower:   staker.GetDepositTickLower(1),
-		depositTickUpper:   staker.GetDepositTickUpper(1),
-		depositWarmupCount: len(staker.GetDepositWarmUp(1)),
-		depositWarmups:     staker.GetDepositWarmUp(1),
-		depositCollected:   staker.GetDepositCollectedInternalReward(1),
+		depositLiquidity:   depositLiquidity,
+		depositStakeTime:   depositStakeTime,
+		depositTickLower:   depositTickLower,
+		depositTickUpper:   depositTickUpper,
+		depositWarmupCount: len(depositWarmups),
+		depositWarmups:     depositWarmups,
+		depositCollected:   depositCollected,
 		totalEmissionSent:  staker.GetTotalEmissionSent(),
-		incentiveTotal:     staker.GetIncentiveTotalRewardAmount(barFoo500PoolPath, externalIncentiveId),
-		incentiveDistrib:   staker.GetIncentiveDistributedRewardAmount(barFoo500PoolPath, externalIncentiveId),
-		incentiveRefunded:  staker.GetIncentiveRefunded(barFoo500PoolPath, externalIncentiveId),
+		incentiveTotal:     incentiveTotal,
+		incentiveDistrib:   incentiveDistributed,
+		incentiveRefunded:  incentiveRefunded,
 		devOpsPct:          protocolFee.GetDevOpsPct(),
 		govStakerPct:       protocolFee.GetGovStakerPct(),
 		accuGovStakerBar:   protocolFee.GetAccuTransferToGovStakerByTokenPath(barPath),
@@ -1611,8 +1693,16 @@ func windDown(cur realm) {
 	testing.SetRealm(adminRealm)
 	staker.EndExternalIncentive(cross(cur), barFoo500PoolPath, externalIncentiveId, adminAddr)
 	testing.SkipHeights(1)
-	println("[EXPECTED] incentive refunded:", staker.GetIncentiveRefunded(barFoo500PoolPath, externalIncentiveId))
-	println("[EXPECTED] incentive distributed:", staker.GetIncentiveDistributedRewardAmount(barFoo500PoolPath, externalIncentiveId))
+	incentiveRefunded, err := staker.GetIncentiveRefunded(barFoo500PoolPath, externalIncentiveId)
+	if err != nil {
+		panic(err)
+	}
+	incentiveDistributed, err := staker.GetIncentiveDistributedRewardAmount(barFoo500PoolPath, externalIncentiveId)
+	if err != nil {
+		panic(err)
+	}
+	println("[EXPECTED] incentive refunded:", incentiveRefunded)
+	println("[EXPECTED] incentive distributed:", incentiveDistributed)
 
 	penalty := staker.CollectExternalIncentivePenalty(cross(cur), barFoo500PoolPath, externalIncentiveId, adminAddr)
 	testing.SkipHeights(1)
@@ -1691,15 +1781,35 @@ func finalInvariants(cur realm) {
 	// external incentive ledger: the amount handed out (rewards + the refund
 	// booked at EndExternalIncentive) can never exceed the funded total, and
 	// the incentive must be marked refunded once it has been ended.
-	total := staker.GetIncentiveTotalRewardAmount(barFoo500PoolPath, externalIncentiveId)
-	distributed := staker.GetIncentiveDistributedRewardAmount(barFoo500PoolPath, externalIncentiveId)
-	remaining := staker.GetIncentiveRemainingRewardAmount(barFoo500PoolPath, externalIncentiveId)
-	penalty := staker.GetIncentiveAccumulatedPenaltyAmount(barFoo500PoolPath, externalIncentiveId)
+	total, err := staker.GetIncentiveTotalRewardAmount(barFoo500PoolPath, externalIncentiveId)
+	if err != nil {
+		panic(err)
+	}
+	distributed, err := staker.GetIncentiveDistributedRewardAmount(barFoo500PoolPath, externalIncentiveId)
+	if err != nil {
+		panic(err)
+	}
+	remaining, err := staker.GetIncentiveRemainingRewardAmount(barFoo500PoolPath, externalIncentiveId)
+	if err != nil {
+		panic(err)
+	}
+	penalty, err := staker.GetIncentiveAccumulatedPenaltyAmount(barFoo500PoolPath, externalIncentiveId)
+	if err != nil {
+		panic(err)
+	}
+	incentiveRefunded, err := staker.GetIncentiveRefunded(barFoo500PoolPath, externalIncentiveId)
+	if err != nil {
+		panic(err)
+	}
+	incentiveActive, err := staker.IsIncentiveActive(barFoo500PoolPath, externalIncentiveId)
+	if err != nil {
+		panic(err)
+	}
 	println("[EXPECTED] incentive total/distributed/remaining/penalty:", total, distributed, remaining, penalty)
 	uassert.True(t, distributed > 0)
 	uassert.True(t, distributed <= total)
-	uassert.True(t, staker.GetIncentiveRefunded(barFoo500PoolPath, externalIncentiveId))
-	uassert.False(t, staker.IsIncentiveActive(barFoo500PoolPath, externalIncentiveId))
+	uassert.True(t, incentiveRefunded)
+	uassert.False(t, incentiveActive)
 
 	printImplementations()
 }

--- a/contract/r/scenario/upgrade/implements/mock/staker/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/mock/staker/test_impl.gno
@@ -76,7 +76,10 @@ func (t *TestStaker) SetPoolTier(_ int, rlm realm, poolPath string, tier uint64)
 func (t *TestStaker) ChangePoolTier(_ int, rlm realm, poolPath string, tier uint64) {
 	t.ExecuteFn(
 		"ChangePoolTier",
-		func(args ...any) any { t.instance.ChangePoolTier(0, rlm, args[0].(string), args[1].(uint64)); return nil },
+		func(args ...any) any {
+			t.instance.ChangePoolTier(0, rlm, args[0].(string), args[1].(uint64))
+			return nil
+		},
 		poolPath, tier,
 	)
 }
@@ -178,436 +181,204 @@ func (t *TestStaker) SetUnStakingFee(_ int, rlm realm, fee uint64) {
 }
 
 // IStakerGetter interface
-func (t *TestStaker) GetPool(poolPath string) *staker.Pool {
-	return t.ExecuteFn(
-		"GetPool",
-		func(args ...any) any { return t.instance.GetPool(args[0].(string)) },
-		poolPath,
-	).(*staker.Pool)
+func (t *TestStaker) GetPool(poolPath string) (*staker.Pool, error) {
+	return t.instance.GetPool(poolPath)
 }
 
-func (t *TestStaker) GetDeposit(lpTokenId uint64) *staker.Deposit {
-	return t.ExecuteFn(
-		"GetDeposit",
-		func(args ...any) any { return t.instance.GetDeposit(args[0].(uint64)) },
-		lpTokenId,
-	).(*staker.Deposit)
+func (t *TestStaker) GetDeposit(lpTokenId uint64) (*staker.Deposit, error) {
+	return t.instance.GetDeposit(lpTokenId)
 }
 
-func (t *TestStaker) CollectableEmissionReward(positionId uint64) int64 {
-	return t.ExecuteFn(
-		"CollectableEmissionReward",
-		func(args ...any) any { return t.instance.CollectableEmissionReward(args[0].(uint64)) },
-		positionId,
-	).(int64)
+func (t *TestStaker) CollectableEmissionReward(positionId uint64) (int64, error) {
+	return t.instance.CollectableEmissionReward(positionId)
 }
 
-func (t *TestStaker) CollectableExternalIncentiveReward(positionId uint64, incentiveId string) int64 {
-	return t.ExecuteFn(
-		"CollectableExternalIncentiveReward",
-		func(args ...any) any {
-			return t.instance.CollectableExternalIncentiveReward(args[0].(uint64), args[1].(string))
-		},
-		positionId, incentiveId,
-	).(int64)
+func (t *TestStaker) CollectableExternalIncentiveReward(positionId uint64, incentiveId string) (int64, error) {
+	return t.instance.CollectableExternalIncentiveReward(positionId, incentiveId)
 }
 
-func (t *TestStaker) GetCreatedHeightOfIncentive(poolPath string, incentiveId string) int64 {
-	return t.ExecuteFn(
-		"GetCreatedHeightOfIncentive",
-		func(args ...any) any {
-			return t.instance.GetCreatedHeightOfIncentive(args[0].(string), args[1].(string))
-		},
-		poolPath, incentiveId,
-	).(int64)
+func (t *TestStaker) GetCreatedHeightOfIncentive(poolPath string, incentiveId string) (int64, error) {
+	return t.instance.GetCreatedHeightOfIncentive(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveCreatedTimestamp(poolPath string, incentiveId string) int64 {
-	return t.ExecuteFn(
-		"GetIncentiveCreatedTimestamp",
-		func(args ...any) any {
-			return t.instance.GetIncentiveCreatedTimestamp(args[0].(string), args[1].(string))
-		},
-		poolPath, incentiveId,
-	).(int64)
+func (t *TestStaker) GetIncentiveCreatedTimestamp(poolPath string, incentiveId string) (int64, error) {
+	return t.instance.GetIncentiveCreatedTimestamp(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveTotalRewardAmount(poolPath string, incentiveId string) int64 {
-	return t.ExecuteFn(
-		"GetIncentiveTotalRewardAmount",
-		func(args ...any) any {
-			return t.instance.GetIncentiveTotalRewardAmount(args[0].(string), args[1].(string))
-		},
-		poolPath, incentiveId,
-	).(int64)
+func (t *TestStaker) GetIncentiveTotalRewardAmount(poolPath string, incentiveId string) (int64, error) {
+	return t.instance.GetIncentiveTotalRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveDistributedRewardAmount(poolPath string, incentiveId string) int64 {
-	return t.ExecuteFn(
-		"GetIncentiveDistributedRewardAmount",
-		func(args ...any) any {
-			return t.instance.GetIncentiveDistributedRewardAmount(args[0].(string), args[1].(string))
-		},
-		poolPath, incentiveId,
-	).(int64)
+func (t *TestStaker) GetIncentiveDistributedRewardAmount(poolPath string, incentiveId string) (int64, error) {
+	return t.instance.GetIncentiveDistributedRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) int64 {
-	return t.ExecuteFn(
-		"GetIncentiveRemainingRewardAmount",
-		func(args ...any) any {
-			return t.instance.GetIncentiveRemainingRewardAmount(args[0].(string), args[1].(string))
-		},
-		poolPath, incentiveId,
-	).(int64)
+func (t *TestStaker) GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) (int64, error) {
+	return t.instance.GetIncentiveRemainingRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) int64 {
-	return t.ExecuteFn(
-		"GetIncentiveAccumulatedPenaltyAmount",
-		func(args ...any) any {
-			return t.instance.GetIncentiveAccumulatedPenaltyAmount(args[0].(string), args[1].(string))
-		},
-		poolPath, incentiveId,
-	).(int64)
+func (t *TestStaker) GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) (int64, error) {
+	return t.instance.GetIncentiveAccumulatedPenaltyAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) int64 {
-	return t.ExecuteFn(
-		"GetIncentiveDepositGnsAmount",
-		func(args ...any) any {
-			return t.instance.GetIncentiveDepositGnsAmount(args[0].(string), args[1].(string))
-		},
-		poolPath, incentiveId,
-	).(int64)
+func (t *TestStaker) GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) (int64, error) {
+	return t.instance.GetIncentiveDepositGnsAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRefunded(poolPath string, incentiveId string) bool {
-	return t.ExecuteFn(
-		"GetIncentiveRefunded",
-		func(args ...any) any {
-			return t.instance.GetIncentiveRefunded(args[0].(string), args[1].(string))
-		},
-		poolPath, incentiveId,
-	).(bool)
+func (t *TestStaker) GetIncentiveRefunded(poolPath string, incentiveId string) (bool, error) {
+	return t.instance.GetIncentiveRefunded(poolPath, incentiveId)
 }
 
-func (t *TestStaker) IsIncentiveActive(poolPath string, incentiveId string) bool {
-	return t.ExecuteFn(
-		"IsIncentiveActive",
-		func(args ...any) any {
-			return t.instance.IsIncentiveActive(args[0].(string), args[1].(string))
-		},
-		poolPath, incentiveId,
-	).(bool)
+func (t *TestStaker) IsIncentiveActive(poolPath string, incentiveId string) (bool, error) {
+	return t.instance.IsIncentiveActive(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetDepositExternalRewardLastCollectTimestamp(lpTokenId uint64, incentiveId string) int64 {
-	return t.ExecuteFn(
-		"GetDepositExternalRewardLastCollectTimestamp",
-		func(args ...any) any {
-			return t.instance.GetDepositExternalRewardLastCollectTimestamp(args[0].(uint64), args[1].(string))
-		},
-		lpTokenId, incentiveId,
-	).(int64)
+func (t *TestStaker) GetDepositExternalRewardLastCollectTimestamp(lpTokenId uint64, incentiveId string) (int64, error) {
+	return t.instance.GetDepositExternalRewardLastCollectTimestamp(lpTokenId, incentiveId)
 }
 
 func (t *TestStaker) GetDepositGnsAmount() int64 {
-	return t.ExecuteFn(
-		"GetDepositGnsAmount",
-		func(args ...any) any { return t.instance.GetDepositGnsAmount() },
-	).(int64)
+	return t.instance.GetDepositGnsAmount()
 }
 
-func (t *TestStaker) GetDepositInternalRewardLastCollectTimestamp(lpTokenId uint64) int64 {
-	return t.ExecuteFn(
-		"GetDepositInternalRewardLastCollectTimestamp",
-		func(args ...any) any {
-			return t.instance.GetDepositInternalRewardLastCollectTimestamp(args[0].(uint64))
-		},
-		lpTokenId,
-	).(int64)
+func (t *TestStaker) GetDepositInternalRewardLastCollectTimestamp(lpTokenId uint64) (int64, error) {
+	return t.instance.GetDepositInternalRewardLastCollectTimestamp(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositCollectedInternalReward(lpTokenId uint64) int64 {
-	return t.ExecuteFn(
-		"GetDepositCollectedInternalReward",
-		func(args ...any) any { return t.instance.GetDepositCollectedInternalReward(args[0].(uint64)) },
-		lpTokenId,
-	).(int64)
+func (t *TestStaker) GetDepositCollectedInternalReward(lpTokenId uint64) (int64, error) {
+	return t.instance.GetDepositCollectedInternalReward(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositCollectedExternalReward(lpTokenId uint64, incentiveId string) int64 {
-	return t.ExecuteFn(
-		"GetDepositCollectedExternalReward",
-		func(args ...any) any {
-			return t.instance.GetDepositCollectedExternalReward(args[0].(uint64), args[1].(string))
-		},
-		lpTokenId, incentiveId,
-	).(int64)
+func (t *TestStaker) GetDepositCollectedExternalReward(lpTokenId uint64, incentiveId string) (int64, error) {
+	return t.instance.GetDepositCollectedExternalReward(lpTokenId, incentiveId)
 }
 
-func (t *TestStaker) GetDepositLiquidity(lpTokenId uint64) *u256.Uint {
-	return t.ExecuteFn(
-		"GetDepositLiquidity",
-		func(args ...any) any { return t.instance.GetDepositLiquidity(args[0].(uint64)) },
-		lpTokenId,
-	).(*u256.Uint)
+func (t *TestStaker) GetDepositLiquidity(lpTokenId uint64) (*u256.Uint, error) {
+	return t.instance.GetDepositLiquidity(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositLiquidityAsString(lpTokenId uint64) string {
-	return t.ExecuteFn(
-		"GetDepositLiquidityAsString",
-		func(args ...any) any { return t.instance.GetDepositLiquidityAsString(args[0].(uint64)) },
-		lpTokenId,
-	).(string)
+func (t *TestStaker) GetDepositLiquidityAsString(lpTokenId uint64) (string, error) {
+	return t.instance.GetDepositLiquidityAsString(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositOwner(lpTokenId uint64) address {
-	return t.ExecuteFn(
-		"GetDepositOwner",
-		func(args ...any) any { return t.instance.GetDepositOwner(args[0].(uint64)) },
-		lpTokenId,
-	).(address)
+func (t *TestStaker) GetDepositOwner(lpTokenId uint64) (address, error) {
+	return t.instance.GetDepositOwner(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositStakeTime(lpTokenId uint64) int64 {
-	return t.ExecuteFn(
-		"GetDepositStakeTime",
-		func(args ...any) any { return t.instance.GetDepositStakeTime(args[0].(uint64)) },
-		lpTokenId,
-	).(int64)
+func (t *TestStaker) GetDepositStakeTime(lpTokenId uint64) (int64, error) {
+	return t.instance.GetDepositStakeTime(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositTargetPoolPath(lpTokenId uint64) string {
-	return t.ExecuteFn(
-		"GetDepositTargetPoolPath",
-		func(args ...any) any { return t.instance.GetDepositTargetPoolPath(args[0].(uint64)) },
-		lpTokenId,
-	).(string)
+func (t *TestStaker) GetDepositTargetPoolPath(lpTokenId uint64) (string, error) {
+	return t.instance.GetDepositTargetPoolPath(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositTickLower(lpTokenId uint64) int32 {
-	return t.ExecuteFn(
-		"GetDepositTickLower",
-		func(args ...any) any { return t.instance.GetDepositTickLower(args[0].(uint64)) },
-		lpTokenId,
-	).(int32)
+func (t *TestStaker) GetDepositTickLower(lpTokenId uint64) (int32, error) {
+	return t.instance.GetDepositTickLower(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositTickUpper(lpTokenId uint64) int32 {
-	return t.ExecuteFn(
-		"GetDepositTickUpper",
-		func(args ...any) any { return t.instance.GetDepositTickUpper(args[0].(uint64)) },
-		lpTokenId,
-	).(int32)
+func (t *TestStaker) GetDepositTickUpper(lpTokenId uint64) (int32, error) {
+	return t.instance.GetDepositTickUpper(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositWarmUp(lpTokenId uint64) []staker.Warmup {
-	return t.ExecuteFn(
-		"GetDepositWarmUp",
-		func(args ...any) any { return t.instance.GetDepositWarmUp(args[0].(uint64)) },
-		lpTokenId,
-	).([]staker.Warmup)
+func (t *TestStaker) GetDepositWarmUp(lpTokenId uint64) ([]staker.Warmup, error) {
+	return t.instance.GetDepositWarmUp(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositExternalIncentiveIdList(lpTokenId uint64) []string {
-	return t.ExecuteFn(
-		"GetDepositExternalIncentiveIdList",
-		func(args ...any) any { return t.instance.GetDepositExternalIncentiveIdList(args[0].(uint64)) },
-		lpTokenId,
-	).([]string)
+func (t *TestStaker) GetDepositExternalIncentiveIdList(lpTokenId uint64) ([]string, error) {
+	return t.instance.GetDepositExternalIncentiveIdList(lpTokenId)
 }
 
-func (t *TestStaker) GetExternalIncentiveByPoolPath(poolPath string) []staker.ExternalIncentive {
-	return t.ExecuteFn(
-		"GetExternalIncentiveByPoolPath",
-		func(args ...any) any { return t.instance.GetExternalIncentiveByPoolPath(args[0].(string)) },
-		poolPath,
-	).([]staker.ExternalIncentive)
+func (t *TestStaker) GetExternalIncentiveByPoolPath(poolPath string) ([]staker.ExternalIncentive, error) {
+	return t.instance.GetExternalIncentiveByPoolPath(poolPath)
 }
 
-func (t *TestStaker) GetIncentiveEndTimestamp(poolPath string, incentiveId string) int64 {
-	return t.ExecuteFn(
-		"GetIncentiveEndTimestamp",
-		func(args ...any) any { return t.instance.GetIncentiveEndTimestamp(args[0].(string), args[1].(string)) },
-		poolPath, incentiveId,
-	).(int64)
+func (t *TestStaker) GetIncentiveEndTimestamp(poolPath string, incentiveId string) (int64, error) {
+	return t.instance.GetIncentiveEndTimestamp(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveCreator(poolPath string, incentiveId string) address {
-	return t.ExecuteFn(
-		"GetIncentiveCreator",
-		func(args ...any) any { return t.instance.GetIncentiveCreator(args[0].(string), args[1].(string)) },
-		poolPath, incentiveId,
-	).(address)
+func (t *TestStaker) GetIncentiveCreator(poolPath string, incentiveId string) (address, error) {
+	return t.instance.GetIncentiveCreator(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardAmount(poolPath string, incentiveId string) *u256.Uint {
-	return t.ExecuteFn(
-		"GetIncentiveRewardAmount",
-		func(args ...any) any { return t.instance.GetIncentiveRewardAmount(args[0].(string), args[1].(string)) },
-		poolPath, incentiveId,
-	).(*u256.Uint)
+func (t *TestStaker) GetIncentiveRewardAmount(poolPath string, incentiveId string) (*u256.Uint, error) {
+	return t.instance.GetIncentiveRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) string {
-	return t.ExecuteFn(
-		"GetIncentiveRewardAmountAsString",
-		func(args ...any) any {
-			return t.instance.GetIncentiveRewardAmountAsString(args[0].(string), args[1].(string))
-		},
-		poolPath, incentiveId,
-	).(string)
+func (t *TestStaker) GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) (string, error) {
+	return t.instance.GetIncentiveRewardAmountAsString(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) *u256.Uint {
-	return t.ExecuteFn(
-		"GetIncentiveRewardPerSecondX128",
-		func(args ...any) any {
-			return t.instance.GetIncentiveRewardPerSecondX128(args[0].(string), args[1].(string))
-		},
-		poolPath, incentiveId,
-	).(*u256.Uint)
+func (t *TestStaker) GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) (*u256.Uint, error) {
+	return t.instance.GetIncentiveRewardPerSecondX128(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardToken(poolPath string, incentiveId string) string {
-	return t.ExecuteFn(
-		"GetIncentiveRewardToken",
-		func(args ...any) any { return t.instance.GetIncentiveRewardToken(args[0].(string), args[1].(string)) },
-		poolPath, incentiveId,
-	).(string)
+func (t *TestStaker) GetIncentiveRewardToken(poolPath string, incentiveId string) (string, error) {
+	return t.instance.GetIncentiveRewardToken(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveStartTimestamp(poolPath string, incentiveId string) int64 {
-	return t.ExecuteFn(
-		"GetIncentiveStartTimestamp",
-		func(args ...any) any {
-			return t.instance.GetIncentiveStartTimestamp(args[0].(string), args[1].(string))
-		},
-		poolPath, incentiveId,
-	).(int64)
+func (t *TestStaker) GetIncentiveStartTimestamp(poolPath string, incentiveId string) (int64, error) {
+	return t.instance.GetIncentiveStartTimestamp(poolPath, incentiveId)
 }
 
 func (t *TestStaker) GetMinimumRewardAmount() int64 {
-	return t.ExecuteFn(
-		"GetMinimumRewardAmount",
-		func(args ...any) any { return t.instance.GetMinimumRewardAmount() },
-	).(int64)
+	return t.instance.GetMinimumRewardAmount()
 }
 
 func (t *TestStaker) GetMinimumRewardAmountForToken(tokenPath string) int64 {
-	return t.ExecuteFn(
-		"GetMinimumRewardAmountForToken",
-		func(args ...any) any { return t.instance.GetMinimumRewardAmountForToken(args[0].(string)) },
-		tokenPath,
-	).(int64)
+	return t.instance.GetMinimumRewardAmountForToken(tokenPath)
 }
 
-func (t *TestStaker) GetPoolStakedLiquidity(poolPath string) string {
-	return t.ExecuteFn(
-		"GetPoolStakedLiquidity",
-		func(args ...any) any { return t.instance.GetPoolStakedLiquidity(args[0].(string)) },
-		poolPath,
-	).(string)
+func (t *TestStaker) GetPoolStakedLiquidity(poolPath string) (string, error) {
+	return t.instance.GetPoolStakedLiquidity(poolPath)
 }
 
-func (t *TestStaker) GetPoolsByTier(tier uint64) []string {
-	return t.ExecuteFn(
-		"GetPoolsByTier",
-		func(args ...any) any { return t.instance.GetPoolsByTier(args[0].(uint64)) },
-		tier,
-	).([]string)
+func (t *TestStaker) GetPoolsByTier(tier uint64) ([]string, error) {
+	return t.instance.GetPoolsByTier(tier)
 }
 
-func (t *TestStaker) GetPoolReward(tier uint64) int64 {
-	return t.ExecuteFn(
-		"GetPoolReward",
-		func(args ...any) any { return t.instance.GetPoolReward(args[0].(uint64)) },
-		tier,
-	).(int64)
+func (t *TestStaker) GetPoolReward(tier uint64) (int64, error) {
+	return t.instance.GetPoolReward(tier)
 }
 
 func (t *TestStaker) GetPoolTier(poolPath string) uint64 {
-	return t.ExecuteFn(
-		"GetPoolTier",
-		func(args ...any) any { return t.instance.GetPoolTier(args[0].(string)) },
-		poolPath,
-	).(uint64)
+	return t.instance.GetPoolTier(poolPath)
 }
 
 func (t *TestStaker) GetPoolTierCount(tier uint64) uint64 {
-	return t.ExecuteFn(
-		"GetPoolTierCount",
-		func(args ...any) any { return t.instance.GetPoolTierCount(args[0].(uint64)) },
-		tier,
-	).(uint64)
+	return t.instance.GetPoolTierCount(tier)
 }
 
-func (t *TestStaker) GetPoolTierRatio(poolPath string) uint64 {
-	return t.ExecuteFn(
-		"GetPoolTierRatio",
-		func(args ...any) any { return t.instance.GetPoolTierRatio(args[0].(string)) },
-		poolPath,
-	).(uint64)
+func (t *TestStaker) GetPoolTierRatio(poolPath string) (uint64, error) {
+	return t.instance.GetPoolTierRatio(poolPath)
 }
 
 func (t *TestStaker) GetSpecificTokenMinimumRewardAmount(tokenPath string) (int64, bool) {
-	result := t.ExecuteFn(
-		"GetSpecificTokenMinimumRewardAmount",
-		func(args ...any) any {
-			r1, r2 := t.instance.GetSpecificTokenMinimumRewardAmount(args[0].(string))
-			return []any{r1, r2}
-		},
-		tokenPath,
-	).([]any)
-	return result[0].(int64), result[1].(bool)
+	return t.instance.GetSpecificTokenMinimumRewardAmount(tokenPath)
 }
 
-func (t *TestStaker) GetTargetPoolPathByIncentiveId(poolPath string, incentiveId string) string {
-	return t.ExecuteFn(
-		"GetTargetPoolPathByIncentiveId",
-		func(args ...any) any {
-			return t.instance.GetTargetPoolPathByIncentiveId(args[0].(string), args[1].(string))
-		},
-		poolPath, incentiveId,
-	).(string)
+func (t *TestStaker) GetTargetPoolPathByIncentiveId(poolPath string, incentiveId string) (string, error) {
+	return t.instance.GetTargetPoolPathByIncentiveId(poolPath, incentiveId)
 }
 
 func (t *TestStaker) GetUnstakingFee() uint64 {
-	return t.ExecuteFn(
-		"GetUnstakingFee",
-		func(args ...any) any { return t.instance.GetUnstakingFee() },
-	).(uint64)
+	return t.instance.GetUnstakingFee()
 }
 
 func (t *TestStaker) IsStaked(positionId uint64) bool {
-	return t.ExecuteFn(
-		"IsStaked",
-		func(args ...any) any { return t.instance.IsStaked(args[0].(uint64)) },
-		positionId,
-	).(bool)
+	return t.instance.IsStaked(positionId)
 }
 
 func (t *TestStaker) GetTotalEmissionSent() int64 {
-	return t.ExecuteFn(
-		"GetTotalEmissionSent",
-		func(args ...any) any { return t.instance.GetTotalEmissionSent() },
-	).(int64)
+	return t.instance.GetTotalEmissionSent()
 }
 
 func (t *TestStaker) GetAllowedTokens() []string {
-	return t.ExecuteFn(
-		"GetAllowedTokens",
-		func(args ...any) any { return t.instance.GetAllowedTokens() },
-	).([]string)
+	return t.instance.GetAllowedTokens()
 }
 
 func (t *TestStaker) GetWarmupTemplate() []staker.Warmup {
-	return t.ExecuteFn(
-		"GetWarmupTemplate",
-		func(args ...any) any { return t.instance.GetWarmupTemplate() },
-	).([]staker.Warmup)
+	return t.instance.GetWarmupTemplate()
 }
 
 func (t *TestStaker) GetPoolRewardCaches(poolPath string) *rotree.ReadOnlyTree {

--- a/contract/r/scenario/upgrade/implements/mock/staker/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/mock/staker/test_impl.gno
@@ -192,436 +192,204 @@ func (t *TestStaker) SetUnStakingFee(_ int, rlm realm, fee uint64) {
 }
 
 // IStakerGetter interface
-func (t *TestStaker) GetPool(poolPath string) *staker.Pool {
-	return t.ExecuteFn(
-		"GetPool",
-		func(args ...any) any { return t.instance.GetPool(args[0].(string)) },
-		poolPath,
-	).(*staker.Pool)
+func (t *TestStaker) GetPool(poolPath string) (*staker.Pool, error) {
+	return t.instance.GetPool(poolPath)
 }
 
-func (t *TestStaker) GetDeposit(lpTokenId uint64) *staker.Deposit {
-	return t.ExecuteFn(
-		"GetDeposit",
-		func(args ...any) any { return t.instance.GetDeposit(args[0].(uint64)) },
-		lpTokenId,
-	).(*staker.Deposit)
+func (t *TestStaker) GetDeposit(lpTokenId uint64) (*staker.Deposit, error) {
+	return t.instance.GetDeposit(lpTokenId)
 }
 
-func (t *TestStaker) CollectableEmissionReward(positionId uint64) int64 {
-	return t.ExecuteFn(
-		"CollectableEmissionReward",
-		func(args ...any) any { return t.instance.CollectableEmissionReward(args[0].(uint64)) },
-		positionId,
-	).(int64)
+func (t *TestStaker) CollectableEmissionReward(positionId uint64) (int64, error) {
+	return t.instance.CollectableEmissionReward(positionId)
 }
 
-func (t *TestStaker) CollectableExternalIncentiveReward(positionId uint64, incentiveId string) int64 {
-	return t.ExecuteFn(
-		"CollectableExternalIncentiveReward",
-		func(args ...any) any {
-			return t.instance.CollectableExternalIncentiveReward(args[0].(uint64), args[1].(string))
-		},
-		positionId, incentiveId,
-	).(int64)
+func (t *TestStaker) CollectableExternalIncentiveReward(positionId uint64, incentiveId string) (int64, error) {
+	return t.instance.CollectableExternalIncentiveReward(positionId, incentiveId)
 }
 
-func (t *TestStaker) GetCreatedHeightOfIncentive(poolPath string, incentiveId string) int64 {
-	return t.ExecuteFn(
-		"GetCreatedHeightOfIncentive",
-		func(args ...any) any {
-			return t.instance.GetCreatedHeightOfIncentive(args[0].(string), args[1].(string))
-		},
-		poolPath, incentiveId,
-	).(int64)
+func (t *TestStaker) GetCreatedHeightOfIncentive(poolPath string, incentiveId string) (int64, error) {
+	return t.instance.GetCreatedHeightOfIncentive(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveCreatedTimestamp(poolPath string, incentiveId string) int64 {
-	return t.ExecuteFn(
-		"GetIncentiveCreatedTimestamp",
-		func(args ...any) any {
-			return t.instance.GetIncentiveCreatedTimestamp(args[0].(string), args[1].(string))
-		},
-		poolPath, incentiveId,
-	).(int64)
+func (t *TestStaker) GetIncentiveCreatedTimestamp(poolPath string, incentiveId string) (int64, error) {
+	return t.instance.GetIncentiveCreatedTimestamp(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveTotalRewardAmount(poolPath string, incentiveId string) int64 {
-	return t.ExecuteFn(
-		"GetIncentiveTotalRewardAmount",
-		func(args ...any) any {
-			return t.instance.GetIncentiveTotalRewardAmount(args[0].(string), args[1].(string))
-		},
-		poolPath, incentiveId,
-	).(int64)
+func (t *TestStaker) GetIncentiveTotalRewardAmount(poolPath string, incentiveId string) (int64, error) {
+	return t.instance.GetIncentiveTotalRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveDistributedRewardAmount(poolPath string, incentiveId string) int64 {
-	return t.ExecuteFn(
-		"GetIncentiveDistributedRewardAmount",
-		func(args ...any) any {
-			return t.instance.GetIncentiveDistributedRewardAmount(args[0].(string), args[1].(string))
-		},
-		poolPath, incentiveId,
-	).(int64)
+func (t *TestStaker) GetIncentiveDistributedRewardAmount(poolPath string, incentiveId string) (int64, error) {
+	return t.instance.GetIncentiveDistributedRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) int64 {
-	return t.ExecuteFn(
-		"GetIncentiveRemainingRewardAmount",
-		func(args ...any) any {
-			return t.instance.GetIncentiveRemainingRewardAmount(args[0].(string), args[1].(string))
-		},
-		poolPath, incentiveId,
-	).(int64)
+func (t *TestStaker) GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) (int64, error) {
+	return t.instance.GetIncentiveRemainingRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) int64 {
-	return t.ExecuteFn(
-		"GetIncentiveAccumulatedPenaltyAmount",
-		func(args ...any) any {
-			return t.instance.GetIncentiveAccumulatedPenaltyAmount(args[0].(string), args[1].(string))
-		},
-		poolPath, incentiveId,
-	).(int64)
+func (t *TestStaker) GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) (int64, error) {
+	return t.instance.GetIncentiveAccumulatedPenaltyAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) int64 {
-	return t.ExecuteFn(
-		"GetIncentiveDepositGnsAmount",
-		func(args ...any) any {
-			return t.instance.GetIncentiveDepositGnsAmount(args[0].(string), args[1].(string))
-		},
-		poolPath, incentiveId,
-	).(int64)
+func (t *TestStaker) GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) (int64, error) {
+	return t.instance.GetIncentiveDepositGnsAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRefunded(poolPath string, incentiveId string) bool {
-	return t.ExecuteFn(
-		"GetIncentiveRefunded",
-		func(args ...any) any {
-			return t.instance.GetIncentiveRefunded(args[0].(string), args[1].(string))
-		},
-		poolPath, incentiveId,
-	).(bool)
+func (t *TestStaker) GetIncentiveRefunded(poolPath string, incentiveId string) (bool, error) {
+	return t.instance.GetIncentiveRefunded(poolPath, incentiveId)
 }
 
-func (t *TestStaker) IsIncentiveActive(poolPath string, incentiveId string) bool {
-	return t.ExecuteFn(
-		"IsIncentiveActive",
-		func(args ...any) any {
-			return t.instance.IsIncentiveActive(args[0].(string), args[1].(string))
-		},
-		poolPath, incentiveId,
-	).(bool)
+func (t *TestStaker) IsIncentiveActive(poolPath string, incentiveId string) (bool, error) {
+	return t.instance.IsIncentiveActive(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetDepositExternalRewardLastCollectTimestamp(lpTokenId uint64, incentiveId string) int64 {
-	return t.ExecuteFn(
-		"GetDepositExternalRewardLastCollectTimestamp",
-		func(args ...any) any {
-			return t.instance.GetDepositExternalRewardLastCollectTimestamp(args[0].(uint64), args[1].(string))
-		},
-		lpTokenId, incentiveId,
-	).(int64)
+func (t *TestStaker) GetDepositExternalRewardLastCollectTimestamp(lpTokenId uint64, incentiveId string) (int64, error) {
+	return t.instance.GetDepositExternalRewardLastCollectTimestamp(lpTokenId, incentiveId)
 }
 
 func (t *TestStaker) GetDepositGnsAmount() int64 {
-	return t.ExecuteFn(
-		"GetDepositGnsAmount",
-		func(args ...any) any { return t.instance.GetDepositGnsAmount() },
-	).(int64)
+	return t.instance.GetDepositGnsAmount()
 }
 
-func (t *TestStaker) GetDepositInternalRewardLastCollectTimestamp(lpTokenId uint64) int64 {
-	return t.ExecuteFn(
-		"GetDepositInternalRewardLastCollectTimestamp",
-		func(args ...any) any {
-			return t.instance.GetDepositInternalRewardLastCollectTimestamp(args[0].(uint64))
-		},
-		lpTokenId,
-	).(int64)
+func (t *TestStaker) GetDepositInternalRewardLastCollectTimestamp(lpTokenId uint64) (int64, error) {
+	return t.instance.GetDepositInternalRewardLastCollectTimestamp(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositCollectedInternalReward(lpTokenId uint64) int64 {
-	return t.ExecuteFn(
-		"GetDepositCollectedInternalReward",
-		func(args ...any) any { return t.instance.GetDepositCollectedInternalReward(args[0].(uint64)) },
-		lpTokenId,
-	).(int64)
+func (t *TestStaker) GetDepositCollectedInternalReward(lpTokenId uint64) (int64, error) {
+	return t.instance.GetDepositCollectedInternalReward(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositCollectedExternalReward(lpTokenId uint64, incentiveId string) int64 {
-	return t.ExecuteFn(
-		"GetDepositCollectedExternalReward",
-		func(args ...any) any {
-			return t.instance.GetDepositCollectedExternalReward(args[0].(uint64), args[1].(string))
-		},
-		lpTokenId, incentiveId,
-	).(int64)
+func (t *TestStaker) GetDepositCollectedExternalReward(lpTokenId uint64, incentiveId string) (int64, error) {
+	return t.instance.GetDepositCollectedExternalReward(lpTokenId, incentiveId)
 }
 
-func (t *TestStaker) GetDepositLiquidity(lpTokenId uint64) *u256.Uint {
-	return t.ExecuteFn(
-		"GetDepositLiquidity",
-		func(args ...any) any { return t.instance.GetDepositLiquidity(args[0].(uint64)) },
-		lpTokenId,
-	).(*u256.Uint)
+func (t *TestStaker) GetDepositLiquidity(lpTokenId uint64) (*u256.Uint, error) {
+	return t.instance.GetDepositLiquidity(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositLiquidityAsString(lpTokenId uint64) string {
-	return t.ExecuteFn(
-		"GetDepositLiquidityAsString",
-		func(args ...any) any { return t.instance.GetDepositLiquidityAsString(args[0].(uint64)) },
-		lpTokenId,
-	).(string)
+func (t *TestStaker) GetDepositLiquidityAsString(lpTokenId uint64) (string, error) {
+	return t.instance.GetDepositLiquidityAsString(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositOwner(lpTokenId uint64) address {
-	return t.ExecuteFn(
-		"GetDepositOwner",
-		func(args ...any) any { return t.instance.GetDepositOwner(args[0].(uint64)) },
-		lpTokenId,
-	).(address)
+func (t *TestStaker) GetDepositOwner(lpTokenId uint64) (address, error) {
+	return t.instance.GetDepositOwner(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositStakeTime(lpTokenId uint64) int64 {
-	return t.ExecuteFn(
-		"GetDepositStakeTime",
-		func(args ...any) any { return t.instance.GetDepositStakeTime(args[0].(uint64)) },
-		lpTokenId,
-	).(int64)
+func (t *TestStaker) GetDepositStakeTime(lpTokenId uint64) (int64, error) {
+	return t.instance.GetDepositStakeTime(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositTargetPoolPath(lpTokenId uint64) string {
-	return t.ExecuteFn(
-		"GetDepositTargetPoolPath",
-		func(args ...any) any { return t.instance.GetDepositTargetPoolPath(args[0].(uint64)) },
-		lpTokenId,
-	).(string)
+func (t *TestStaker) GetDepositTargetPoolPath(lpTokenId uint64) (string, error) {
+	return t.instance.GetDepositTargetPoolPath(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositTickLower(lpTokenId uint64) int32 {
-	return t.ExecuteFn(
-		"GetDepositTickLower",
-		func(args ...any) any { return t.instance.GetDepositTickLower(args[0].(uint64)) },
-		lpTokenId,
-	).(int32)
+func (t *TestStaker) GetDepositTickLower(lpTokenId uint64) (int32, error) {
+	return t.instance.GetDepositTickLower(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositTickUpper(lpTokenId uint64) int32 {
-	return t.ExecuteFn(
-		"GetDepositTickUpper",
-		func(args ...any) any { return t.instance.GetDepositTickUpper(args[0].(uint64)) },
-		lpTokenId,
-	).(int32)
+func (t *TestStaker) GetDepositTickUpper(lpTokenId uint64) (int32, error) {
+	return t.instance.GetDepositTickUpper(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositWarmUp(lpTokenId uint64) []staker.Warmup {
-	return t.ExecuteFn(
-		"GetDepositWarmUp",
-		func(args ...any) any { return t.instance.GetDepositWarmUp(args[0].(uint64)) },
-		lpTokenId,
-	).([]staker.Warmup)
+func (t *TestStaker) GetDepositWarmUp(lpTokenId uint64) ([]staker.Warmup, error) {
+	return t.instance.GetDepositWarmUp(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositExternalIncentiveIdList(lpTokenId uint64) []string {
-	return t.ExecuteFn(
-		"GetDepositExternalIncentiveIdList",
-		func(args ...any) any { return t.instance.GetDepositExternalIncentiveIdList(args[0].(uint64)) },
-		lpTokenId,
-	).([]string)
+func (t *TestStaker) GetDepositExternalIncentiveIdList(lpTokenId uint64) ([]string, error) {
+	return t.instance.GetDepositExternalIncentiveIdList(lpTokenId)
 }
 
-func (t *TestStaker) GetExternalIncentiveByPoolPath(poolPath string) []staker.ExternalIncentive {
-	return t.ExecuteFn(
-		"GetExternalIncentiveByPoolPath",
-		func(args ...any) any { return t.instance.GetExternalIncentiveByPoolPath(args[0].(string)) },
-		poolPath,
-	).([]staker.ExternalIncentive)
+func (t *TestStaker) GetExternalIncentiveByPoolPath(poolPath string) ([]staker.ExternalIncentive, error) {
+	return t.instance.GetExternalIncentiveByPoolPath(poolPath)
 }
 
-func (t *TestStaker) GetIncentiveEndTimestamp(poolPath string, incentiveId string) int64 {
-	return t.ExecuteFn(
-		"GetIncentiveEndTimestamp",
-		func(args ...any) any { return t.instance.GetIncentiveEndTimestamp(args[0].(string), args[1].(string)) },
-		poolPath, incentiveId,
-	).(int64)
+func (t *TestStaker) GetIncentiveEndTimestamp(poolPath string, incentiveId string) (int64, error) {
+	return t.instance.GetIncentiveEndTimestamp(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveCreator(poolPath string, incentiveId string) address {
-	return t.ExecuteFn(
-		"GetIncentiveCreator",
-		func(args ...any) any { return t.instance.GetIncentiveCreator(args[0].(string), args[1].(string)) },
-		poolPath, incentiveId,
-	).(address)
+func (t *TestStaker) GetIncentiveCreator(poolPath string, incentiveId string) (address, error) {
+	return t.instance.GetIncentiveCreator(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardAmount(poolPath string, incentiveId string) *u256.Uint {
-	return t.ExecuteFn(
-		"GetIncentiveRewardAmount",
-		func(args ...any) any { return t.instance.GetIncentiveRewardAmount(args[0].(string), args[1].(string)) },
-		poolPath, incentiveId,
-	).(*u256.Uint)
+func (t *TestStaker) GetIncentiveRewardAmount(poolPath string, incentiveId string) (*u256.Uint, error) {
+	return t.instance.GetIncentiveRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) string {
-	return t.ExecuteFn(
-		"GetIncentiveRewardAmountAsString",
-		func(args ...any) any {
-			return t.instance.GetIncentiveRewardAmountAsString(args[0].(string), args[1].(string))
-		},
-		poolPath, incentiveId,
-	).(string)
+func (t *TestStaker) GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) (string, error) {
+	return t.instance.GetIncentiveRewardAmountAsString(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) *u256.Uint {
-	return t.ExecuteFn(
-		"GetIncentiveRewardPerSecondX128",
-		func(args ...any) any {
-			return t.instance.GetIncentiveRewardPerSecondX128(args[0].(string), args[1].(string))
-		},
-		poolPath, incentiveId,
-	).(*u256.Uint)
+func (t *TestStaker) GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) (*u256.Uint, error) {
+	return t.instance.GetIncentiveRewardPerSecondX128(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardToken(poolPath string, incentiveId string) string {
-	return t.ExecuteFn(
-		"GetIncentiveRewardToken",
-		func(args ...any) any { return t.instance.GetIncentiveRewardToken(args[0].(string), args[1].(string)) },
-		poolPath, incentiveId,
-	).(string)
+func (t *TestStaker) GetIncentiveRewardToken(poolPath string, incentiveId string) (string, error) {
+	return t.instance.GetIncentiveRewardToken(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveStartTimestamp(poolPath string, incentiveId string) int64 {
-	return t.ExecuteFn(
-		"GetIncentiveStartTimestamp",
-		func(args ...any) any {
-			return t.instance.GetIncentiveStartTimestamp(args[0].(string), args[1].(string))
-		},
-		poolPath, incentiveId,
-	).(int64)
+func (t *TestStaker) GetIncentiveStartTimestamp(poolPath string, incentiveId string) (int64, error) {
+	return t.instance.GetIncentiveStartTimestamp(poolPath, incentiveId)
 }
 
 func (t *TestStaker) GetMinimumRewardAmount() int64 {
-	return t.ExecuteFn(
-		"GetMinimumRewardAmount",
-		func(args ...any) any { return t.instance.GetMinimumRewardAmount() },
-	).(int64)
+	return t.instance.GetMinimumRewardAmount()
 }
 
 func (t *TestStaker) GetMinimumRewardAmountForToken(tokenPath string) int64 {
-	return t.ExecuteFn(
-		"GetMinimumRewardAmountForToken",
-		func(args ...any) any { return t.instance.GetMinimumRewardAmountForToken(args[0].(string)) },
-		tokenPath,
-	).(int64)
+	return t.instance.GetMinimumRewardAmountForToken(tokenPath)
 }
 
-func (t *TestStaker) GetPoolStakedLiquidity(poolPath string) string {
-	return t.ExecuteFn(
-		"GetPoolStakedLiquidity",
-		func(args ...any) any { return t.instance.GetPoolStakedLiquidity(args[0].(string)) },
-		poolPath,
-	).(string)
+func (t *TestStaker) GetPoolStakedLiquidity(poolPath string) (string, error) {
+	return t.instance.GetPoolStakedLiquidity(poolPath)
 }
 
-func (t *TestStaker) GetPoolsByTier(tier uint64) []string {
-	return t.ExecuteFn(
-		"GetPoolsByTier",
-		func(args ...any) any { return t.instance.GetPoolsByTier(args[0].(uint64)) },
-		tier,
-	).([]string)
+func (t *TestStaker) GetPoolsByTier(tier uint64) ([]string, error) {
+	return t.instance.GetPoolsByTier(tier)
 }
 
-func (t *TestStaker) GetPoolReward(tier uint64) int64 {
-	return t.ExecuteFn(
-		"GetPoolReward",
-		func(args ...any) any { return t.instance.GetPoolReward(args[0].(uint64)) },
-		tier,
-	).(int64)
+func (t *TestStaker) GetPoolReward(tier uint64) (int64, error) {
+	return t.instance.GetPoolReward(tier)
 }
 
 func (t *TestStaker) GetPoolTier(poolPath string) uint64 {
-	return t.ExecuteFn(
-		"GetPoolTier",
-		func(args ...any) any { return t.instance.GetPoolTier(args[0].(string)) },
-		poolPath,
-	).(uint64)
+	return t.instance.GetPoolTier(poolPath)
 }
 
 func (t *TestStaker) GetPoolTierCount(tier uint64) uint64 {
-	return t.ExecuteFn(
-		"GetPoolTierCount",
-		func(args ...any) any { return t.instance.GetPoolTierCount(args[0].(uint64)) },
-		tier,
-	).(uint64)
+	return t.instance.GetPoolTierCount(tier)
 }
 
-func (t *TestStaker) GetPoolTierRatio(poolPath string) uint64 {
-	return t.ExecuteFn(
-		"GetPoolTierRatio",
-		func(args ...any) any { return t.instance.GetPoolTierRatio(args[0].(string)) },
-		poolPath,
-	).(uint64)
+func (t *TestStaker) GetPoolTierRatio(poolPath string) (uint64, error) {
+	return t.instance.GetPoolTierRatio(poolPath)
 }
 
 func (t *TestStaker) GetSpecificTokenMinimumRewardAmount(tokenPath string) (int64, bool) {
-	result := t.ExecuteFn(
-		"GetSpecificTokenMinimumRewardAmount",
-		func(args ...any) any {
-			r1, r2 := t.instance.GetSpecificTokenMinimumRewardAmount(args[0].(string))
-			return []any{r1, r2}
-		},
-		tokenPath,
-	).([]any)
-	return result[0].(int64), result[1].(bool)
+	return t.instance.GetSpecificTokenMinimumRewardAmount(tokenPath)
 }
 
-func (t *TestStaker) GetTargetPoolPathByIncentiveId(poolPath string, incentiveId string) string {
-	return t.ExecuteFn(
-		"GetTargetPoolPathByIncentiveId",
-		func(args ...any) any {
-			return t.instance.GetTargetPoolPathByIncentiveId(args[0].(string), args[1].(string))
-		},
-		poolPath, incentiveId,
-	).(string)
+func (t *TestStaker) GetTargetPoolPathByIncentiveId(poolPath string, incentiveId string) (string, error) {
+	return t.instance.GetTargetPoolPathByIncentiveId(poolPath, incentiveId)
 }
 
 func (t *TestStaker) GetUnstakingFee() uint64 {
-	return t.ExecuteFn(
-		"GetUnstakingFee",
-		func(args ...any) any { return t.instance.GetUnstakingFee() },
-	).(uint64)
+	return t.instance.GetUnstakingFee()
 }
 
 func (t *TestStaker) IsStaked(positionId uint64) bool {
-	return t.ExecuteFn(
-		"IsStaked",
-		func(args ...any) any { return t.instance.IsStaked(args[0].(uint64)) },
-		positionId,
-	).(bool)
+	return t.instance.IsStaked(positionId)
 }
 
 func (t *TestStaker) GetTotalEmissionSent() int64 {
-	return t.ExecuteFn(
-		"GetTotalEmissionSent",
-		func(args ...any) any { return t.instance.GetTotalEmissionSent() },
-	).(int64)
+	return t.instance.GetTotalEmissionSent()
 }
 
 func (t *TestStaker) GetAllowedTokens() []string {
-	return t.ExecuteFn(
-		"GetAllowedTokens",
-		func(args ...any) any { return t.instance.GetAllowedTokens() },
-	).([]string)
+	return t.instance.GetAllowedTokens()
 }
 
 func (t *TestStaker) GetWarmupTemplate() []staker.Warmup {
-	return t.ExecuteFn(
-		"GetWarmupTemplate",
-		func(args ...any) any { return t.instance.GetWarmupTemplate() },
-	).([]staker.Warmup)
+	return t.instance.GetWarmupTemplate()
 }
 
 func (t *TestStaker) GetPoolRewardCaches(poolPath string) *rotree.ReadOnlyTree {

--- a/contract/r/scenario/upgrade/implements/security/insecure_staker_callback/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/security/insecure_staker_callback/test_impl.gno
@@ -157,98 +157,98 @@ func (t *TestStaker) SetUnStakingFee(_ int, rlm realm, fee uint64) {
 }
 
 // IStakerGetter interface
-func (t *TestStaker) GetPool(poolPath string) *staker.Pool {
+func (t *TestStaker) GetPool(poolPath string) (*staker.Pool, error) {
 	if !t.isActive("GetPool") {
 		panic("test implementation: GetPool not supported")
 	}
 	return t.instance.GetPool(poolPath)
 }
 
-func (t *TestStaker) GetDeposit(lpTokenId uint64) *staker.Deposit {
+func (t *TestStaker) GetDeposit(lpTokenId uint64) (*staker.Deposit, error) {
 	if !t.isActive("GetDeposit") {
 		panic("test implementation: GetDeposit not supported")
 	}
 	return t.instance.GetDeposit(lpTokenId)
 }
 
-func (t *TestStaker) CollectableEmissionReward(positionId uint64) int64 {
+func (t *TestStaker) CollectableEmissionReward(positionId uint64) (int64, error) {
 	if !t.isActive("CollectableEmissionReward") {
 		panic("test implementation: CollectableEmissionReward not supported")
 	}
 	return t.instance.CollectableEmissionReward(positionId)
 }
 
-func (t *TestStaker) CollectableExternalIncentiveReward(positionId uint64, incentiveId string) int64 {
+func (t *TestStaker) CollectableExternalIncentiveReward(positionId uint64, incentiveId string) (int64, error) {
 	if !t.isActive("CollectableExternalIncentiveReward") {
 		panic("test implementation: CollectableExternalIncentiveReward not supported")
 	}
 	return t.instance.CollectableExternalIncentiveReward(positionId, incentiveId)
 }
 
-func (t *TestStaker) GetCreatedHeightOfIncentive(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetCreatedHeightOfIncentive(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetCreatedHeightOfIncentive") {
 		panic("test implementation: GetCreatedHeightOfIncentive not supported")
 	}
 	return t.instance.GetCreatedHeightOfIncentive(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveCreatedTimestamp(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveCreatedTimestamp(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveCreatedTimestamp") {
 		panic("test implementation: GetIncentiveCreatedTimestamp not supported")
 	}
 	return t.instance.GetIncentiveCreatedTimestamp(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveTotalRewardAmount(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveTotalRewardAmount(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveTotalRewardAmount") {
 		panic("test implementation: GetIncentiveTotalRewardAmount not supported")
 	}
 	return t.instance.GetIncentiveTotalRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveDistributedRewardAmount(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveDistributedRewardAmount(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveDistributedRewardAmount") {
 		panic("test implementation: GetIncentiveDistributedRewardAmount not supported")
 	}
 	return t.instance.GetIncentiveDistributedRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveRemainingRewardAmount") {
 		panic("test implementation: GetIncentiveRemainingRewardAmount not supported")
 	}
 	return t.instance.GetIncentiveRemainingRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveAccumulatedPenaltyAmount") {
 		panic("test implementation: GetIncentiveAccumulatedPenaltyAmount not supported")
 	}
 	return t.instance.GetIncentiveAccumulatedPenaltyAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveDepositGnsAmount") {
 		panic("test implementation: GetIncentiveDepositGnsAmount not supported")
 	}
 	return t.instance.GetIncentiveDepositGnsAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRefunded(poolPath string, incentiveId string) bool {
+func (t *TestStaker) GetIncentiveRefunded(poolPath string, incentiveId string) (bool, error) {
 	if !t.isActive("GetIncentiveRefunded") {
 		panic("test implementation: GetIncentiveRefunded not supported")
 	}
 	return t.instance.GetIncentiveRefunded(poolPath, incentiveId)
 }
 
-func (t *TestStaker) IsIncentiveActive(poolPath string, incentiveId string) bool {
+func (t *TestStaker) IsIncentiveActive(poolPath string, incentiveId string) (bool, error) {
 	if !t.isActive("IsIncentiveActive") {
 		panic("test implementation: IsIncentiveActive not supported")
 	}
 	return t.instance.IsIncentiveActive(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetDepositExternalRewardLastCollectTimestamp(lpTokenId uint64, incentiveId string) int64 {
+func (t *TestStaker) GetDepositExternalRewardLastCollectTimestamp(lpTokenId uint64, incentiveId string) (int64, error) {
 	if !t.isActive("GetDepositExternalRewardLastCollectTimestamp") {
 		panic("test implementation: GetDepositExternalRewardLastCollectTimestamp not supported")
 	}
@@ -262,140 +262,140 @@ func (t *TestStaker) GetDepositGnsAmount() int64 {
 	return t.instance.GetDepositGnsAmount()
 }
 
-func (t *TestStaker) GetDepositInternalRewardLastCollectTimestamp(lpTokenId uint64) int64 {
+func (t *TestStaker) GetDepositInternalRewardLastCollectTimestamp(lpTokenId uint64) (int64, error) {
 	if !t.isActive("GetDepositInternalRewardLastCollectTimestamp") {
 		panic("test implementation: GetDepositInternalRewardLastCollectTimestamp not supported")
 	}
 	return t.instance.GetDepositInternalRewardLastCollectTimestamp(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositCollectedInternalReward(lpTokenId uint64) int64 {
+func (t *TestStaker) GetDepositCollectedInternalReward(lpTokenId uint64) (int64, error) {
 	if !t.isActive("GetDepositCollectedInternalReward") {
 		panic("test implementation: GetDepositCollectedInternalReward not supported")
 	}
 	return t.instance.GetDepositCollectedInternalReward(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositCollectedExternalReward(lpTokenId uint64, incentiveId string) int64 {
+func (t *TestStaker) GetDepositCollectedExternalReward(lpTokenId uint64, incentiveId string) (int64, error) {
 	if !t.isActive("GetDepositCollectedExternalReward") {
 		panic("test implementation: GetDepositCollectedExternalReward not supported")
 	}
 	return t.instance.GetDepositCollectedExternalReward(lpTokenId, incentiveId)
 }
 
-func (t *TestStaker) GetDepositLiquidity(lpTokenId uint64) *u256.Uint {
+func (t *TestStaker) GetDepositLiquidity(lpTokenId uint64) (*u256.Uint, error) {
 	if !t.isActive("GetDepositLiquidity") {
 		panic("test implementation: GetDepositLiquidity not supported")
 	}
 	return t.instance.GetDepositLiquidity(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositLiquidityAsString(lpTokenId uint64) string {
+func (t *TestStaker) GetDepositLiquidityAsString(lpTokenId uint64) (string, error) {
 	if !t.isActive("GetDepositLiquidityAsString") {
 		panic("test implementation: GetDepositLiquidityAsString not supported")
 	}
 	return t.instance.GetDepositLiquidityAsString(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositOwner(lpTokenId uint64) address {
+func (t *TestStaker) GetDepositOwner(lpTokenId uint64) (address, error) {
 	if !t.isActive("GetDepositOwner") {
 		panic("test implementation: GetDepositOwner not supported")
 	}
 	return t.instance.GetDepositOwner(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositStakeTime(lpTokenId uint64) int64 {
+func (t *TestStaker) GetDepositStakeTime(lpTokenId uint64) (int64, error) {
 	if !t.isActive("GetDepositStakeTime") {
 		panic("test implementation: GetDepositStakeTime not supported")
 	}
 	return t.instance.GetDepositStakeTime(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositTargetPoolPath(lpTokenId uint64) string {
+func (t *TestStaker) GetDepositTargetPoolPath(lpTokenId uint64) (string, error) {
 	if !t.isActive("GetDepositTargetPoolPath") {
 		panic("test implementation: GetDepositTargetPoolPath not supported")
 	}
 	return t.instance.GetDepositTargetPoolPath(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositTickLower(lpTokenId uint64) int32 {
+func (t *TestStaker) GetDepositTickLower(lpTokenId uint64) (int32, error) {
 	if !t.isActive("GetDepositTickLower") {
 		panic("test implementation: GetDepositTickLower not supported")
 	}
 	return t.instance.GetDepositTickLower(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositTickUpper(lpTokenId uint64) int32 {
+func (t *TestStaker) GetDepositTickUpper(lpTokenId uint64) (int32, error) {
 	if !t.isActive("GetDepositTickUpper") {
 		panic("test implementation: GetDepositTickUpper not supported")
 	}
 	return t.instance.GetDepositTickUpper(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositWarmUp(lpTokenId uint64) []staker.Warmup {
+func (t *TestStaker) GetDepositWarmUp(lpTokenId uint64) ([]staker.Warmup, error) {
 	if !t.isActive("GetDepositWarmUp") {
 		panic("test implementation: GetDepositWarmUp not supported")
 	}
 	return t.instance.GetDepositWarmUp(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositExternalIncentiveIdList(lpTokenId uint64) []string {
+func (t *TestStaker) GetDepositExternalIncentiveIdList(lpTokenId uint64) ([]string, error) {
 	if !t.isActive("GetDepositExternalIncentiveIdList") {
 		panic("test implementation: GetDepositExternalIncentiveIdList not supported")
 	}
 	return t.instance.GetDepositExternalIncentiveIdList(lpTokenId)
 }
 
-func (t *TestStaker) GetExternalIncentiveByPoolPath(poolPath string) []staker.ExternalIncentive {
+func (t *TestStaker) GetExternalIncentiveByPoolPath(poolPath string) ([]staker.ExternalIncentive, error) {
 	if !t.isActive("GetExternalIncentiveByPoolPath") {
 		panic("test implementation: GetExternalIncentiveByPoolPath not supported")
 	}
 	return t.instance.GetExternalIncentiveByPoolPath(poolPath)
 }
 
-func (t *TestStaker) GetIncentiveEndTimestamp(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveEndTimestamp(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveEndTimestamp") {
 		panic("test implementation: GetIncentiveEndTimestamp not supported")
 	}
 	return t.instance.GetIncentiveEndTimestamp(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveCreator(poolPath string, incentiveId string) address {
+func (t *TestStaker) GetIncentiveCreator(poolPath string, incentiveId string) (address, error) {
 	if !t.isActive("GetIncentiveCreator") {
 		panic("test implementation: GetIncentiveCreator not supported")
 	}
 	return t.instance.GetIncentiveCreator(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardAmount(poolPath string, incentiveId string) *u256.Uint {
+func (t *TestStaker) GetIncentiveRewardAmount(poolPath string, incentiveId string) (*u256.Uint, error) {
 	if !t.isActive("GetIncentiveRewardAmount") {
 		panic("test implementation: GetIncentiveRewardAmount not supported")
 	}
 	return t.instance.GetIncentiveRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) string {
+func (t *TestStaker) GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) (string, error) {
 	if !t.isActive("GetIncentiveRewardAmountAsString") {
 		panic("test implementation: GetIncentiveRewardAmountAsString not supported")
 	}
 	return t.instance.GetIncentiveRewardAmountAsString(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) *u256.Uint {
+func (t *TestStaker) GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) (*u256.Uint, error) {
 	if !t.isActive("GetIncentiveRewardPerSecondX128") {
 		panic("test implementation: GetIncentiveRewardPerSecondX128 not supported")
 	}
 	return t.instance.GetIncentiveRewardPerSecondX128(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardToken(poolPath string, incentiveId string) string {
+func (t *TestStaker) GetIncentiveRewardToken(poolPath string, incentiveId string) (string, error) {
 	if !t.isActive("GetIncentiveRewardToken") {
 		panic("test implementation: GetIncentiveRewardToken not supported")
 	}
 	return t.instance.GetIncentiveRewardToken(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveStartTimestamp(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveStartTimestamp(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveStartTimestamp") {
 		panic("test implementation: GetIncentiveStartTimestamp not supported")
 	}
@@ -416,21 +416,21 @@ func (t *TestStaker) GetMinimumRewardAmountForToken(tokenPath string) int64 {
 	return t.instance.GetMinimumRewardAmountForToken(tokenPath)
 }
 
-func (t *TestStaker) GetPoolStakedLiquidity(poolPath string) string {
+func (t *TestStaker) GetPoolStakedLiquidity(poolPath string) (string, error) {
 	if !t.isActive("GetPoolStakedLiquidity") {
 		panic("test implementation: GetPoolStakedLiquidity not supported")
 	}
 	return t.instance.GetPoolStakedLiquidity(poolPath)
 }
 
-func (t *TestStaker) GetPoolsByTier(tier uint64) []string {
+func (t *TestStaker) GetPoolsByTier(tier uint64) ([]string, error) {
 	if !t.isActive("GetPoolsByTier") {
 		panic("test implementation: GetPoolsByTier not supported")
 	}
 	return t.instance.GetPoolsByTier(tier)
 }
 
-func (t *TestStaker) GetPoolReward(tier uint64) int64 {
+func (t *TestStaker) GetPoolReward(tier uint64) (int64, error) {
 	if !t.isActive("GetPoolReward") {
 		panic("test implementation: GetPoolReward not supported")
 	}
@@ -451,7 +451,7 @@ func (t *TestStaker) GetPoolTierCount(tier uint64) uint64 {
 	return t.instance.GetPoolTierCount(tier)
 }
 
-func (t *TestStaker) GetPoolTierRatio(poolPath string) uint64 {
+func (t *TestStaker) GetPoolTierRatio(poolPath string) (uint64, error) {
 	if !t.isActive("GetPoolTierRatio") {
 		panic("test implementation: GetPoolTierRatio not supported")
 	}
@@ -465,7 +465,7 @@ func (t *TestStaker) GetSpecificTokenMinimumRewardAmount(tokenPath string) (int6
 	return t.instance.GetSpecificTokenMinimumRewardAmount(tokenPath)
 }
 
-func (t *TestStaker) GetTargetPoolPathByIncentiveId(poolPath string, incentiveId string) string {
+func (t *TestStaker) GetTargetPoolPathByIncentiveId(poolPath string, incentiveId string) (string, error) {
 	if !t.isActive("GetTargetPoolPathByIncentiveId") {
 		panic("test implementation: GetTargetPoolPathByIncentiveId not supported")
 	}

--- a/contract/r/scenario/upgrade/implements/security/insecure_staker_callback/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/security/insecure_staker_callback/test_impl.gno
@@ -164,98 +164,98 @@ func (t *TestStaker) SetUnStakingFee(_ int, rlm realm, fee uint64) {
 }
 
 // IStakerGetter interface
-func (t *TestStaker) GetPool(poolPath string) *staker.Pool {
+func (t *TestStaker) GetPool(poolPath string) (*staker.Pool, error) {
 	if !t.isActive("GetPool") {
 		panic("test implementation: GetPool not supported")
 	}
 	return t.instance.GetPool(poolPath)
 }
 
-func (t *TestStaker) GetDeposit(lpTokenId uint64) *staker.Deposit {
+func (t *TestStaker) GetDeposit(lpTokenId uint64) (*staker.Deposit, error) {
 	if !t.isActive("GetDeposit") {
 		panic("test implementation: GetDeposit not supported")
 	}
 	return t.instance.GetDeposit(lpTokenId)
 }
 
-func (t *TestStaker) CollectableEmissionReward(positionId uint64) int64 {
+func (t *TestStaker) CollectableEmissionReward(positionId uint64) (int64, error) {
 	if !t.isActive("CollectableEmissionReward") {
 		panic("test implementation: CollectableEmissionReward not supported")
 	}
 	return t.instance.CollectableEmissionReward(positionId)
 }
 
-func (t *TestStaker) CollectableExternalIncentiveReward(positionId uint64, incentiveId string) int64 {
+func (t *TestStaker) CollectableExternalIncentiveReward(positionId uint64, incentiveId string) (int64, error) {
 	if !t.isActive("CollectableExternalIncentiveReward") {
 		panic("test implementation: CollectableExternalIncentiveReward not supported")
 	}
 	return t.instance.CollectableExternalIncentiveReward(positionId, incentiveId)
 }
 
-func (t *TestStaker) GetCreatedHeightOfIncentive(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetCreatedHeightOfIncentive(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetCreatedHeightOfIncentive") {
 		panic("test implementation: GetCreatedHeightOfIncentive not supported")
 	}
 	return t.instance.GetCreatedHeightOfIncentive(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveCreatedTimestamp(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveCreatedTimestamp(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveCreatedTimestamp") {
 		panic("test implementation: GetIncentiveCreatedTimestamp not supported")
 	}
 	return t.instance.GetIncentiveCreatedTimestamp(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveTotalRewardAmount(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveTotalRewardAmount(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveTotalRewardAmount") {
 		panic("test implementation: GetIncentiveTotalRewardAmount not supported")
 	}
 	return t.instance.GetIncentiveTotalRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveDistributedRewardAmount(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveDistributedRewardAmount(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveDistributedRewardAmount") {
 		panic("test implementation: GetIncentiveDistributedRewardAmount not supported")
 	}
 	return t.instance.GetIncentiveDistributedRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveRemainingRewardAmount") {
 		panic("test implementation: GetIncentiveRemainingRewardAmount not supported")
 	}
 	return t.instance.GetIncentiveRemainingRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveAccumulatedPenaltyAmount") {
 		panic("test implementation: GetIncentiveAccumulatedPenaltyAmount not supported")
 	}
 	return t.instance.GetIncentiveAccumulatedPenaltyAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveDepositGnsAmount") {
 		panic("test implementation: GetIncentiveDepositGnsAmount not supported")
 	}
 	return t.instance.GetIncentiveDepositGnsAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRefunded(poolPath string, incentiveId string) bool {
+func (t *TestStaker) GetIncentiveRefunded(poolPath string, incentiveId string) (bool, error) {
 	if !t.isActive("GetIncentiveRefunded") {
 		panic("test implementation: GetIncentiveRefunded not supported")
 	}
 	return t.instance.GetIncentiveRefunded(poolPath, incentiveId)
 }
 
-func (t *TestStaker) IsIncentiveActive(poolPath string, incentiveId string) bool {
+func (t *TestStaker) IsIncentiveActive(poolPath string, incentiveId string) (bool, error) {
 	if !t.isActive("IsIncentiveActive") {
 		panic("test implementation: IsIncentiveActive not supported")
 	}
 	return t.instance.IsIncentiveActive(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetDepositExternalRewardLastCollectTimestamp(lpTokenId uint64, incentiveId string) int64 {
+func (t *TestStaker) GetDepositExternalRewardLastCollectTimestamp(lpTokenId uint64, incentiveId string) (int64, error) {
 	if !t.isActive("GetDepositExternalRewardLastCollectTimestamp") {
 		panic("test implementation: GetDepositExternalRewardLastCollectTimestamp not supported")
 	}
@@ -269,140 +269,140 @@ func (t *TestStaker) GetDepositGnsAmount() int64 {
 	return t.instance.GetDepositGnsAmount()
 }
 
-func (t *TestStaker) GetDepositInternalRewardLastCollectTimestamp(lpTokenId uint64) int64 {
+func (t *TestStaker) GetDepositInternalRewardLastCollectTimestamp(lpTokenId uint64) (int64, error) {
 	if !t.isActive("GetDepositInternalRewardLastCollectTimestamp") {
 		panic("test implementation: GetDepositInternalRewardLastCollectTimestamp not supported")
 	}
 	return t.instance.GetDepositInternalRewardLastCollectTimestamp(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositCollectedInternalReward(lpTokenId uint64) int64 {
+func (t *TestStaker) GetDepositCollectedInternalReward(lpTokenId uint64) (int64, error) {
 	if !t.isActive("GetDepositCollectedInternalReward") {
 		panic("test implementation: GetDepositCollectedInternalReward not supported")
 	}
 	return t.instance.GetDepositCollectedInternalReward(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositCollectedExternalReward(lpTokenId uint64, incentiveId string) int64 {
+func (t *TestStaker) GetDepositCollectedExternalReward(lpTokenId uint64, incentiveId string) (int64, error) {
 	if !t.isActive("GetDepositCollectedExternalReward") {
 		panic("test implementation: GetDepositCollectedExternalReward not supported")
 	}
 	return t.instance.GetDepositCollectedExternalReward(lpTokenId, incentiveId)
 }
 
-func (t *TestStaker) GetDepositLiquidity(lpTokenId uint64) *u256.Uint {
+func (t *TestStaker) GetDepositLiquidity(lpTokenId uint64) (*u256.Uint, error) {
 	if !t.isActive("GetDepositLiquidity") {
 		panic("test implementation: GetDepositLiquidity not supported")
 	}
 	return t.instance.GetDepositLiquidity(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositLiquidityAsString(lpTokenId uint64) string {
+func (t *TestStaker) GetDepositLiquidityAsString(lpTokenId uint64) (string, error) {
 	if !t.isActive("GetDepositLiquidityAsString") {
 		panic("test implementation: GetDepositLiquidityAsString not supported")
 	}
 	return t.instance.GetDepositLiquidityAsString(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositOwner(lpTokenId uint64) address {
+func (t *TestStaker) GetDepositOwner(lpTokenId uint64) (address, error) {
 	if !t.isActive("GetDepositOwner") {
 		panic("test implementation: GetDepositOwner not supported")
 	}
 	return t.instance.GetDepositOwner(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositStakeTime(lpTokenId uint64) int64 {
+func (t *TestStaker) GetDepositStakeTime(lpTokenId uint64) (int64, error) {
 	if !t.isActive("GetDepositStakeTime") {
 		panic("test implementation: GetDepositStakeTime not supported")
 	}
 	return t.instance.GetDepositStakeTime(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositTargetPoolPath(lpTokenId uint64) string {
+func (t *TestStaker) GetDepositTargetPoolPath(lpTokenId uint64) (string, error) {
 	if !t.isActive("GetDepositTargetPoolPath") {
 		panic("test implementation: GetDepositTargetPoolPath not supported")
 	}
 	return t.instance.GetDepositTargetPoolPath(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositTickLower(lpTokenId uint64) int32 {
+func (t *TestStaker) GetDepositTickLower(lpTokenId uint64) (int32, error) {
 	if !t.isActive("GetDepositTickLower") {
 		panic("test implementation: GetDepositTickLower not supported")
 	}
 	return t.instance.GetDepositTickLower(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositTickUpper(lpTokenId uint64) int32 {
+func (t *TestStaker) GetDepositTickUpper(lpTokenId uint64) (int32, error) {
 	if !t.isActive("GetDepositTickUpper") {
 		panic("test implementation: GetDepositTickUpper not supported")
 	}
 	return t.instance.GetDepositTickUpper(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositWarmUp(lpTokenId uint64) []staker.Warmup {
+func (t *TestStaker) GetDepositWarmUp(lpTokenId uint64) ([]staker.Warmup, error) {
 	if !t.isActive("GetDepositWarmUp") {
 		panic("test implementation: GetDepositWarmUp not supported")
 	}
 	return t.instance.GetDepositWarmUp(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositExternalIncentiveIdList(lpTokenId uint64) []string {
+func (t *TestStaker) GetDepositExternalIncentiveIdList(lpTokenId uint64) ([]string, error) {
 	if !t.isActive("GetDepositExternalIncentiveIdList") {
 		panic("test implementation: GetDepositExternalIncentiveIdList not supported")
 	}
 	return t.instance.GetDepositExternalIncentiveIdList(lpTokenId)
 }
 
-func (t *TestStaker) GetExternalIncentiveByPoolPath(poolPath string) []staker.ExternalIncentive {
+func (t *TestStaker) GetExternalIncentiveByPoolPath(poolPath string) ([]staker.ExternalIncentive, error) {
 	if !t.isActive("GetExternalIncentiveByPoolPath") {
 		panic("test implementation: GetExternalIncentiveByPoolPath not supported")
 	}
 	return t.instance.GetExternalIncentiveByPoolPath(poolPath)
 }
 
-func (t *TestStaker) GetIncentiveEndTimestamp(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveEndTimestamp(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveEndTimestamp") {
 		panic("test implementation: GetIncentiveEndTimestamp not supported")
 	}
 	return t.instance.GetIncentiveEndTimestamp(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveCreator(poolPath string, incentiveId string) address {
+func (t *TestStaker) GetIncentiveCreator(poolPath string, incentiveId string) (address, error) {
 	if !t.isActive("GetIncentiveCreator") {
 		panic("test implementation: GetIncentiveCreator not supported")
 	}
 	return t.instance.GetIncentiveCreator(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardAmount(poolPath string, incentiveId string) *u256.Uint {
+func (t *TestStaker) GetIncentiveRewardAmount(poolPath string, incentiveId string) (*u256.Uint, error) {
 	if !t.isActive("GetIncentiveRewardAmount") {
 		panic("test implementation: GetIncentiveRewardAmount not supported")
 	}
 	return t.instance.GetIncentiveRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) string {
+func (t *TestStaker) GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) (string, error) {
 	if !t.isActive("GetIncentiveRewardAmountAsString") {
 		panic("test implementation: GetIncentiveRewardAmountAsString not supported")
 	}
 	return t.instance.GetIncentiveRewardAmountAsString(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) *u256.Uint {
+func (t *TestStaker) GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) (*u256.Uint, error) {
 	if !t.isActive("GetIncentiveRewardPerSecondX128") {
 		panic("test implementation: GetIncentiveRewardPerSecondX128 not supported")
 	}
 	return t.instance.GetIncentiveRewardPerSecondX128(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardToken(poolPath string, incentiveId string) string {
+func (t *TestStaker) GetIncentiveRewardToken(poolPath string, incentiveId string) (string, error) {
 	if !t.isActive("GetIncentiveRewardToken") {
 		panic("test implementation: GetIncentiveRewardToken not supported")
 	}
 	return t.instance.GetIncentiveRewardToken(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveStartTimestamp(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveStartTimestamp(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveStartTimestamp") {
 		panic("test implementation: GetIncentiveStartTimestamp not supported")
 	}
@@ -423,21 +423,21 @@ func (t *TestStaker) GetMinimumRewardAmountForToken(tokenPath string) int64 {
 	return t.instance.GetMinimumRewardAmountForToken(tokenPath)
 }
 
-func (t *TestStaker) GetPoolStakedLiquidity(poolPath string) string {
+func (t *TestStaker) GetPoolStakedLiquidity(poolPath string) (string, error) {
 	if !t.isActive("GetPoolStakedLiquidity") {
 		panic("test implementation: GetPoolStakedLiquidity not supported")
 	}
 	return t.instance.GetPoolStakedLiquidity(poolPath)
 }
 
-func (t *TestStaker) GetPoolsByTier(tier uint64) []string {
+func (t *TestStaker) GetPoolsByTier(tier uint64) ([]string, error) {
 	if !t.isActive("GetPoolsByTier") {
 		panic("test implementation: GetPoolsByTier not supported")
 	}
 	return t.instance.GetPoolsByTier(tier)
 }
 
-func (t *TestStaker) GetPoolReward(tier uint64) int64 {
+func (t *TestStaker) GetPoolReward(tier uint64) (int64, error) {
 	if !t.isActive("GetPoolReward") {
 		panic("test implementation: GetPoolReward not supported")
 	}
@@ -458,7 +458,7 @@ func (t *TestStaker) GetPoolTierCount(tier uint64) uint64 {
 	return t.instance.GetPoolTierCount(tier)
 }
 
-func (t *TestStaker) GetPoolTierRatio(poolPath string) uint64 {
+func (t *TestStaker) GetPoolTierRatio(poolPath string) (uint64, error) {
 	if !t.isActive("GetPoolTierRatio") {
 		panic("test implementation: GetPoolTierRatio not supported")
 	}
@@ -472,7 +472,7 @@ func (t *TestStaker) GetSpecificTokenMinimumRewardAmount(tokenPath string) (int6
 	return t.instance.GetSpecificTokenMinimumRewardAmount(tokenPath)
 }
 
-func (t *TestStaker) GetTargetPoolPathByIncentiveId(poolPath string, incentiveId string) string {
+func (t *TestStaker) GetTargetPoolPathByIncentiveId(poolPath string, incentiveId string) (string, error) {
 	if !t.isActive("GetTargetPoolPathByIncentiveId") {
 		panic("test implementation: GetTargetPoolPathByIncentiveId not supported")
 	}

--- a/contract/r/scenario/upgrade/implements/v2_invalid/staker/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v2_invalid/staker/test_impl.gno
@@ -152,98 +152,98 @@ func (t *TestStaker) SetUnStakingFee(_ int, rlm realm, fee uint64) {
 }
 
 // IStakerGetter interface
-func (t *TestStaker) GetPool(poolPath string) *staker.Pool {
+func (t *TestStaker) GetPool(poolPath string) (*staker.Pool, error) {
 	if !t.isActive("GetPool") {
 		panic("test implementation: GetPool not supported")
 	}
 	return t.instance.GetPool(poolPath)
 }
 
-func (t *TestStaker) GetDeposit(lpTokenId uint64) *staker.Deposit {
+func (t *TestStaker) GetDeposit(lpTokenId uint64) (*staker.Deposit, error) {
 	if !t.isActive("GetDeposit") {
 		panic("test implementation: GetDeposit not supported")
 	}
 	return t.instance.GetDeposit(lpTokenId)
 }
 
-func (t *TestStaker) CollectableEmissionReward(positionId uint64) int64 {
+func (t *TestStaker) CollectableEmissionReward(positionId uint64) (int64, error) {
 	if !t.isActive("CollectableEmissionReward") {
 		panic("test implementation: CollectableEmissionReward not supported")
 	}
 	return t.instance.CollectableEmissionReward(positionId)
 }
 
-func (t *TestStaker) CollectableExternalIncentiveReward(positionId uint64, incentiveId string) int64 {
+func (t *TestStaker) CollectableExternalIncentiveReward(positionId uint64, incentiveId string) (int64, error) {
 	if !t.isActive("CollectableExternalIncentiveReward") {
 		panic("test implementation: CollectableExternalIncentiveReward not supported")
 	}
 	return t.instance.CollectableExternalIncentiveReward(positionId, incentiveId)
 }
 
-func (t *TestStaker) GetCreatedHeightOfIncentive(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetCreatedHeightOfIncentive(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetCreatedHeightOfIncentive") {
 		panic("test implementation: GetCreatedHeightOfIncentive not supported")
 	}
 	return t.instance.GetCreatedHeightOfIncentive(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveCreatedTimestamp(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveCreatedTimestamp(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveCreatedTimestamp") {
 		panic("test implementation: GetIncentiveCreatedTimestamp not supported")
 	}
 	return t.instance.GetIncentiveCreatedTimestamp(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveTotalRewardAmount(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveTotalRewardAmount(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveTotalRewardAmount") {
 		panic("test implementation: GetIncentiveTotalRewardAmount not supported")
 	}
 	return t.instance.GetIncentiveTotalRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveDistributedRewardAmount(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveDistributedRewardAmount(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveDistributedRewardAmount") {
 		panic("test implementation: GetIncentiveDistributedRewardAmount not supported")
 	}
 	return t.instance.GetIncentiveDistributedRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveRemainingRewardAmount") {
 		panic("test implementation: GetIncentiveRemainingRewardAmount not supported")
 	}
 	return t.instance.GetIncentiveRemainingRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveAccumulatedPenaltyAmount") {
 		panic("test implementation: GetIncentiveAccumulatedPenaltyAmount not supported")
 	}
 	return t.instance.GetIncentiveAccumulatedPenaltyAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveDepositGnsAmount") {
 		panic("test implementation: GetIncentiveDepositGnsAmount not supported")
 	}
 	return t.instance.GetIncentiveDepositGnsAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRefunded(poolPath string, incentiveId string) bool {
+func (t *TestStaker) GetIncentiveRefunded(poolPath string, incentiveId string) (bool, error) {
 	if !t.isActive("GetIncentiveRefunded") {
 		panic("test implementation: GetIncentiveRefunded not supported")
 	}
 	return t.instance.GetIncentiveRefunded(poolPath, incentiveId)
 }
 
-func (t *TestStaker) IsIncentiveActive(poolPath string, incentiveId string) bool {
+func (t *TestStaker) IsIncentiveActive(poolPath string, incentiveId string) (bool, error) {
 	if !t.isActive("IsIncentiveActive") {
 		panic("test implementation: IsIncentiveActive not supported")
 	}
 	return t.instance.IsIncentiveActive(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetDepositExternalRewardLastCollectTimestamp(lpTokenId uint64, incentiveId string) int64 {
+func (t *TestStaker) GetDepositExternalRewardLastCollectTimestamp(lpTokenId uint64, incentiveId string) (int64, error) {
 	if !t.isActive("GetDepositExternalRewardLastCollectTimestamp") {
 		panic("test implementation: GetDepositExternalRewardLastCollectTimestamp not supported")
 	}
@@ -257,140 +257,140 @@ func (t *TestStaker) GetDepositGnsAmount() int64 {
 	return t.instance.GetDepositGnsAmount()
 }
 
-func (t *TestStaker) GetDepositInternalRewardLastCollectTimestamp(lpTokenId uint64) int64 {
+func (t *TestStaker) GetDepositInternalRewardLastCollectTimestamp(lpTokenId uint64) (int64, error) {
 	if !t.isActive("GetDepositInternalRewardLastCollectTimestamp") {
 		panic("test implementation: GetDepositInternalRewardLastCollectTimestamp not supported")
 	}
 	return t.instance.GetDepositInternalRewardLastCollectTimestamp(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositCollectedInternalReward(lpTokenId uint64) int64 {
+func (t *TestStaker) GetDepositCollectedInternalReward(lpTokenId uint64) (int64, error) {
 	if !t.isActive("GetDepositCollectedInternalReward") {
 		panic("test implementation: GetDepositCollectedInternalReward not supported")
 	}
 	return t.instance.GetDepositCollectedInternalReward(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositCollectedExternalReward(lpTokenId uint64, incentiveId string) int64 {
+func (t *TestStaker) GetDepositCollectedExternalReward(lpTokenId uint64, incentiveId string) (int64, error) {
 	if !t.isActive("GetDepositCollectedExternalReward") {
 		panic("test implementation: GetDepositCollectedExternalReward not supported")
 	}
 	return t.instance.GetDepositCollectedExternalReward(lpTokenId, incentiveId)
 }
 
-func (t *TestStaker) GetDepositLiquidity(lpTokenId uint64) *u256.Uint {
+func (t *TestStaker) GetDepositLiquidity(lpTokenId uint64) (*u256.Uint, error) {
 	if !t.isActive("GetDepositLiquidity") {
 		panic("test implementation: GetDepositLiquidity not supported")
 	}
 	return t.instance.GetDepositLiquidity(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositLiquidityAsString(lpTokenId uint64) string {
+func (t *TestStaker) GetDepositLiquidityAsString(lpTokenId uint64) (string, error) {
 	if !t.isActive("GetDepositLiquidityAsString") {
 		panic("test implementation: GetDepositLiquidityAsString not supported")
 	}
 	return t.instance.GetDepositLiquidityAsString(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositOwner(lpTokenId uint64) address {
+func (t *TestStaker) GetDepositOwner(lpTokenId uint64) (address, error) {
 	if !t.isActive("GetDepositOwner") {
 		panic("test implementation: GetDepositOwner not supported")
 	}
 	return t.instance.GetDepositOwner(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositStakeTime(lpTokenId uint64) int64 {
+func (t *TestStaker) GetDepositStakeTime(lpTokenId uint64) (int64, error) {
 	if !t.isActive("GetDepositStakeTime") {
 		panic("test implementation: GetDepositStakeTime not supported")
 	}
 	return t.instance.GetDepositStakeTime(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositTargetPoolPath(lpTokenId uint64) string {
+func (t *TestStaker) GetDepositTargetPoolPath(lpTokenId uint64) (string, error) {
 	if !t.isActive("GetDepositTargetPoolPath") {
 		panic("test implementation: GetDepositTargetPoolPath not supported")
 	}
 	return t.instance.GetDepositTargetPoolPath(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositTickLower(lpTokenId uint64) int32 {
+func (t *TestStaker) GetDepositTickLower(lpTokenId uint64) (int32, error) {
 	if !t.isActive("GetDepositTickLower") {
 		panic("test implementation: GetDepositTickLower not supported")
 	}
 	return t.instance.GetDepositTickLower(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositTickUpper(lpTokenId uint64) int32 {
+func (t *TestStaker) GetDepositTickUpper(lpTokenId uint64) (int32, error) {
 	if !t.isActive("GetDepositTickUpper") {
 		panic("test implementation: GetDepositTickUpper not supported")
 	}
 	return t.instance.GetDepositTickUpper(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositWarmUp(lpTokenId uint64) []staker.Warmup {
+func (t *TestStaker) GetDepositWarmUp(lpTokenId uint64) ([]staker.Warmup, error) {
 	if !t.isActive("GetDepositWarmUp") {
 		panic("test implementation: GetDepositWarmUp not supported")
 	}
 	return t.instance.GetDepositWarmUp(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositExternalIncentiveIdList(lpTokenId uint64) []string {
+func (t *TestStaker) GetDepositExternalIncentiveIdList(lpTokenId uint64) ([]string, error) {
 	if !t.isActive("GetDepositExternalIncentiveIdList") {
 		panic("test implementation: GetDepositExternalIncentiveIdList not supported")
 	}
 	return t.instance.GetDepositExternalIncentiveIdList(lpTokenId)
 }
 
-func (t *TestStaker) GetExternalIncentiveByPoolPath(poolPath string) []staker.ExternalIncentive {
+func (t *TestStaker) GetExternalIncentiveByPoolPath(poolPath string) ([]staker.ExternalIncentive, error) {
 	if !t.isActive("GetExternalIncentiveByPoolPath") {
 		panic("test implementation: GetExternalIncentiveByPoolPath not supported")
 	}
 	return t.instance.GetExternalIncentiveByPoolPath(poolPath)
 }
 
-func (t *TestStaker) GetIncentiveEndTimestamp(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveEndTimestamp(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveEndTimestamp") {
 		panic("test implementation: GetIncentiveEndTimestamp not supported")
 	}
 	return t.instance.GetIncentiveEndTimestamp(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveCreator(poolPath string, incentiveId string) address {
+func (t *TestStaker) GetIncentiveCreator(poolPath string, incentiveId string) (address, error) {
 	if !t.isActive("GetIncentiveCreator") {
 		panic("test implementation: GetIncentiveCreator not supported")
 	}
 	return t.instance.GetIncentiveCreator(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardAmount(poolPath string, incentiveId string) *u256.Uint {
+func (t *TestStaker) GetIncentiveRewardAmount(poolPath string, incentiveId string) (*u256.Uint, error) {
 	if !t.isActive("GetIncentiveRewardAmount") {
 		panic("test implementation: GetIncentiveRewardAmount not supported")
 	}
 	return t.instance.GetIncentiveRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) string {
+func (t *TestStaker) GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) (string, error) {
 	if !t.isActive("GetIncentiveRewardAmountAsString") {
 		panic("test implementation: GetIncentiveRewardAmountAsString not supported")
 	}
 	return t.instance.GetIncentiveRewardAmountAsString(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) *u256.Uint {
+func (t *TestStaker) GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) (*u256.Uint, error) {
 	if !t.isActive("GetIncentiveRewardPerSecondX128") {
 		panic("test implementation: GetIncentiveRewardPerSecondX128 not supported")
 	}
 	return t.instance.GetIncentiveRewardPerSecondX128(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardToken(poolPath string, incentiveId string) string {
+func (t *TestStaker) GetIncentiveRewardToken(poolPath string, incentiveId string) (string, error) {
 	if !t.isActive("GetIncentiveRewardToken") {
 		panic("test implementation: GetIncentiveRewardToken not supported")
 	}
 	return t.instance.GetIncentiveRewardToken(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveStartTimestamp(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveStartTimestamp(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveStartTimestamp") {
 		panic("test implementation: GetIncentiveStartTimestamp not supported")
 	}
@@ -411,21 +411,21 @@ func (t *TestStaker) GetMinimumRewardAmountForToken(tokenPath string) int64 {
 	return t.instance.GetMinimumRewardAmountForToken(tokenPath)
 }
 
-func (t *TestStaker) GetPoolStakedLiquidity(poolPath string) string {
+func (t *TestStaker) GetPoolStakedLiquidity(poolPath string) (string, error) {
 	if !t.isActive("GetPoolStakedLiquidity") {
 		panic("test implementation: GetPoolStakedLiquidity not supported")
 	}
 	return t.instance.GetPoolStakedLiquidity(poolPath)
 }
 
-func (t *TestStaker) GetPoolsByTier(tier uint64) []string {
+func (t *TestStaker) GetPoolsByTier(tier uint64) ([]string, error) {
 	if !t.isActive("GetPoolsByTier") {
 		panic("test implementation: GetPoolsByTier not supported")
 	}
 	return t.instance.GetPoolsByTier(tier)
 }
 
-func (t *TestStaker) GetPoolReward(tier uint64) int64 {
+func (t *TestStaker) GetPoolReward(tier uint64) (int64, error) {
 	if !t.isActive("GetPoolReward") {
 		panic("test implementation: GetPoolReward not supported")
 	}
@@ -446,7 +446,7 @@ func (t *TestStaker) GetPoolTierCount(tier uint64) uint64 {
 	return t.instance.GetPoolTierCount(tier)
 }
 
-func (t *TestStaker) GetPoolTierRatio(poolPath string) uint64 {
+func (t *TestStaker) GetPoolTierRatio(poolPath string) (uint64, error) {
 	if !t.isActive("GetPoolTierRatio") {
 		panic("test implementation: GetPoolTierRatio not supported")
 	}
@@ -460,7 +460,7 @@ func (t *TestStaker) GetSpecificTokenMinimumRewardAmount(tokenPath string) (int6
 	return t.instance.GetSpecificTokenMinimumRewardAmount(tokenPath)
 }
 
-func (t *TestStaker) GetTargetPoolPathByIncentiveId(poolPath string, incentiveId string) string {
+func (t *TestStaker) GetTargetPoolPathByIncentiveId(poolPath string, incentiveId string) (string, error) {
 	if !t.isActive("GetTargetPoolPathByIncentiveId") {
 		panic("test implementation: GetTargetPoolPathByIncentiveId not supported")
 	}

--- a/contract/r/scenario/upgrade/implements/v2_invalid/staker/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v2_invalid/staker/test_impl.gno
@@ -159,98 +159,98 @@ func (t *TestStaker) SetUnStakingFee(_ int, rlm realm, fee uint64) {
 }
 
 // IStakerGetter interface
-func (t *TestStaker) GetPool(poolPath string) *staker.Pool {
+func (t *TestStaker) GetPool(poolPath string) (*staker.Pool, error) {
 	if !t.isActive("GetPool") {
 		panic("test implementation: GetPool not supported")
 	}
 	return t.instance.GetPool(poolPath)
 }
 
-func (t *TestStaker) GetDeposit(lpTokenId uint64) *staker.Deposit {
+func (t *TestStaker) GetDeposit(lpTokenId uint64) (*staker.Deposit, error) {
 	if !t.isActive("GetDeposit") {
 		panic("test implementation: GetDeposit not supported")
 	}
 	return t.instance.GetDeposit(lpTokenId)
 }
 
-func (t *TestStaker) CollectableEmissionReward(positionId uint64) int64 {
+func (t *TestStaker) CollectableEmissionReward(positionId uint64) (int64, error) {
 	if !t.isActive("CollectableEmissionReward") {
 		panic("test implementation: CollectableEmissionReward not supported")
 	}
 	return t.instance.CollectableEmissionReward(positionId)
 }
 
-func (t *TestStaker) CollectableExternalIncentiveReward(positionId uint64, incentiveId string) int64 {
+func (t *TestStaker) CollectableExternalIncentiveReward(positionId uint64, incentiveId string) (int64, error) {
 	if !t.isActive("CollectableExternalIncentiveReward") {
 		panic("test implementation: CollectableExternalIncentiveReward not supported")
 	}
 	return t.instance.CollectableExternalIncentiveReward(positionId, incentiveId)
 }
 
-func (t *TestStaker) GetCreatedHeightOfIncentive(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetCreatedHeightOfIncentive(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetCreatedHeightOfIncentive") {
 		panic("test implementation: GetCreatedHeightOfIncentive not supported")
 	}
 	return t.instance.GetCreatedHeightOfIncentive(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveCreatedTimestamp(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveCreatedTimestamp(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveCreatedTimestamp") {
 		panic("test implementation: GetIncentiveCreatedTimestamp not supported")
 	}
 	return t.instance.GetIncentiveCreatedTimestamp(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveTotalRewardAmount(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveTotalRewardAmount(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveTotalRewardAmount") {
 		panic("test implementation: GetIncentiveTotalRewardAmount not supported")
 	}
 	return t.instance.GetIncentiveTotalRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveDistributedRewardAmount(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveDistributedRewardAmount(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveDistributedRewardAmount") {
 		panic("test implementation: GetIncentiveDistributedRewardAmount not supported")
 	}
 	return t.instance.GetIncentiveDistributedRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveRemainingRewardAmount") {
 		panic("test implementation: GetIncentiveRemainingRewardAmount not supported")
 	}
 	return t.instance.GetIncentiveRemainingRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveAccumulatedPenaltyAmount") {
 		panic("test implementation: GetIncentiveAccumulatedPenaltyAmount not supported")
 	}
 	return t.instance.GetIncentiveAccumulatedPenaltyAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveDepositGnsAmount") {
 		panic("test implementation: GetIncentiveDepositGnsAmount not supported")
 	}
 	return t.instance.GetIncentiveDepositGnsAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRefunded(poolPath string, incentiveId string) bool {
+func (t *TestStaker) GetIncentiveRefunded(poolPath string, incentiveId string) (bool, error) {
 	if !t.isActive("GetIncentiveRefunded") {
 		panic("test implementation: GetIncentiveRefunded not supported")
 	}
 	return t.instance.GetIncentiveRefunded(poolPath, incentiveId)
 }
 
-func (t *TestStaker) IsIncentiveActive(poolPath string, incentiveId string) bool {
+func (t *TestStaker) IsIncentiveActive(poolPath string, incentiveId string) (bool, error) {
 	if !t.isActive("IsIncentiveActive") {
 		panic("test implementation: IsIncentiveActive not supported")
 	}
 	return t.instance.IsIncentiveActive(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetDepositExternalRewardLastCollectTimestamp(lpTokenId uint64, incentiveId string) int64 {
+func (t *TestStaker) GetDepositExternalRewardLastCollectTimestamp(lpTokenId uint64, incentiveId string) (int64, error) {
 	if !t.isActive("GetDepositExternalRewardLastCollectTimestamp") {
 		panic("test implementation: GetDepositExternalRewardLastCollectTimestamp not supported")
 	}
@@ -264,140 +264,140 @@ func (t *TestStaker) GetDepositGnsAmount() int64 {
 	return t.instance.GetDepositGnsAmount()
 }
 
-func (t *TestStaker) GetDepositInternalRewardLastCollectTimestamp(lpTokenId uint64) int64 {
+func (t *TestStaker) GetDepositInternalRewardLastCollectTimestamp(lpTokenId uint64) (int64, error) {
 	if !t.isActive("GetDepositInternalRewardLastCollectTimestamp") {
 		panic("test implementation: GetDepositInternalRewardLastCollectTimestamp not supported")
 	}
 	return t.instance.GetDepositInternalRewardLastCollectTimestamp(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositCollectedInternalReward(lpTokenId uint64) int64 {
+func (t *TestStaker) GetDepositCollectedInternalReward(lpTokenId uint64) (int64, error) {
 	if !t.isActive("GetDepositCollectedInternalReward") {
 		panic("test implementation: GetDepositCollectedInternalReward not supported")
 	}
 	return t.instance.GetDepositCollectedInternalReward(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositCollectedExternalReward(lpTokenId uint64, incentiveId string) int64 {
+func (t *TestStaker) GetDepositCollectedExternalReward(lpTokenId uint64, incentiveId string) (int64, error) {
 	if !t.isActive("GetDepositCollectedExternalReward") {
 		panic("test implementation: GetDepositCollectedExternalReward not supported")
 	}
 	return t.instance.GetDepositCollectedExternalReward(lpTokenId, incentiveId)
 }
 
-func (t *TestStaker) GetDepositLiquidity(lpTokenId uint64) *u256.Uint {
+func (t *TestStaker) GetDepositLiquidity(lpTokenId uint64) (*u256.Uint, error) {
 	if !t.isActive("GetDepositLiquidity") {
 		panic("test implementation: GetDepositLiquidity not supported")
 	}
 	return t.instance.GetDepositLiquidity(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositLiquidityAsString(lpTokenId uint64) string {
+func (t *TestStaker) GetDepositLiquidityAsString(lpTokenId uint64) (string, error) {
 	if !t.isActive("GetDepositLiquidityAsString") {
 		panic("test implementation: GetDepositLiquidityAsString not supported")
 	}
 	return t.instance.GetDepositLiquidityAsString(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositOwner(lpTokenId uint64) address {
+func (t *TestStaker) GetDepositOwner(lpTokenId uint64) (address, error) {
 	if !t.isActive("GetDepositOwner") {
 		panic("test implementation: GetDepositOwner not supported")
 	}
 	return t.instance.GetDepositOwner(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositStakeTime(lpTokenId uint64) int64 {
+func (t *TestStaker) GetDepositStakeTime(lpTokenId uint64) (int64, error) {
 	if !t.isActive("GetDepositStakeTime") {
 		panic("test implementation: GetDepositStakeTime not supported")
 	}
 	return t.instance.GetDepositStakeTime(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositTargetPoolPath(lpTokenId uint64) string {
+func (t *TestStaker) GetDepositTargetPoolPath(lpTokenId uint64) (string, error) {
 	if !t.isActive("GetDepositTargetPoolPath") {
 		panic("test implementation: GetDepositTargetPoolPath not supported")
 	}
 	return t.instance.GetDepositTargetPoolPath(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositTickLower(lpTokenId uint64) int32 {
+func (t *TestStaker) GetDepositTickLower(lpTokenId uint64) (int32, error) {
 	if !t.isActive("GetDepositTickLower") {
 		panic("test implementation: GetDepositTickLower not supported")
 	}
 	return t.instance.GetDepositTickLower(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositTickUpper(lpTokenId uint64) int32 {
+func (t *TestStaker) GetDepositTickUpper(lpTokenId uint64) (int32, error) {
 	if !t.isActive("GetDepositTickUpper") {
 		panic("test implementation: GetDepositTickUpper not supported")
 	}
 	return t.instance.GetDepositTickUpper(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositWarmUp(lpTokenId uint64) []staker.Warmup {
+func (t *TestStaker) GetDepositWarmUp(lpTokenId uint64) ([]staker.Warmup, error) {
 	if !t.isActive("GetDepositWarmUp") {
 		panic("test implementation: GetDepositWarmUp not supported")
 	}
 	return t.instance.GetDepositWarmUp(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositExternalIncentiveIdList(lpTokenId uint64) []string {
+func (t *TestStaker) GetDepositExternalIncentiveIdList(lpTokenId uint64) ([]string, error) {
 	if !t.isActive("GetDepositExternalIncentiveIdList") {
 		panic("test implementation: GetDepositExternalIncentiveIdList not supported")
 	}
 	return t.instance.GetDepositExternalIncentiveIdList(lpTokenId)
 }
 
-func (t *TestStaker) GetExternalIncentiveByPoolPath(poolPath string) []staker.ExternalIncentive {
+func (t *TestStaker) GetExternalIncentiveByPoolPath(poolPath string) ([]staker.ExternalIncentive, error) {
 	if !t.isActive("GetExternalIncentiveByPoolPath") {
 		panic("test implementation: GetExternalIncentiveByPoolPath not supported")
 	}
 	return t.instance.GetExternalIncentiveByPoolPath(poolPath)
 }
 
-func (t *TestStaker) GetIncentiveEndTimestamp(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveEndTimestamp(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveEndTimestamp") {
 		panic("test implementation: GetIncentiveEndTimestamp not supported")
 	}
 	return t.instance.GetIncentiveEndTimestamp(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveCreator(poolPath string, incentiveId string) address {
+func (t *TestStaker) GetIncentiveCreator(poolPath string, incentiveId string) (address, error) {
 	if !t.isActive("GetIncentiveCreator") {
 		panic("test implementation: GetIncentiveCreator not supported")
 	}
 	return t.instance.GetIncentiveCreator(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardAmount(poolPath string, incentiveId string) *u256.Uint {
+func (t *TestStaker) GetIncentiveRewardAmount(poolPath string, incentiveId string) (*u256.Uint, error) {
 	if !t.isActive("GetIncentiveRewardAmount") {
 		panic("test implementation: GetIncentiveRewardAmount not supported")
 	}
 	return t.instance.GetIncentiveRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) string {
+func (t *TestStaker) GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) (string, error) {
 	if !t.isActive("GetIncentiveRewardAmountAsString") {
 		panic("test implementation: GetIncentiveRewardAmountAsString not supported")
 	}
 	return t.instance.GetIncentiveRewardAmountAsString(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) *u256.Uint {
+func (t *TestStaker) GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) (*u256.Uint, error) {
 	if !t.isActive("GetIncentiveRewardPerSecondX128") {
 		panic("test implementation: GetIncentiveRewardPerSecondX128 not supported")
 	}
 	return t.instance.GetIncentiveRewardPerSecondX128(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardToken(poolPath string, incentiveId string) string {
+func (t *TestStaker) GetIncentiveRewardToken(poolPath string, incentiveId string) (string, error) {
 	if !t.isActive("GetIncentiveRewardToken") {
 		panic("test implementation: GetIncentiveRewardToken not supported")
 	}
 	return t.instance.GetIncentiveRewardToken(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveStartTimestamp(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveStartTimestamp(poolPath string, incentiveId string) (int64, error) {
 	if !t.isActive("GetIncentiveStartTimestamp") {
 		panic("test implementation: GetIncentiveStartTimestamp not supported")
 	}
@@ -418,21 +418,21 @@ func (t *TestStaker) GetMinimumRewardAmountForToken(tokenPath string) int64 {
 	return t.instance.GetMinimumRewardAmountForToken(tokenPath)
 }
 
-func (t *TestStaker) GetPoolStakedLiquidity(poolPath string) string {
+func (t *TestStaker) GetPoolStakedLiquidity(poolPath string) (string, error) {
 	if !t.isActive("GetPoolStakedLiquidity") {
 		panic("test implementation: GetPoolStakedLiquidity not supported")
 	}
 	return t.instance.GetPoolStakedLiquidity(poolPath)
 }
 
-func (t *TestStaker) GetPoolsByTier(tier uint64) []string {
+func (t *TestStaker) GetPoolsByTier(tier uint64) ([]string, error) {
 	if !t.isActive("GetPoolsByTier") {
 		panic("test implementation: GetPoolsByTier not supported")
 	}
 	return t.instance.GetPoolsByTier(tier)
 }
 
-func (t *TestStaker) GetPoolReward(tier uint64) int64 {
+func (t *TestStaker) GetPoolReward(tier uint64) (int64, error) {
 	if !t.isActive("GetPoolReward") {
 		panic("test implementation: GetPoolReward not supported")
 	}
@@ -453,7 +453,7 @@ func (t *TestStaker) GetPoolTierCount(tier uint64) uint64 {
 	return t.instance.GetPoolTierCount(tier)
 }
 
-func (t *TestStaker) GetPoolTierRatio(poolPath string) uint64 {
+func (t *TestStaker) GetPoolTierRatio(poolPath string) (uint64, error) {
 	if !t.isActive("GetPoolTierRatio") {
 		panic("test implementation: GetPoolTierRatio not supported")
 	}
@@ -467,7 +467,7 @@ func (t *TestStaker) GetSpecificTokenMinimumRewardAmount(tokenPath string) (int6
 	return t.instance.GetSpecificTokenMinimumRewardAmount(tokenPath)
 }
 
-func (t *TestStaker) GetTargetPoolPathByIncentiveId(poolPath string, incentiveId string) string {
+func (t *TestStaker) GetTargetPoolPathByIncentiveId(poolPath string, incentiveId string) (string, error) {
 	if !t.isActive("GetTargetPoolPathByIncentiveId") {
 		panic("test implementation: GetTargetPoolPathByIncentiveId not supported")
 	}

--- a/contract/r/scenario/upgrade/implements/v3_valid/staker/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/staker/test_impl.gno
@@ -91,59 +91,59 @@ func (t *TestStaker) SetUnStakingFee(_ int, rlm realm, fee uint64) {
 }
 
 // IStakerGetter interface
-func (t *TestStaker) GetPool(poolPath string) *staker.Pool {
+func (t *TestStaker) GetPool(poolPath string) (*staker.Pool, error) {
 	return t.instance.GetPool(poolPath)
 }
 
-func (t *TestStaker) GetDeposit(lpTokenId uint64) *staker.Deposit {
+func (t *TestStaker) GetDeposit(lpTokenId uint64) (*staker.Deposit, error) {
 	return t.instance.GetDeposit(lpTokenId)
 }
 
-func (t *TestStaker) CollectableEmissionReward(positionId uint64) int64 {
+func (t *TestStaker) CollectableEmissionReward(positionId uint64) (int64, error) {
 	return t.instance.CollectableEmissionReward(positionId)
 }
 
-func (t *TestStaker) CollectableExternalIncentiveReward(positionId uint64, incentiveId string) int64 {
+func (t *TestStaker) CollectableExternalIncentiveReward(positionId uint64, incentiveId string) (int64, error) {
 	return t.instance.CollectableExternalIncentiveReward(positionId, incentiveId)
 }
 
-func (t *TestStaker) GetCreatedHeightOfIncentive(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetCreatedHeightOfIncentive(poolPath string, incentiveId string) (int64, error) {
 	return t.instance.GetCreatedHeightOfIncentive(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveCreatedTimestamp(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveCreatedTimestamp(poolPath string, incentiveId string) (int64, error) {
 	return t.instance.GetIncentiveCreatedTimestamp(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveTotalRewardAmount(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveTotalRewardAmount(poolPath string, incentiveId string) (int64, error) {
 	return t.instance.GetIncentiveTotalRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveDistributedRewardAmount(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveDistributedRewardAmount(poolPath string, incentiveId string) (int64, error) {
 	return t.instance.GetIncentiveDistributedRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) (int64, error) {
 	return t.instance.GetIncentiveRemainingRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) (int64, error) {
 	return t.instance.GetIncentiveAccumulatedPenaltyAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) (int64, error) {
 	return t.instance.GetIncentiveDepositGnsAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRefunded(poolPath string, incentiveId string) bool {
+func (t *TestStaker) GetIncentiveRefunded(poolPath string, incentiveId string) (bool, error) {
 	return t.instance.GetIncentiveRefunded(poolPath, incentiveId)
 }
 
-func (t *TestStaker) IsIncentiveActive(poolPath string, incentiveId string) bool {
+func (t *TestStaker) IsIncentiveActive(poolPath string, incentiveId string) (bool, error) {
 	return t.instance.IsIncentiveActive(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetDepositExternalRewardLastCollectTimestamp(lpTokenId uint64, incentiveId string) int64 {
+func (t *TestStaker) GetDepositExternalRewardLastCollectTimestamp(lpTokenId uint64, incentiveId string) (int64, error) {
 	return t.instance.GetDepositExternalRewardLastCollectTimestamp(lpTokenId, incentiveId)
 }
 
@@ -151,83 +151,83 @@ func (t *TestStaker) GetDepositGnsAmount() int64 {
 	return t.instance.GetDepositGnsAmount()
 }
 
-func (t *TestStaker) GetDepositInternalRewardLastCollectTimestamp(lpTokenId uint64) int64 {
+func (t *TestStaker) GetDepositInternalRewardLastCollectTimestamp(lpTokenId uint64) (int64, error) {
 	return t.instance.GetDepositInternalRewardLastCollectTimestamp(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositCollectedInternalReward(lpTokenId uint64) int64 {
+func (t *TestStaker) GetDepositCollectedInternalReward(lpTokenId uint64) (int64, error) {
 	return t.instance.GetDepositCollectedInternalReward(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositCollectedExternalReward(lpTokenId uint64, incentiveId string) int64 {
+func (t *TestStaker) GetDepositCollectedExternalReward(lpTokenId uint64, incentiveId string) (int64, error) {
 	return t.instance.GetDepositCollectedExternalReward(lpTokenId, incentiveId)
 }
 
-func (t *TestStaker) GetDepositLiquidity(lpTokenId uint64) *u256.Uint {
+func (t *TestStaker) GetDepositLiquidity(lpTokenId uint64) (*u256.Uint, error) {
 	return t.instance.GetDepositLiquidity(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositLiquidityAsString(lpTokenId uint64) string {
+func (t *TestStaker) GetDepositLiquidityAsString(lpTokenId uint64) (string, error) {
 	return t.instance.GetDepositLiquidityAsString(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositOwner(lpTokenId uint64) address {
+func (t *TestStaker) GetDepositOwner(lpTokenId uint64) (address, error) {
 	return t.instance.GetDepositOwner(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositStakeTime(lpTokenId uint64) int64 {
+func (t *TestStaker) GetDepositStakeTime(lpTokenId uint64) (int64, error) {
 	return t.instance.GetDepositStakeTime(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositTargetPoolPath(lpTokenId uint64) string {
+func (t *TestStaker) GetDepositTargetPoolPath(lpTokenId uint64) (string, error) {
 	return t.instance.GetDepositTargetPoolPath(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositTickLower(lpTokenId uint64) int32 {
+func (t *TestStaker) GetDepositTickLower(lpTokenId uint64) (int32, error) {
 	return t.instance.GetDepositTickLower(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositTickUpper(lpTokenId uint64) int32 {
+func (t *TestStaker) GetDepositTickUpper(lpTokenId uint64) (int32, error) {
 	return t.instance.GetDepositTickUpper(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositWarmUp(lpTokenId uint64) []staker.Warmup {
+func (t *TestStaker) GetDepositWarmUp(lpTokenId uint64) ([]staker.Warmup, error) {
 	return t.instance.GetDepositWarmUp(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositExternalIncentiveIdList(lpTokenId uint64) []string {
+func (t *TestStaker) GetDepositExternalIncentiveIdList(lpTokenId uint64) ([]string, error) {
 	return t.instance.GetDepositExternalIncentiveIdList(lpTokenId)
 }
 
-func (t *TestStaker) GetExternalIncentiveByPoolPath(poolPath string) []staker.ExternalIncentive {
+func (t *TestStaker) GetExternalIncentiveByPoolPath(poolPath string) ([]staker.ExternalIncentive, error) {
 	return t.instance.GetExternalIncentiveByPoolPath(poolPath)
 }
 
-func (t *TestStaker) GetIncentiveEndTimestamp(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveEndTimestamp(poolPath string, incentiveId string) (int64, error) {
 	return t.instance.GetIncentiveEndTimestamp(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveCreator(poolPath string, incentiveId string) address {
+func (t *TestStaker) GetIncentiveCreator(poolPath string, incentiveId string) (address, error) {
 	return t.instance.GetIncentiveCreator(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardAmount(poolPath string, incentiveId string) *u256.Uint {
+func (t *TestStaker) GetIncentiveRewardAmount(poolPath string, incentiveId string) (*u256.Uint, error) {
 	return t.instance.GetIncentiveRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) string {
+func (t *TestStaker) GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) (string, error) {
 	return t.instance.GetIncentiveRewardAmountAsString(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) *u256.Uint {
+func (t *TestStaker) GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) (*u256.Uint, error) {
 	return t.instance.GetIncentiveRewardPerSecondX128(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardToken(poolPath string, incentiveId string) string {
+func (t *TestStaker) GetIncentiveRewardToken(poolPath string, incentiveId string) (string, error) {
 	return t.instance.GetIncentiveRewardToken(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveStartTimestamp(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveStartTimestamp(poolPath string, incentiveId string) (int64, error) {
 	return t.instance.GetIncentiveStartTimestamp(poolPath, incentiveId)
 }
 
@@ -239,15 +239,15 @@ func (t *TestStaker) GetMinimumRewardAmountForToken(tokenPath string) int64 {
 	return t.instance.GetMinimumRewardAmountForToken(tokenPath)
 }
 
-func (t *TestStaker) GetPoolStakedLiquidity(poolPath string) string {
+func (t *TestStaker) GetPoolStakedLiquidity(poolPath string) (string, error) {
 	return t.instance.GetPoolStakedLiquidity(poolPath)
 }
 
-func (t *TestStaker) GetPoolsByTier(tier uint64) []string {
+func (t *TestStaker) GetPoolsByTier(tier uint64) ([]string, error) {
 	return t.instance.GetPoolsByTier(tier)
 }
 
-func (t *TestStaker) GetPoolReward(tier uint64) int64 {
+func (t *TestStaker) GetPoolReward(tier uint64) (int64, error) {
 	return t.instance.GetPoolReward(tier)
 }
 
@@ -259,7 +259,7 @@ func (t *TestStaker) GetPoolTierCount(tier uint64) uint64 {
 	return t.instance.GetPoolTierCount(tier)
 }
 
-func (t *TestStaker) GetPoolTierRatio(poolPath string) uint64 {
+func (t *TestStaker) GetPoolTierRatio(poolPath string) (uint64, error) {
 	return t.instance.GetPoolTierRatio(poolPath)
 }
 
@@ -267,7 +267,7 @@ func (t *TestStaker) GetSpecificTokenMinimumRewardAmount(tokenPath string) (int6
 	return t.instance.GetSpecificTokenMinimumRewardAmount(tokenPath)
 }
 
-func (t *TestStaker) GetTargetPoolPathByIncentiveId(poolPath string, incentiveId string) string {
+func (t *TestStaker) GetTargetPoolPathByIncentiveId(poolPath string, incentiveId string) (string, error) {
 	return t.instance.GetTargetPoolPathByIncentiveId(poolPath, incentiveId)
 }
 

--- a/contract/r/scenario/upgrade/implements/v3_valid/staker/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/staker/test_impl.gno
@@ -95,59 +95,59 @@ func (t *TestStaker) SetUnStakingFee(_ int, rlm realm, fee uint64) {
 }
 
 // IStakerGetter interface
-func (t *TestStaker) GetPool(poolPath string) *staker.Pool {
+func (t *TestStaker) GetPool(poolPath string) (*staker.Pool, error) {
 	return t.instance.GetPool(poolPath)
 }
 
-func (t *TestStaker) GetDeposit(lpTokenId uint64) *staker.Deposit {
+func (t *TestStaker) GetDeposit(lpTokenId uint64) (*staker.Deposit, error) {
 	return t.instance.GetDeposit(lpTokenId)
 }
 
-func (t *TestStaker) CollectableEmissionReward(positionId uint64) int64 {
+func (t *TestStaker) CollectableEmissionReward(positionId uint64) (int64, error) {
 	return t.instance.CollectableEmissionReward(positionId)
 }
 
-func (t *TestStaker) CollectableExternalIncentiveReward(positionId uint64, incentiveId string) int64 {
+func (t *TestStaker) CollectableExternalIncentiveReward(positionId uint64, incentiveId string) (int64, error) {
 	return t.instance.CollectableExternalIncentiveReward(positionId, incentiveId)
 }
 
-func (t *TestStaker) GetCreatedHeightOfIncentive(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetCreatedHeightOfIncentive(poolPath string, incentiveId string) (int64, error) {
 	return t.instance.GetCreatedHeightOfIncentive(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveCreatedTimestamp(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveCreatedTimestamp(poolPath string, incentiveId string) (int64, error) {
 	return t.instance.GetIncentiveCreatedTimestamp(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveTotalRewardAmount(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveTotalRewardAmount(poolPath string, incentiveId string) (int64, error) {
 	return t.instance.GetIncentiveTotalRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveDistributedRewardAmount(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveDistributedRewardAmount(poolPath string, incentiveId string) (int64, error) {
 	return t.instance.GetIncentiveDistributedRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveRemainingRewardAmount(poolPath string, incentiveId string) (int64, error) {
 	return t.instance.GetIncentiveRemainingRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveAccumulatedPenaltyAmount(poolPath string, incentiveId string) (int64, error) {
 	return t.instance.GetIncentiveAccumulatedPenaltyAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveDepositGnsAmount(poolPath string, incentiveId string) (int64, error) {
 	return t.instance.GetIncentiveDepositGnsAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRefunded(poolPath string, incentiveId string) bool {
+func (t *TestStaker) GetIncentiveRefunded(poolPath string, incentiveId string) (bool, error) {
 	return t.instance.GetIncentiveRefunded(poolPath, incentiveId)
 }
 
-func (t *TestStaker) IsIncentiveActive(poolPath string, incentiveId string) bool {
+func (t *TestStaker) IsIncentiveActive(poolPath string, incentiveId string) (bool, error) {
 	return t.instance.IsIncentiveActive(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetDepositExternalRewardLastCollectTimestamp(lpTokenId uint64, incentiveId string) int64 {
+func (t *TestStaker) GetDepositExternalRewardLastCollectTimestamp(lpTokenId uint64, incentiveId string) (int64, error) {
 	return t.instance.GetDepositExternalRewardLastCollectTimestamp(lpTokenId, incentiveId)
 }
 
@@ -155,83 +155,83 @@ func (t *TestStaker) GetDepositGnsAmount() int64 {
 	return t.instance.GetDepositGnsAmount()
 }
 
-func (t *TestStaker) GetDepositInternalRewardLastCollectTimestamp(lpTokenId uint64) int64 {
+func (t *TestStaker) GetDepositInternalRewardLastCollectTimestamp(lpTokenId uint64) (int64, error) {
 	return t.instance.GetDepositInternalRewardLastCollectTimestamp(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositCollectedInternalReward(lpTokenId uint64) int64 {
+func (t *TestStaker) GetDepositCollectedInternalReward(lpTokenId uint64) (int64, error) {
 	return t.instance.GetDepositCollectedInternalReward(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositCollectedExternalReward(lpTokenId uint64, incentiveId string) int64 {
+func (t *TestStaker) GetDepositCollectedExternalReward(lpTokenId uint64, incentiveId string) (int64, error) {
 	return t.instance.GetDepositCollectedExternalReward(lpTokenId, incentiveId)
 }
 
-func (t *TestStaker) GetDepositLiquidity(lpTokenId uint64) *u256.Uint {
+func (t *TestStaker) GetDepositLiquidity(lpTokenId uint64) (*u256.Uint, error) {
 	return t.instance.GetDepositLiquidity(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositLiquidityAsString(lpTokenId uint64) string {
+func (t *TestStaker) GetDepositLiquidityAsString(lpTokenId uint64) (string, error) {
 	return t.instance.GetDepositLiquidityAsString(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositOwner(lpTokenId uint64) address {
+func (t *TestStaker) GetDepositOwner(lpTokenId uint64) (address, error) {
 	return t.instance.GetDepositOwner(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositStakeTime(lpTokenId uint64) int64 {
+func (t *TestStaker) GetDepositStakeTime(lpTokenId uint64) (int64, error) {
 	return t.instance.GetDepositStakeTime(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositTargetPoolPath(lpTokenId uint64) string {
+func (t *TestStaker) GetDepositTargetPoolPath(lpTokenId uint64) (string, error) {
 	return t.instance.GetDepositTargetPoolPath(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositTickLower(lpTokenId uint64) int32 {
+func (t *TestStaker) GetDepositTickLower(lpTokenId uint64) (int32, error) {
 	return t.instance.GetDepositTickLower(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositTickUpper(lpTokenId uint64) int32 {
+func (t *TestStaker) GetDepositTickUpper(lpTokenId uint64) (int32, error) {
 	return t.instance.GetDepositTickUpper(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositWarmUp(lpTokenId uint64) []staker.Warmup {
+func (t *TestStaker) GetDepositWarmUp(lpTokenId uint64) ([]staker.Warmup, error) {
 	return t.instance.GetDepositWarmUp(lpTokenId)
 }
 
-func (t *TestStaker) GetDepositExternalIncentiveIdList(lpTokenId uint64) []string {
+func (t *TestStaker) GetDepositExternalIncentiveIdList(lpTokenId uint64) ([]string, error) {
 	return t.instance.GetDepositExternalIncentiveIdList(lpTokenId)
 }
 
-func (t *TestStaker) GetExternalIncentiveByPoolPath(poolPath string) []staker.ExternalIncentive {
+func (t *TestStaker) GetExternalIncentiveByPoolPath(poolPath string) ([]staker.ExternalIncentive, error) {
 	return t.instance.GetExternalIncentiveByPoolPath(poolPath)
 }
 
-func (t *TestStaker) GetIncentiveEndTimestamp(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveEndTimestamp(poolPath string, incentiveId string) (int64, error) {
 	return t.instance.GetIncentiveEndTimestamp(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveCreator(poolPath string, incentiveId string) address {
+func (t *TestStaker) GetIncentiveCreator(poolPath string, incentiveId string) (address, error) {
 	return t.instance.GetIncentiveCreator(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardAmount(poolPath string, incentiveId string) *u256.Uint {
+func (t *TestStaker) GetIncentiveRewardAmount(poolPath string, incentiveId string) (*u256.Uint, error) {
 	return t.instance.GetIncentiveRewardAmount(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) string {
+func (t *TestStaker) GetIncentiveRewardAmountAsString(poolPath string, incentiveId string) (string, error) {
 	return t.instance.GetIncentiveRewardAmountAsString(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) *u256.Uint {
+func (t *TestStaker) GetIncentiveRewardPerSecondX128(poolPath string, incentiveId string) (*u256.Uint, error) {
 	return t.instance.GetIncentiveRewardPerSecondX128(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveRewardToken(poolPath string, incentiveId string) string {
+func (t *TestStaker) GetIncentiveRewardToken(poolPath string, incentiveId string) (string, error) {
 	return t.instance.GetIncentiveRewardToken(poolPath, incentiveId)
 }
 
-func (t *TestStaker) GetIncentiveStartTimestamp(poolPath string, incentiveId string) int64 {
+func (t *TestStaker) GetIncentiveStartTimestamp(poolPath string, incentiveId string) (int64, error) {
 	return t.instance.GetIncentiveStartTimestamp(poolPath, incentiveId)
 }
 
@@ -243,15 +243,15 @@ func (t *TestStaker) GetMinimumRewardAmountForToken(tokenPath string) int64 {
 	return t.instance.GetMinimumRewardAmountForToken(tokenPath)
 }
 
-func (t *TestStaker) GetPoolStakedLiquidity(poolPath string) string {
+func (t *TestStaker) GetPoolStakedLiquidity(poolPath string) (string, error) {
 	return t.instance.GetPoolStakedLiquidity(poolPath)
 }
 
-func (t *TestStaker) GetPoolsByTier(tier uint64) []string {
+func (t *TestStaker) GetPoolsByTier(tier uint64) ([]string, error) {
 	return t.instance.GetPoolsByTier(tier)
 }
 
-func (t *TestStaker) GetPoolReward(tier uint64) int64 {
+func (t *TestStaker) GetPoolReward(tier uint64) (int64, error) {
 	return t.instance.GetPoolReward(tier)
 }
 
@@ -263,7 +263,7 @@ func (t *TestStaker) GetPoolTierCount(tier uint64) uint64 {
 	return t.instance.GetPoolTierCount(tier)
 }
 
-func (t *TestStaker) GetPoolTierRatio(poolPath string) uint64 {
+func (t *TestStaker) GetPoolTierRatio(poolPath string) (uint64, error) {
 	return t.instance.GetPoolTierRatio(poolPath)
 }
 
@@ -271,7 +271,7 @@ func (t *TestStaker) GetSpecificTokenMinimumRewardAmount(tokenPath string) (int6
 	return t.instance.GetSpecificTokenMinimumRewardAmount(tokenPath)
 }
 
-func (t *TestStaker) GetTargetPoolPathByIncentiveId(poolPath string, incentiveId string) string {
+func (t *TestStaker) GetTargetPoolPathByIncentiveId(poolPath string, incentiveId string) (string, error) {
 	return t.instance.GetTargetPoolPathByIncentiveId(poolPath, incentiveId)
 }
 

--- a/contract/r/scenario/upgrade/staker_collect_reward_distribution_rollback_with_validate_data_filetest.gno
+++ b/contract/r/scenario/upgrade/staker_collect_reward_distribution_rollback_with_validate_data_filetest.gno
@@ -203,9 +203,9 @@ func checkStakingInfo(cur realm, positionId uint64) {
 	println("[EXPECTED] Is staked:", isStaked)
 
 	if isStaked {
-		targetPoolPath := staker.GetDepositTargetPoolPath(positionId)
-		liquidity := staker.GetDepositLiquidityAsString(positionId)
-		stakeTime := staker.GetDepositStakeTime(positionId)
+		targetPoolPath, _ := staker.GetDepositTargetPoolPath(positionId)
+		liquidity, _ := staker.GetDepositLiquidityAsString(positionId)
+		stakeTime, _ := staker.GetDepositStakeTime(positionId)
 
 		println("[EXPECTED] Target pool path:", targetPoolPath)
 		println("[EXPECTED] Staked liquidity:", liquidity)

--- a/contract/r/scenario/upgrade/staker_collect_reward_distribution_upgrade_with_validate_data_filetest.gno
+++ b/contract/r/scenario/upgrade/staker_collect_reward_distribution_upgrade_with_validate_data_filetest.gno
@@ -205,9 +205,9 @@ func checkStakingInfo(cur realm, positionId uint64) {
 	println("[EXPECTED] Is staked:", isStaked)
 
 	if isStaked {
-		targetPoolPath := staker.GetDepositTargetPoolPath(positionId)
-		liquidity := staker.GetDepositLiquidityAsString(positionId)
-		stakeTime := staker.GetDepositStakeTime(positionId)
+		targetPoolPath, _ := staker.GetDepositTargetPoolPath(positionId)
+		liquidity, _ := staker.GetDepositLiquidityAsString(positionId)
+		stakeTime, _ := staker.GetDepositStakeTime(positionId)
 
 		println("[EXPECTED] Target pool path:", targetPoolPath)
 		println("[EXPECTED] Staked liquidity:", liquidity)

--- a/contract/r/scenario/upgrade/staker_collect_reward_upgrade_with_validate_data_filetest.gno
+++ b/contract/r/scenario/upgrade/staker_collect_reward_upgrade_with_validate_data_filetest.gno
@@ -45,23 +45,25 @@ var (
 	barFoo500PoolPath = "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:500"
 	positionId        = uint64(1)
 
-	// snapshot of the staking state written by v1
-	v1DepositOwner       address
-	v1DepositPoolPath    string
-	v1DepositLiquidity   string
-	v1DepositStakeTime   int64
-	v1DepositTickLower   int32
-	v1DepositTickUpper   int32
-	v1DepositWarmupCount int
-	v1CollectedInternal  int64
-	v1PoolTier           uint64
-	v1PoolTierRatio      uint64
-	v1PoolStakedLiq      string
-	v1UnstakingFee       uint64
-	v1DepositGnsAmount   int64
-	v1AllowedTokenCount  int
-	v1TotalEmissionSent  int64
 )
+
+type stakerSnapshot struct {
+	depositOwner       address
+	depositPoolPath    string
+	depositLiquidity   string
+	depositStakeTime   int64
+	depositTickLower   int32
+	depositTickUpper   int32
+	depositWarmupCount int
+	collectedInternal  int64
+	poolTier           uint64
+	poolTierRatio      uint64
+	poolStakedLiq      string
+	unstakingFee       uint64
+	depositGnsAmount   int64
+	allowedTokenCount  int
+	totalEmissionSent  int64
+}
 
 const (
 	stakerV1Path        = "gno.land/r/gnoswap/staker/v1"
@@ -100,7 +102,7 @@ func main(cur realm) {
 	println()
 
 	println("[SCENARIO] 7-1. Snapshot the staking state written by v1")
-	captureV1Snapshot()
+	snapshot := captureV1Snapshot()
 	println()
 
 	println("[SCENARIO] 8. Staker Contract Upgrade to v2_invalid")
@@ -108,9 +110,9 @@ func main(cur realm) {
 	println()
 
 	println("[SCENARIO] 9. Collect reward with v2_invalid (should panic)")
+	waitBlocks(cur, 10)
 	withAbortsWithMessage(
 		cur, func() {
-			waitBlocks(cur, 10)
 			collectReward(cur, positionId)
 		},
 		"[EXPECTED] Collect reward panics correctly with v2_invalid",
@@ -131,7 +133,7 @@ func main(cur realm) {
 	println()
 
 	println("[SCENARIO] 11-1. Validate the v1 staking data exactly, before collecting again")
-	validateExactAfterUpgrade()
+	validateExactAfterUpgrade(snapshot)
 	println()
 
 	println("[SCENARIO] 12. Check staking info after upgrade to v3_valid")
@@ -147,32 +149,34 @@ func main(cur realm) {
 	println()
 
 	println("[SCENARIO] 15. Validate the reward ledgers after the post-upgrade collection")
-	validateAccrualAfterUpgrade()
+	validateAccrualAfterUpgrade(snapshot)
 	println()
 }
 
-func captureV1Snapshot() {
-	v1DepositOwner, err := staker.GetDepositOwner(positionId)
+func captureV1Snapshot() stakerSnapshot {
+	snapshot := stakerSnapshot{}
+	var err error
+	snapshot.depositOwner, err = staker.GetDepositOwner(positionId)
 	if err != nil {
 		panic(err)
 	}
-	v1DepositPoolPath, err = staker.GetDepositTargetPoolPath(positionId)
+	snapshot.depositPoolPath, err = staker.GetDepositTargetPoolPath(positionId)
 	if err != nil {
 		panic(err)
 	}
-	v1DepositLiquidity, err = staker.GetDepositLiquidityAsString(positionId)
+	snapshot.depositLiquidity, err = staker.GetDepositLiquidityAsString(positionId)
 	if err != nil {
 		panic(err)
 	}
-	v1DepositStakeTime, err = staker.GetDepositStakeTime(positionId)
+	snapshot.depositStakeTime, err = staker.GetDepositStakeTime(positionId)
 	if err != nil {
 		panic(err)
 	}
-	v1DepositTickLower, err = staker.GetDepositTickLower(positionId)
+	snapshot.depositTickLower, err = staker.GetDepositTickLower(positionId)
 	if err != nil {
 		panic(err)
 	}
-	v1DepositTickUpper, err = staker.GetDepositTickUpper(positionId)
+	snapshot.depositTickUpper, err = staker.GetDepositTickUpper(positionId)
 	if err != nil {
 		panic(err)
 	}
@@ -180,104 +184,106 @@ func captureV1Snapshot() {
 	if err != nil {
 		panic(err)
 	}
-	v1DepositWarmupCount = len(warmUp)
-	v1CollectedInternal, err = staker.GetDepositCollectedInternalReward(positionId)
+	snapshot.depositWarmupCount = len(warmUp)
+	snapshot.collectedInternal, err = staker.GetDepositCollectedInternalReward(positionId)
 	if err != nil {
 		panic(err)
 	}
-	v1PoolTier = staker.GetPoolTier(barFoo500PoolPath)
-	v1PoolTierRatio, err = staker.GetPoolTierRatio(barFoo500PoolPath)
+	snapshot.poolTier = staker.GetPoolTier(barFoo500PoolPath)
+	snapshot.poolTierRatio, err = staker.GetPoolTierRatio(barFoo500PoolPath)
 	if err != nil {
 		panic(err)
 	}
-	v1PoolStakedLiq, err = staker.GetPoolStakedLiquidity(barFoo500PoolPath)
+	snapshot.poolStakedLiq, err = staker.GetPoolStakedLiquidity(barFoo500PoolPath)
 	if err != nil {
 		panic(err)
 	}
-	v1UnstakingFee = staker.GetUnstakingFee()
-	v1DepositGnsAmount = staker.GetDepositGnsAmount()
-	v1AllowedTokenCount = len(staker.GetAllowedTokens())
-	v1TotalEmissionSent = staker.GetTotalEmissionSent()
+	snapshot.unstakingFee = staker.GetUnstakingFee()
+	snapshot.depositGnsAmount = staker.GetDepositGnsAmount()
+	snapshot.allowedTokenCount = len(staker.GetAllowedTokens())
+	snapshot.totalEmissionSent = staker.GetTotalEmissionSent()
 
-	println("[EXPECTED] Deposit owner:", v1DepositOwner)
-	println("[EXPECTED] Deposit liquidity:", v1DepositLiquidity)
-	println("[EXPECTED] Deposit ticks:", v1DepositTickLower, v1DepositTickUpper)
-	println("[EXPECTED] Deposit warmup tiers:", v1DepositWarmupCount)
-	println("[EXPECTED] Collected internal reward so far:", v1CollectedInternal)
-	println("[EXPECTED] Pool tier / ratio:", v1PoolTier, v1PoolTierRatio)
-	println("[EXPECTED] Pool staked liquidity:", v1PoolStakedLiq)
-	println("[EXPECTED] Unstaking fee / deposit GNS amount:", v1UnstakingFee, v1DepositGnsAmount)
-	println("[EXPECTED] Allowed token count:", v1AllowedTokenCount)
-	println("[EXPECTED] Total emission sent:", v1TotalEmissionSent)
+	println("[EXPECTED] Deposit owner:", snapshot.depositOwner)
+	println("[EXPECTED] Deposit liquidity:", snapshot.depositLiquidity)
+	println("[EXPECTED] Deposit ticks:", snapshot.depositTickLower, snapshot.depositTickUpper)
+	println("[EXPECTED] Deposit warmup tiers:", snapshot.depositWarmupCount)
+	println("[EXPECTED] Collected internal reward so far:", snapshot.collectedInternal)
+	println("[EXPECTED] Pool tier / ratio:", snapshot.poolTier, snapshot.poolTierRatio)
+	println("[EXPECTED] Pool staked liquidity:", snapshot.poolStakedLiq)
+	println("[EXPECTED] Unstaking fee / deposit GNS amount:", snapshot.unstakingFee, snapshot.depositGnsAmount)
+	println("[EXPECTED] Allowed token count:", snapshot.allowedTokenCount)
+	println("[EXPECTED] Total emission sent:", snapshot.totalEmissionSent)
 
 	// the deposit must mirror the staked position and already have collected
 	// a non-zero internal reward
-	uassert.Equal(t, barFoo500PoolPath, v1DepositPoolPath)
-	uassert.Equal(t, v1DepositLiquidity, v1PoolStakedLiq)
-	uassert.True(t, v1CollectedInternal > 0)
-	uassert.Equal(t, uint64(1), v1PoolTier)
+	uassert.Equal(t, barFoo500PoolPath, snapshot.depositPoolPath)
+	uassert.Equal(t, snapshot.depositLiquidity, snapshot.poolStakedLiq)
+	uassert.True(t, snapshot.collectedInternal > 0)
+	uassert.Equal(t, uint64(1), snapshot.poolTier)
+
+	return snapshot
 }
 
 // validateExactAfterUpgrade runs before any post-upgrade collection, so the
 // reward ledgers must still hold exactly their v1 values. Checking only that
 // they grew, after a fresh collection, would let a reset-then-refilled ledger
 // pass.
-func validateExactAfterUpgrade() {
+func validateExactAfterUpgrade(snapshot stakerSnapshot) {
 	depositOwner, err := staker.GetDepositOwner(positionId)
 	if err != nil {
 		panic(err)
 	}
-	uassert.Equal(t, v1DepositOwner, depositOwner)
+	uassert.Equal(t, snapshot.depositOwner, depositOwner)
 	depositPoolPath, err := staker.GetDepositTargetPoolPath(positionId)
 	if err != nil {
 		panic(err)
 	}
-	uassert.Equal(t, v1DepositPoolPath, depositPoolPath)
+	uassert.Equal(t, snapshot.depositPoolPath, depositPoolPath)
 	depositLiquidity, err := staker.GetDepositLiquidityAsString(positionId)
 	if err != nil {
 		panic(err)
 	}
-	uassert.Equal(t, v1DepositLiquidity, depositLiquidity)
+	uassert.Equal(t, snapshot.depositLiquidity, depositLiquidity)
 	depositStakeTime, err := staker.GetDepositStakeTime(positionId)
 	if err != nil {
 		panic(err)
 	}
-	uassert.Equal(t, v1DepositStakeTime, depositStakeTime)
+	uassert.Equal(t, snapshot.depositStakeTime, depositStakeTime)
 	depositTickLower, err := staker.GetDepositTickLower(positionId)
 	if err != nil {
 		panic(err)
 	}
-	uassert.Equal(t, v1DepositTickLower, depositTickLower)
+	uassert.Equal(t, snapshot.depositTickLower, depositTickLower)
 	depositTickUpper, err := staker.GetDepositTickUpper(positionId)
 	if err != nil {
 		panic(err)
 	}
-	uassert.Equal(t, v1DepositTickUpper, depositTickUpper)
+	uassert.Equal(t, snapshot.depositTickUpper, depositTickUpper)
 	warmUp, err := staker.GetDepositWarmUp(positionId)
 	if err != nil {
 		panic(err)
 	}
-	uassert.Equal(t, v1DepositWarmupCount, len(warmUp))
+	uassert.Equal(t, snapshot.depositWarmupCount, len(warmUp))
 	collectedInternalReward, err := staker.GetDepositCollectedInternalReward(positionId)
 	if err != nil {
 		panic(err)
 	}
-	uassert.Equal(t, v1CollectedInternal, collectedInternalReward)
-	uassert.Equal(t, v1TotalEmissionSent, staker.GetTotalEmissionSent())
-	uassert.Equal(t, v1PoolTier, staker.GetPoolTier(barFoo500PoolPath))
+	uassert.Equal(t, snapshot.collectedInternal, collectedInternalReward)
+	uassert.Equal(t, snapshot.totalEmissionSent, staker.GetTotalEmissionSent())
+	uassert.Equal(t, snapshot.poolTier, staker.GetPoolTier(barFoo500PoolPath))
 	poolTierRatio, err := staker.GetPoolTierRatio(barFoo500PoolPath)
 	if err != nil {
 		panic(err)
 	}
-	uassert.Equal(t, v1PoolTierRatio, poolTierRatio)
+	uassert.Equal(t, snapshot.poolTierRatio, poolTierRatio)
 	poolStakedLiquidity, err := staker.GetPoolStakedLiquidity(barFoo500PoolPath)
 	if err != nil {
 		panic(err)
 	}
-	uassert.Equal(t, v1PoolStakedLiq, poolStakedLiquidity)
-	uassert.Equal(t, v1UnstakingFee, staker.GetUnstakingFee())
-	uassert.Equal(t, v1DepositGnsAmount, staker.GetDepositGnsAmount())
-	uassert.Equal(t, v1AllowedTokenCount, len(staker.GetAllowedTokens()))
+	uassert.Equal(t, snapshot.poolStakedLiq, poolStakedLiquidity)
+	uassert.Equal(t, snapshot.unstakingFee, staker.GetUnstakingFee())
+	uassert.Equal(t, snapshot.depositGnsAmount, staker.GetDepositGnsAmount())
+	uassert.Equal(t, snapshot.allowedTokenCount, len(staker.GetAllowedTokens()))
 	uassert.True(t, staker.IsStaked(positionId))
 
 	println("[EXPECTED] Every snapshot field matches exactly right after the upgrade")
@@ -289,57 +295,57 @@ func validateExactAfterUpgrade() {
 	println("[EXPECTED] Total emission sent:", staker.GetTotalEmissionSent())
 }
 
-func validateAccrualAfterUpgrade() {
+func validateAccrualAfterUpgrade(snapshot stakerSnapshot) {
 	// deposit identity is immutable across upgrades
 	depositOwner, err := staker.GetDepositOwner(positionId)
 	if err != nil {
 		panic(err)
 	}
-	uassert.Equal(t, v1DepositOwner, depositOwner)
+	uassert.Equal(t, snapshot.depositOwner, depositOwner)
 	depositPoolPath, err := staker.GetDepositTargetPoolPath(positionId)
 	if err != nil {
 		panic(err)
 	}
-	uassert.Equal(t, v1DepositPoolPath, depositPoolPath)
+	uassert.Equal(t, snapshot.depositPoolPath, depositPoolPath)
 	depositLiquidity, err := staker.GetDepositLiquidityAsString(positionId)
 	if err != nil {
 		panic(err)
 	}
-	uassert.Equal(t, v1DepositLiquidity, depositLiquidity)
+	uassert.Equal(t, snapshot.depositLiquidity, depositLiquidity)
 	depositStakeTime, err := staker.GetDepositStakeTime(positionId)
 	if err != nil {
 		panic(err)
 	}
-	uassert.Equal(t, v1DepositStakeTime, depositStakeTime)
+	uassert.Equal(t, snapshot.depositStakeTime, depositStakeTime)
 	depositTickLower, err := staker.GetDepositTickLower(positionId)
 	if err != nil {
 		panic(err)
 	}
-	uassert.Equal(t, v1DepositTickLower, depositTickLower)
+	uassert.Equal(t, snapshot.depositTickLower, depositTickLower)
 	depositTickUpper, err := staker.GetDepositTickUpper(positionId)
 	if err != nil {
 		panic(err)
 	}
-	uassert.Equal(t, v1DepositTickUpper, depositTickUpper)
+	uassert.Equal(t, snapshot.depositTickUpper, depositTickUpper)
 	warmUp, err := staker.GetDepositWarmUp(positionId)
 	if err != nil {
 		panic(err)
 	}
-	uassert.Equal(t, v1DepositWarmupCount, len(warmUp))
-	uassert.Equal(t, v1PoolTier, staker.GetPoolTier(barFoo500PoolPath))
+	uassert.Equal(t, snapshot.depositWarmupCount, len(warmUp))
+	uassert.Equal(t, snapshot.poolTier, staker.GetPoolTier(barFoo500PoolPath))
 	poolTierRatio, err := staker.GetPoolTierRatio(barFoo500PoolPath)
 	if err != nil {
 		panic(err)
 	}
-	uassert.Equal(t, v1PoolTierRatio, poolTierRatio)
+	uassert.Equal(t, snapshot.poolTierRatio, poolTierRatio)
 	poolStakedLiquidity, err := staker.GetPoolStakedLiquidity(barFoo500PoolPath)
 	if err != nil {
 		panic(err)
 	}
-	uassert.Equal(t, v1PoolStakedLiq, poolStakedLiquidity)
-	uassert.Equal(t, v1UnstakingFee, staker.GetUnstakingFee())
-	uassert.Equal(t, v1DepositGnsAmount, staker.GetDepositGnsAmount())
-	uassert.Equal(t, v1AllowedTokenCount, len(staker.GetAllowedTokens()))
+	uassert.Equal(t, snapshot.poolStakedLiq, poolStakedLiquidity)
+	uassert.Equal(t, snapshot.unstakingFee, staker.GetUnstakingFee())
+	uassert.Equal(t, snapshot.depositGnsAmount, staker.GetDepositGnsAmount())
+	uassert.Equal(t, snapshot.allowedTokenCount, len(staker.GetAllowedTokens()))
 	uassert.True(t, staker.IsStaked(positionId))
 
 	// reward ledgers only ever move forward
@@ -347,17 +353,17 @@ func validateAccrualAfterUpgrade() {
 	if err != nil {
 		panic(err)
 	}
-	uassert.True(t, collectedInternalReward > v1CollectedInternal)
-	uassert.True(t, staker.GetTotalEmissionSent() > v1TotalEmissionSent)
+	uassert.True(t, collectedInternalReward > snapshot.collectedInternal)
+	uassert.True(t, staker.GetTotalEmissionSent() > snapshot.totalEmissionSent)
 
 	println("[EXPECTED] Deposit identity data is unchanged after the upgrades")
 	collectedInternalReward, err = staker.GetDepositCollectedInternalReward(positionId)
 	if err != nil {
 		panic(err)
 	}
-	println("[EXPECTED] Collected internal reward grew from", v1CollectedInternal,
+	println("[EXPECTED] Collected internal reward grew from", snapshot.collectedInternal,
 		"to", collectedInternalReward)
-	println("[EXPECTED] Total emission sent grew from", v1TotalEmissionSent,
+	println("[EXPECTED] Total emission sent grew from", snapshot.totalEmissionSent,
 		"to", staker.GetTotalEmissionSent())
 }
 

--- a/contract/r/scenario/upgrade/staker_collect_reward_upgrade_with_validate_data_filetest.gno
+++ b/contract/r/scenario/upgrade/staker_collect_reward_upgrade_with_validate_data_filetest.gno
@@ -152,17 +152,48 @@ func main(cur realm) {
 }
 
 func captureV1Snapshot() {
-	v1DepositOwner = staker.GetDepositOwner(positionId)
-	v1DepositPoolPath = staker.GetDepositTargetPoolPath(positionId)
-	v1DepositLiquidity = staker.GetDepositLiquidityAsString(positionId)
-	v1DepositStakeTime = staker.GetDepositStakeTime(positionId)
-	v1DepositTickLower = staker.GetDepositTickLower(positionId)
-	v1DepositTickUpper = staker.GetDepositTickUpper(positionId)
-	v1DepositWarmupCount = len(staker.GetDepositWarmUp(positionId))
-	v1CollectedInternal = staker.GetDepositCollectedInternalReward(positionId)
+	v1DepositOwner, err := staker.GetDepositOwner(positionId)
+	if err != nil {
+		panic(err)
+	}
+	v1DepositPoolPath, err = staker.GetDepositTargetPoolPath(positionId)
+	if err != nil {
+		panic(err)
+	}
+	v1DepositLiquidity, err = staker.GetDepositLiquidityAsString(positionId)
+	if err != nil {
+		panic(err)
+	}
+	v1DepositStakeTime, err = staker.GetDepositStakeTime(positionId)
+	if err != nil {
+		panic(err)
+	}
+	v1DepositTickLower, err = staker.GetDepositTickLower(positionId)
+	if err != nil {
+		panic(err)
+	}
+	v1DepositTickUpper, err = staker.GetDepositTickUpper(positionId)
+	if err != nil {
+		panic(err)
+	}
+	warmUp, err := staker.GetDepositWarmUp(positionId)
+	if err != nil {
+		panic(err)
+	}
+	v1DepositWarmupCount = len(warmUp)
+	v1CollectedInternal, err = staker.GetDepositCollectedInternalReward(positionId)
+	if err != nil {
+		panic(err)
+	}
 	v1PoolTier = staker.GetPoolTier(barFoo500PoolPath)
-	v1PoolTierRatio = staker.GetPoolTierRatio(barFoo500PoolPath)
-	v1PoolStakedLiq = staker.GetPoolStakedLiquidity(barFoo500PoolPath)
+	v1PoolTierRatio, err = staker.GetPoolTierRatio(barFoo500PoolPath)
+	if err != nil {
+		panic(err)
+	}
+	v1PoolStakedLiq, err = staker.GetPoolStakedLiquidity(barFoo500PoolPath)
+	if err != nil {
+		panic(err)
+	}
 	v1UnstakingFee = staker.GetUnstakingFee()
 	v1DepositGnsAmount = staker.GetDepositGnsAmount()
 	v1AllowedTokenCount = len(staker.GetAllowedTokens())
@@ -192,52 +223,140 @@ func captureV1Snapshot() {
 // they grew, after a fresh collection, would let a reset-then-refilled ledger
 // pass.
 func validateExactAfterUpgrade() {
-	uassert.Equal(t, v1DepositOwner, staker.GetDepositOwner(positionId))
-	uassert.Equal(t, v1DepositPoolPath, staker.GetDepositTargetPoolPath(positionId))
-	uassert.Equal(t, v1DepositLiquidity, staker.GetDepositLiquidityAsString(positionId))
-	uassert.Equal(t, v1DepositStakeTime, staker.GetDepositStakeTime(positionId))
-	uassert.Equal(t, v1DepositTickLower, staker.GetDepositTickLower(positionId))
-	uassert.Equal(t, v1DepositTickUpper, staker.GetDepositTickUpper(positionId))
-	uassert.Equal(t, v1DepositWarmupCount, len(staker.GetDepositWarmUp(positionId)))
-	uassert.Equal(t, v1CollectedInternal, staker.GetDepositCollectedInternalReward(positionId))
+	depositOwner, err := staker.GetDepositOwner(positionId)
+	if err != nil {
+		panic(err)
+	}
+	uassert.Equal(t, v1DepositOwner, depositOwner)
+	depositPoolPath, err := staker.GetDepositTargetPoolPath(positionId)
+	if err != nil {
+		panic(err)
+	}
+	uassert.Equal(t, v1DepositPoolPath, depositPoolPath)
+	depositLiquidity, err := staker.GetDepositLiquidityAsString(positionId)
+	if err != nil {
+		panic(err)
+	}
+	uassert.Equal(t, v1DepositLiquidity, depositLiquidity)
+	depositStakeTime, err := staker.GetDepositStakeTime(positionId)
+	if err != nil {
+		panic(err)
+	}
+	uassert.Equal(t, v1DepositStakeTime, depositStakeTime)
+	depositTickLower, err := staker.GetDepositTickLower(positionId)
+	if err != nil {
+		panic(err)
+	}
+	uassert.Equal(t, v1DepositTickLower, depositTickLower)
+	depositTickUpper, err := staker.GetDepositTickUpper(positionId)
+	if err != nil {
+		panic(err)
+	}
+	uassert.Equal(t, v1DepositTickUpper, depositTickUpper)
+	warmUp, err := staker.GetDepositWarmUp(positionId)
+	if err != nil {
+		panic(err)
+	}
+	uassert.Equal(t, v1DepositWarmupCount, len(warmUp))
+	collectedInternalReward, err := staker.GetDepositCollectedInternalReward(positionId)
+	if err != nil {
+		panic(err)
+	}
+	uassert.Equal(t, v1CollectedInternal, collectedInternalReward)
 	uassert.Equal(t, v1TotalEmissionSent, staker.GetTotalEmissionSent())
 	uassert.Equal(t, v1PoolTier, staker.GetPoolTier(barFoo500PoolPath))
-	uassert.Equal(t, v1PoolTierRatio, staker.GetPoolTierRatio(barFoo500PoolPath))
-	uassert.Equal(t, v1PoolStakedLiq, staker.GetPoolStakedLiquidity(barFoo500PoolPath))
+	poolTierRatio, err := staker.GetPoolTierRatio(barFoo500PoolPath)
+	if err != nil {
+		panic(err)
+	}
+	uassert.Equal(t, v1PoolTierRatio, poolTierRatio)
+	poolStakedLiquidity, err := staker.GetPoolStakedLiquidity(barFoo500PoolPath)
+	if err != nil {
+		panic(err)
+	}
+	uassert.Equal(t, v1PoolStakedLiq, poolStakedLiquidity)
 	uassert.Equal(t, v1UnstakingFee, staker.GetUnstakingFee())
 	uassert.Equal(t, v1DepositGnsAmount, staker.GetDepositGnsAmount())
 	uassert.Equal(t, v1AllowedTokenCount, len(staker.GetAllowedTokens()))
 	uassert.True(t, staker.IsStaked(positionId))
 
 	println("[EXPECTED] Every snapshot field matches exactly right after the upgrade")
-	println("[EXPECTED] Collected internal reward:", staker.GetDepositCollectedInternalReward(positionId))
+	collectedInternalReward, err = staker.GetDepositCollectedInternalReward(positionId)
+	if err != nil {
+		panic(err)
+	}
+	println("[EXPECTED] Collected internal reward:", collectedInternalReward)
 	println("[EXPECTED] Total emission sent:", staker.GetTotalEmissionSent())
 }
 
 func validateAccrualAfterUpgrade() {
 	// deposit identity is immutable across upgrades
-	uassert.Equal(t, v1DepositOwner, staker.GetDepositOwner(positionId))
-	uassert.Equal(t, v1DepositPoolPath, staker.GetDepositTargetPoolPath(positionId))
-	uassert.Equal(t, v1DepositLiquidity, staker.GetDepositLiquidityAsString(positionId))
-	uassert.Equal(t, v1DepositStakeTime, staker.GetDepositStakeTime(positionId))
-	uassert.Equal(t, v1DepositTickLower, staker.GetDepositTickLower(positionId))
-	uassert.Equal(t, v1DepositTickUpper, staker.GetDepositTickUpper(positionId))
-	uassert.Equal(t, v1DepositWarmupCount, len(staker.GetDepositWarmUp(positionId)))
+	depositOwner, err := staker.GetDepositOwner(positionId)
+	if err != nil {
+		panic(err)
+	}
+	uassert.Equal(t, v1DepositOwner, depositOwner)
+	depositPoolPath, err := staker.GetDepositTargetPoolPath(positionId)
+	if err != nil {
+		panic(err)
+	}
+	uassert.Equal(t, v1DepositPoolPath, depositPoolPath)
+	depositLiquidity, err := staker.GetDepositLiquidityAsString(positionId)
+	if err != nil {
+		panic(err)
+	}
+	uassert.Equal(t, v1DepositLiquidity, depositLiquidity)
+	depositStakeTime, err := staker.GetDepositStakeTime(positionId)
+	if err != nil {
+		panic(err)
+	}
+	uassert.Equal(t, v1DepositStakeTime, depositStakeTime)
+	depositTickLower, err := staker.GetDepositTickLower(positionId)
+	if err != nil {
+		panic(err)
+	}
+	uassert.Equal(t, v1DepositTickLower, depositTickLower)
+	depositTickUpper, err := staker.GetDepositTickUpper(positionId)
+	if err != nil {
+		panic(err)
+	}
+	uassert.Equal(t, v1DepositTickUpper, depositTickUpper)
+	warmUp, err := staker.GetDepositWarmUp(positionId)
+	if err != nil {
+		panic(err)
+	}
+	uassert.Equal(t, v1DepositWarmupCount, len(warmUp))
 	uassert.Equal(t, v1PoolTier, staker.GetPoolTier(barFoo500PoolPath))
-	uassert.Equal(t, v1PoolTierRatio, staker.GetPoolTierRatio(barFoo500PoolPath))
-	uassert.Equal(t, v1PoolStakedLiq, staker.GetPoolStakedLiquidity(barFoo500PoolPath))
+	poolTierRatio, err := staker.GetPoolTierRatio(barFoo500PoolPath)
+	if err != nil {
+		panic(err)
+	}
+	uassert.Equal(t, v1PoolTierRatio, poolTierRatio)
+	poolStakedLiquidity, err := staker.GetPoolStakedLiquidity(barFoo500PoolPath)
+	if err != nil {
+		panic(err)
+	}
+	uassert.Equal(t, v1PoolStakedLiq, poolStakedLiquidity)
 	uassert.Equal(t, v1UnstakingFee, staker.GetUnstakingFee())
 	uassert.Equal(t, v1DepositGnsAmount, staker.GetDepositGnsAmount())
 	uassert.Equal(t, v1AllowedTokenCount, len(staker.GetAllowedTokens()))
 	uassert.True(t, staker.IsStaked(positionId))
 
 	// reward ledgers only ever move forward
-	uassert.True(t, staker.GetDepositCollectedInternalReward(positionId) > v1CollectedInternal)
+	collectedInternalReward, err := staker.GetDepositCollectedInternalReward(positionId)
+	if err != nil {
+		panic(err)
+	}
+	uassert.True(t, collectedInternalReward > v1CollectedInternal)
 	uassert.True(t, staker.GetTotalEmissionSent() > v1TotalEmissionSent)
 
 	println("[EXPECTED] Deposit identity data is unchanged after the upgrades")
+	collectedInternalReward, err = staker.GetDepositCollectedInternalReward(positionId)
+	if err != nil {
+		panic(err)
+	}
 	println("[EXPECTED] Collected internal reward grew from", v1CollectedInternal,
-		"to", staker.GetDepositCollectedInternalReward(positionId))
+		"to", collectedInternalReward)
 	println("[EXPECTED] Total emission sent grew from", v1TotalEmissionSent,
 		"to", staker.GetTotalEmissionSent())
 }
@@ -320,9 +439,18 @@ func checkStakingInfo(cur realm, positionId uint64) {
 	println("[EXPECTED] Is staked:", isStaked)
 
 	if isStaked {
-		targetPoolPath := staker.GetDepositTargetPoolPath(positionId)
-		liquidity := staker.GetDepositLiquidityAsString(positionId)
-		stakeTime := staker.GetDepositStakeTime(positionId)
+		targetPoolPath, err := staker.GetDepositTargetPoolPath(positionId)
+		if err != nil {
+			panic(err)
+		}
+		liquidity, err := staker.GetDepositLiquidityAsString(positionId)
+		if err != nil {
+			panic(err)
+		}
+		stakeTime, err := staker.GetDepositStakeTime(positionId)
+		if err != nil {
+			panic(err)
+		}
 
 		println("[EXPECTED] Target pool path:", targetPoolPath)
 		println("[EXPECTED] Staked liquidity:", liquidity)

--- a/contract/r/scenario/upgrade/staker_v2_valid_upgrade_filetest.gno
+++ b/contract/r/scenario/upgrade/staker_v2_valid_upgrade_filetest.gno
@@ -224,7 +224,8 @@ func collectReward(cur realm, positionId uint64) {
 func unStakePosition(cur realm, positionId uint64) {
 	testing.SetRealm(adminRealm)
 	staker.UnStakeToken(cross(cur), positionId)
-	println("[EXPECTED] UnStaked position ID:", positionId, "isStaked now:", staker.IsStaked(positionId))
+	isStaked := staker.IsStaked(positionId)
+	println("[EXPECTED] UnStaked position ID:", positionId, "isStaked now:", isStaked)
 }
 
 func checkStakingInfo(cur realm, positionId uint64) {
@@ -232,52 +233,62 @@ func checkStakingInfo(cur realm, positionId uint64) {
 	isStaked := staker.IsStaked(positionId)
 	println("[EXPECTED] pos", positionId, "isStaked:", isStaked)
 	if isStaked {
-		println("[EXPECTED] pos", positionId, "targetPool:", staker.GetDepositTargetPoolPath(positionId))
-		println("[EXPECTED] pos", positionId, "liquidity:", staker.GetDepositLiquidityAsString(positionId))
-		println("[EXPECTED] pos", positionId, "stakeTime:", staker.GetDepositStakeTime(positionId))
+		targetPoolPath, _ := staker.GetDepositTargetPoolPath(positionId)
+		liquidity, _ := staker.GetDepositLiquidityAsString(positionId)
+		stakeTime, _ := staker.GetDepositStakeTime(positionId)
+		println("[EXPECTED] pos", positionId, "targetPool:", targetPoolPath)
+		println("[EXPECTED] pos", positionId, "liquidity:", liquidity)
+		println("[EXPECTED] pos", positionId, "stakeTime:", stakeTime)
 	}
 }
 
 func changePoolTier(cur realm, poolPath string, tier uint64) {
 	testing.SetRealm(adminRealm)
 	staker.ChangePoolTier(cross(cur), poolPath, tier)
-	println("[EXPECTED] ChangePoolTier", poolPath, "-> tier:", staker.GetPoolTier(poolPath))
+	currentTier := staker.GetPoolTier(poolPath)
+	println("[EXPECTED] ChangePoolTier", poolPath, "-> tier:", currentTier)
 }
 
 func removePoolTier(cur realm, poolPath string) {
 	testing.SetRealm(adminRealm)
 	staker.RemovePoolTier(cross(cur), poolPath)
-	println("[EXPECTED] RemovePoolTier", poolPath, "-> tier:", staker.GetPoolTier(poolPath))
+	currentTier := staker.GetPoolTier(poolPath)
+	println("[EXPECTED] RemovePoolTier", poolPath, "-> tier:", currentTier)
 }
 
 func addToken(cur realm, tokenPath string) {
 	testing.SetRealm(adminRealm)
 	staker.AddToken(cross(cur), tokenPath)
-	println("[EXPECTED] AddToken", tokenPath, "allowedCount:", len(staker.GetAllowedTokens()))
+	allowedTokens := staker.GetAllowedTokens()
+	println("[EXPECTED] AddToken", tokenPath, "allowedCount:", len(allowedTokens))
 }
 
 func removeToken(cur realm, tokenPath string) {
 	testing.SetRealm(adminRealm)
 	staker.RemoveToken(cross(cur), tokenPath)
-	println("[EXPECTED] RemoveToken", tokenPath, "allowedCount:", len(staker.GetAllowedTokens()))
+	allowedTokens := staker.GetAllowedTokens()
+	println("[EXPECTED] RemoveToken", tokenPath, "allowedCount:", len(allowedTokens))
 }
 
 func setUnStakingFee(cur realm, fee uint64) {
 	testing.SetRealm(adminRealm)
 	staker.SetUnStakingFee(cross(cur), fee)
-	println("[EXPECTED] SetUnStakingFee ->", staker.GetUnstakingFee())
+	unstakingFee := staker.GetUnstakingFee()
+	println("[EXPECTED] SetUnStakingFee ->", unstakingFee)
 }
 
 func setDepositGnsAmount(cur realm, amount int64) {
 	testing.SetRealm(adminRealm)
 	staker.SetDepositGnsAmount(cross(cur), amount)
-	println("[EXPECTED] SetDepositGnsAmount ->", staker.GetDepositGnsAmount())
+	depositGnsAmount := staker.GetDepositGnsAmount()
+	println("[EXPECTED] SetDepositGnsAmount ->", depositGnsAmount)
 }
 
 func setMinimumRewardAmount(cur realm, amount int64) {
 	testing.SetRealm(adminRealm)
 	staker.SetMinimumRewardAmount(cross(cur), amount)
-	println("[EXPECTED] SetMinimumRewardAmount ->", staker.GetMinimumRewardAmount())
+	minimumRewardAmount := staker.GetMinimumRewardAmount()
+	println("[EXPECTED] SetMinimumRewardAmount ->", minimumRewardAmount)
 }
 
 func setTokenMinimumRewardAmount(cur realm, tokenPath string, amount int64) {
@@ -290,7 +301,8 @@ func setTokenMinimumRewardAmount(cur realm, tokenPath string, amount int64) {
 func setWarmUp(cur realm, pct, timeDuration int64) {
 	testing.SetRealm(adminRealm)
 	staker.SetWarmUp(cross(cur), pct, timeDuration)
-	println("[EXPECTED] SetWarmUp warmupTiers:", len(staker.GetWarmupTemplate()))
+	warmupTemplate := staker.GetWarmupTemplate()
+	println("[EXPECTED] SetWarmUp warmupTiers:", len(warmupTemplate))
 }
 
 func createExternalIncentive(cur realm) {
@@ -314,8 +326,10 @@ func createExternalIncentive(cur realm) {
 		endTime,
 	)
 	println("[EXPECTED] CreateExternalIncentive id:", externalIncentiveId)
-	println("[EXPECTED] incentive rewardToken:", staker.GetIncentiveRewardToken(barFoo500PoolPath, externalIncentiveId))
-	println("[EXPECTED] incentive totalReward:", staker.GetIncentiveTotalRewardAmount(barFoo500PoolPath, externalIncentiveId))
+	rewardToken, _ := staker.GetIncentiveRewardToken(barFoo500PoolPath, externalIncentiveId)
+	totalReward, _ := staker.GetIncentiveTotalRewardAmount(barFoo500PoolPath, externalIncentiveId)
+	println("[EXPECTED] incentive rewardToken:", rewardToken)
+	println("[EXPECTED] incentive totalReward:", totalReward)
 }
 
 func skipPastIncentiveEnd(cur realm) {
@@ -328,7 +342,8 @@ func skipPastIncentiveEnd(cur realm) {
 func endExternalIncentive(cur realm) {
 	testing.SetRealm(adminRealm)
 	staker.EndExternalIncentive(cross(cur), barFoo500PoolPath, externalIncentiveId, adminAddr)
-	println("[EXPECTED] EndExternalIncentive refunded:", staker.GetIncentiveRefunded(barFoo500PoolPath, externalIncentiveId))
+	refunded, _ := staker.GetIncentiveRefunded(barFoo500PoolPath, externalIncentiveId)
+	println("[EXPECTED] EndExternalIncentive refunded:", refunded)
 }
 
 func collectExternalIncentivePenalty(cur realm) {

--- a/tests/integration/testdata/staker/collectable_reward_getters_read_only.txtar
+++ b/tests/integration/testdata/staker/collectable_reward_getters_read_only.txtar
@@ -133,7 +133,11 @@ package main
 import staker "gno.land/r/gnoswap/staker"
 
 func main() {
-	if staker.CollectableEmissionReward(1) != 0 {
+	emissionReward, err := staker.CollectableEmissionReward(1)
+	if err != nil {
+		panic(err)
+	}
+	if emissionReward != 0 {
 		panic("unexpected emission reward")
 	}
 	incentives := staker.GetPoolIncentives("gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:3000")
@@ -147,10 +151,18 @@ func main() {
 		return true
 	})
 
-	if staker.CollectableExternalIncentiveReward(1, incentiveId) != 0 {
+	externalReward, err := staker.CollectableExternalIncentiveReward(1, incentiveId)
+	if err != nil {
+		panic(err)
+	}
+	if externalReward != 0 {
 		panic("unexpected external incentive reward")
 	}
-	if len(staker.GetDepositExternalIncentiveIdList(1)) != 0 {
+	depositIncentiveIds, err := staker.GetDepositExternalIncentiveIdList(1)
+	if err != nil {
+		panic(err)
+	}
+	if len(depositIncentiveIds) != 0 {
 		panic("getter persisted external incentive ID")
 	}
 	println("collectable getters are read only")

--- a/tests/integration/testdata/staker/collectable_reward_getters_read_only.txtar
+++ b/tests/integration/testdata/staker/collectable_reward_getters_read_only.txtar
@@ -112,7 +112,11 @@ package main
 import staker "gno.land/r/gnoswap/staker"
 
 func main() {
-	if staker.CollectableEmissionReward(1) != 0 {
+	emissionReward, err := staker.CollectableEmissionReward(1)
+	if err != nil {
+		panic(err)
+	}
+	if emissionReward != 0 {
 		panic("unexpected emission reward")
 	}
 	incentives := staker.GetPoolIncentives("gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:3000")
@@ -126,10 +130,18 @@ func main() {
 		return true
 	})
 
-	if staker.CollectableExternalIncentiveReward(1, incentiveId) != 0 {
+	externalReward, err := staker.CollectableExternalIncentiveReward(1, incentiveId)
+	if err != nil {
+		panic(err)
+	}
+	if externalReward != 0 {
 		panic("unexpected external incentive reward")
 	}
-	if len(staker.GetDepositExternalIncentiveIdList(1)) != 0 {
+	depositIncentiveIds, err := staker.GetDepositExternalIncentiveIdList(1)
+	if err != nil {
+		panic(err)
+	}
+	if len(depositIncentiveIds) != 0 {
 		panic("getter persisted external incentive ID")
 	}
 	println("collectable getters are read only")


### PR DESCRIPTION
## Summary

- Return errors from staker getters when requested deposits, pools, or incentives are unavailable.
- Propagate the error-returning getter contract through staker reward, position, and pool integrations.
- Update mocks, upgrade coverage, unit tests, and staker scenarios for the migrated getter API.

## Validation

- `make test PKG=gno.land/r/gnoswap/pool/v1`
- `make test PKG=gno.land/r/gnoswap/position/v1`
- `make test PKG=gno.land/r/gnoswap/staker/v1`
- `make test PKG=gno.land/r/gnoswap/scenario/staker`
- `git diff --check origin/main..HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Staker read-only queries now return explicit errors alongside their values.
  - Missing pools, deposits, incentives, and invalid tiers are reported safely instead of causing panics.
  - Errors are propagated through dependent pool, deposit, reward, liquidity, and incentive queries.

- **Bug Fixes**
  - Improved handling of failed deposit and incentive lookups.
  - Preserved existing getter values and defaults when queries succeed.

- **Tests**
  - Expanded unit, integration, fuzz, and upgrade coverage to validate successful results and expected errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->