### PR TITLE
refactor(getter): propagate cross-module errors

### DIFF
--- a/contract/r/gnoswap/community_pool/community_pool.gno
+++ b/contract/r/gnoswap/community_pool/community_pool.gno
@@ -16,11 +16,16 @@ import (
 // Parameters:
 //   - tokenPath: the path to the token contract (e.g., "gno.land/r/gnoswap/gns")
 //
-// Returns the balance of the specified token held by the community pool.
-func GetBalanceOf(tokenPath string) int64 {
+// Returns the balance of the specified token held by the community pool, or an error
+// if the token is not registered.
+func GetBalanceOf(tokenPath string) (int64, error) {
 	communityPoolAddr := access.MustGetAddress(prbac.ROLE_COMMUNITY_POOL.String())
 
-	return common.BalanceOf(tokenPath, communityPoolAddr)
+	if err := common.IsRegistered(tokenPath); err != nil {
+		return 0, err
+	}
+
+	return common.BalanceOf(tokenPath, communityPoolAddr), nil
 }
 
 // TransferToken transfers tokens from the community pool.

--- a/contract/r/gnoswap/community_pool/community_pool_test.gno
+++ b/contract/r/gnoswap/community_pool/community_pool_test.gno
@@ -238,8 +238,8 @@ func TestCommunityPool_GetBalanceOf(cur realm, t *testing.T) {
 		setup           func(cur realm)
 		tokenPath       string
 		expectedBalance int64
-		shouldAbort     bool
-		panicMsg        string
+		shouldError     bool
+		errorMsg        string
 	}{
 		{
 			name: "returns zero when pool has no tokens",
@@ -287,22 +287,22 @@ func TestCommunityPool_GetBalanceOf(cur realm, t *testing.T) {
 			expectedBalance: 6_000,
 		},
 		{
-			name: "panics with unregistered token path",
+			name: "error with unregistered token path",
 			setup: func(cur realm) {
 				testing.SetRealm(adminRealm)
 			},
 			tokenPath:   "gno.land/r/demo/unregistered_token",
-			shouldAbort: true,
-			panicMsg:    "unknown token",
+			shouldError: true,
+			errorMsg:    "not registered",
 		},
 		{
-			name: "panics with empty token path",
+			name: "error with empty token path",
 			setup: func(cur realm) {
 				testing.SetRealm(adminRealm)
 			},
 			tokenPath:   "",
-			shouldAbort: true,
-			panicMsg:    "unknown token",
+			shouldError: true,
+			errorMsg:    "not registered",
 		},
 	}
 
@@ -312,12 +312,11 @@ func TestCommunityPool_GetBalanceOf(cur realm, t *testing.T) {
 				tt.setup(cur)
 			}
 
-			if tt.shouldAbort {
-				uassert.AbortsContains(t, cur, tt.panicMsg, func() {
-					GetBalanceOf(tt.tokenPath)
-				})
+			balance, err := GetBalanceOf(tt.tokenPath)
+			if tt.shouldError {
+				uassert.ErrorContains(t, err, tt.errorMsg)
 			} else {
-				balance := GetBalanceOf(tt.tokenPath)
+				uassert.NoError(t, err)
 				uassert.Equal(t, tt.expectedBalance, balance)
 			}
 		})

--- a/contract/r/gnoswap/emission/README.md
+++ b/contract/r/gnoswap/emission/README.md
@@ -61,7 +61,7 @@ Updates distribution percentages (admin or governance only).
 
 ### `GetDistributionBpsPct`
 
-Returns current distribution percentage in basis points for a target.
+Returns current distribution percentage in basis points for a target, or an error if the target is invalid.
 
 ## Technical Details
 
@@ -104,9 +104,15 @@ ChangeDistributionPct(
 )
 
 // Query distribution info
-stakerPct := GetDistributionBpsPct(LIQUIDITY_STAKER)
+stakerPct, err := GetDistributionBpsPct(LIQUIDITY_STAKER)
+if err != nil {
+    panic(err)
+}
 accumulated := GetAccuDistributedToStaker()
-rate := GetStakerEmissionAmountPerSecond()
+rate, err := GetStakerEmissionAmountPerSecond()
+if err != nil {
+    panic(err)
+}
 ```
 
 ## Security

--- a/contract/r/gnoswap/emission/README.md
+++ b/contract/r/gnoswap/emission/README.md
@@ -61,7 +61,7 @@ Updates distribution percentages (admin or governance only).
 
 ### `GetDistributionBpsPct`
 
-Returns current distribution percentage in basis points for a target.
+Returns current distribution percentage in basis points for a target, or an error if the target is invalid.
 
 ## Technical Details
 
@@ -104,7 +104,10 @@ ChangeDistributionPct(
 )
 
 // Query distribution info
-stakerPct := GetDistributionBpsPct(LIQUIDITY_STAKER)
+stakerPct, err := GetDistributionBpsPct(LIQUIDITY_STAKER)
+if err != nil {
+    panic(err)
+}
 accumulated := GetAccuDistributedToStaker()
 rate := GetStakerEmissionAmountPerSecond()
 ```

--- a/contract/r/gnoswap/emission/README.md
+++ b/contract/r/gnoswap/emission/README.md
@@ -109,7 +109,10 @@ if err != nil {
     panic(err)
 }
 accumulated := GetAccuDistributedToStaker()
-rate := GetStakerEmissionAmountPerSecond()
+rate, err := GetStakerEmissionAmountPerSecond()
+if err != nil {
+    panic(err)
+}
 ```
 
 ## Security

--- a/contract/r/gnoswap/emission/assert.gno
+++ b/contract/r/gnoswap/emission/assert.gno
@@ -14,8 +14,8 @@ func assertDefaultInitialPoolExists() {
 	}
 }
 
-// assertValidDistributionTarget panics if the given distribution target is invalid.
-func assertValidDistributionTarget(target int) {
+// validateDistributionTarget returns an error if the given distribution target is invalid.
+func validateDistributionTarget(target int) error {
 	validTargets := map[int]bool{
 		LIQUIDITY_STAKER: false,
 		DEVOPS:           false,
@@ -24,10 +24,20 @@ func assertValidDistributionTarget(target int) {
 	}
 
 	if _, ok := validTargets[target]; !ok {
-		panic(makeErrorWithDetails(
+		return makeErrorWithDetails(
 			errInvalidEmissionTarget,
 			ufmt.Sprintf("invalid target(%d)", target),
-		))
+		)
+	}
+
+	return nil
+}
+
+// assertValidDistributionTarget panics if the given distribution target is invalid.
+// Kept for internal invariant checks.
+func assertValidDistributionTarget(target int) {
+	if err := validateDistributionTarget(target); err != nil {
+		panic(err)
 	}
 }
 

--- a/contract/r/gnoswap/emission/distribution.gno
+++ b/contract/r/gnoswap/emission/distribution.gno
@@ -223,21 +223,27 @@ func transferToTarget(_ int, rlm realm, targets map[address]int64) error {
 }
 
 // GetDistributionBpsPct returns the distribution percentage in basis points for a specific target.
-func GetDistributionBpsPct(target int) int64 {
-	assertValidDistributionTarget(target)
+func GetDistributionBpsPct(target int) (int64, error) {
+	if err := validateDistributionTarget(target); err != nil {
+		return 0, err
+	}
+
 	if distributionBpsPct == nil {
-		panic("distributionBpsPct is nil")
+		return 0, makeErrorWithDetails(
+			errInvalidEmissionTarget,
+			ufmt.Sprintf("distributionBpsPct is nil"),
+		)
 	}
 
 	pct, exist := distributionBpsPct[target]
 	if !exist {
-		panic(makeErrorWithDetails(
+		return 0, makeErrorWithDetails(
 			errInvalidEmissionTarget,
 			ufmt.Sprintf("invalid target(%d)", target),
-		))
+		)
 	}
 
-	return pct
+	return pct, nil
 }
 
 // GetDistributedToStaker returns pending GNS for liquidity stakers.
@@ -294,24 +300,33 @@ func GetEmissionAmountPerSecondBy(timestamp, distributionPct int64) int64 {
 }
 
 // GetStakerEmissionAmountPerSecond returns the current per-second emission amount allocated to liquidity stakers.
-func GetStakerEmissionAmountPerSecond() int64 {
+func GetStakerEmissionAmountPerSecond() (int64, error) {
 	currentTimestamp := time.Now().Unix()
-	return GetEmissionAmountPerSecondBy(currentTimestamp, GetDistributionBpsPct(LIQUIDITY_STAKER))
+	pct, err := GetDistributionBpsPct(LIQUIDITY_STAKER)
+	if err != nil {
+		return 0, err
+	}
+	return GetEmissionAmountPerSecondBy(currentTimestamp, pct), nil
 }
 
 // GetStakerEmissionAmountPerSecondInRange returns emission amounts allocated to liquidity stakers for a time range.
-func GetStakerEmissionAmountPerSecondInRange(start, end int64) ([]int64, []int64) {
+func GetStakerEmissionAmountPerSecondInRange(start, end int64) ([]int64, []int64, error) {
 	gnsHalvingBlocks, gnsHalvingEmissions := gns.GetEmissionAmountPerSecondInRange(start, end)
 	halvingBlocks := make([]int64, len(gnsHalvingBlocks))
 	halvingEmissions := make([]int64, len(gnsHalvingEmissions))
 
+	pct, err := GetDistributionBpsPct(LIQUIDITY_STAKER)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	for i := range halvingBlocks {
 		halvingBlocks[i] = gnsHalvingBlocks[i]
 		// Applying staker ratio for past halving blocks
-		halvingEmissions[i] = calculateAmount(gnsHalvingEmissions[i], GetDistributionBpsPct(LIQUIDITY_STAKER))
+		halvingEmissions[i] = calculateAmount(gnsHalvingEmissions[i], pct)
 	}
 
-	return halvingBlocks, halvingEmissions
+	return halvingBlocks, halvingEmissions, nil
 }
 
 // ClearDistributedToStaker resets the pending distribution amount for liquidity stakers.

--- a/contract/r/gnoswap/emission/distribution.gno
+++ b/contract/r/gnoswap/emission/distribution.gno
@@ -300,24 +300,24 @@ func GetEmissionAmountPerSecondBy(timestamp, distributionPct int64) int64 {
 }
 
 // GetStakerEmissionAmountPerSecond returns the current per-second emission amount allocated to liquidity stakers.
-func GetStakerEmissionAmountPerSecond() int64 {
+func GetStakerEmissionAmountPerSecond() (int64, error) {
 	currentTimestamp := time.Now().Unix()
 	pct, err := GetDistributionBpsPct(LIQUIDITY_STAKER)
 	if err != nil {
-		panic(err)
+		return 0, err
 	}
-	return GetEmissionAmountPerSecondBy(currentTimestamp, pct)
+	return GetEmissionAmountPerSecondBy(currentTimestamp, pct), nil
 }
 
 // GetStakerEmissionAmountPerSecondInRange returns emission amounts allocated to liquidity stakers for a time range.
-func GetStakerEmissionAmountPerSecondInRange(start, end int64) ([]int64, []int64) {
+func GetStakerEmissionAmountPerSecondInRange(start, end int64) ([]int64, []int64, error) {
 	gnsHalvingBlocks, gnsHalvingEmissions := gns.GetEmissionAmountPerSecondInRange(start, end)
 	halvingBlocks := make([]int64, len(gnsHalvingBlocks))
 	halvingEmissions := make([]int64, len(gnsHalvingEmissions))
 
 	pct, err := GetDistributionBpsPct(LIQUIDITY_STAKER)
 	if err != nil {
-		panic(err)
+		return nil, nil, err
 	}
 
 	for i := range halvingBlocks {
@@ -326,7 +326,7 @@ func GetStakerEmissionAmountPerSecondInRange(start, end int64) ([]int64, []int64
 		halvingEmissions[i] = calculateAmount(gnsHalvingEmissions[i], pct)
 	}
 
-	return halvingBlocks, halvingEmissions
+	return halvingBlocks, halvingEmissions, nil
 }
 
 // ClearDistributedToStaker resets the pending distribution amount for liquidity stakers.

--- a/contract/r/gnoswap/emission/distribution.gno
+++ b/contract/r/gnoswap/emission/distribution.gno
@@ -223,21 +223,27 @@ func transferToTarget(_ int, rlm realm, targets map[address]int64) error {
 }
 
 // GetDistributionBpsPct returns the distribution percentage in basis points for a specific target.
-func GetDistributionBpsPct(target int) int64 {
-	assertValidDistributionTarget(target)
+func GetDistributionBpsPct(target int) (int64, error) {
+	if err := validateDistributionTarget(target); err != nil {
+		return 0, err
+	}
+
 	if distributionBpsPct == nil {
-		panic("distributionBpsPct is nil")
+		return 0, makeErrorWithDetails(
+			errInvalidEmissionTarget,
+			ufmt.Sprintf("distributionBpsPct is nil"),
+		)
 	}
 
 	pct, exist := distributionBpsPct[target]
 	if !exist {
-		panic(makeErrorWithDetails(
+		return 0, makeErrorWithDetails(
 			errInvalidEmissionTarget,
 			ufmt.Sprintf("invalid target(%d)", target),
-		))
+		)
 	}
 
-	return pct
+	return pct, nil
 }
 
 // GetDistributedToStaker returns pending GNS for liquidity stakers.
@@ -296,7 +302,11 @@ func GetEmissionAmountPerSecondBy(timestamp, distributionPct int64) int64 {
 // GetStakerEmissionAmountPerSecond returns the current per-second emission amount allocated to liquidity stakers.
 func GetStakerEmissionAmountPerSecond() int64 {
 	currentTimestamp := time.Now().Unix()
-	return GetEmissionAmountPerSecondBy(currentTimestamp, GetDistributionBpsPct(LIQUIDITY_STAKER))
+	pct, err := GetDistributionBpsPct(LIQUIDITY_STAKER)
+	if err != nil {
+		panic(err)
+	}
+	return GetEmissionAmountPerSecondBy(currentTimestamp, pct)
 }
 
 // GetStakerEmissionAmountPerSecondInRange returns emission amounts allocated to liquidity stakers for a time range.
@@ -305,10 +315,15 @@ func GetStakerEmissionAmountPerSecondInRange(start, end int64) ([]int64, []int64
 	halvingBlocks := make([]int64, len(gnsHalvingBlocks))
 	halvingEmissions := make([]int64, len(gnsHalvingEmissions))
 
+	pct, err := GetDistributionBpsPct(LIQUIDITY_STAKER)
+	if err != nil {
+		panic(err)
+	}
+
 	for i := range halvingBlocks {
 		halvingBlocks[i] = gnsHalvingBlocks[i]
 		// Applying staker ratio for past halving blocks
-		halvingEmissions[i] = calculateAmount(gnsHalvingEmissions[i], GetDistributionBpsPct(LIQUIDITY_STAKER))
+		halvingEmissions[i] = calculateAmount(gnsHalvingEmissions[i], pct)
 	}
 
 	return halvingBlocks, halvingEmissions

--- a/contract/r/gnoswap/emission/distribution_test.gno
+++ b/contract/r/gnoswap/emission/distribution_test.gno
@@ -57,10 +57,21 @@ func TestChangeDistributionPct(cur realm, t *testing.T) {
 			communityPoolPct:   3000,
 			govStakerPct:       4000,
 			verify: func() {
-				uassert.Equal(t, int64(1000), GetDistributionBpsPct(LIQUIDITY_STAKER))
-				uassert.Equal(t, int64(2000), GetDistributionBpsPct(DEVOPS))
-				uassert.Equal(t, int64(3000), GetDistributionBpsPct(COMMUNITY_POOL))
-				uassert.Equal(t, int64(4000), GetDistributionBpsPct(GOV_STAKER))
+				pct, err := GetDistributionBpsPct(LIQUIDITY_STAKER)
+				uassert.NoError(t, err)
+				uassert.Equal(t, int64(1000), pct)
+
+				pct, err = GetDistributionBpsPct(DEVOPS)
+				uassert.NoError(t, err)
+				uassert.Equal(t, int64(2000), pct)
+
+				pct, err = GetDistributionBpsPct(COMMUNITY_POOL)
+				uassert.NoError(t, err)
+				uassert.Equal(t, int64(3000), pct)
+
+				pct, err = GetDistributionBpsPct(GOV_STAKER)
+				uassert.NoError(t, err)
+				uassert.Equal(t, int64(4000), pct)
 			},
 		},
 	}
@@ -105,10 +116,22 @@ func TestChangeDistributionPcts(cur realm, t *testing.T) {
 	resetObject(t)
 
 	changeDistributionPcts(1000, 2000, 3000, 4000)
-	uassert.Equal(t, int64(1000), GetDistributionBpsPct(LIQUIDITY_STAKER))
-	uassert.Equal(t, int64(2000), GetDistributionBpsPct(DEVOPS))
-	uassert.Equal(t, int64(3000), GetDistributionBpsPct(COMMUNITY_POOL))
-	uassert.Equal(t, int64(4000), GetDistributionBpsPct(GOV_STAKER))
+
+	pct, err := GetDistributionBpsPct(LIQUIDITY_STAKER)
+	uassert.NoError(t, err)
+	uassert.Equal(t, int64(1000), pct)
+
+	pct, err = GetDistributionBpsPct(DEVOPS)
+	uassert.NoError(t, err)
+	uassert.Equal(t, int64(2000), pct)
+
+	pct, err = GetDistributionBpsPct(COMMUNITY_POOL)
+	uassert.NoError(t, err)
+	uassert.Equal(t, int64(3000), pct)
+
+	pct, err = GetDistributionBpsPct(GOV_STAKER)
+	uassert.NoError(t, err)
+	uassert.Equal(t, int64(4000), pct)
 }
 
 func TestCalculateAmount(cur realm, t *testing.T) {
@@ -548,6 +571,33 @@ func TestDistribution_SetOnDistributionPctChangeCallback(cur realm, t *testing.T
 	}
 }
 
+func TestDistribution_StakerEmissionGettersReturnDistributionErrors(cur realm, t *testing.T) {
+	resetObject(t)
+
+	distributionBpsPct[LIQUIDITY_STAKER] = 0
+	rate, err := GetStakerEmissionAmountPerSecond()
+	uassert.NoError(t, err)
+	uassert.Equal(t, int64(0), rate)
+
+	_, emissions, err := GetStakerEmissionAmountPerSecondInRange(0, 1)
+	uassert.NoError(t, err)
+	for _, emissionAmount := range emissions {
+		uassert.Equal(t, int64(0), emissionAmount)
+	}
+
+	distributionBpsPct = nil
+	_, err = GetStakerEmissionAmountPerSecond()
+	uassert.ErrorContains(t, err, "distributionBpsPct is nil")
+	_, _, err = GetStakerEmissionAmountPerSecondInRange(0, 1)
+	uassert.ErrorContains(t, err, "distributionBpsPct is nil")
+
+	distributionBpsPct = make(map[int]int64)
+	_, err = GetStakerEmissionAmountPerSecond()
+	uassert.ErrorContains(t, err, "invalid target(1)")
+	_, _, err = GetStakerEmissionAmountPerSecondInRange(0, 1)
+	uassert.ErrorContains(t, err, "invalid target(1)")
+}
+
 func TestDistribution_GetDistributionBpsPct_EdgeCases(cur realm, t *testing.T) {
 	tests := []struct {
 		name    string
@@ -652,17 +702,16 @@ func TestDistribution_GetDistributionBpsPct_EdgeCases(cur realm, t *testing.T) {
 
 			// When - Then
 			if tt.wantErr {
-				uassert.PanicsWithMessage(
-					t, cur, tt.errMsg, func() {
-						GetDistributionBpsPct(tt.target)
-					})
+				_, err := GetDistributionBpsPct(tt.target)
+				uassert.ErrorContains(t, err, tt.errMsg)
 				return
 			}
 
 			// When
-			got := GetDistributionBpsPct(tt.target)
+			got, err := GetDistributionBpsPct(tt.target)
 
 			// Then
+			uassert.NoError(t, err)
 			uassert.Equal(t, tt.want, got)
 		})
 	}
@@ -1063,18 +1112,16 @@ func TestMapBasedDistribution_EdgeCases(cur realm, t *testing.T) {
 			cleanupFunc func(savedMap map[int]int64)
 		}{
 			{
-				name:        "nil map access should panic",
-				description: "GetDistributionBpsPct panics when map is nil",
+				name:        "nil map access should return error",
+				description: "GetDistributionBpsPct returns error when map is nil",
 				setupFunc: func() map[int]int64 {
 					saved := distributionBpsPct
 					distributionBpsPct = nil
 					return saved
 				},
 				testFunc: func(t *testing.T) {
-					uassert.PanicsWithMessage(
-						t, cur, "distributionBpsPct is nil", func() {
-							GetDistributionBpsPct(LIQUIDITY_STAKER)
-						})
+					_, err := GetDistributionBpsPct(LIQUIDITY_STAKER)
+					uassert.ErrorContains(t, err, "distributionBpsPct is nil")
 				},
 				cleanupFunc: func(saved map[int]int64) {
 					distributionBpsPct = saved
@@ -1098,8 +1145,8 @@ func TestMapBasedDistribution_EdgeCases(cur realm, t *testing.T) {
 				},
 			},
 			{
-				name:        "partial map missing key access panics",
-				description: "accessing non-existent key after validation panics",
+				name:        "partial map missing key access returns error",
+				description: "accessing non-existent key after validation returns error",
 				setupFunc: func() map[int]int64 {
 					saved := distributionBpsPct
 					distributionBpsPct = make(map[int]int64)
@@ -1107,10 +1154,8 @@ func TestMapBasedDistribution_EdgeCases(cur realm, t *testing.T) {
 					return saved
 				},
 				testFunc: func(t *testing.T) {
-					uassert.PanicsWithMessage(
-						t, cur, "[GNOSWAP-EMISSION-001] invalid emission target || invalid target(2)", func() {
-							GetDistributionBpsPct(DEVOPS)
-						})
+					_, err := GetDistributionBpsPct(DEVOPS)
+					uassert.ErrorContains(t, err, "[GNOSWAP-EMISSION-001] invalid emission target || invalid target(2)")
 				},
 				cleanupFunc: func(saved map[int]int64) {
 					distributionBpsPct = saved
@@ -1264,7 +1309,8 @@ func TestMapBasedDistribution_EdgeCases(cur realm, t *testing.T) {
 
 				// Multiple reads
 				for i := 0; i < tt.readCount; i++ {
-					pct := GetDistributionBpsPct(tt.target)
+					pct, err := GetDistributionBpsPct(tt.target)
+					uassert.NoError(t, err)
 					uassert.Equal(t, tt.initialValue, pct)
 				}
 

--- a/contract/r/gnoswap/emission/distribution_test.gno
+++ b/contract/r/gnoswap/emission/distribution_test.gno
@@ -571,6 +571,49 @@ func TestDistribution_SetOnDistributionPctChangeCallback(cur realm, t *testing.T
 	}
 }
 
+func TestDistribution_StakerEmissionGettersReturnDistributionErrors(cur realm, t *testing.T) {
+	resetObject(t)
+
+	distributionBpsPct[LIQUIDITY_STAKER] = 0
+	rate, err := GetStakerEmissionAmountPerSecond()
+	uassert.NoError(t, err)
+	uassert.Equal(t, int64(0), rate)
+
+	_, emissions, err := GetStakerEmissionAmountPerSecondInRange(0, 1)
+	uassert.NoError(t, err)
+	for _, emissionAmount := range emissions {
+		uassert.Equal(t, int64(0), emissionAmount)
+	}
+
+	distributionBpsPct = nil
+	_, err = GetStakerEmissionAmountPerSecond()
+	uassert.ErrorContains(t, err, "distributionBpsPct is nil")
+	_, _, err = GetStakerEmissionAmountPerSecondInRange(0, 1)
+	uassert.ErrorContains(t, err, "distributionBpsPct is nil")
+
+	distributionBpsPct = make(map[int]int64)
+	_, err = GetStakerEmissionAmountPerSecond()
+	uassert.ErrorContains(t, err, "invalid target(1)")
+	_, _, err = GetStakerEmissionAmountPerSecondInRange(0, 1)
+	uassert.ErrorContains(t, err, "invalid target(1)")
+}
+
+func TestDistribution_SetOnDistributionPctChangeCallbackDoesNotPersistOnGetterError(cur realm, t *testing.T) {
+	resetObject(t)
+	callbackCalled := false
+	onDistributionPctChangeCallback = func(cur realm, amount int64) {
+		callbackCalled = true
+	}
+	distributionBpsPct = nil
+	testing.SetRealm(stakerRealm)
+
+	err := SetOnDistributionPctChangeCallback(cross(cur), func(cur realm, amount int64) {})
+	uassert.ErrorContains(t, err, "distributionBpsPct is nil")
+
+	onDistributionPctChangeCallback(cross(cur), 1)
+	uassert.True(t, callbackCalled)
+}
+
 func TestDistribution_GetDistributionBpsPct_EdgeCases(cur realm, t *testing.T) {
 	tests := []struct {
 		name    string

--- a/contract/r/gnoswap/emission/distribution_test.gno
+++ b/contract/r/gnoswap/emission/distribution_test.gno
@@ -57,10 +57,21 @@ func TestChangeDistributionPct(cur realm, t *testing.T) {
 			communityPoolPct:   3000,
 			govStakerPct:       4000,
 			verify: func() {
-				uassert.Equal(t, int64(1000), GetDistributionBpsPct(LIQUIDITY_STAKER))
-				uassert.Equal(t, int64(2000), GetDistributionBpsPct(DEVOPS))
-				uassert.Equal(t, int64(3000), GetDistributionBpsPct(COMMUNITY_POOL))
-				uassert.Equal(t, int64(4000), GetDistributionBpsPct(GOV_STAKER))
+				pct, err := GetDistributionBpsPct(LIQUIDITY_STAKER)
+				uassert.NoError(t, err)
+				uassert.Equal(t, int64(1000), pct)
+
+				pct, err = GetDistributionBpsPct(DEVOPS)
+				uassert.NoError(t, err)
+				uassert.Equal(t, int64(2000), pct)
+
+				pct, err = GetDistributionBpsPct(COMMUNITY_POOL)
+				uassert.NoError(t, err)
+				uassert.Equal(t, int64(3000), pct)
+
+				pct, err = GetDistributionBpsPct(GOV_STAKER)
+				uassert.NoError(t, err)
+				uassert.Equal(t, int64(4000), pct)
 			},
 		},
 	}
@@ -105,10 +116,22 @@ func TestChangeDistributionPcts(cur realm, t *testing.T) {
 	resetObject(t)
 
 	changeDistributionPcts(1000, 2000, 3000, 4000)
-	uassert.Equal(t, int64(1000), GetDistributionBpsPct(LIQUIDITY_STAKER))
-	uassert.Equal(t, int64(2000), GetDistributionBpsPct(DEVOPS))
-	uassert.Equal(t, int64(3000), GetDistributionBpsPct(COMMUNITY_POOL))
-	uassert.Equal(t, int64(4000), GetDistributionBpsPct(GOV_STAKER))
+
+	pct, err := GetDistributionBpsPct(LIQUIDITY_STAKER)
+	uassert.NoError(t, err)
+	uassert.Equal(t, int64(1000), pct)
+
+	pct, err = GetDistributionBpsPct(DEVOPS)
+	uassert.NoError(t, err)
+	uassert.Equal(t, int64(2000), pct)
+
+	pct, err = GetDistributionBpsPct(COMMUNITY_POOL)
+	uassert.NoError(t, err)
+	uassert.Equal(t, int64(3000), pct)
+
+	pct, err = GetDistributionBpsPct(GOV_STAKER)
+	uassert.NoError(t, err)
+	uassert.Equal(t, int64(4000), pct)
 }
 
 func TestCalculateAmount(cur realm, t *testing.T) {
@@ -652,17 +675,16 @@ func TestDistribution_GetDistributionBpsPct_EdgeCases(cur realm, t *testing.T) {
 
 			// When - Then
 			if tt.wantErr {
-				uassert.PanicsWithMessage(
-					t, cur, tt.errMsg, func() {
-						GetDistributionBpsPct(tt.target)
-					})
+				_, err := GetDistributionBpsPct(tt.target)
+				uassert.ErrorContains(t, err, tt.errMsg)
 				return
 			}
 
 			// When
-			got := GetDistributionBpsPct(tt.target)
+			got, err := GetDistributionBpsPct(tt.target)
 
 			// Then
+			uassert.NoError(t, err)
 			uassert.Equal(t, tt.want, got)
 		})
 	}
@@ -1063,18 +1085,16 @@ func TestMapBasedDistribution_EdgeCases(cur realm, t *testing.T) {
 			cleanupFunc func(savedMap map[int]int64)
 		}{
 			{
-				name:        "nil map access should panic",
-				description: "GetDistributionBpsPct panics when map is nil",
+				name:        "nil map access should return error",
+				description: "GetDistributionBpsPct returns error when map is nil",
 				setupFunc: func() map[int]int64 {
 					saved := distributionBpsPct
 					distributionBpsPct = nil
 					return saved
 				},
 				testFunc: func(t *testing.T) {
-					uassert.PanicsWithMessage(
-						t, cur, "distributionBpsPct is nil", func() {
-							GetDistributionBpsPct(LIQUIDITY_STAKER)
-						})
+					_, err := GetDistributionBpsPct(LIQUIDITY_STAKER)
+					uassert.ErrorContains(t, err, "distributionBpsPct is nil")
 				},
 				cleanupFunc: func(saved map[int]int64) {
 					distributionBpsPct = saved
@@ -1098,8 +1118,8 @@ func TestMapBasedDistribution_EdgeCases(cur realm, t *testing.T) {
 				},
 			},
 			{
-				name:        "partial map missing key access panics",
-				description: "accessing non-existent key after validation panics",
+				name:        "partial map missing key access returns error",
+				description: "accessing non-existent key after validation returns error",
 				setupFunc: func() map[int]int64 {
 					saved := distributionBpsPct
 					distributionBpsPct = make(map[int]int64)
@@ -1107,10 +1127,8 @@ func TestMapBasedDistribution_EdgeCases(cur realm, t *testing.T) {
 					return saved
 				},
 				testFunc: func(t *testing.T) {
-					uassert.PanicsWithMessage(
-						t, cur, "[GNOSWAP-EMISSION-001] invalid emission target || invalid target(2)", func() {
-							GetDistributionBpsPct(DEVOPS)
-						})
+					_, err := GetDistributionBpsPct(DEVOPS)
+					uassert.ErrorContains(t, err, "[GNOSWAP-EMISSION-001] invalid emission target || invalid target(2)")
 				},
 				cleanupFunc: func(saved map[int]int64) {
 					distributionBpsPct = saved
@@ -1264,7 +1282,8 @@ func TestMapBasedDistribution_EdgeCases(cur realm, t *testing.T) {
 
 				// Multiple reads
 				for i := 0; i < tt.readCount; i++ {
-					pct := GetDistributionBpsPct(tt.target)
+					pct, err := GetDistributionBpsPct(tt.target)
+					uassert.NoError(t, err)
 					uassert.Equal(t, tt.initialValue, pct)
 				}
 

--- a/contract/r/gnoswap/emission/emission.gno
+++ b/contract/r/gnoswap/emission/emission.gno
@@ -246,16 +246,24 @@ func SetDistributionStartTime(cur realm, startTimestamp int64) {
 // This allows external contracts (like staker) to update their internal caches when governance changes emission rates.
 //
 // Only callable by the staker contract.
-func SetOnDistributionPctChangeCallback(cur realm, callback func(cur realm, emissionAmountPerSecond int64)) {
+func SetOnDistributionPctChangeCallback(cur realm, callback func(cur realm, emissionAmountPerSecond int64)) error {
 	caller := cur.Previous().Address()
 	access.AssertIsStaker(caller)
 
-	onDistributionPctChangeCallback = callback
-
-	if onDistributionPctChangeCallback != nil {
-		emissionAmountPerSecond := GetStakerEmissionAmountPerSecond()
-		onDistributionPctChangeCallback(cross(cur), emissionAmountPerSecond)
+	if callback == nil {
+		onDistributionPctChangeCallback = nil
+		return nil
 	}
+
+	emissionAmountPerSecond, err := GetStakerEmissionAmountPerSecond()
+	if err != nil {
+		return err
+	}
+
+	onDistributionPctChangeCallback = callback
+	onDistributionPctChangeCallback(cross(cur), emissionAmountPerSecond)
+
+	return nil
 }
 
 // SetDefaultInitialPoolChecker registers the callback that verifies the

--- a/contract/r/gnoswap/emission/emission.gno
+++ b/contract/r/gnoswap/emission/emission.gno
@@ -144,8 +144,17 @@ func MintAndDistributeGns(cur realm) (int64, bool) {
 		panic(err)
 	}
 
-	stakerRewardPerSecond := GetEmissionAmountPerSecondBy(currentTimestamp, GetDistributionBpsPct(LIQUIDITY_STAKER))
-	govStakerRewardPerSecond := GetEmissionAmountPerSecondBy(currentTimestamp, GetDistributionBpsPct(GOV_STAKER))
+	stakerPct, err := GetDistributionBpsPct(LIQUIDITY_STAKER)
+	if err != nil {
+		panic(err)
+	}
+	stakerRewardPerSecond := GetEmissionAmountPerSecondBy(currentTimestamp, stakerPct)
+
+	govStakerPct, err := GetDistributionBpsPct(GOV_STAKER)
+	if err != nil {
+		panic(err)
+	}
+	govStakerRewardPerSecond := GetEmissionAmountPerSecondBy(currentTimestamp, govStakerPct)
 
 	previousRealm := cur.Previous()
 	chain.Emit(

--- a/contract/r/gnoswap/emission/emission.gno
+++ b/contract/r/gnoswap/emission/emission.gno
@@ -144,8 +144,17 @@ func MintAndDistributeGns(cur realm) (int64, bool) {
 		panic(err)
 	}
 
-	stakerRewardPerSecond := GetEmissionAmountPerSecondBy(currentTimestamp, GetDistributionBpsPct(LIQUIDITY_STAKER))
-	govStakerRewardPerSecond := GetEmissionAmountPerSecondBy(currentTimestamp, GetDistributionBpsPct(GOV_STAKER))
+	stakerPct, err := GetDistributionBpsPct(LIQUIDITY_STAKER)
+	if err != nil {
+		panic(err)
+	}
+	stakerRewardPerSecond := GetEmissionAmountPerSecondBy(currentTimestamp, stakerPct)
+
+	govStakerPct, err := GetDistributionBpsPct(GOV_STAKER)
+	if err != nil {
+		panic(err)
+	}
+	govStakerRewardPerSecond := GetEmissionAmountPerSecondBy(currentTimestamp, govStakerPct)
 
 	previousRealm := cur.Previous()
 	chain.Emit(
@@ -241,12 +250,18 @@ func SetOnDistributionPctChangeCallback(cur realm, callback func(cur realm, emis
 	caller := cur.Previous().Address()
 	access.AssertIsStaker(caller)
 
-	onDistributionPctChangeCallback = callback
-
-	if onDistributionPctChangeCallback != nil {
-		emissionAmountPerSecond := GetStakerEmissionAmountPerSecond()
-		onDistributionPctChangeCallback(cross(cur), emissionAmountPerSecond)
+	if callback == nil {
+		onDistributionPctChangeCallback = nil
+		return
 	}
+
+	emissionAmountPerSecond, err := GetStakerEmissionAmountPerSecond()
+	if err != nil {
+		panic(err)
+	}
+
+	onDistributionPctChangeCallback = callback
+	onDistributionPctChangeCallback(cross(cur), emissionAmountPerSecond)
 }
 
 // SetDefaultInitialPoolChecker registers the callback that verifies the

--- a/contract/r/gnoswap/gov/governance/_mock_test.gno
+++ b/contract/r/gnoswap/gov/governance/_mock_test.gno
@@ -147,12 +147,12 @@ func (m *MockGovernance) GetMaxSmoothingPeriod() int64 {
 }
 
 // Config getters
-func (m *MockGovernance) GetLatestConfig() Config {
+func (m *MockGovernance) GetLatestConfig() (Config, error) {
 	res, ok := m.Response.Get("GetLatestConfig")
 	if !ok {
-		return Config{}
+		return Config{}, nil
 	}
-	return res[0].(Config)
+	return res[0].(Config), nil
 }
 
 func (m *MockGovernance) GetConfig(configVersion int64) (Config, error) {

--- a/contract/r/gnoswap/gov/governance/getters.gno
+++ b/contract/r/gnoswap/gov/governance/getters.gno
@@ -28,7 +28,7 @@ func GetMaxSmoothingPeriod() int64 {
 // ==================================
 
 // GetLatestConfig returns the latest governance configuration.
-func GetLatestConfig() Config {
+func GetLatestConfig() (Config, error) {
 	return getImplementation().GetLatestConfig()
 }
 

--- a/contract/r/gnoswap/gov/governance/types.gno
+++ b/contract/r/gnoswap/gov/governance/types.gno
@@ -74,7 +74,7 @@ type IGovernanceGetter interface {
 	GetMaxSmoothingPeriod() int64
 
 	// Config getters
-	GetLatestConfig() Config
+	GetLatestConfig() (Config, error)
 	GetConfig(configVersion int64) (Config, error)
 
 	GetProposals() *rotree.ReadOnlyTree

--- a/contract/r/gnoswap/gov/governance/upgrade_test.gno
+++ b/contract/r/gnoswap/gov/governance/upgrade_test.gno
@@ -810,7 +810,7 @@ func TestUpgrade_GetLatestConfig(cur realm, t *testing.T) {
 			testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/gov/governance"))
 
 			// Action
-			GetLatestConfig()
+			_, _ = GetLatestConfig()
 
 			// Assert
 			mockGovernance := implementation.(*MockGovernance)

--- a/contract/r/gnoswap/gov/governance/v1/config_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/config_test.gno
@@ -255,7 +255,8 @@ func zzSkip2_TestConfig_Reconfigure(cur realm, t *testing.T) {
 					tc.executionDelay,
 					tc.executionWindow,
 				)
-				cfg := gs.GetLatestConfig()
+				cfg, err := gs.GetLatestConfig()
+				uassert.NoError(t, err)
 				uassert.NotNil(t, cfg)
 				uassert.Equal(t, cfg.VotingStartDelay, tc.votingStartDelay)
 				uassert.Equal(t, cfg.VotingPeriod, tc.votingPeriod)

--- a/contract/r/gnoswap/gov/governance/v1/getter.gno
+++ b/contract/r/gnoswap/gov/governance/v1/getter.gno
@@ -26,14 +26,14 @@ func (gv *governanceV1) GetMaxSmoothingPeriod() int64 {
 }
 
 // GetLatestConfig returns the latest governance configuration.
-func (gv *governanceV1) GetLatestConfig() governance.Config {
+func (gv *governanceV1) GetLatestConfig() (governance.Config, error) {
 	currentVersion := gv.getCurrentConfigVersion()
 	config, ok := gv.getConfig(currentVersion)
 	if !ok {
-		panic(errors.New(errDataNotFound))
+		return governance.NewConfig(0, 0, 0, 0, 0, 0, 0), errors.New(errDataNotFound)
 	}
 
-	return config
+	return config, nil
 }
 
 // GetConfig returns a specific governance configuration by version.

--- a/contract/r/gnoswap/gov/governance/v1/getter_test.gno
+++ b/contract/r/gnoswap/gov/governance/v1/getter_test.gno
@@ -131,10 +131,17 @@ func TestGetLatestConfig(cur realm, t *testing.T) {
 	gv := setupGetterTest(cur, t)
 
 	t.Run("returns latest config", func(cur realm, t *testing.T) {
-		config := gv.GetLatestConfig()
+		config, err := gv.GetLatestConfig()
+		uassert.NoError(t, err)
 		uassert.Equal(t, int64(100), config.VotingStartDelay)
 		uassert.Equal(t, int64(200), config.VotingPeriod)
 		uassert.Equal(t, int64(50), config.Quorum)
+	})
+
+	t.Run("returns error when no config exists", func(cur realm, t *testing.T) {
+		emptyGV := newMockGovernance()
+		_, err := emptyGV.GetLatestConfig()
+		uassert.ErrorContains(t, err, errDataNotFound)
 	})
 }
 

--- a/contract/r/gnoswap/staker/accessor.gno
+++ b/contract/r/gnoswap/staker/accessor.gno
@@ -72,8 +72,8 @@ func newPoolAccessor() PoolAccessor {
 
 type EmissionAccessor interface {
 	MintAndDistributeGns(_ int, rlm realm) (int64, bool)
-	GetStakerEmissionAmountPerSecond() int64
-	GetStakerEmissionAmountPerSecondInRange(start, end int64) ([]int64, []int64)
+	GetStakerEmissionAmountPerSecond() (int64, error)
+	GetStakerEmissionAmountPerSecondInRange(start, end int64) ([]int64, []int64, error)
 	SetOnDistributionPctChangeCallback(_ int, rlm realm, callback func(_ int, rlm realm, emissionAmountPerSecond int64))
 }
 
@@ -85,11 +85,11 @@ func (e *emissionAccessor) MintAndDistributeGns(_ int, rlm realm) (int64, bool) 
 	return emission.MintAndDistributeGns(cross(rlm))
 }
 
-func (e *emissionAccessor) GetStakerEmissionAmountPerSecond() int64 {
+func (e *emissionAccessor) GetStakerEmissionAmountPerSecond() (int64, error) {
 	return emission.GetStakerEmissionAmountPerSecond()
 }
 
-func (e *emissionAccessor) GetStakerEmissionAmountPerSecondInRange(start, end int64) ([]int64, []int64) {
+func (e *emissionAccessor) GetStakerEmissionAmountPerSecondInRange(start, end int64) ([]int64, []int64, error) {
 	return emission.GetStakerEmissionAmountPerSecondInRange(start, end)
 }
 

--- a/contract/r/gnoswap/staker/accessor.gno
+++ b/contract/r/gnoswap/staker/accessor.gno
@@ -72,9 +72,9 @@ func newPoolAccessor() PoolAccessor {
 
 type EmissionAccessor interface {
 	MintAndDistributeGns(_ int, rlm realm) (int64, bool)
-	GetStakerEmissionAmountPerSecond() int64
-	GetStakerEmissionAmountPerSecondInRange(start, end int64) ([]int64, []int64)
-	SetOnDistributionPctChangeCallback(_ int, rlm realm, callback func(_ int, rlm realm, emissionAmountPerSecond int64))
+	GetStakerEmissionAmountPerSecond() (int64, error)
+	GetStakerEmissionAmountPerSecondInRange(start, end int64) ([]int64, []int64, error)
+	SetOnDistributionPctChangeCallback(_ int, rlm realm, callback func(_ int, rlm realm, emissionAmountPerSecond int64)) error
 }
 
 type emissionAccessor struct{}
@@ -85,15 +85,15 @@ func (e *emissionAccessor) MintAndDistributeGns(_ int, rlm realm) (int64, bool) 
 	return emission.MintAndDistributeGns(cross(rlm))
 }
 
-func (e *emissionAccessor) GetStakerEmissionAmountPerSecond() int64 {
+func (e *emissionAccessor) GetStakerEmissionAmountPerSecond() (int64, error) {
 	return emission.GetStakerEmissionAmountPerSecond()
 }
 
-func (e *emissionAccessor) GetStakerEmissionAmountPerSecondInRange(start, end int64) ([]int64, []int64) {
+func (e *emissionAccessor) GetStakerEmissionAmountPerSecondInRange(start, end int64) ([]int64, []int64, error) {
 	return emission.GetStakerEmissionAmountPerSecondInRange(start, end)
 }
 
-func (e *emissionAccessor) SetOnDistributionPctChangeCallback(_ int, rlm realm, callback func(_ int, rlm realm, emissionAmountPerSecond int64)) {
+func (e *emissionAccessor) SetOnDistributionPctChangeCallback(_ int, rlm realm, callback func(_ int, rlm realm, emissionAmountPerSecond int64)) error {
 	access.AssertIsRlmCurrent(0, rlm)
 
 	// Wrap the caller-provided callback in an adapter constructed HERE, inside
@@ -103,7 +103,7 @@ func (e *emissionAccessor) SetOnDistributionPctChangeCallback(_ int, rlm realm, 
 	// hook accessors above and lets emission persist the callback into its
 	// package-level var without hitting "cannot persist realm value" (which
 	// fired when a v1-constructed closure was stored there directly).
-	emission.SetOnDistributionPctChangeCallback(cross(rlm), func(cur realm, emissionAmountPerSecond int64) {
+	return emission.SetOnDistributionPctChangeCallback(cross(rlm), func(cur realm, emissionAmountPerSecond int64) {
 		callback(0, cur, emissionAmountPerSecond)
 	})
 }

--- a/contract/r/gnoswap/staker/store.gno
+++ b/contract/r/gnoswap/staker/store.gno
@@ -552,21 +552,21 @@ func (s *stakerStore) HasPoolTierGetEmissionStoreKey() bool {
 	return s.kvStore.Has(StoreKeyPoolTierGetEmission.String())
 }
 
-func (s *stakerStore) GetPoolTierGetEmission() func() int64 {
+func (s *stakerStore) GetPoolTierGetEmission() func() (int64, error) {
 	result, err := s.kvStore.Get(StoreKeyPoolTierGetEmission.String())
 	if err != nil {
 		panic(err)
 	}
 
-	fn, ok := result.(func() int64)
+	fn, ok := result.(func() (int64, error))
 	if !ok {
-		panic(ufmt.Sprintf("failed to cast result to func() int64: %T", result))
+		panic(ufmt.Sprintf("failed to cast result to func() (int64, error): %T", result))
 	}
 
 	return fn
 }
 
-func (s *stakerStore) SetPoolTierGetEmission(_ int, rlm realm, fn func() int64) error {
+func (s *stakerStore) SetPoolTierGetEmission(_ int, rlm realm, fn func() (int64, error)) error {
 	if !rlm.IsCurrent() {
 		return errors.New(ErrSpoofedRealm)
 	}
@@ -579,21 +579,21 @@ func (s *stakerStore) HasPoolTierGetHalvingBlocksInRangeStoreKey() bool {
 	return s.kvStore.Has(StoreKeyPoolTierGetHalvingBlocksInRange.String())
 }
 
-func (s *stakerStore) GetPoolTierGetHalvingBlocksInRange() func(start, end int64) ([]int64, []int64) {
+func (s *stakerStore) GetPoolTierGetHalvingBlocksInRange() func(start, end int64) ([]int64, []int64, error) {
 	result, err := s.kvStore.Get(StoreKeyPoolTierGetHalvingBlocksInRange.String())
 	if err != nil {
 		panic(err)
 	}
 
-	fn, ok := result.(func(start, end int64) ([]int64, []int64))
+	fn, ok := result.(func(start, end int64) ([]int64, []int64, error))
 	if !ok {
-		panic(ufmt.Sprintf("failed to cast result to func(start, end int64) ([]int64, []int64): %T", result))
+		panic(ufmt.Sprintf("failed to cast result to func(start, end int64) ([]int64, []int64, error): %T", result))
 	}
 
 	return fn
 }
 
-func (s *stakerStore) SetPoolTierGetHalvingBlocksInRange(_ int, rlm realm, fn func(start, end int64) ([]int64, []int64)) error {
+func (s *stakerStore) SetPoolTierGetHalvingBlocksInRange(_ int, rlm realm, fn func(start, end int64) ([]int64, []int64, error)) error {
 	if !rlm.IsCurrent() {
 		return errors.New(ErrSpoofedRealm)
 	}

--- a/contract/r/gnoswap/staker/store_test.gno
+++ b/contract/r/gnoswap/staker/store_test.gno
@@ -1007,14 +1007,16 @@ func TestStoreSetAndGetPoolTierGetEmission(cur realm, t *testing.T) {
 		{
 			name: "set and get pool tier get emission successfully",
 			setupFn: func(cur realm, ss IStakerStore) {
-				emissionFunc := func() int64 { return 1000 }
+			emissionFunc := func() (int64, error) { return 1000, nil }
 				ss.SetPoolTierGetEmission(0, cur, emissionFunc)
 			},
 			testFn: func(cur realm, t *testing.T, ss IStakerStore) {
 				uassert.True(t, ss.HasPoolTierGetEmissionStoreKey(), "should have pool tier get emission after setting")
 				retrieved := ss.GetPoolTierGetEmission()
 				uassert.NotEqual(t, nil, retrieved)
-				uassert.Equal(t, int64(1000), retrieved())
+				amount, err := retrieved()
+				uassert.NoError(t, err)
+				uassert.Equal(t, int64(1000), amount)
 			},
 		},
 		{
@@ -1065,8 +1067,8 @@ func TestStoreSetAndGetPoolTierGetHalvingBlocksInRange(cur realm, t *testing.T) 
 		{
 			name: "set and get pool tier get halving blocks in range successfully",
 			setupFn: func(cur realm, ss IStakerStore) {
-				halvingFunc := func(start, end int64) ([]int64, []int64) {
-					return []int64{100, 200}, []int64{10, 20}
+			halvingFunc := func(start, end int64) ([]int64, []int64, error) {
+				return []int64{100, 200}, []int64{10, 20}, nil
 				}
 				ss.SetPoolTierGetHalvingBlocksInRange(0, cur, halvingFunc)
 			},
@@ -1075,7 +1077,8 @@ func TestStoreSetAndGetPoolTierGetHalvingBlocksInRange(cur realm, t *testing.T) 
 				retrieved := ss.GetPoolTierGetHalvingBlocksInRange()
 				uassert.NotEqual(t, nil, retrieved)
 
-				blocks, heights := retrieved(0, 1000)
+				blocks, heights, err := retrieved(0, 1000)
+				uassert.NoError(t, err)
 				uassert.Equal(t, 2, len(blocks))
 				uassert.Equal(t, 2, len(heights))
 				uassert.Equal(t, int64(100), blocks[0])

--- a/contract/r/gnoswap/staker/types.gno
+++ b/contract/r/gnoswap/staker/types.gno
@@ -187,13 +187,13 @@ type IStakerStore interface {
 
 	// PoolTierGetEmission
 	HasPoolTierGetEmissionStoreKey() bool
-	GetPoolTierGetEmission() func() int64
-	SetPoolTierGetEmission(_ int, rlm realm, fn func() int64) error
+	GetPoolTierGetEmission() func() (int64, error)
+	SetPoolTierGetEmission(_ int, rlm realm, fn func() (int64, error)) error
 
 	// PoolTierGetHalvingBlocksInRange
 	HasPoolTierGetHalvingBlocksInRangeStoreKey() bool
-	GetPoolTierGetHalvingBlocksInRange() func(start, end int64) ([]int64, []int64)
-	SetPoolTierGetHalvingBlocksInRange(_ int, rlm realm, fn func(start, end int64) ([]int64, []int64)) error
+	GetPoolTierGetHalvingBlocksInRange() func(start, end int64) ([]int64, []int64, error)
+	SetPoolTierGetHalvingBlocksInRange(_ int, rlm realm, fn func(start, end int64) ([]int64, []int64, error)) error
 
 	HasWarmupTemplateStoreKey() bool
 	GetWarmupTemplate() []Warmup

--- a/contract/r/gnoswap/staker/types.gno
+++ b/contract/r/gnoswap/staker/types.gno
@@ -186,13 +186,13 @@ type IStakerStore interface {
 
 	// PoolTierGetEmission
 	HasPoolTierGetEmissionStoreKey() bool
-	GetPoolTierGetEmission() func() int64
-	SetPoolTierGetEmission(_ int, rlm realm, fn func() int64) error
+	GetPoolTierGetEmission() func() (int64, error)
+	SetPoolTierGetEmission(_ int, rlm realm, fn func() (int64, error)) error
 
 	// PoolTierGetHalvingBlocksInRange
 	HasPoolTierGetHalvingBlocksInRangeStoreKey() bool
-	GetPoolTierGetHalvingBlocksInRange() func(start, end int64) ([]int64, []int64)
-	SetPoolTierGetHalvingBlocksInRange(_ int, rlm realm, fn func(start, end int64) ([]int64, []int64)) error
+	GetPoolTierGetHalvingBlocksInRange() func(start, end int64) ([]int64, []int64, error)
+	SetPoolTierGetHalvingBlocksInRange(_ int, rlm realm, fn func(start, end int64) ([]int64, []int64, error)) error
 
 	HasWarmupTemplateStoreKey() bool
 	GetWarmupTemplate() []Warmup

--- a/contract/r/gnoswap/staker/v1/_mock_test.gno
+++ b/contract/r/gnoswap/staker/v1/_mock_test.gno
@@ -30,8 +30,8 @@ type MockStakerStore struct {
 	poolTierCounts                   [sr.AllTierCount]uint64
 	poolTierLastRewardCacheTimestamp int64
 	poolTierCurrentEmission          int64
-	poolTierGetEmission              func() int64
-	poolTierGetHalvingBlocksInRange  func(start, end int64) ([]int64, []int64)
+	poolTierGetEmission              func() (int64, error)
+	poolTierGetHalvingBlocksInRange  func(start, end int64) ([]int64, []int64, error)
 	warmupTemplate                   []sr.Warmup
 	currentSwapBatch                 *sr.SwapBatchProcessor
 }
@@ -302,11 +302,11 @@ func (s *MockStakerStore) HasPoolTierGetEmissionStoreKey() bool {
 	return s.poolTierGetEmission != nil
 }
 
-func (s *MockStakerStore) GetPoolTierGetEmission() func() int64 {
+func (s *MockStakerStore) GetPoolTierGetEmission() func() (int64, error) {
 	return s.poolTierGetEmission
 }
 
-func (s *MockStakerStore) SetPoolTierGetEmission(_ int, rlm realm, fn func() int64) error {
+func (s *MockStakerStore) SetPoolTierGetEmission(_ int, rlm realm, fn func() (int64, error)) error {
 	s.poolTierGetEmission = fn
 	return nil
 }
@@ -316,11 +316,11 @@ func (s *MockStakerStore) HasPoolTierGetHalvingBlocksInRangeStoreKey() bool {
 	return s.poolTierGetHalvingBlocksInRange != nil
 }
 
-func (s *MockStakerStore) GetPoolTierGetHalvingBlocksInRange() func(start, end int64) ([]int64, []int64) {
+func (s *MockStakerStore) GetPoolTierGetHalvingBlocksInRange() func(start, end int64) ([]int64, []int64, error) {
 	return s.poolTierGetHalvingBlocksInRange
 }
 
-func (s *MockStakerStore) SetPoolTierGetHalvingBlocksInRange(_ int, rlm realm, fn func(start, end int64) ([]int64, []int64)) error {
+func (s *MockStakerStore) SetPoolTierGetHalvingBlocksInRange(_ int, rlm realm, fn func(start, end int64) ([]int64, []int64, error)) error {
 	s.poolTierGetHalvingBlocksInRange = fn
 	return nil
 }
@@ -373,8 +373,8 @@ func newMockStakerStore() *MockStakerStore {
 		poolTierCounts:                   [sr.AllTierCount]uint64{},
 		poolTierLastRewardCacheTimestamp: 0,
 		poolTierCurrentEmission:          0,
-		poolTierGetEmission:              func() int64 { return 0 },
-		poolTierGetHalvingBlocksInRange:  func(start, end int64) ([]int64, []int64) { return nil, nil },
+		poolTierGetEmission:              func() (int64, error) { return 0, nil },
+		poolTierGetHalvingBlocksInRange:  func(start, end int64) ([]int64, []int64, error) { return nil, nil, nil },
 		warmupTemplate:                   sr.DefaultWarmupTemplate(),
 		currentSwapBatch:                 swapBatch,
 	}
@@ -441,18 +441,18 @@ func (e *mockEmissionAccessor) MintAndDistributeGns(_ int, rlm realm) (int64, bo
 	return emission.MintAndDistributeGns(cross(rlm))
 }
 
-func (e *mockEmissionAccessor) GetStakerEmissionAmountPerSecond() int64 {
+func (e *mockEmissionAccessor) GetStakerEmissionAmountPerSecond() (int64, error) {
 	return emission.GetStakerEmissionAmountPerSecond()
 }
 
-func (e *mockEmissionAccessor) GetStakerEmissionAmountPerSecondInRange(start, end int64) ([]int64, []int64) {
+func (e *mockEmissionAccessor) GetStakerEmissionAmountPerSecondInRange(start, end int64) ([]int64, []int64, error) {
 	return emission.GetStakerEmissionAmountPerSecondInRange(start, end)
 }
 
-func (e *mockEmissionAccessor) SetOnDistributionPctChangeCallback(_ int, rlm realm, callback func(_ int, rlm realm, emissionAmountPerSecond int64)) {
+func (e *mockEmissionAccessor) SetOnDistributionPctChangeCallback(_ int, rlm realm, callback func(_ int, rlm realm, emissionAmountPerSecond int64)) error {
 	access.AssertIsRlmCurrent(0, rlm)
 
-	emission.SetOnDistributionPctChangeCallback(cross(rlm), func(cur realm, emissionAmountPerSecond int64) {
+	return emission.SetOnDistributionPctChangeCallback(cross(rlm), func(cur realm, emissionAmountPerSecond int64) {
 		callback(0, cur, emissionAmountPerSecond)
 	})
 }

--- a/contract/r/gnoswap/staker/v1/_mock_test.gno
+++ b/contract/r/gnoswap/staker/v1/_mock_test.gno
@@ -30,8 +30,8 @@ type MockStakerStore struct {
 	poolTierCounts                   [sr.AllTierCount]uint64
 	poolTierLastRewardCacheTimestamp int64
 	poolTierCurrentEmission          int64
-	poolTierGetEmission              func() int64
-	poolTierGetHalvingBlocksInRange  func(start, end int64) ([]int64, []int64)
+	poolTierGetEmission              func() (int64, error)
+	poolTierGetHalvingBlocksInRange  func(start, end int64) ([]int64, []int64, error)
 	warmupTemplate                   []sr.Warmup
 	currentSwapBatch                 *sr.SwapBatchProcessor
 }
@@ -302,11 +302,11 @@ func (s *MockStakerStore) HasPoolTierGetEmissionStoreKey() bool {
 	return s.poolTierGetEmission != nil
 }
 
-func (s *MockStakerStore) GetPoolTierGetEmission() func() int64 {
+func (s *MockStakerStore) GetPoolTierGetEmission() func() (int64, error) {
 	return s.poolTierGetEmission
 }
 
-func (s *MockStakerStore) SetPoolTierGetEmission(_ int, rlm realm, fn func() int64) error {
+func (s *MockStakerStore) SetPoolTierGetEmission(_ int, rlm realm, fn func() (int64, error)) error {
 	s.poolTierGetEmission = fn
 	return nil
 }
@@ -316,11 +316,11 @@ func (s *MockStakerStore) HasPoolTierGetHalvingBlocksInRangeStoreKey() bool {
 	return s.poolTierGetHalvingBlocksInRange != nil
 }
 
-func (s *MockStakerStore) GetPoolTierGetHalvingBlocksInRange() func(start, end int64) ([]int64, []int64) {
+func (s *MockStakerStore) GetPoolTierGetHalvingBlocksInRange() func(start, end int64) ([]int64, []int64, error) {
 	return s.poolTierGetHalvingBlocksInRange
 }
 
-func (s *MockStakerStore) SetPoolTierGetHalvingBlocksInRange(_ int, rlm realm, fn func(start, end int64) ([]int64, []int64)) error {
+func (s *MockStakerStore) SetPoolTierGetHalvingBlocksInRange(_ int, rlm realm, fn func(start, end int64) ([]int64, []int64, error)) error {
 	s.poolTierGetHalvingBlocksInRange = fn
 	return nil
 }
@@ -373,8 +373,8 @@ func newMockStakerStore() *MockStakerStore {
 		poolTierCounts:                   [sr.AllTierCount]uint64{},
 		poolTierLastRewardCacheTimestamp: 0,
 		poolTierCurrentEmission:          0,
-		poolTierGetEmission:              func() int64 { return 0 },
-		poolTierGetHalvingBlocksInRange:  func(start, end int64) ([]int64, []int64) { return nil, nil },
+		poolTierGetEmission:              func() (int64, error) { return 0, nil },
+		poolTierGetHalvingBlocksInRange:  func(start, end int64) ([]int64, []int64, error) { return nil, nil, nil },
 		warmupTemplate:                   sr.DefaultWarmupTemplate(),
 		currentSwapBatch:                 swapBatch,
 	}
@@ -441,11 +441,11 @@ func (e *mockEmissionAccessor) MintAndDistributeGns(_ int, rlm realm) (int64, bo
 	return emission.MintAndDistributeGns(cross(rlm))
 }
 
-func (e *mockEmissionAccessor) GetStakerEmissionAmountPerSecond() int64 {
+func (e *mockEmissionAccessor) GetStakerEmissionAmountPerSecond() (int64, error) {
 	return emission.GetStakerEmissionAmountPerSecond()
 }
 
-func (e *mockEmissionAccessor) GetStakerEmissionAmountPerSecondInRange(start, end int64) ([]int64, []int64) {
+func (e *mockEmissionAccessor) GetStakerEmissionAmountPerSecondInRange(start, end int64) ([]int64, []int64, error) {
 	return emission.GetStakerEmissionAmountPerSecondInRange(start, end)
 }
 

--- a/contract/r/gnoswap/staker/v1/calculate_pool_position_reward.gno
+++ b/contract/r/gnoswap/staker/v1/calculate_pool_position_reward.gno
@@ -79,8 +79,8 @@ type positionRewardUpdate struct {
 //
 // It is the shared, read-only entry point used by both the Collectable* view getters and CollectReward.
 // This keeps the calculation identical for both callers and guarantees views never write.
-func (s *stakerV1) calculateCollectablePositionReward(currentHeight, currentTimestamp int64, positionId uint64) Reward {
-	rewards, _ := s.calculatePositionReward(&calculatePositionRewardParam{
+func (s *stakerV1) calculateCollectablePositionReward(currentHeight, currentTimestamp int64, positionId uint64) (Reward, error) {
+	rewards, _, err := s.calculatePositionReward(&calculatePositionRewardParam{
 		CurrentHeight: currentHeight,
 		CurrentTime:   currentTimestamp,
 		Deposits:      s.getDeposits(),
@@ -88,8 +88,11 @@ func (s *stakerV1) calculateCollectablePositionReward(currentHeight, currentTime
 		PoolTier:      s.getPoolTier(),
 		PositionId:    positionId,
 	})
+	if err != nil {
+		return Reward{}, err
+	}
 
-	return aggregateRewards(rewards)
+	return aggregateRewards(rewards), nil
 }
 
 // calculatePositionReward computes a position's per-warmup rewards WITHOUT mutating persisted state.
@@ -98,7 +101,7 @@ func (s *stakerV1) calculateCollectablePositionReward(currentHeight, currentTime
 // the single internal-reward calculator, so the calculation needs no reward-cache materialization.
 // External incentive discovery is done into a local set rather than by mutating the deposit. All would-be
 // state changes are returned as a positionRewardUpdate for the caller to apply (collect only).
-func (s *stakerV1) calculatePositionReward(param *calculatePositionRewardParam) ([]Reward, positionRewardUpdate) {
+func (s *stakerV1) calculatePositionReward(param *calculatePositionRewardParam) ([]Reward, positionRewardUpdate, error) {
 	deposit := param.Deposits.get(param.PositionId)
 	depositResolver := NewDepositResolver(deposit)
 	poolPath := deposit.TargetPoolPath()
@@ -122,7 +125,10 @@ func (s *stakerV1) calculatePositionReward(param *calculatePositionRewardParam) 
 	rewardState := poolResolver.RewardStateOf(deposit)
 
 	// Resolve the per-second reward-rate schedule (pure) and calculate internal rewards from it.
-	internalSegments := poolResolver.resolveInternalRewardSegments(param.PoolTier, poolPath, lastCollectTime, param.CurrentTime)
+	internalSegments, err := poolResolver.resolveInternalRewardSegments(param.PoolTier, poolPath, lastCollectTime, param.CurrentTime)
+	if err != nil {
+		return nil, positionRewardUpdate{}, err
+	}
 	calculatedInternalRewards, calculatedInternalPenalties := rewardState.calculateInternalReward(internalSegments)
 
 	warmupLen := len(deposit.Warmups())
@@ -200,7 +206,7 @@ func (s *stakerV1) calculatePositionReward(param *calculatePositionRewardParam) 
 		rewardState.reset()
 	}
 
-	return rewards, updateParams
+	return rewards, updateParams, nil
 }
 
 // updatePositionReward applies the persisted-state changes produced by calculatePositionReward.
@@ -245,10 +251,10 @@ type internalRewardSegment struct {
 // tail rate is recomputed with the same calculatePoolReward arithmetic the cache writer uses, so a
 // schedule resolved from a fully materialized cache and one resolved from the emission halvings are
 // identical.
-func (self *PoolResolver) resolveInternalRewardSegments(poolTier *PoolTier, poolPath string, startTime, endTime int64) []internalRewardSegment {
+func (self *PoolResolver) resolveInternalRewardSegments(poolTier *PoolTier, poolPath string, startTime, endTime int64) ([]internalRewardSegment, error) {
 	segments := make([]internalRewardSegment, 0)
 	if startTime >= endTime {
-		return segments
+		return segments, nil
 	}
 
 	currentReward := self.CurrentReward(startTime)
@@ -267,20 +273,24 @@ func (self *PoolResolver) resolveInternalRewardSegments(poolTier *PoolTier, pool
 	})
 
 	if cursor < endTime {
-		segments = appendInternalRewardTailSegments(segments, poolTier, poolPath, cursor, endTime, currentReward)
+		var err error
+		segments, err = appendInternalRewardTailSegments(segments, poolTier, poolPath, cursor, endTime, currentReward)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	return segments
+	return segments, nil
 }
 
 // appendInternalRewardTailSegments appends the schedule for the tail [startTime, endTime], where no
 // persisted cache entry exists beyond startTime. Over this span tier/count are constant, so the rate
 // changes only at halving boundaries.
-func appendInternalRewardTailSegments(segments []internalRewardSegment, poolTier *PoolTier, poolPath string, startTime, endTime, baseReward int64) []internalRewardSegment {
+func appendInternalRewardTailSegments(segments []internalRewardSegment, poolTier *PoolTier, poolPath string, startTime, endTime, baseReward int64) ([]internalRewardSegment, error) {
 	tier := poolTier.CurrentTier(poolPath)
 	if tier == 0 || tier >= AllTierCount {
 		// Not currently tiered: the rate cannot increase; the base is 0 after de-tier.
-		return append(segments, internalRewardSegment{start: startTime, end: endTime, rewardPerSecond: baseReward})
+		return append(segments, internalRewardSegment{start: startTime, end: endTime, rewardPerSecond: baseReward}), nil
 	}
 
 	tierRatio, err := poolTier.tierRatio.Get(tier)
@@ -290,7 +300,10 @@ func appendInternalRewardTailSegments(segments []internalRewardSegment, poolTier
 	tierRatioInt64 := int64(tierRatio)
 	tierCount := int64(poolTier.counts[tier])
 
-	halvingTimestamps, halvingEmissions := poolTier.getHalvingBlocksInRange(startTime, endTime)
+	halvingTimestamps, halvingEmissions, err := poolTier.getHalvingBlocksInRange(startTime, endTime)
+	if err != nil {
+		return nil, err
+	}
 
 	segStart := startTime
 	rate := baseReward
@@ -309,7 +322,7 @@ func appendInternalRewardTailSegments(segments []internalRewardSegment, poolTier
 		segStart = hv
 	}
 
-	return append(segments, internalRewardSegment{start: segStart, end: endTime, rewardPerSecond: rate})
+	return append(segments, internalRewardSegment{start: segStart, end: endTime, rewardPerSecond: rate}), nil
 }
 
 // calculates internal unclaimable reward for the pool

--- a/contract/r/gnoswap/staker/v1/calculate_pool_position_reward.gno
+++ b/contract/r/gnoswap/staker/v1/calculate_pool_position_reward.gno
@@ -295,7 +295,7 @@ func appendInternalRewardTailSegments(segments []internalRewardSegment, poolTier
 
 	tierRatio, err := poolTier.tierRatio.Get(tier)
 	if err != nil {
-		panic(makeErrorWithDetails(errInvalidPoolTier, err.Error()))
+		return nil, makeErrorWithDetails(errInvalidPoolTier, err.Error())
 	}
 	tierRatioInt64 := int64(tierRatio)
 	tierCount := int64(poolTier.counts[tier])
@@ -310,7 +310,10 @@ func appendInternalRewardTailSegments(segments []internalRewardSegment, poolTier
 	for i, hv := range halvingTimestamps {
 		if hv <= segStart {
 			// Halving effective at/before the segment start: only switch the rate.
-			rate = calculatePoolReward(halvingEmissions[i], tierRatioInt64, tierCount)
+			rate, err = calculatePoolReward(halvingEmissions[i], tierRatioInt64, tierCount)
+			if err != nil {
+				return nil, err
+			}
 			continue
 		}
 		if hv >= endTime {
@@ -318,7 +321,10 @@ func appendInternalRewardTailSegments(segments []internalRewardSegment, poolTier
 		}
 
 		segments = append(segments, internalRewardSegment{start: segStart, end: hv, rewardPerSecond: rate})
-		rate = calculatePoolReward(halvingEmissions[i], tierRatioInt64, tierCount)
+		rate, err = calculatePoolReward(halvingEmissions[i], tierRatioInt64, tierCount)
+		if err != nil {
+			return nil, err
+		}
 		segStart = hv
 	}
 

--- a/contract/r/gnoswap/staker/v1/calculate_pool_position_reward_test.gno
+++ b/contract/r/gnoswap/staker/v1/calculate_pool_position_reward_test.gno
@@ -423,7 +423,8 @@ func TestCalculateCollectablePositionReward_Prevent_ExternalPenaltyOnly(cur real
 	currentTimestamp := time.Now().Unix() + 1
 	currentHeight := runtime.ChainHeight() + 1
 
-	reward := getMockInstance().calculateCollectablePositionReward(currentHeight, currentTimestamp, positionId)
+	reward, err := getMockInstance().calculateCollectablePositionReward(currentHeight, currentTimestamp, positionId)
+	uassert.NoError(t, err)
 
 	_, hasExternalReward := reward.External[incentiveId]
 	uassert.True(t, hasExternalReward)
@@ -1238,7 +1239,8 @@ func TestCalculateCollectablePositionReward(cur realm, t *testing.T) {
 			positionId, _ := tt.setupFunc(t, s, baseTime)
 
 			// Execute
-			reward := s.calculateCollectablePositionReward(tt.currentHeight, tt.currentTimestamp, positionId)
+			reward, err := s.calculateCollectablePositionReward(tt.currentHeight, tt.currentTimestamp, positionId)
+			uassert.NoError(t, err)
 
 			// Validate internal reward expectations
 			if tt.expectInternalReward {
@@ -1393,7 +1395,8 @@ func TestCalculateCollectablePositionReward_BoundaryConditions(cur realm, t *tes
 			poolResolver.Pool.SetRewardCacheAt(baseTime, int64(1000000))
 
 			// Execute
-			reward := s.calculateCollectablePositionReward(baseHeight+10, baseTime+100, positionId)
+			reward, err := s.calculateCollectablePositionReward(baseHeight+10, baseTime+100, positionId)
+			uassert.NoError(t, err)
 
 			// Verify
 			if tt.expectInRange {
@@ -1455,7 +1458,8 @@ func TestCalculateCollectablePositionReward_RewardAggregation(cur realm, t *test
 
 	var prevReward int64
 	for _, ts := range times {
-		reward := s.calculateCollectablePositionReward(baseHeight+10, ts, positionId)
+		reward, err := s.calculateCollectablePositionReward(baseHeight+10, ts, positionId)
+		uassert.NoError(t, err)
 
 		// Total reward should always be positive and increasing over time
 		totalReward := reward.Internal + reward.InternalPenalty
@@ -1516,14 +1520,16 @@ func TestCalculateCollectablePositionReward_ExternalRewardMapIntegrity(cur realm
 	poolResolver.Pool.SetStakedLiquidityAt(baseTime-100, u256.NewUint(1000000))
 
 	// Get first reward
-	reward1 := s.calculateCollectablePositionReward(baseHeight+10, baseTime+10, positionId)
+	reward1, err := s.calculateCollectablePositionReward(baseHeight+10, baseTime+10, positionId)
+	uassert.NoError(t, err)
 
 	// Modify the returned map (should not affect future calls)
 	reward1.External["modified-key"] = 999999
 	reward1.ExternalPenalty["modified-key"] = 888888
 
 	// Get second reward
-	reward2 := s.calculateCollectablePositionReward(baseHeight+20, baseTime+20, positionId)
+	reward2, err := s.calculateCollectablePositionReward(baseHeight+20, baseTime+20, positionId)
+	uassert.NoError(t, err)
 
 	// Verify the modification didn't affect reward2
 	_, hasModified := reward2.External["modified-key"]

--- a/contract/r/gnoswap/staker/v1/getter.gno
+++ b/contract/r/gnoswap/staker/v1/getter.gno
@@ -280,7 +280,10 @@ func (s *stakerV1) CollectableEmissionReward(positionId uint64) (int64, error) {
 	if _, err := s.getDeposit(positionId); err != nil {
 		return 0, err
 	}
-	reward := s.calculateCollectablePositionReward(currentHeight, currentTime, positionId)
+	reward, err := s.calculateCollectablePositionReward(currentHeight, currentTime, positionId)
+	if err != nil {
+		return 0, err
+	}
 	return reward.Internal, nil
 }
 
@@ -292,7 +295,10 @@ func (s *stakerV1) CollectableExternalIncentiveReward(positionId uint64, incenti
 	if _, err := s.getDeposit(positionId); err != nil {
 		return 0, err
 	}
-	reward := s.calculateCollectablePositionReward(currentHeight, currentTime, positionId)
+	reward, err := s.calculateCollectablePositionReward(currentHeight, currentTime, positionId)
+	if err != nil {
+		return 0, err
+	}
 	amount, ok := reward.External[incentiveId]
 	if !ok {
 		return 0, nil
@@ -460,7 +466,7 @@ func (s *stakerV1) GetPoolReward(tier uint64) (int64, error) {
 			ufmt.Sprintf("tier(%d) must be between 1 and %d", tier, AllTierCount-1),
 		)
 	}
-	return s.getPoolTier().CurrentReward(tier), nil
+	return s.getPoolTier().CurrentReward(tier)
 }
 
 // GetPoolStakedLiquidity returns the current total staked liquidity of a pool.

--- a/contract/r/gnoswap/staker/v1/getter.gno
+++ b/contract/r/gnoswap/staker/v1/getter.gno
@@ -279,7 +279,10 @@ func (s *stakerV1) CollectableEmissionReward(positionId uint64) (int64, error) {
 	if _, err := s.getDeposit(positionId); err != nil {
 		return 0, err
 	}
-	reward := s.calculateCollectablePositionReward(currentHeight, currentTime, positionId)
+	reward, err := s.calculateCollectablePositionReward(currentHeight, currentTime, positionId)
+	if err != nil {
+		return 0, err
+	}
 	return reward.Internal, nil
 }
 
@@ -291,7 +294,10 @@ func (s *stakerV1) CollectableExternalIncentiveReward(positionId uint64, incenti
 	if _, err := s.getDeposit(positionId); err != nil {
 		return 0, err
 	}
-	reward := s.calculateCollectablePositionReward(currentHeight, currentTime, positionId)
+	reward, err := s.calculateCollectablePositionReward(currentHeight, currentTime, positionId)
+	if err != nil {
+		return 0, err
+	}
 	amount, ok := reward.External[incentiveId]
 	if !ok {
 		return 0, nil
@@ -459,7 +465,7 @@ func (s *stakerV1) GetPoolReward(tier uint64) (int64, error) {
 			ufmt.Sprintf("tier(%d) must be between 1 and %d", tier, AllTierCount-1),
 		)
 	}
-	return s.getPoolTier().CurrentReward(tier), nil
+	return s.getPoolTier().CurrentReward(tier)
 }
 
 // GetPoolStakedLiquidity returns the current total staked liquidity of a pool.

--- a/contract/r/gnoswap/staker/v1/getter_test.gno
+++ b/contract/r/gnoswap/staker/v1/getter_test.gno
@@ -1,6 +1,7 @@
 package staker
 
 import (
+	"errors"
 	"testing"
 
 	rotree "gno.land/p/nt/bptree/v0/rotree"
@@ -11,6 +12,38 @@ import (
 
 	sr "gno.land/r/gnoswap/staker"
 )
+
+func TestCollectableRewards_PropagateHalvingLookupError(cur realm, t *testing.T) {
+	state := setupBasicTestState(cur, t)
+	mockStore := state.instance.store.(*MockStakerStore)
+	mockStore.poolTierGetHalvingBlocksInRange = func(start, end int64) ([]int64, []int64, error) {
+		return nil, nil, errors.New("halving lookup failed")
+	}
+
+	_, err := state.instance.CollectableEmissionReward(state.positionId)
+	uassert.ErrorContains(t, err, "halving lookup failed")
+
+	_, err = state.instance.CollectableExternalIncentiveReward(state.positionId, state.incentiveId)
+	uassert.ErrorContains(t, err, "halving lookup failed")
+}
+
+func TestCollectReward_PanicsOnHalvingLookupErrorBeforeRewardUpdates(cur realm, t *testing.T) {
+	state := setupBasicTestState(cur, t)
+	mockStore := state.instance.store.(*MockStakerStore)
+	mockStore.poolTierGetHalvingBlocksInRange = func(start, end int64) ([]int64, []int64, error) {
+		return nil, nil, errors.New("halving lookup failed")
+	}
+	lastCollectTime := state.deposit.InternalRewardLastCollectTime()
+	rewardCacheSize := state.pool.RewardCache().Size()
+
+	testing.SetRealm(testing.NewUserRealm(state.owner))
+	uassert.AbortsWithMessage(t, cur, "halving lookup failed", func() {
+		sr.CollectReward(cross(cur), state.positionId)
+	})
+
+	uassert.Equal(t, lastCollectTime, state.deposit.InternalRewardLastCollectTime())
+	uassert.Equal(t, rewardCacheSize, state.pool.RewardCache().Size())
+}
 
 // testState holds a complete test state setup for getter tests.
 // This allows setting up state once and verifying multiple getters.

--- a/contract/r/gnoswap/staker/v1/getter_test.gno
+++ b/contract/r/gnoswap/staker/v1/getter_test.gno
@@ -1,6 +1,7 @@
 package staker
 
 import (
+	"errors"
 	"testing"
 
 	rotree "gno.land/p/nt/bptree/v0/rotree"
@@ -10,6 +11,38 @@ import (
 
 	sr "gno.land/r/gnoswap/staker"
 )
+
+func TestCollectableRewards_PropagateHalvingLookupError(cur realm, t *testing.T) {
+	state := setupBasicTestState(cur, t)
+	mockStore := state.instance.store.(*MockStakerStore)
+	mockStore.poolTierGetHalvingBlocksInRange = func(start, end int64) ([]int64, []int64, error) {
+		return nil, nil, errors.New("halving lookup failed")
+	}
+
+	_, err := state.instance.CollectableEmissionReward(state.positionId)
+	uassert.ErrorContains(t, err, "halving lookup failed")
+
+	_, err = state.instance.CollectableExternalIncentiveReward(state.positionId, state.incentiveId)
+	uassert.ErrorContains(t, err, "halving lookup failed")
+}
+
+func TestCollectReward_PanicsOnHalvingLookupErrorBeforeRewardUpdates(cur realm, t *testing.T) {
+	state := setupBasicTestState(cur, t)
+	mockStore := state.instance.store.(*MockStakerStore)
+	mockStore.poolTierGetHalvingBlocksInRange = func(start, end int64) ([]int64, []int64, error) {
+		return nil, nil, errors.New("halving lookup failed")
+	}
+	lastCollectTime := state.deposit.InternalRewardLastCollectTime()
+	rewardCacheSize := state.pool.RewardCache().Size()
+
+	testing.SetRealm(testing.NewUserRealm(state.owner))
+	uassert.AbortsWithMessage(t, cur, "halving lookup failed", func() {
+		sr.CollectReward(cross(cur), state.positionId)
+	})
+
+	uassert.Equal(t, lastCollectTime, state.deposit.InternalRewardLastCollectTime())
+	uassert.Equal(t, rewardCacheSize, state.pool.RewardCache().Size())
+}
 
 // testState holds a complete test state setup for getter tests.
 // This allows setting up state once and verifying multiple getters.

--- a/contract/r/gnoswap/staker/v1/init.gno
+++ b/contract/r/gnoswap/staker/v1/init.gno
@@ -34,7 +34,9 @@ func registerStakerV1(cur realm) {
 
 		instance := NewStakerV1(stakerStore, poolAccessor, emissionAccessor, nftAccessor)
 		instance.setupSwapHooks(0, rlm)
-		emissionAccessor.SetOnDistributionPctChangeCallback(0, rlm, instance.emissionCacheUpdateHook)
+		if err := emissionAccessor.SetOnDistributionPctChangeCallback(0, rlm, instance.emissionCacheUpdateHook); err != nil {
+			panic(err)
+		}
 
 		return instance
 	})
@@ -179,7 +181,7 @@ func initStoreData(_ int, rlm realm, stakerStore sr.IStakerStore, emissionAccess
 	}
 
 	if !stakerStore.HasPoolTierGetEmissionStoreKey() {
-		getEmissionFn := func() int64 {
+		getEmissionFn := func() (int64, error) {
 			return emissionAccessor.GetStakerEmissionAmountPerSecond()
 		}
 
@@ -190,7 +192,7 @@ func initStoreData(_ int, rlm realm, stakerStore sr.IStakerStore, emissionAccess
 	}
 
 	if !stakerStore.HasPoolTierGetHalvingBlocksInRangeStoreKey() {
-		getHalvingBlocksInRangeFn := func(start, end int64) ([]int64, []int64) {
+		getHalvingBlocksInRangeFn := func(start, end int64) ([]int64, []int64, error) {
 			return emissionAccessor.GetStakerEmissionAmountPerSecondInRange(start, end)
 		}
 

--- a/contract/r/gnoswap/staker/v1/init.gno
+++ b/contract/r/gnoswap/staker/v1/init.gno
@@ -179,7 +179,7 @@ func initStoreData(_ int, rlm realm, stakerStore sr.IStakerStore, emissionAccess
 	}
 
 	if !stakerStore.HasPoolTierGetEmissionStoreKey() {
-		getEmissionFn := func() int64 {
+		getEmissionFn := func() (int64, error) {
 			return emissionAccessor.GetStakerEmissionAmountPerSecond()
 		}
 
@@ -190,7 +190,7 @@ func initStoreData(_ int, rlm realm, stakerStore sr.IStakerStore, emissionAccess
 	}
 
 	if !stakerStore.HasPoolTierGetHalvingBlocksInRangeStoreKey() {
-		getHalvingBlocksInRangeFn := func(start, end int64) ([]int64, []int64) {
+		getHalvingBlocksInRangeFn := func(start, end int64) ([]int64, []int64, error) {
 			return emissionAccessor.GetStakerEmissionAmountPerSecondInRange(start, end)
 		}
 

--- a/contract/r/gnoswap/staker/v1/resolve_internal_reward_segments_test.gno
+++ b/contract/r/gnoswap/staker/v1/resolve_internal_reward_segments_test.gno
@@ -25,7 +25,7 @@ func newTestPoolTier(poolPath string, tier uint64, counts [AllTierCount]uint64, 
 	}
 	ratio := TierRatioFromCounts(counts[Tier1], counts[Tier2], counts[Tier3])
 
-	getHalvings := func(start, end int64) ([]int64, []int64) {
+	getHalvings := func(start, end int64) ([]int64, []int64, error) {
 		ts := make([]int64, 0)
 		em := make([]int64, 0)
 		for _, h := range halvings {
@@ -34,10 +34,10 @@ func newTestPoolTier(poolPath string, tier uint64, counts [AllTierCount]uint64, 
 				em = append(em, h.emission)
 			}
 		}
-		return ts, em
+		return ts, em, nil
 	}
 
-	return NewPoolTierBy(membership, ratio, counts, 0, 0, func() int64 { return 0 }, getHalvings)
+	return NewPoolTierBy(membership, ratio, counts, 0, 0, func() (int64, error) { return 0, nil }, getHalvings)
 }
 
 // newLinearAccPool builds a pool with constant staked liquidity and one global-accumulation checkpoint at
@@ -207,7 +207,9 @@ func TestResolveInternalRewardSegments(cur realm, t *testing.T) {
 
 			poolTier := newTestPoolTier("test_pool", tt.tier, tt.counts, tt.halvings)
 
-			got := nonEmptySegments(resolver.resolveInternalRewardSegments(poolTier, "test_pool", tt.start, tt.end))
+			segments, err := resolver.resolveInternalRewardSegments(poolTier, "test_pool", tt.start, tt.end)
+			uassert.NoError(t, err)
+			got := nonEmptySegments(segments)
 
 			uassert.Equal(t, len(tt.want), len(got))
 			for i := range tt.want {
@@ -242,14 +244,16 @@ func TestResolveInternalRewardSegments_EmissionMatchesMaterializedCache(cur real
 	refResolver := newLinearAccPool("pool_ref", createTime, poolLiq)
 	refResolver.Pool.SetRewardCacheAt(createTime, emission0)
 	refResolver.Pool.SetRewardCacheAt(halveTime, emission1)
-	refSegments := refResolver.resolveInternalRewardSegments(poolTier, "pool_ref", createTime, endTime)
+	refSegments, err := refResolver.resolveInternalRewardSegments(poolTier, "pool_ref", createTime, endTime)
+	uassert.NoError(t, err)
 	refRewards, refPenalties := refResolver.RewardStateOf(deposit).calculateInternalReward(refSegments)
 
 	// Emission path: only the base entry is cached; the halving comes from the schedule.
 	emResolver := newLinearAccPool("pool_emission", createTime, poolLiq)
 	emResolver.Pool.SetRewardCacheAt(createTime, emission0)
 	cacheSizeBefore := emResolver.Pool.RewardCache().Size()
-	emSegments := emResolver.resolveInternalRewardSegments(poolTier, "pool_emission", createTime, endTime)
+	emSegments, err := emResolver.resolveInternalRewardSegments(poolTier, "pool_emission", createTime, endTime)
+	uassert.NoError(t, err)
 	emRewards, emPenalties := emResolver.RewardStateOf(deposit).calculateInternalReward(emSegments)
 	cacheSizeAfter := emResolver.Pool.RewardCache().Size()
 

--- a/contract/r/gnoswap/staker/v1/reward_calculation_canonical_env_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_canonical_env_test.gno
@@ -96,7 +96,7 @@ func NewCanonicalRewardState(
 	currentTime := time.Now().Unix()
 
 	// Technically, the block number being provided to the NewPoolTier should be 124, but because of duplicate creation of the default pool, we put 123 here to just make rewardCache work for the testing.
-	result.global.poolTier = NewPoolTier(pools, currentTime, test_gnousdc, func() int64 { return int64(result.PerSecondEmission) }, func(start, end int64) ([]int64, []int64) {
+	result.global.poolTier = NewPoolTier(pools, currentTime, test_gnousdc, func() (int64, error) { return int64(result.PerSecondEmission), nil }, func(start, end int64) ([]int64, []int64, error) {
 		heights := make([]int64, 0)
 		emissions := make([]int64, 0)
 		result.emissionUpdates.Iterate(start, end, func(key int64, value any) bool {
@@ -108,7 +108,7 @@ func NewCanonicalRewardState(
 			emissions = append(emissions, int64(v))
 			return false
 		})
-		return heights, emissions
+		return heights, emissions, nil
 	})
 
 	result.NextBlock() // must skip height 0
@@ -281,7 +281,10 @@ func (self *canonicalRewardState) EmulateCalculateCollectablePositionReward(posi
 	lastCollectTimestamp := deposit.InternalRewardLastCollectTime()
 
 	// Emulator materialized the reward cache above, so resolving the schedule reads it in full.
-	internalSegments := poolResolver.resolveInternalRewardSegments(self.global.poolTier, poolPath, lastCollectTimestamp, currentTimestamp)
+	internalSegments, err := poolResolver.resolveInternalRewardSegments(self.global.poolTier, poolPath, lastCollectTimestamp, currentTimestamp)
+	if err != nil {
+		panic(err)
+	}
 	internalRewards, internalPenalties := poolResolver.RewardStateOf(deposit).calculateInternalReward(internalSegments)
 
 	externalRewards := make([]map[string]int64, 4)

--- a/contract/r/gnoswap/staker/v1/reward_calculation_outside_accumulation_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_outside_accumulation_test.gno
@@ -452,7 +452,11 @@ func mustGetPool(t *testing.T, poolPath string) *sr.Pool {
 
 // rewardOf returns the deposit's collectable internal reward.
 func rewardOf(positionId uint64, currentTime int64) int64 {
-	return getMockInstance().calculateCollectablePositionReward(currentTime, currentTime, positionId).Internal
+	reward, err := getMockInstance().calculateCollectablePositionReward(currentTime, currentTime, positionId)
+	if err != nil {
+		panic(err)
+	}
+	return reward.Internal
 }
 
 // collectPanics runs the shared read-only reward calculation - the same code
@@ -476,13 +480,19 @@ func collectPanics(positionId uint64, currentTime int64) (panicked bool, message
 		message = "unknown panic"
 	}()
 
-	getMockInstance().calculateCollectablePositionReward(currentTime, currentTime, positionId)
+	_, err := getMockInstance().calculateCollectablePositionReward(currentTime, currentTime, positionId)
+	if err != nil {
+		return true, err.Error()
+	}
 	return false, ""
 }
 
 // externalRewardOf returns the deposit's collectable reward for one incentive.
 func externalRewardOf(positionId uint64, incentiveId string, currentTime int64) int64 {
-	reward := getMockInstance().calculateCollectablePositionReward(currentTime, currentTime, positionId)
+	reward, err := getMockInstance().calculateCollectablePositionReward(currentTime, currentTime, positionId)
+	if err != nil {
+		panic(err)
+	}
 	return reward.External[incentiveId]
 }
 
@@ -491,7 +501,10 @@ func externalRewardOf(positionId uint64, incentiveId string, currentTime int64) 
 func totalExternalDistributed(incentiveId string, currentTime int64) int64 {
 	total := int64(0)
 	getMockInstance().getDeposits().Iterate(0, math.MaxUint64, func(positionId uint64, _ *sr.Deposit) bool {
-		reward := getMockInstance().calculateCollectablePositionReward(currentTime, currentTime, positionId)
+		reward, err := getMockInstance().calculateCollectablePositionReward(currentTime, currentTime, positionId)
+		if err != nil {
+			panic(err)
+		}
 		total += reward.External[incentiveId] + reward.ExternalPenalty[incentiveId]
 		return false
 	})

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier.gno
@@ -133,13 +133,13 @@ func (self *PoolTier) CurrentReward(tier uint64) (int64, error) {
 	}
 	tierRatio, err := self.tierRatio.Get(tier)
 	if err != nil {
-		panic(makeErrorWithDetails(errInvalidPoolTier, err.Error()))
+		return 0, makeErrorWithDetails(errInvalidPoolTier, err.Error())
 	}
 
 	tierRatioInt64 := int64(tierRatio)
 	count := int64(self.CurrentCount(tier))
 
-	return calculatePoolReward(currentEmission, tierRatioInt64, count), nil
+	return calculatePoolReward(currentEmission, tierRatioInt64, count)
 }
 
 // CurrentCount returns the current count of pools in the given tier.
@@ -416,7 +416,7 @@ func (self *PoolTier) CurrentRewardPerPool(poolPath string) int64 {
 		panic(err)
 	}
 
-	return calculatePoolReward(currentEmission, tierRatioInt64, tierCount)
+	return mustCalculatePoolReward(currentEmission, tierRatioInt64, tierCount)
 }
 
 // calculatePoolReward calculates the reward for a pool based on the emission, tier ratio, and tier count.
@@ -428,18 +428,29 @@ func (self *PoolTier) CurrentRewardPerPool(poolPath string) int64 {
 //
 // Returns:
 // - int64: The reward for the pool.
-func calculatePoolReward(emission int64, tierRatio int64, tierCount int64) int64 {
+// - error: An invalid calculation input.
+func calculatePoolReward(emission int64, tierRatio int64, tierCount int64) (int64, error) {
 	if emission < 0 || tierRatio < 0 || tierCount < 0 {
-		panic(errors.New(errCalculationError))
+		return 0, errors.New(errCalculationError)
 	}
 
 	if emission == 0 || tierRatio == 0 || tierCount == 0 {
-		return 0
+		return 0, nil
 	}
 
 	tierReward := gnsmath.SafeMulDivInt64(emission, tierRatio, 100)
 
-	return tierReward / tierCount
+	return tierReward / tierCount, nil
+}
+
+// mustCalculatePoolReward preserves panic semantics for state-mutating cache paths.
+func mustCalculatePoolReward(emission int64, tierRatio int64, tierCount int64) int64 {
+	reward, err := calculatePoolReward(emission, tierRatio, tierCount)
+	if err != nil {
+		panic(err)
+	}
+
+	return reward
 }
 
 // computeTierRewards caches per-tier pool rewards to avoid recalculating for each pool iteration.
@@ -457,7 +468,7 @@ func (self *PoolTier) computeTierRewards(emission int64) map[uint64]int64 {
 			panic(makeErrorWithDetails(errInvalidPoolTier, err.Error()))
 		}
 
-		tierRewards[tierNum] = calculatePoolReward(emission, int64(tierRatio), tierCount)
+		tierRewards[tierNum] = mustCalculatePoolReward(emission, int64(tierRatio), tierCount)
 	}
 
 	return tierRewards

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier.gno
@@ -67,11 +67,11 @@ type PoolTier struct {
 	currentEmission int64
 
 	// returns current emission.
-	getEmission func() int64
+	getEmission func() (int64, error)
 	// Returns a list of halving timestamps and their emission amounts within the interval [start, end) in ascending order.
 	// The first return value is a list of timestamps where halving occurs.
 	// The second return value is a list of emission amounts corresponding to each halving timestamp.
-	getHalvingBlocksInRange func(start, end int64) ([]int64, []int64)
+	getHalvingBlocksInRange func(start, end int64) ([]int64, []int64, error)
 }
 
 // NewPoolTier creates a new PoolTier instance with single initial 1 tier pool.
@@ -85,14 +85,19 @@ type PoolTier struct {
 //
 // Returns:
 // - *PoolTier: The new PoolTier instance.
-func NewPoolTier(pools *Pools, currentTime int64, initialPoolPath string, getEmission func() int64, getHalvingBlocksInRange func(start, end int64) ([]int64, []int64)) *PoolTier {
+func NewPoolTier(pools *Pools, currentTime int64, initialPoolPath string, getEmission func() (int64, error), getHalvingBlocksInRange func(start, end int64) ([]int64, []int64, error)) *PoolTier {
+	currentEmission, err := getEmission()
+	if err != nil {
+		panic(err)
+	}
+
 	result := &PoolTier{
 		membership:               sr.NewBPTreeN(16),
 		tierRatio:                TierRatioFromCounts(1, 0, 0),
 		lastRewardCacheTimestamp: gnsmath.SafeAddInt64(currentTime, 1),
 		getEmission:              getEmission,
 		getHalvingBlocksInRange:  getHalvingBlocksInRange,
-		currentEmission:          getEmission(),
+		currentEmission:          currentEmission,
 	}
 
 	pools.set(initialPoolPath, sr.NewPool(initialPoolPath, currentTime+1))
@@ -106,8 +111,8 @@ func NewPoolTierBy(
 	counts [AllTierCount]uint64,
 	lastRewardCacheTimestamp int64,
 	currentEmission int64,
-	getEmission func() int64,
-	getHalvingBlocksInRange func(start, end int64) ([]int64, []int64),
+	getEmission func() (int64, error),
+	getHalvingBlocksInRange func(start, end int64) ([]int64, []int64, error),
 ) *PoolTier {
 	return &PoolTier{
 		membership:               membership,
@@ -121,8 +126,11 @@ func NewPoolTierBy(
 }
 
 // CurrentReward returns the current per-pool reward for the given tier.
-func (self *PoolTier) CurrentReward(tier uint64) int64 {
-	currentEmission := self.getEmission()
+func (self *PoolTier) CurrentReward(tier uint64) (int64, error) {
+	currentEmission, err := self.getEmission()
+	if err != nil {
+		return 0, err
+	}
 	tierRatio, err := self.tierRatio.Get(tier)
 	if err != nil {
 		panic(makeErrorWithDetails(errInvalidPoolTier, err.Error()))
@@ -131,7 +139,7 @@ func (self *PoolTier) CurrentReward(tier uint64) int64 {
 	tierRatioInt64 := int64(tierRatio)
 	count := int64(self.CurrentCount(tier))
 
-	return calculatePoolReward(currentEmission, tierRatioInt64, count)
+	return calculatePoolReward(currentEmission, tierRatioInt64, count), nil
 }
 
 // CurrentCount returns the current count of pools in the given tier.
@@ -200,7 +208,10 @@ func (self *PoolTier) changeTier(currentTime int64, pools *Pools, poolPath strin
 	}
 
 	self.tierRatio = TierRatioFromCounts(self.counts[Tier1], self.counts[Tier2], self.counts[Tier3])
-	currentEmission := self.getEmission()
+	currentEmission, err := self.getEmission()
+	if err != nil {
+		panic(err)
+	}
 	tierRewards := self.computeTierRewards(currentEmission)
 
 	// Cache updated reward for each tiered pool
@@ -242,7 +253,10 @@ func (self *PoolTier) cacheReward(currentTimestamp int64, pools *Pools) {
 	}
 
 	// find halving blocks in range
-	halvingTimestamps, halvingEmissions := self.getHalvingBlocksInRange(lastTimestamp, currentTimestamp)
+	halvingTimestamps, halvingEmissions, err := self.getHalvingBlocksInRange(lastTimestamp, currentTimestamp)
+	if err != nil {
+		panic(err)
+	}
 
 	if len(halvingTimestamps) == 0 {
 		self.applyCacheToAllPools(pools, currentTimestamp, self.currentEmission)
@@ -298,12 +312,19 @@ func (self *PoolTier) cacheRewardForPool(currentTimestamp int64, pools *Pools, p
 	}
 
 	// Determine halving boundaries since the pool's last cached reward timestamp.
-	halvingTimestamps, halvingEmissions := self.getHalvingBlocksInRange(lastTimestamp, currentTimestamp)
+	halvingTimestamps, halvingEmissions, err := self.getHalvingBlocksInRange(lastTimestamp, currentTimestamp)
+	if err != nil {
+		panic(err)
+	}
 	poolResolver := NewPoolResolver(pool)
 
 	if len(halvingTimestamps) == 0 {
 		// No emission change within the range => use the live emission.
-		self.applyCacheToPool(poolResolver, tierNum, currentTimestamp, self.getEmission())
+		currentEmission, err := self.getEmission()
+		if err != nil {
+			panic(err)
+		}
+		self.applyCacheToPool(poolResolver, tierNum, currentTimestamp, currentEmission)
 		return
 	}
 
@@ -372,10 +393,10 @@ func (self *PoolTier) IsInternallyIncentivizedPool(poolPath string) bool {
 	return self.CurrentTier(poolPath) > 0
 }
 
-func (self *PoolTier) CurrentRewardPerPool(poolPath string) int64 {
+func (self *PoolTier) CurrentRewardPerPool(poolPath string) (int64, error) {
 	tierNum := self.CurrentTier(poolPath)
 	if tierNum == 0 {
-		return 0 // Pool not in any tier
+		return 0, nil // Pool not in any tier
 	}
 
 	tierRatio, err := self.tierRatio.Get(tierNum)
@@ -387,10 +408,15 @@ func (self *PoolTier) CurrentRewardPerPool(poolPath string) int64 {
 	counts := self.CurrentAllTierCounts()
 	tierCount := int64(counts[tierNum])
 	if tierCount == 0 {
-		return 0 // No pools in tier
+		return 0, nil // No pools in tier
 	}
 
-	return calculatePoolReward(self.getEmission(), tierRatioInt64, tierCount)
+	currentEmission, err := self.getEmission()
+	if err != nil {
+		return 0, err
+	}
+
+	return calculatePoolReward(currentEmission, tierRatioInt64, tierCount), nil
 }
 
 // calculatePoolReward calculates the reward for a pool based on the emission, tier ratio, and tier count.

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier.gno
@@ -394,30 +394,6 @@ func (self *PoolTier) IsInternallyIncentivizedPool(poolPath string) bool {
 }
 
 
-// CurrentRewardPerPool returns the current reward rate for a pool, if tiered.
-func (self *PoolTier) CurrentRewardPerPool(poolPath string) (int64, error) {
-	tierNum := self.CurrentTier(poolPath)
-	if tierNum == 0 {
-		return 0, nil
-	}
-
-	tierRatio, err := self.tierRatio.Get(tierNum)
-	if err != nil {
-		return 0, makeErrorWithDetails(errInvalidPoolTier, err.Error())
-	}
-
-	tierCount := int64(self.counts[tierNum])
-	if tierCount == 0 {
-		return 0, nil
-	}
-
-	currentEmission, err := self.getEmission()
-	if err != nil {
-		return 0, err
-	}
-
-	return calculatePoolReward(currentEmission, int64(tierRatio), tierCount)
-}
 
 // calculatePoolReward calculates the reward for a pool based on the emission, tier ratio, and tier count.
 //

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier.gno
@@ -393,30 +393,30 @@ func (self *PoolTier) IsInternallyIncentivizedPool(poolPath string) bool {
 	return self.CurrentTier(poolPath) > 0
 }
 
-func (self *PoolTier) CurrentRewardPerPool(poolPath string) int64 {
+
+// CurrentRewardPerPool returns the current reward rate for a pool, if tiered.
+func (self *PoolTier) CurrentRewardPerPool(poolPath string) (int64, error) {
 	tierNum := self.CurrentTier(poolPath)
 	if tierNum == 0 {
-		return 0 // Pool not in any tier
+		return 0, nil
 	}
 
 	tierRatio, err := self.tierRatio.Get(tierNum)
 	if err != nil {
-		panic(makeErrorWithDetails(errInvalidPoolTier, err.Error()))
+		return 0, makeErrorWithDetails(errInvalidPoolTier, err.Error())
 	}
-	tierRatioInt64 := int64(tierRatio)
 
-	counts := self.CurrentAllTierCounts()
-	tierCount := int64(counts[tierNum])
+	tierCount := int64(self.counts[tierNum])
 	if tierCount == 0 {
-		return 0 // No pools in tier
+		return 0, nil
 	}
 
 	currentEmission, err := self.getEmission()
 	if err != nil {
-		panic(err)
+		return 0, err
 	}
 
-	return mustCalculatePoolReward(currentEmission, tierRatioInt64, tierCount)
+	return calculatePoolReward(currentEmission, int64(tierRatio), tierCount)
 }
 
 // calculatePoolReward calculates the reward for a pool based on the emission, tier ratio, and tier count.
@@ -443,15 +443,6 @@ func calculatePoolReward(emission int64, tierRatio int64, tierCount int64) (int6
 	return tierReward / tierCount, nil
 }
 
-// mustCalculatePoolReward preserves panic semantics for state-mutating cache paths.
-func mustCalculatePoolReward(emission int64, tierRatio int64, tierCount int64) int64 {
-	reward, err := calculatePoolReward(emission, tierRatio, tierCount)
-	if err != nil {
-		panic(err)
-	}
-
-	return reward
-}
 
 // computeTierRewards caches per-tier pool rewards to avoid recalculating for each pool iteration.
 func (self *PoolTier) computeTierRewards(emission int64) map[uint64]int64 {
@@ -468,7 +459,11 @@ func (self *PoolTier) computeTierRewards(emission int64) map[uint64]int64 {
 			panic(makeErrorWithDetails(errInvalidPoolTier, err.Error()))
 		}
 
-		tierRewards[tierNum] = mustCalculatePoolReward(emission, int64(tierRatio), tierCount)
+		reward, err := calculatePoolReward(emission, int64(tierRatio), tierCount)
+		if err != nil {
+			panic(err)
+		}
+		tierRewards[tierNum] = reward
 	}
 
 	return tierRewards

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier.gno
@@ -67,11 +67,11 @@ type PoolTier struct {
 	currentEmission int64
 
 	// returns current emission.
-	getEmission func() int64
+	getEmission func() (int64, error)
 	// Returns a list of halving timestamps and their emission amounts within the interval [start, end) in ascending order.
 	// The first return value is a list of timestamps where halving occurs.
 	// The second return value is a list of emission amounts corresponding to each halving timestamp.
-	getHalvingBlocksInRange func(start, end int64) ([]int64, []int64)
+	getHalvingBlocksInRange func(start, end int64) ([]int64, []int64, error)
 }
 
 // NewPoolTier creates a new PoolTier instance with single initial 1 tier pool.
@@ -85,14 +85,19 @@ type PoolTier struct {
 //
 // Returns:
 // - *PoolTier: The new PoolTier instance.
-func NewPoolTier(pools *Pools, currentTime int64, initialPoolPath string, getEmission func() int64, getHalvingBlocksInRange func(start, end int64) ([]int64, []int64)) *PoolTier {
+func NewPoolTier(pools *Pools, currentTime int64, initialPoolPath string, getEmission func() (int64, error), getHalvingBlocksInRange func(start, end int64) ([]int64, []int64, error)) *PoolTier {
+	currentEmission, err := getEmission()
+	if err != nil {
+		panic(err)
+	}
+
 	result := &PoolTier{
 		membership:               sr.NewBPTreeN(16),
 		tierRatio:                TierRatioFromCounts(1, 0, 0),
 		lastRewardCacheTimestamp: gnsmath.SafeAddInt64(currentTime, 1),
 		getEmission:              getEmission,
 		getHalvingBlocksInRange:  getHalvingBlocksInRange,
-		currentEmission:          getEmission(),
+		currentEmission:          currentEmission,
 	}
 
 	pools.set(initialPoolPath, sr.NewPool(initialPoolPath, currentTime+1))
@@ -106,8 +111,8 @@ func NewPoolTierBy(
 	counts [AllTierCount]uint64,
 	lastRewardCacheTimestamp int64,
 	currentEmission int64,
-	getEmission func() int64,
-	getHalvingBlocksInRange func(start, end int64) ([]int64, []int64),
+	getEmission func() (int64, error),
+	getHalvingBlocksInRange func(start, end int64) ([]int64, []int64, error),
 ) *PoolTier {
 	return &PoolTier{
 		membership:               membership,
@@ -121,8 +126,11 @@ func NewPoolTierBy(
 }
 
 // CurrentReward returns the current per-pool reward for the given tier.
-func (self *PoolTier) CurrentReward(tier uint64) int64 {
-	currentEmission := self.getEmission()
+func (self *PoolTier) CurrentReward(tier uint64) (int64, error) {
+	currentEmission, err := self.getEmission()
+	if err != nil {
+		return 0, err
+	}
 	tierRatio, err := self.tierRatio.Get(tier)
 	if err != nil {
 		panic(makeErrorWithDetails(errInvalidPoolTier, err.Error()))
@@ -131,7 +139,7 @@ func (self *PoolTier) CurrentReward(tier uint64) int64 {
 	tierRatioInt64 := int64(tierRatio)
 	count := int64(self.CurrentCount(tier))
 
-	return calculatePoolReward(currentEmission, tierRatioInt64, count)
+	return calculatePoolReward(currentEmission, tierRatioInt64, count), nil
 }
 
 // CurrentCount returns the current count of pools in the given tier.
@@ -200,7 +208,10 @@ func (self *PoolTier) changeTier(currentTime int64, pools *Pools, poolPath strin
 	}
 
 	self.tierRatio = TierRatioFromCounts(self.counts[Tier1], self.counts[Tier2], self.counts[Tier3])
-	currentEmission := self.getEmission()
+	currentEmission, err := self.getEmission()
+	if err != nil {
+		panic(err)
+	}
 	tierRewards := self.computeTierRewards(currentEmission)
 
 	// Cache updated reward for each tiered pool
@@ -242,7 +253,10 @@ func (self *PoolTier) cacheReward(currentTimestamp int64, pools *Pools) {
 	}
 
 	// find halving blocks in range
-	halvingTimestamps, halvingEmissions := self.getHalvingBlocksInRange(lastTimestamp, currentTimestamp)
+	halvingTimestamps, halvingEmissions, err := self.getHalvingBlocksInRange(lastTimestamp, currentTimestamp)
+	if err != nil {
+		panic(err)
+	}
 
 	if len(halvingTimestamps) == 0 {
 		self.applyCacheToAllPools(pools, currentTimestamp, self.currentEmission)
@@ -298,12 +312,19 @@ func (self *PoolTier) cacheRewardForPool(currentTimestamp int64, pools *Pools, p
 	}
 
 	// Determine halving boundaries since the pool's last cached reward timestamp.
-	halvingTimestamps, halvingEmissions := self.getHalvingBlocksInRange(lastTimestamp, currentTimestamp)
+	halvingTimestamps, halvingEmissions, err := self.getHalvingBlocksInRange(lastTimestamp, currentTimestamp)
+	if err != nil {
+		panic(err)
+	}
 	poolResolver := NewPoolResolver(pool)
 
 	if len(halvingTimestamps) == 0 {
 		// No emission change within the range => use the live emission.
-		self.applyCacheToPool(poolResolver, tierNum, currentTimestamp, self.getEmission())
+		currentEmission, err := self.getEmission()
+		if err != nil {
+			panic(err)
+		}
+		self.applyCacheToPool(poolResolver, tierNum, currentTimestamp, currentEmission)
 		return
 	}
 
@@ -390,7 +411,12 @@ func (self *PoolTier) CurrentRewardPerPool(poolPath string) int64 {
 		return 0 // No pools in tier
 	}
 
-	return calculatePoolReward(self.getEmission(), tierRatioInt64, tierCount)
+	currentEmission, err := self.getEmission()
+	if err != nil {
+		panic(err)
+	}
+
+	return calculatePoolReward(currentEmission, tierRatioInt64, tierCount)
 }
 
 // calculatePoolReward calculates the reward for a pool based on the emission, tier ratio, and tier count.

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier_test.gno
@@ -370,7 +370,8 @@ func TestCurrentRewardPerPool(cur realm, t *testing.T) {
 		func(start, end int64) ([]int64, []int64, error) { return nil, nil, nil })
 
 	// With only tier 1 pool, it should get 100% of emission
-	reward1 := poolTier.CurrentRewardPerPool(testPool1)
+	reward1, err := poolTier.CurrentRewardPerPool(testPool1)
+	uassert.NoError(t, err)
 	expectedReward1 := emission * 100 / 100 / 1 // 100% ratio, 1 pool
 	if reward1 != expectedReward1 {
 		t.Errorf("Expected reward %d, got %d", expectedReward1, reward1)
@@ -381,17 +382,23 @@ func TestCurrentRewardPerPool(cur realm, t *testing.T) {
 	poolTier.changeTier(currentTime+1, pools, testPool2, 2)
 
 	// Now tier1 gets 70%, tier2 gets 30%
-	reward1After := poolTier.CurrentRewardPerPool(testPool1)
+	reward1After, err := poolTier.CurrentRewardPerPool(testPool1)
+	uassert.NoError(t, err)
 	expectedReward1After := emission * 70 / 100 / 1 // 70% ratio, 1 pool
 	if reward1After != expectedReward1After {
 		t.Errorf("Expected tier1 reward %d, got %d", expectedReward1After, reward1After)
 	}
 
-	reward2 := poolTier.CurrentRewardPerPool(testPool2)
+	reward2, err := poolTier.CurrentRewardPerPool(testPool2)
+	uassert.NoError(t, err)
 	expectedReward2 := emission * 30 / 100 / 1 // 30% ratio, 1 pool
 	if reward2 != expectedReward2 {
 		t.Errorf("Expected tier2 reward %d, got %d", expectedReward2, reward2)
 	}
+
+	emission = -1
+	_, err = poolTier.CurrentRewardPerPool(testPool1)
+	uassert.ErrorContains(t, err, errCalculationError)
 }
 
 // Test CurrentReward for different tiers
@@ -1050,9 +1057,14 @@ func TestCalculatePoolReward(cur realm, t *testing.T) {
 	}
 }
 
-func TestMustCalculatePoolRewardPanicsOnInvalidInput(cur realm, t *testing.T) {
+func TestComputeTierRewardsPanicsOnInvalidInput(cur realm, t *testing.T) {
+	poolTier := &PoolTier{
+		tierRatio: TierRatioFromCounts(1, 0, 0),
+		counts:    [AllTierCount]uint64{0, 1, 0, 0},
+	}
+
 	uassert.PanicsContains(t, cur, errCalculationError, func() {
-		mustCalculatePoolReward(-1, 50, 1)
+		poolTier.computeTierRewards(-1)
 	})
 }
 

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier_test.gno
@@ -35,7 +35,7 @@ func TestNewPoolTier(cur realm, t *testing.T) {
 	currentTime := int64(100000) // Arbitrary time for testing
 	mustExistsInTier1 := "testPool"
 
-	poolTier := NewPoolTier(NewPools(), currentTime, mustExistsInTier1, func() int64 { return 0 }, func(start, end int64) ([]int64, []int64) { return nil, nil })
+	poolTier := NewPoolTier(NewPools(), currentTime, mustExistsInTier1, func() (int64, error) { return 0, nil }, func(start, end int64) ([]int64, []int64, error) { return nil, nil, nil })
 
 	// Test initial counts
 	if count := poolTier.CurrentCount(1); count != 1 {
@@ -58,15 +58,16 @@ func TestCacheReward(cur realm, t *testing.T) {
 	currentTime := int64(250000)
 	// Simulate emission updates
 	pools := NewPools()
-	poolTier := NewPoolTier(pools, currentTime, "testPool", func() int64 { return 1000 }, func(startHeight int64, endHeight int64) ([]int64, []int64) {
-		return []int64{100, 150, 200}, []int64{1000, 500, 250}
+	poolTier := NewPoolTier(pools, currentTime, "testPool", func() (int64, error) { return 1000, nil }, func(startHeight int64, endHeight int64) ([]int64, []int64, error) {
+		return []int64{100, 150, 200}, []int64{1000, 500, 250}, nil
 	})
 
 	// Cache rewards
 	poolTier.cacheReward(currentTime, pools)
 
 	// Verify rewards
-	reward := poolTier.CurrentReward(1)
+	reward, err := poolTier.CurrentReward(1)
+	uassert.NoError(t, err)
 	if reward == 0 {
 		t.Errorf("Expected reward for tier 1 at height 250, got 0")
 	}
@@ -86,12 +87,12 @@ func TestCacheRewardForPoolUsesLatestHalvingEmission(t *testing.T) {
 			[AllTierCount]uint64{0, 1, 0, 0},
 			1000,
 			1000,
-			func() int64 { return 500 },
-			func(start, end int64) ([]int64, []int64) {
+			func() (int64, error) { return 500, nil },
+			func(start, end int64) ([]int64, []int64, error) {
 				if start < 1010 && end > 1010 {
-					return []int64{1010}, []int64{500}
+					return []int64{1010}, []int64{500}, nil
 				}
-				return nil, nil
+				return nil, nil, nil
 			},
 		)
 		poolTier.membership.Set(poolPath, uint64(1))
@@ -113,8 +114,8 @@ func TestCacheRewardForPoolUsesLatestHalvingEmission(t *testing.T) {
 			[AllTierCount]uint64{0, 1, 0, 0},
 			1000,
 			1000,
-			func() int64 { return 500 },
-			func(start, end int64) ([]int64, []int64) { return nil, nil },
+			func() (int64, error) { return 500, nil },
+			func(start, end int64) ([]int64, []int64, error) { return nil, nil, nil },
 		)
 		poolTier.membership.Set(poolPath, uint64(1))
 
@@ -139,12 +140,12 @@ func TestCacheRewardStopsAtEmissionEndBoundary(t *testing.T) {
 			[AllTierCount]uint64{0, 1, 0, 0},
 			1000,
 			1000,
-			func() int64 { return 0 },
-			func(start, end int64) ([]int64, []int64) {
+			func() (int64, error) { return 0, nil },
+			func(start, end int64) ([]int64, []int64, error) {
 				if start <= 1020 && 1020 < end {
-					return []int64{1021}, []int64{0}
+					return []int64{1021}, []int64{0}, nil
 				}
-				return nil, nil
+				return nil, nil, nil
 			},
 		)
 		poolTier.membership.Set(poolPath, uint64(1))
@@ -174,7 +175,7 @@ var test_gnousdc = pl.GetPoolPath("gno.land/r/gnoland/wugnot.wugnot", "gno.land/
 
 func SetupPoolTier(t *testing.T) *PoolTier {
 	pools := NewPools()
-	poolTier := NewPoolTier(pools, int64(1000), test_gnousdc, func() int64 { return 1000 }, func(start, end int64) ([]int64, []int64) { return nil, nil })
+	poolTier := NewPoolTier(pools, int64(1000), test_gnousdc, func() (int64, error) { return 1000, nil }, func(start, end int64) ([]int64, []int64, error) { return nil, nil, nil })
 
 	poolTier.changeTier(int64(1000), pools, test_gnousdc, 1)
 	return poolTier
@@ -211,8 +212,8 @@ func TestPoolTierChangeTier(cur realm, t *testing.T) {
 	testPool2 := pl.GetPoolPath("gno.land/r/onbloc/foo.FOO", "gno.land/r/onbloc/qux.QUX", 3000)
 
 	poolTier := NewPoolTier(pools, currentTime, testPool1,
-		func() int64 { return 1000000 },
-		func(start, end int64) ([]int64, []int64) { return nil, nil })
+		func() (int64, error) { return 1000000, nil },
+		func(start, end int64) ([]int64, []int64, error) { return nil, nil, nil })
 
 	// Add second pool to tier 2
 	pools.set(testPool2, sr.NewPool(testPool2, currentTime+1))
@@ -272,8 +273,8 @@ func TestPoolTierChangeTierRejectsEmptyTier1(cur realm, t *testing.T) {
 			pools := NewPools()
 			currentTime := int64(100000)
 			poolTier := NewPoolTier(pools, currentTime, en.DefaultInitialPoolTierPath,
-				func() int64 { return 1000000 },
-				func(start, end int64) ([]int64, []int64) { return nil, nil })
+				func() (int64, error) { return 1000000, nil },
+				func(start, end int64) ([]int64, []int64, error) { return nil, nil, nil })
 
 			if tt.panics {
 				uassert.PanicsContains(t, cur, errInvalidPoolTier, func() {
@@ -294,8 +295,8 @@ func TestPoolTierChangeTierAllowsTier1PoolMutationWhenAnotherTier1Remains(cur re
 	secondTier1Pool := pl.GetPoolPath("gno.land/r/onbloc/foo.FOO", "gno.land/r/onbloc/bar.BAR", 3000)
 
 	poolTier := NewPoolTier(pools, currentTime, en.DefaultInitialPoolTierPath,
-		func() int64 { return 1000000 },
-		func(start, end int64) ([]int64, []int64) { return nil, nil })
+		func() (int64, error) { return 1000000, nil },
+		func(start, end int64) ([]int64, []int64, error) { return nil, nil, nil })
 
 	pools.set(secondTier1Pool, sr.NewPool(secondTier1Pool, currentTime+1))
 	poolTier.changeTier(currentTime+1, pools, secondTier1Pool, Tier1)
@@ -315,8 +316,8 @@ func TestCurrentAllTierCounts(cur realm, t *testing.T) {
 	testPool3 := pl.GetPoolPath("gno.land/r/gnoland/wugnot.wugnot", "gno.land/r/onbloc/bar.BAR", 3000)
 
 	poolTier := NewPoolTier(pools, currentTime, testPool1,
-		func() int64 { return 1000000 },
-		func(start, end int64) ([]int64, []int64) { return nil, nil })
+		func() (int64, error) { return 1000000, nil },
+		func(start, end int64) ([]int64, []int64, error) { return nil, nil, nil })
 
 	// Add pools to different tiers
 	pools.set(testPool2, sr.NewPool(testPool2, currentTime+1))
@@ -343,8 +344,8 @@ func TestIsInternallyIncentivizedPool(cur realm, t *testing.T) {
 	testPool2 := pl.GetPoolPath("gno.land/r/onbloc/foo.FOO", "gno.land/r/onbloc/qux.QUX", 3000)
 
 	poolTier := NewPoolTier(pools, currentTime, testPool1,
-		func() int64 { return 1000000 },
-		func(start, end int64) ([]int64, []int64) { return nil, nil })
+		func() (int64, error) { return 1000000, nil },
+		func(start, end int64) ([]int64, []int64, error) { return nil, nil, nil })
 
 	// testPool1 is in tier 1, should be incentivized
 	if !poolTier.IsInternallyIncentivizedPool(testPool1) {
@@ -365,8 +366,8 @@ func TestCurrentRewardPerPool(cur realm, t *testing.T) {
 	testPool2 := pl.GetPoolPath("gno.land/r/onbloc/foo.FOO", "gno.land/r/onbloc/qux.QUX", 3000)
 
 	poolTier := NewPoolTier(pools, currentTime, testPool1,
-		func() int64 { return emission },
-		func(start, end int64) ([]int64, []int64) { return nil, nil })
+		func() (int64, error) { return emission, nil },
+		func(start, end int64) ([]int64, []int64, error) { return nil, nil, nil })
 
 	// With only tier 1 pool, it should get 100% of emission
 	reward1 := poolTier.CurrentRewardPerPool(testPool1)
@@ -450,10 +451,11 @@ func TestCurrentReward(cur realm, t *testing.T) {
 			poolTier := &PoolTier{
 				tierRatio:   TierRatioFromCounts(tt.tierCounts[Tier1], tt.tierCounts[Tier2], tt.tierCounts[Tier3]),
 				counts:      tt.tierCounts,
-				getEmission: func() int64 { return tt.emission },
+				getEmission: func() (int64, error) { return tt.emission, nil },
 			}
 
-			reward := poolTier.CurrentReward(tt.tier)
+			reward, err := poolTier.CurrentReward(tt.tier)
+			uassert.NoError(t, err)
 
 			if tt.shouldBeZero {
 				uassert.Equal(t, int64(0), reward)
@@ -494,8 +496,8 @@ func TestNewPoolTierBy(cur realm, t *testing.T) {
 				tt.tierCounts,
 				tt.lastRewardCacheTimestamp,
 				tt.currentEmission,
-				func() int64 { return tt.currentEmission },
-				func(start, end int64) ([]int64, []int64) { return nil, nil },
+				func() (int64, error) { return tt.currentEmission, nil },
+				func(start, end int64) ([]int64, []int64, error) { return nil, nil, nil },
 			)
 
 			uassert.NotNil(t, poolTier)
@@ -580,7 +582,7 @@ func TestApplyCacheToAllPools(cur realm, t *testing.T) {
 				membership:  sr.NewBPTreeN(16),
 				tierRatio:   TierRatioFromCounts(tt.tierCounts[Tier1], tt.tierCounts[Tier2], tt.tierCounts[Tier3]),
 				counts:      tt.tierCounts,
-				getEmission: func() int64 { return tt.emissionInThisInterval },
+				getEmission: func() (int64, error) { return tt.emissionInThisInterval, nil },
 			}
 
 			currentTime := int64(1000)
@@ -791,9 +793,9 @@ func TestCacheRewardForPool(cur realm, t *testing.T) {
 				[AllTierCount]uint64{0, 1, 0, 0},
 				tt.lastCacheTs,
 				tt.initialEmission,
-				func() int64 { return tt.initialEmission },
-				func(start, end int64) ([]int64, []int64) {
-					return tt.halvingTimestamps, tt.halvingEmissions
+				func() (int64, error) { return tt.initialEmission, nil },
+				func(start, end int64) ([]int64, []int64, error) {
+					return tt.halvingTimestamps, tt.halvingEmissions, nil
 				},
 			)
 			if tt.addMembership {

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier_test.gno
@@ -358,48 +358,6 @@ func TestIsInternallyIncentivizedPool(cur realm, t *testing.T) {
 	}
 }
 
-func TestCurrentRewardPerPool(cur realm, t *testing.T) {
-	pools := NewPools()
-	currentTime := int64(100000)
-	emission := int64(1000000)
-	testPool1 := pl.GetPoolPath("gno.land/r/onbloc/bar.BAR", "gno.land/r/onbloc/baz.BAZ", 3000)
-	testPool2 := pl.GetPoolPath("gno.land/r/onbloc/foo.FOO", "gno.land/r/onbloc/qux.QUX", 3000)
-
-	poolTier := NewPoolTier(pools, currentTime, testPool1,
-		func() (int64, error) { return emission, nil },
-		func(start, end int64) ([]int64, []int64, error) { return nil, nil, nil })
-
-	// With only tier 1 pool, it should get 100% of emission
-	reward1, err := poolTier.CurrentRewardPerPool(testPool1)
-	uassert.NoError(t, err)
-	expectedReward1 := emission * 100 / 100 / 1 // 100% ratio, 1 pool
-	if reward1 != expectedReward1 {
-		t.Errorf("Expected reward %d, got %d", expectedReward1, reward1)
-	}
-
-	// Add pool to tier 2
-	pools.set(testPool2, sr.NewPool(testPool2, currentTime+1))
-	poolTier.changeTier(currentTime+1, pools, testPool2, 2)
-
-	// Now tier1 gets 70%, tier2 gets 30%
-	reward1After, err := poolTier.CurrentRewardPerPool(testPool1)
-	uassert.NoError(t, err)
-	expectedReward1After := emission * 70 / 100 / 1 // 70% ratio, 1 pool
-	if reward1After != expectedReward1After {
-		t.Errorf("Expected tier1 reward %d, got %d", expectedReward1After, reward1After)
-	}
-
-	reward2, err := poolTier.CurrentRewardPerPool(testPool2)
-	uassert.NoError(t, err)
-	expectedReward2 := emission * 30 / 100 / 1 // 30% ratio, 1 pool
-	if reward2 != expectedReward2 {
-		t.Errorf("Expected tier2 reward %d, got %d", expectedReward2, reward2)
-	}
-
-	emission = -1
-	_, err = poolTier.CurrentRewardPerPool(testPool1)
-	uassert.ErrorContains(t, err, errCalculationError)
-}
 
 // Test CurrentReward for different tiers
 func TestCurrentReward(cur realm, t *testing.T) {

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier_test.gno
@@ -403,6 +403,7 @@ func TestCurrentReward(cur realm, t *testing.T) {
 		emission       int64
 		expectedReward int64
 		shouldBeZero   bool
+		errMsg         string
 	}{
 		{
 			name:           "tier 1 with single pool",
@@ -444,6 +445,20 @@ func TestCurrentReward(cur realm, t *testing.T) {
 			expectedReward: 9223372036854775807,
 			shouldBeZero:   false,
 		},
+		{
+			name:       "returns calculation error for negative emission",
+			tier:       1,
+			tierCounts: [AllTierCount]uint64{0, 1, 0, 0},
+			emission:   -1,
+			errMsg:     errCalculationError,
+		},
+		{
+			name:       "returns tier error for unsupported tier",
+			tier:       AllTierCount,
+			tierCounts: [AllTierCount]uint64{0, 1, 0, 0},
+			emission:   1_000_000,
+			errMsg:     "unsupported tier",
+		},
 	}
 
 	for _, tt := range tests {
@@ -455,6 +470,10 @@ func TestCurrentReward(cur realm, t *testing.T) {
 			}
 
 			reward, err := poolTier.CurrentReward(tt.tier)
+			if tt.errMsg != "" {
+				uassert.ErrorContains(t, err, tt.errMsg)
+				return
+			}
 			uassert.NoError(t, err)
 
 			if tt.shouldBeZero {
@@ -834,7 +853,7 @@ func TestCalculatePoolReward(cur realm, t *testing.T) {
 		tierRatio   int64
 		tierCount   int64
 		expected    int64
-		shouldPanic bool
+		shouldError bool
 	}{
 		// Normal cases
 		{
@@ -985,50 +1004,56 @@ func TestCalculatePoolReward(cur realm, t *testing.T) {
 			emission:    -1000000,
 			tierRatio:   50,
 			tierCount:   1,
-			shouldPanic: true,
+			shouldError: true,
 		},
 		{
 			name:        "negative tier ratio",
 			emission:    1000000,
 			tierRatio:   -50,
 			tierCount:   1,
-			shouldPanic: true,
+			shouldError: true,
 		},
 		{
 			name:        "negative tier count",
 			emission:    1000000,
 			tierRatio:   50,
 			tierCount:   -1,
-			shouldPanic: true,
+			shouldError: true,
 		},
 		{
 			name:        "both emission and ratio negative",
 			emission:    -1000000,
 			tierRatio:   -50,
 			tierCount:   1,
-			shouldPanic: true,
+			shouldError: true,
 		},
 		{
 			name:        "all negative",
 			emission:    -1000000,
 			tierRatio:   -50,
 			tierCount:   -1,
-			shouldPanic: true,
+			shouldError: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
-			if tt.shouldPanic {
-				uassert.PanicsContains(t, cur, "unexpected calculation error", func() {
-					calculatePoolReward(tt.emission, tt.tierRatio, tt.tierCount)
-				})
-			} else {
-				result := calculatePoolReward(tt.emission, tt.tierRatio, tt.tierCount)
-				uassert.Equal(t, tt.expected, result)
+			result, err := calculatePoolReward(tt.emission, tt.tierRatio, tt.tierCount)
+			if tt.shouldError {
+				uassert.ErrorContains(t, err, errCalculationError)
+				return
 			}
+
+			uassert.NoError(t, err)
+			uassert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestMustCalculatePoolRewardPanicsOnInvalidInput(cur realm, t *testing.T) {
+	uassert.PanicsContains(t, cur, errCalculationError, func() {
+		mustCalculatePoolReward(-1, 50, 1)
+	})
 }
 
 func TestCalculatePoolReward_Boundary(cur realm, t *testing.T) {
@@ -1093,11 +1118,11 @@ func TestCalculatePoolReward_Boundary(cur realm, t *testing.T) {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
 			if tt.shouldPanic {
 				uassert.PanicsContains(t, cur, "overflow", func() {
-					result := calculatePoolReward(tt.emission, tt.tierRatio, tt.tierCount)
-					t.Logf("result: %d", result)
+					calculatePoolReward(tt.emission, tt.tierRatio, tt.tierCount)
 				})
 			} else {
-				result := calculatePoolReward(tt.emission, tt.tierRatio, tt.tierCount)
+				result, err := calculatePoolReward(tt.emission, tt.tierRatio, tt.tierCount)
+				uassert.NoError(t, err)
 				uassert.Equal(t, tt.expected, result)
 			}
 		})
@@ -1131,7 +1156,8 @@ func TestCalculatePoolReward_I256Overflow(cur realm, t *testing.T) {
 					calculatePoolReward(tt.emission, tt.tierRatio, tt.tierCount)
 				})
 			} else {
-				result := calculatePoolReward(tt.emission, tt.tierRatio, tt.tierCount)
+				result, err := calculatePoolReward(tt.emission, tt.tierRatio, tt.tierCount)
+				uassert.NoError(t, err)
 				t.Logf("result: %d", result)
 			}
 		})

--- a/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_pool_tier_test.gno
@@ -35,7 +35,7 @@ func TestNewPoolTier(cur realm, t *testing.T) {
 	currentTime := int64(100000) // Arbitrary time for testing
 	mustExistsInTier1 := "testPool"
 
-	poolTier := NewPoolTier(NewPools(), currentTime, mustExistsInTier1, func() int64 { return 0 }, func(start, end int64) ([]int64, []int64) { return nil, nil })
+	poolTier := NewPoolTier(NewPools(), currentTime, mustExistsInTier1, func() (int64, error) { return 0, nil }, func(start, end int64) ([]int64, []int64, error) { return nil, nil, nil })
 
 	// Test initial counts
 	if count := poolTier.CurrentCount(1); count != 1 {
@@ -58,15 +58,16 @@ func TestCacheReward(cur realm, t *testing.T) {
 	currentTime := int64(250000)
 	// Simulate emission updates
 	pools := NewPools()
-	poolTier := NewPoolTier(pools, currentTime, "testPool", func() int64 { return 1000 }, func(startHeight int64, endHeight int64) ([]int64, []int64) {
-		return []int64{100, 150, 200}, []int64{1000, 500, 250}
+	poolTier := NewPoolTier(pools, currentTime, "testPool", func() (int64, error) { return 1000, nil }, func(startHeight int64, endHeight int64) ([]int64, []int64, error) {
+		return []int64{100, 150, 200}, []int64{1000, 500, 250}, nil
 	})
 
 	// Cache rewards
 	poolTier.cacheReward(currentTime, pools)
 
 	// Verify rewards
-	reward := poolTier.CurrentReward(1)
+	reward, err := poolTier.CurrentReward(1)
+	uassert.NoError(t, err)
 	if reward == 0 {
 		t.Errorf("Expected reward for tier 1 at height 250, got 0")
 	}
@@ -86,12 +87,12 @@ func TestCacheRewardForPoolUsesLatestHalvingEmission(t *testing.T) {
 			[AllTierCount]uint64{0, 1, 0, 0},
 			1000,
 			1000,
-			func() int64 { return 500 },
-			func(start, end int64) ([]int64, []int64) {
+			func() (int64, error) { return 500, nil },
+			func(start, end int64) ([]int64, []int64, error) {
 				if start < 1010 && end > 1010 {
-					return []int64{1010}, []int64{500}
+					return []int64{1010}, []int64{500}, nil
 				}
-				return nil, nil
+				return nil, nil, nil
 			},
 		)
 		poolTier.membership.Set(poolPath, uint64(1))
@@ -113,8 +114,8 @@ func TestCacheRewardForPoolUsesLatestHalvingEmission(t *testing.T) {
 			[AllTierCount]uint64{0, 1, 0, 0},
 			1000,
 			1000,
-			func() int64 { return 500 },
-			func(start, end int64) ([]int64, []int64) { return nil, nil },
+			func() (int64, error) { return 500, nil },
+			func(start, end int64) ([]int64, []int64, error) { return nil, nil, nil },
 		)
 		poolTier.membership.Set(poolPath, uint64(1))
 
@@ -139,12 +140,12 @@ func TestCacheRewardStopsAtEmissionEndBoundary(t *testing.T) {
 			[AllTierCount]uint64{0, 1, 0, 0},
 			1000,
 			1000,
-			func() int64 { return 0 },
-			func(start, end int64) ([]int64, []int64) {
+			func() (int64, error) { return 0, nil },
+			func(start, end int64) ([]int64, []int64, error) {
 				if start <= 1020 && 1020 < end {
-					return []int64{1021}, []int64{0}
+					return []int64{1021}, []int64{0}, nil
 				}
-				return nil, nil
+				return nil, nil, nil
 			},
 		)
 		poolTier.membership.Set(poolPath, uint64(1))
@@ -174,7 +175,7 @@ var test_gnousdc = pl.GetPoolPath("gno.land/r/gnoland/wugnot.wugnot", "gno.land/
 
 func SetupPoolTier(t *testing.T) *PoolTier {
 	pools := NewPools()
-	poolTier := NewPoolTier(pools, int64(1000), test_gnousdc, func() int64 { return 1000 }, func(start, end int64) ([]int64, []int64) { return nil, nil })
+	poolTier := NewPoolTier(pools, int64(1000), test_gnousdc, func() (int64, error) { return 1000, nil }, func(start, end int64) ([]int64, []int64, error) { return nil, nil, nil })
 
 	poolTier.changeTier(int64(1000), pools, test_gnousdc, 1)
 	return poolTier
@@ -211,8 +212,8 @@ func TestPoolTierChangeTier(cur realm, t *testing.T) {
 	testPool2 := pl.GetPoolPath("gno.land/r/onbloc/foo.FOO", "gno.land/r/onbloc/qux.QUX", 3000)
 
 	poolTier := NewPoolTier(pools, currentTime, testPool1,
-		func() int64 { return 1000000 },
-		func(start, end int64) ([]int64, []int64) { return nil, nil })
+		func() (int64, error) { return 1000000, nil },
+		func(start, end int64) ([]int64, []int64, error) { return nil, nil, nil })
 
 	// Add second pool to tier 2
 	pools.set(testPool2, sr.NewPool(testPool2, currentTime+1))
@@ -272,8 +273,8 @@ func TestPoolTierChangeTierRejectsEmptyTier1(cur realm, t *testing.T) {
 			pools := NewPools()
 			currentTime := int64(100000)
 			poolTier := NewPoolTier(pools, currentTime, en.DefaultInitialPoolTierPath,
-				func() int64 { return 1000000 },
-				func(start, end int64) ([]int64, []int64) { return nil, nil })
+				func() (int64, error) { return 1000000, nil },
+				func(start, end int64) ([]int64, []int64, error) { return nil, nil, nil })
 
 			if tt.panics {
 				uassert.PanicsContains(t, cur, errInvalidPoolTier, func() {
@@ -294,8 +295,8 @@ func TestPoolTierChangeTierAllowsTier1PoolMutationWhenAnotherTier1Remains(cur re
 	secondTier1Pool := pl.GetPoolPath("gno.land/r/onbloc/foo.FOO", "gno.land/r/onbloc/bar.BAR", 3000)
 
 	poolTier := NewPoolTier(pools, currentTime, en.DefaultInitialPoolTierPath,
-		func() int64 { return 1000000 },
-		func(start, end int64) ([]int64, []int64) { return nil, nil })
+		func() (int64, error) { return 1000000, nil },
+		func(start, end int64) ([]int64, []int64, error) { return nil, nil, nil })
 
 	pools.set(secondTier1Pool, sr.NewPool(secondTier1Pool, currentTime+1))
 	poolTier.changeTier(currentTime+1, pools, secondTier1Pool, Tier1)
@@ -315,8 +316,8 @@ func TestCurrentAllTierCounts(cur realm, t *testing.T) {
 	testPool3 := pl.GetPoolPath("gno.land/r/gnoland/wugnot.wugnot", "gno.land/r/onbloc/bar.BAR", 3000)
 
 	poolTier := NewPoolTier(pools, currentTime, testPool1,
-		func() int64 { return 1000000 },
-		func(start, end int64) ([]int64, []int64) { return nil, nil })
+		func() (int64, error) { return 1000000, nil },
+		func(start, end int64) ([]int64, []int64, error) { return nil, nil, nil })
 
 	// Add pools to different tiers
 	pools.set(testPool2, sr.NewPool(testPool2, currentTime+1))
@@ -343,8 +344,8 @@ func TestIsInternallyIncentivizedPool(cur realm, t *testing.T) {
 	testPool2 := pl.GetPoolPath("gno.land/r/onbloc/foo.FOO", "gno.land/r/onbloc/qux.QUX", 3000)
 
 	poolTier := NewPoolTier(pools, currentTime, testPool1,
-		func() int64 { return 1000000 },
-		func(start, end int64) ([]int64, []int64) { return nil, nil })
+		func() (int64, error) { return 1000000, nil },
+		func(start, end int64) ([]int64, []int64, error) { return nil, nil, nil })
 
 	// testPool1 is in tier 1, should be incentivized
 	if !poolTier.IsInternallyIncentivizedPool(testPool1) {
@@ -365,11 +366,12 @@ func TestCurrentRewardPerPool(cur realm, t *testing.T) {
 	testPool2 := pl.GetPoolPath("gno.land/r/onbloc/foo.FOO", "gno.land/r/onbloc/qux.QUX", 3000)
 
 	poolTier := NewPoolTier(pools, currentTime, testPool1,
-		func() int64 { return emission },
-		func(start, end int64) ([]int64, []int64) { return nil, nil })
+		func() (int64, error) { return emission, nil },
+		func(start, end int64) ([]int64, []int64, error) { return nil, nil, nil })
 
 	// With only tier 1 pool, it should get 100% of emission
-	reward1 := poolTier.CurrentRewardPerPool(testPool1)
+	reward1, err := poolTier.CurrentRewardPerPool(testPool1)
+	uassert.NoError(t, err)
 	expectedReward1 := emission * 100 / 100 / 1 // 100% ratio, 1 pool
 	if reward1 != expectedReward1 {
 		t.Errorf("Expected reward %d, got %d", expectedReward1, reward1)
@@ -380,13 +382,15 @@ func TestCurrentRewardPerPool(cur realm, t *testing.T) {
 	poolTier.changeTier(currentTime+1, pools, testPool2, 2)
 
 	// Now tier1 gets 70%, tier2 gets 30%
-	reward1After := poolTier.CurrentRewardPerPool(testPool1)
+	reward1After, err := poolTier.CurrentRewardPerPool(testPool1)
+	uassert.NoError(t, err)
 	expectedReward1After := emission * 70 / 100 / 1 // 70% ratio, 1 pool
 	if reward1After != expectedReward1After {
 		t.Errorf("Expected tier1 reward %d, got %d", expectedReward1After, reward1After)
 	}
 
-	reward2 := poolTier.CurrentRewardPerPool(testPool2)
+	reward2, err := poolTier.CurrentRewardPerPool(testPool2)
+	uassert.NoError(t, err)
 	expectedReward2 := emission * 30 / 100 / 1 // 30% ratio, 1 pool
 	if reward2 != expectedReward2 {
 		t.Errorf("Expected tier2 reward %d, got %d", expectedReward2, reward2)
@@ -450,10 +454,11 @@ func TestCurrentReward(cur realm, t *testing.T) {
 			poolTier := &PoolTier{
 				tierRatio:   TierRatioFromCounts(tt.tierCounts[Tier1], tt.tierCounts[Tier2], tt.tierCounts[Tier3]),
 				counts:      tt.tierCounts,
-				getEmission: func() int64 { return tt.emission },
+				getEmission: func() (int64, error) { return tt.emission, nil },
 			}
 
-			reward := poolTier.CurrentReward(tt.tier)
+			reward, err := poolTier.CurrentReward(tt.tier)
+			uassert.NoError(t, err)
 
 			if tt.shouldBeZero {
 				uassert.Equal(t, int64(0), reward)
@@ -494,8 +499,8 @@ func TestNewPoolTierBy(cur realm, t *testing.T) {
 				tt.tierCounts,
 				tt.lastRewardCacheTimestamp,
 				tt.currentEmission,
-				func() int64 { return tt.currentEmission },
-				func(start, end int64) ([]int64, []int64) { return nil, nil },
+				func() (int64, error) { return tt.currentEmission, nil },
+				func(start, end int64) ([]int64, []int64, error) { return nil, nil, nil },
 			)
 
 			uassert.NotNil(t, poolTier)
@@ -580,7 +585,7 @@ func TestApplyCacheToAllPools(cur realm, t *testing.T) {
 				membership:  sr.NewBPTreeN(16),
 				tierRatio:   TierRatioFromCounts(tt.tierCounts[Tier1], tt.tierCounts[Tier2], tt.tierCounts[Tier3]),
 				counts:      tt.tierCounts,
-				getEmission: func() int64 { return tt.emissionInThisInterval },
+				getEmission: func() (int64, error) { return tt.emissionInThisInterval, nil },
 			}
 
 			currentTime := int64(1000)
@@ -791,9 +796,9 @@ func TestCacheRewardForPool(cur realm, t *testing.T) {
 				[AllTierCount]uint64{0, 1, 0, 0},
 				tt.lastCacheTs,
 				tt.initialEmission,
-				func() int64 { return tt.initialEmission },
-				func(start, end int64) ([]int64, []int64) {
-					return tt.halvingTimestamps, tt.halvingEmissions
+				func() (int64, error) { return tt.initialEmission, nil },
+				func(start, end int64) ([]int64, []int64, error) {
+					return tt.halvingTimestamps, tt.halvingEmissions, nil
 				},
 			)
 			if tt.addMembership {

--- a/contract/r/gnoswap/staker/v1/staker.gno
+++ b/contract/r/gnoswap/staker/v1/staker.gno
@@ -454,7 +454,10 @@ func (s *stakerV1) CollectReward(_ int, rlm realm, positionId uint64) (string, s
 		PoolTier:      s.getPoolTier(),
 		PositionId:    positionId,
 	}
-	rewards, rewardUpdate := s.calculatePositionReward(rewardParam)
+	rewards, rewardUpdate, err := s.calculatePositionReward(rewardParam)
+	if err != nil {
+		panic(err)
+	}
 
 	// aggregate the reward of internal and external rewards
 	reward := aggregateRewards(rewards)
@@ -639,7 +642,7 @@ func (s *stakerV1) CollectReward(_ int, rlm realm, positionId uint64) (string, s
 		totalEmissionSent = gnsmath.SafeAddInt64(totalEmissionSent, unClaimableInternal)
 	}
 
-	err := s.store.SetTotalEmissionSent(0, rlm, totalEmissionSent)
+	err = s.store.SetTotalEmissionSent(0, rlm, totalEmissionSent)
 	if err != nil {
 		panic(err)
 	}

--- a/contract/r/gnoswap/staker/v1/staker.gno
+++ b/contract/r/gnoswap/staker/v1/staker.gno
@@ -466,7 +466,10 @@ func (s *stakerV1) CollectReward(_ int, rlm realm, positionId uint64) (string, s
 		PoolTier:      s.getPoolTier(),
 		PositionId:    positionId,
 	}
-	rewards, rewardUpdate := s.calculatePositionReward(rewardParam)
+	rewards, rewardUpdate, err := s.calculatePositionReward(rewardParam)
+	if err != nil {
+		panic(err)
+	}
 
 	// aggregate the reward of internal and external rewards
 	reward := aggregateRewards(rewards)
@@ -651,7 +654,7 @@ func (s *stakerV1) CollectReward(_ int, rlm realm, positionId uint64) (string, s
 		totalEmissionSent = gnsmath.SafeAddInt64(totalEmissionSent, unClaimableInternal)
 	}
 
-	err := s.store.SetTotalEmissionSent(0, rlm, totalEmissionSent)
+	err = s.store.SetTotalEmissionSent(0, rlm, totalEmissionSent)
 	if err != nil {
 		panic(err)
 	}

--- a/contract/r/gnoswap/staker/v1/staker_test.gno
+++ b/contract/r/gnoswap/staker/v1/staker_test.gno
@@ -476,7 +476,8 @@ func TestCollectReward_SkipsWhenPenaltyInclusiveDebitExceedsAvailableReward(cur 
 	}
 
 	blockHeight := runtime.ChainHeight()
-	reward := getMockInstance().calculateCollectablePositionReward(blockHeight, time.Now().Unix(), positionId)
+	reward, err := getMockInstance().calculateCollectablePositionReward(blockHeight, time.Now().Unix(), positionId)
+	uassert.NoError(t, err)
 	rewardAmount := reward.External[incentiveId]
 	externalPenalty := reward.ExternalPenalty[incentiveId]
 	if rewardAmount <= 0 {

--- a/contract/r/gnoswap/staker/v1/staker_test.gno
+++ b/contract/r/gnoswap/staker/v1/staker_test.gno
@@ -457,7 +457,8 @@ func TestCollectReward_SkipsWhenPenaltyInclusiveDebitExceedsAvailableReward(cur 
 	}
 
 	blockHeight := runtime.ChainHeight()
-	reward := getMockInstance().calculateCollectablePositionReward(blockHeight, time.Now().Unix(), positionId)
+	reward, err := getMockInstance().calculateCollectablePositionReward(blockHeight, time.Now().Unix(), positionId)
+	uassert.NoError(t, err)
 	rewardAmount := reward.External[incentiveId]
 	externalPenalty := reward.ExternalPenalty[incentiveId]
 	if rewardAmount <= 0 {

--- a/contract/r/gnoswap/test/fuzz/_mock_test.gno
+++ b/contract/r/gnoswap/test/fuzz/_mock_test.gno
@@ -377,8 +377,8 @@ type MockStakerStore struct {
 	poolTierLastRewardCacheTimestamp int64
 	poolTierLastRewardCacheHeight    int64
 	poolTierCurrentEmission          int64
-	poolTierGetEmission              func() int64
-	poolTierGetHalvingBlocksInRange  func(start, end int64) ([]int64, []int64)
+	poolTierGetEmission              func() (int64, error)
+	poolTierGetHalvingBlocksInRange  func(start, end int64) ([]int64, []int64, error)
 	warmupTemplate                   []sr.Warmup
 	currentSwapBatch                 *sr.SwapBatchProcessor
 }
@@ -668,11 +668,11 @@ func (s *MockStakerStore) HasPoolTierGetEmissionStoreKey() bool {
 	return s.poolTierGetEmission != nil
 }
 
-func (s *MockStakerStore) GetPoolTierGetEmission() func() int64 {
+func (s *MockStakerStore) GetPoolTierGetEmission() func() (int64, error) {
 	return s.poolTierGetEmission
 }
 
-func (s *MockStakerStore) SetPoolTierGetEmission(_ int, rlm realm, fn func() int64) error {
+func (s *MockStakerStore) SetPoolTierGetEmission(_ int, rlm realm, fn func() (int64, error)) error {
 	s.poolTierGetEmission = fn
 	return nil
 }
@@ -682,11 +682,11 @@ func (s *MockStakerStore) HasPoolTierGetHalvingBlocksInRangeStoreKey() bool {
 	return s.poolTierGetHalvingBlocksInRange != nil
 }
 
-func (s *MockStakerStore) GetPoolTierGetHalvingBlocksInRange() func(start, end int64) ([]int64, []int64) {
+func (s *MockStakerStore) GetPoolTierGetHalvingBlocksInRange() func(start, end int64) ([]int64, []int64, error) {
 	return s.poolTierGetHalvingBlocksInRange
 }
 
-func (s *MockStakerStore) SetPoolTierGetHalvingBlocksInRange(_ int, rlm realm, fn func(start, end int64) ([]int64, []int64)) error {
+func (s *MockStakerStore) SetPoolTierGetHalvingBlocksInRange(_ int, rlm realm, fn func(start, end int64) ([]int64, []int64, error)) error {
 	s.poolTierGetHalvingBlocksInRange = fn
 	return nil
 }
@@ -722,6 +722,11 @@ func (s *MockStakerStore) SetCurrentSwapBatch(_ int, rlm realm, batch *sr.SwapBa
 func newMockStakerStore() *MockStakerStore {
 	swapBatch := sr.NewSwapBatchProcessor("", nil, 0)
 	swapBatch.SetIsActive(false)
+	currentEmission, err := emission.GetStakerEmissionAmountPerSecond()
+	if err != nil {
+		panic(err)
+	}
+
 	return &MockStakerStore{
 		depositGnsAmount:                 0,
 		minimumRewardAmount:              1_000_000_000,
@@ -739,9 +744,9 @@ func newMockStakerStore() *MockStakerStore {
 		poolTierCounts:                   [sr.AllTierCount]uint64{},
 		poolTierLastRewardCacheTimestamp: 0,
 		poolTierLastRewardCacheHeight:    0,
-		poolTierCurrentEmission:          emission.GetStakerEmissionAmountPerSecond(),
-		poolTierGetEmission:              func() int64 { return emission.GetStakerEmissionAmountPerSecond() },
-		poolTierGetHalvingBlocksInRange: func(start, end int64) ([]int64, []int64) {
+		poolTierCurrentEmission:          currentEmission,
+		poolTierGetEmission:              func() (int64, error) { return emission.GetStakerEmissionAmountPerSecond() },
+		poolTierGetHalvingBlocksInRange: func(start, end int64) ([]int64, []int64, error) {
 			return emission.GetStakerEmissionAmountPerSecondInRange(start, end)
 		},
 		warmupTemplate:                   sr.DefaultWarmupTemplate(),
@@ -812,11 +817,11 @@ func (e *mockEmissionAccessor) MintAndDistributeGns(_ int, rlm realm) (int64, bo
 	return emission.MintAndDistributeGns(cross(rlm))
 }
 
-func (e *mockEmissionAccessor) GetStakerEmissionAmountPerSecond() int64 {
+func (e *mockEmissionAccessor) GetStakerEmissionAmountPerSecond() (int64, error) {
 	return emission.GetStakerEmissionAmountPerSecond()
 }
 
-func (e *mockEmissionAccessor) GetStakerEmissionAmountPerSecondInRange(start, end int64) ([]int64, []int64) {
+func (e *mockEmissionAccessor) GetStakerEmissionAmountPerSecondInRange(start, end int64) ([]int64, []int64, error) {
 	return emission.GetStakerEmissionAmountPerSecondInRange(start, end)
 }
 

--- a/contract/r/gnoswap/test/fuzz/_mock_test.gno
+++ b/contract/r/gnoswap/test/fuzz/_mock_test.gno
@@ -377,8 +377,8 @@ type MockStakerStore struct {
 	poolTierLastRewardCacheTimestamp int64
 	poolTierLastRewardCacheHeight    int64
 	poolTierCurrentEmission          int64
-	poolTierGetEmission              func() int64
-	poolTierGetHalvingBlocksInRange  func(start, end int64) ([]int64, []int64)
+	poolTierGetEmission              func() (int64, error)
+	poolTierGetHalvingBlocksInRange  func(start, end int64) ([]int64, []int64, error)
 	warmupTemplate                   []sr.Warmup
 	currentSwapBatch                 *sr.SwapBatchProcessor
 }
@@ -668,11 +668,11 @@ func (s *MockStakerStore) HasPoolTierGetEmissionStoreKey() bool {
 	return s.poolTierGetEmission != nil
 }
 
-func (s *MockStakerStore) GetPoolTierGetEmission() func() int64 {
+func (s *MockStakerStore) GetPoolTierGetEmission() func() (int64, error) {
 	return s.poolTierGetEmission
 }
 
-func (s *MockStakerStore) SetPoolTierGetEmission(_ int, rlm realm, fn func() int64) error {
+func (s *MockStakerStore) SetPoolTierGetEmission(_ int, rlm realm, fn func() (int64, error)) error {
 	s.poolTierGetEmission = fn
 	return nil
 }
@@ -682,11 +682,11 @@ func (s *MockStakerStore) HasPoolTierGetHalvingBlocksInRangeStoreKey() bool {
 	return s.poolTierGetHalvingBlocksInRange != nil
 }
 
-func (s *MockStakerStore) GetPoolTierGetHalvingBlocksInRange() func(start, end int64) ([]int64, []int64) {
+func (s *MockStakerStore) GetPoolTierGetHalvingBlocksInRange() func(start, end int64) ([]int64, []int64, error) {
 	return s.poolTierGetHalvingBlocksInRange
 }
 
-func (s *MockStakerStore) SetPoolTierGetHalvingBlocksInRange(_ int, rlm realm, fn func(start, end int64) ([]int64, []int64)) error {
+func (s *MockStakerStore) SetPoolTierGetHalvingBlocksInRange(_ int, rlm realm, fn func(start, end int64) ([]int64, []int64, error)) error {
 	s.poolTierGetHalvingBlocksInRange = fn
 	return nil
 }
@@ -722,6 +722,11 @@ func (s *MockStakerStore) SetCurrentSwapBatch(_ int, rlm realm, batch *sr.SwapBa
 func newMockStakerStore() *MockStakerStore {
 	swapBatch := sr.NewSwapBatchProcessor("", nil, 0)
 	swapBatch.SetIsActive(false)
+	currentEmission, err := emission.GetStakerEmissionAmountPerSecond()
+	if err != nil {
+		panic(err)
+	}
+
 	return &MockStakerStore{
 		depositGnsAmount:                 0,
 		minimumRewardAmount:              1_000_000_000,
@@ -739,9 +744,9 @@ func newMockStakerStore() *MockStakerStore {
 		poolTierCounts:                   [sr.AllTierCount]uint64{},
 		poolTierLastRewardCacheTimestamp: 0,
 		poolTierLastRewardCacheHeight:    0,
-		poolTierCurrentEmission:          emission.GetStakerEmissionAmountPerSecond(),
-		poolTierGetEmission:              func() int64 { return emission.GetStakerEmissionAmountPerSecond() },
-		poolTierGetHalvingBlocksInRange: func(start, end int64) ([]int64, []int64) {
+		poolTierCurrentEmission:          currentEmission,
+		poolTierGetEmission:              func() (int64, error) { return emission.GetStakerEmissionAmountPerSecond() },
+		poolTierGetHalvingBlocksInRange: func(start, end int64) ([]int64, []int64, error) {
 			return emission.GetStakerEmissionAmountPerSecondInRange(start, end)
 		},
 		warmupTemplate:                   sr.DefaultWarmupTemplate(),
@@ -812,18 +817,18 @@ func (e *mockEmissionAccessor) MintAndDistributeGns(_ int, rlm realm) (int64, bo
 	return emission.MintAndDistributeGns(cross(rlm))
 }
 
-func (e *mockEmissionAccessor) GetStakerEmissionAmountPerSecond() int64 {
+func (e *mockEmissionAccessor) GetStakerEmissionAmountPerSecond() (int64, error) {
 	return emission.GetStakerEmissionAmountPerSecond()
 }
 
-func (e *mockEmissionAccessor) GetStakerEmissionAmountPerSecondInRange(start, end int64) ([]int64, []int64) {
+func (e *mockEmissionAccessor) GetStakerEmissionAmountPerSecondInRange(start, end int64) ([]int64, []int64, error) {
 	return emission.GetStakerEmissionAmountPerSecondInRange(start, end)
 }
 
-func (e *mockEmissionAccessor) SetOnDistributionPctChangeCallback(_ int, rlm realm, callback func(_ int, rlm realm, emissionAmountPerSecond int64)) {
+func (e *mockEmissionAccessor) SetOnDistributionPctChangeCallback(_ int, rlm realm, callback func(_ int, rlm realm, emissionAmountPerSecond int64)) error {
 	access.AssertIsRlmCurrent(0, rlm)
 
-	emission.SetOnDistributionPctChangeCallback(cross(rlm), func(cur realm, emissionAmountPerSecond int64) {
+	return emission.SetOnDistributionPctChangeCallback(cross(rlm), func(cur realm, emissionAmountPerSecond int64) {
 		callback(0, cur, emissionAmountPerSecond)
 	})
 }

--- a/contract/r/scenario/getter/governance_getter_filetest.gno
+++ b/contract/r/scenario/getter/governance_getter_filetest.gno
@@ -87,7 +87,10 @@ func setupTestData(cur realm) int64 {
 	println("[INFO] GNS delegated to admin:", delegatedAmount)
 
 	// Skip smoothing period
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 	testing.SkipHeights(int64(config.VotingWeightSmoothingDuration) / currentBlockTime)
 	println("[INFO] Skipped smoothing period, current height:", runtime.ChainHeight())
 
@@ -132,7 +135,10 @@ func testConfigGetters(cur realm) {
 	testing.SetRealm(governanceRealm)
 
 	// GetLatestConfig
-	latestConfig := governance.GetLatestConfig()
+	latestConfig, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 	println("[EXPECTED] Latest config:")
 	println("[EXPECTED] - Proposal creation threshold:", latestConfig.ProposalCreationThreshold)
 	println("[EXPECTED] - Voting period:", latestConfig.VotingPeriod)

--- a/contract/r/scenario/gov/governance/governance_proposal_cancel_status_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_proposal_cancel_status_filetest.gno
@@ -38,7 +38,10 @@ var (
 
 func main(cur realm) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	println("[SCENARIO] 1. Delegate gns to admin")
 	delegateGnsToAdmin(cur)

--- a/contract/r/scenario/gov/governance/governance_proposal_community_pool_spend_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_proposal_community_pool_spend_filetest.gno
@@ -45,7 +45,10 @@ var (
 
 func main(cur realm) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 	println("[SCENARIO] 1. Delegate gns to admin")
 	delegateGnsToAdmin(cur)
 	println()

--- a/contract/r/scenario/gov/governance/governance_proposal_execute_blocktime_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_proposal_execute_blocktime_filetest.gno
@@ -38,7 +38,10 @@ var (
 
 func main(cur realm) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	println("[SCENARIO] 1. Delegate gns to admin")
 	delegateGnsToAdmin(cur)

--- a/contract/r/scenario/gov/governance/governance_proposal_execute_emission_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_proposal_execute_emission_filetest.gno
@@ -35,7 +35,10 @@ var (
 
 func main(cur realm) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	println("[SCENARIO] 1. Delegate gns to admin")
 	delegateGnsToAdmin(cur)
@@ -104,21 +107,29 @@ func vote(cur realm, proposalID int64, yea bool) {
 func executeChangeEmissionDistributionPct(cur realm, proposalID int64) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
 
-	prevEmissionDistributionPct1 := emission.GetDistributionBpsPct(1)
-	prevEmissionDistributionPct2 := emission.GetDistributionBpsPct(2)
-	prevEmissionDistributionPct3 := emission.GetDistributionBpsPct(3)
-	prevEmissionDistributionPct4 := emission.GetDistributionBpsPct(4)
+	prevEmissionDistributionPct1 := mustGetDistributionBpsPct(1)
+	prevEmissionDistributionPct2 := mustGetDistributionBpsPct(2)
+	prevEmissionDistributionPct3 := mustGetDistributionBpsPct(3)
+	prevEmissionDistributionPct4 := mustGetDistributionBpsPct(4)
 
 	governance.Execute(cross(cur), proposalID)
 
-	afterEmissionDistributionPct1 := emission.GetDistributionBpsPct(1)
-	afterEmissionDistributionPct2 := emission.GetDistributionBpsPct(2)
-	afterEmissionDistributionPct3 := emission.GetDistributionBpsPct(3)
-	afterEmissionDistributionPct4 := emission.GetDistributionBpsPct(4)
+	afterEmissionDistributionPct1 := mustGetDistributionBpsPct(1)
+	afterEmissionDistributionPct2 := mustGetDistributionBpsPct(2)
+	afterEmissionDistributionPct3 := mustGetDistributionBpsPct(3)
+	afterEmissionDistributionPct4 := mustGetDistributionBpsPct(4)
 
 	ufmt.Printf("[INFO] Change Emission Distribution Percentages Proposal ID: %d\n", proposalID)
 	ufmt.Printf("[EXPECTED] before proposal %d executing - pct 1: %d, pct 2: %d, pct 3: %d, pct 4: %d\n", proposalID, prevEmissionDistributionPct1, prevEmissionDistributionPct2, prevEmissionDistributionPct3, prevEmissionDistributionPct4)
 	ufmt.Printf("[EXPECTED] after proposal %d executing - pct 1: %d, pct 2: %d, pct 3: %d, pct 4: %d\n", proposalID, afterEmissionDistributionPct1, afterEmissionDistributionPct2, afterEmissionDistributionPct3, afterEmissionDistributionPct4)
+}
+
+func mustGetDistributionBpsPct(target int) int64 {
+	pct, err := emission.GetDistributionBpsPct(target)
+	if err != nil {
+		panic(err)
+	}
+	return pct
 }
 
 // Output:

--- a/contract/r/scenario/gov/governance/governance_proposal_execute_pool_fee_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_proposal_execute_pool_fee_filetest.gno
@@ -38,7 +38,10 @@ var (
 
 func main(cur realm) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	println("[SCENARIO] 1. Delegate gns to admin")
 	delegateGnsToAdmin(cur)

--- a/contract/r/scenario/gov/governance/governance_proposal_execute_protocol_fee_gov_staker_pct_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_proposal_execute_protocol_fee_gov_staker_pct_filetest.gno
@@ -35,7 +35,10 @@ var (
 
 func main(cur realm) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	println("[SCENARIO] 1. Delegate gns to admin")
 	delegateGnsToAdmin(cur)

--- a/contract/r/scenario/gov/governance/governance_proposal_execute_reconfigure_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_proposal_execute_reconfigure_filetest.gno
@@ -35,7 +35,10 @@ var (
 
 func main(cur realm) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	println("[SCENARIO] 1. Delegate gns to admin")
 	delegateGnsToAdmin(cur)
@@ -103,11 +106,17 @@ func vote(cur realm, proposalID int64, yea bool) {
 
 func executeReconfigureGovernance(cur realm, proposalID int64) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	prevGovConfig := governance.GetLatestConfig()
+	prevGovConfig, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	governance.Execute(cross(cur), proposalID)
 
-	afterGovConfig := governance.GetLatestConfig()
+	afterGovConfig, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	ufmt.Printf("[EXPECTED] before proposal %d executing - voting start delay: %d, voting period: %d, quorum: %d\n", proposalID, prevGovConfig.VotingStartDelay, prevGovConfig.VotingPeriod, prevGovConfig.Quorum)
 	ufmt.Printf("[EXPECTED] after proposal %d executing - voting start delay: %d, voting period: %d, quorum: %d\n", proposalID, afterGovConfig.VotingStartDelay, afterGovConfig.VotingPeriod, afterGovConfig.Quorum)

--- a/contract/r/scenario/gov/governance/governance_proposal_execute_staker_cancel_external_incentive_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_proposal_execute_staker_cancel_external_incentive_filetest.gno
@@ -79,7 +79,10 @@ var (
 
 func main(cur realm) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	println("[SCENARIO] 1. Delegate gns to admin")
 	delegateGnsToAdmin(cur)

--- a/contract/r/scenario/gov/governance/governance_proposal_execute_staker_cancel_external_incentive_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_proposal_execute_staker_cancel_external_incentive_filetest.gno
@@ -96,7 +96,10 @@ func main(cur realm) {
 	println("[SCENARIO] 3. Adopt a short governance schedule")
 	proposalID := proposeShortVotingSchedule(cur)
 	voteAndExecuteShortSchedule(cur, proposalID, config)
-	config = governance.GetLatestConfig()
+	config, err = governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 	println()
 
 	println("[SCENARIO] 4. Create pool and a pending external incentive")

--- a/contract/r/scenario/gov/governance/governance_proposal_execute_staker_token_list_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_proposal_execute_staker_token_list_filetest.gno
@@ -39,7 +39,10 @@ const testTokenPath = "gno.land/r/onbloc/obl.OBL"
 
 func main(cur realm) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	println("[SCENARIO] 1. Delegate gns to admin")
 	delegateGnsToAdmin(cur)

--- a/contract/r/scenario/gov/governance/governance_proposal_execute_upgrade_governance_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_proposal_execute_upgrade_governance_filetest.gno
@@ -41,7 +41,10 @@ const (
 
 func main(cur realm) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	println("[SCENARIO] 1. Delegate gns to admin")
 	delegateGnsToAdmin(cur)

--- a/contract/r/scenario/gov/governance/governance_proposal_execute_upgrade_launchpad_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_proposal_execute_upgrade_launchpad_filetest.gno
@@ -44,7 +44,10 @@ const (
 
 func main(cur realm) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	println("[SCENARIO] 1. Delegate gns to admin")
 	delegateGnsToAdmin(cur)

--- a/contract/r/scenario/gov/governance/governance_proposal_execute_upgrade_pool_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_proposal_execute_upgrade_pool_filetest.gno
@@ -44,7 +44,10 @@ const (
 
 func main(cur realm) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	println("[SCENARIO] 1. Delegate gns to admin")
 	delegateGnsToAdmin(cur)

--- a/contract/r/scenario/gov/governance/governance_proposal_execute_upgrade_position_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_proposal_execute_upgrade_position_filetest.gno
@@ -44,7 +44,10 @@ const (
 
 func main(cur realm) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	println("[SCENARIO] 1. Delegate gns to admin")
 	delegateGnsToAdmin(cur)

--- a/contract/r/scenario/gov/governance/governance_proposal_execute_upgrade_staker_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_proposal_execute_upgrade_staker_filetest.gno
@@ -44,7 +44,10 @@ const (
 
 func main(cur realm) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	println("[SCENARIO] 1. Delegate gns to admin")
 	delegateGnsToAdmin(cur)

--- a/contract/r/scenario/gov/governance/governance_proposal_multi_execute_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_proposal_multi_execute_filetest.gno
@@ -41,7 +41,10 @@ var (
 
 func main(cur realm) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	println("[SCENARIO] 1. Delegate gns to admin")
 	delegateGnsToAdmin(cur)

--- a/contract/r/scenario/gov/governance/governance_proposal_status_update_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_proposal_status_update_filetest.gno
@@ -35,7 +35,10 @@ var (
 
 func main(cur realm) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	println("[SCENARIO] 1. Delegate gns to admin")
 	delegateGnsToAdmin(cur)

--- a/contract/r/scenario/gov/governance/governance_proposal_text_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_proposal_text_filetest.gno
@@ -35,7 +35,10 @@ var (
 
 func main(cur realm) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	println("[SCENARIO] 1. Delegate gns to admin")
 	delegateGnsToAdmin(cur)

--- a/contract/r/scenario/gov/governance/governance_vote_gov_delegated_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_vote_gov_delegated_filetest.gno
@@ -37,7 +37,10 @@ var (
 
 func main(cur realm) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	println("[SCENARIO] 1. Delegate gns to admin and dummy")
 	delegateGnsToAdminAndDummy(cur)

--- a/contract/r/scenario/gov/governance/governance_vote_gov_delegated_undelegated_after_propose_before_vote_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_vote_gov_delegated_undelegated_after_propose_before_vote_filetest.gno
@@ -38,7 +38,10 @@ var (
 
 func main(cur realm) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	println("[SCENARIO] 1. Delegate gns to admin and dummy")
 	delegateGnsToAdminAndDummy(cur)

--- a/contract/r/scenario/gov/governance/governance_vote_gov_delegated_undelegated_before_propose_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_vote_gov_delegated_undelegated_before_propose_filetest.gno
@@ -37,7 +37,10 @@ var (
 
 func main(cur realm) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	println("[SCENARIO] 1. Delegate gns to admin and dummy")
 	delegateGnsToAdminAndDummy(cur)

--- a/contract/r/scenario/gov/governance/governance_vote_multi_user_launchpad_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_vote_multi_user_launchpad_filetest.gno
@@ -56,7 +56,10 @@ var (
 
 func main(cur realm) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	println("[SCENARIO] 1. Delegate GNS to 3 voters with different amounts")
 	delegateToMultipleVoters(cur)

--- a/contract/r/scenario/gov/governance/governance_vote_multi_user_smoothing_period_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_vote_multi_user_smoothing_period_filetest.gno
@@ -48,7 +48,10 @@ var (
 
 func main(cur realm) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	smoothingPeriodBlocks := int64(config.VotingWeightSmoothingDuration) / currentBlockTime
 

--- a/contract/r/scenario/gov/governance/governance_vote_verify_with_smoothing_period_delegation_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_vote_verify_with_smoothing_period_delegation_filetest.gno
@@ -52,7 +52,10 @@ var (
 
 func main(cur realm) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 	proposalQuorumWeights = make(map[int64]int64)
 
 	// Calculate timing for delegation changes within smoothing period
@@ -172,7 +175,11 @@ func checkCurrentXgnsBalance(cur realm) {
 }
 
 func prepareProposalCreator(cur realm, proposerAddr address) {
-	amount := governance.GetLatestConfig().ProposalCreationThreshold
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
+	amount := config.ProposalCreationThreshold
 
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
 	gns.Transfer(cross(cur), proposerAddr, amount)
@@ -189,7 +196,11 @@ func proposeText(cur realm, proposerAddr address) int64 {
 	proposalId := governance.ProposeText(cross(cur), "test_title", "test_description")
 	quorumAmount, _ := governance.GetQuorumAmountByProposalId(proposalId)
 	quorumWeight := xgns.TotalSupply()
-	expectedQuorumAmount := quorumWeight * governance.GetLatestConfig().Quorum / 100
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
+	expectedQuorumAmount := quorumWeight * config.Quorum / 100
 	proposalQuorumWeights[proposalId] = quorumWeight
 
 	uassert.Equal(t, expectedQuorumAmount, quorumAmount)
@@ -241,7 +252,11 @@ func verifyVotingWeight(cur realm, proposalId int64, hasVoter2VotingWeight bool)
 	nayWeight, _ := governance.GetNayByProposalId(proposalId)
 	quorumAmount, _ := governance.GetQuorumAmountByProposalId(proposalId)
 	quorumWeight := proposalQuorumWeights[proposalId]
-	expectedQuorumAmount := quorumWeight * governance.GetLatestConfig().Quorum / 100
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
+	expectedQuorumAmount := quorumWeight * config.Quorum / 100
 	uassert.Equal(t, expectedQuorumAmount, quorumAmount)
 
 	// Get xGNS balances

--- a/contract/r/scenario/gov/governance/governance_vote_with_launchpad_deposit_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_vote_with_launchpad_deposit_filetest.gno
@@ -51,7 +51,10 @@ var (
 
 func main(cur realm) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	println("[SCENARIO] 1. Check Initial xGNS Supply")
 	checkInitialXgnsSupply(cur)

--- a/contract/r/scenario/gov/governance/governance_vote_with_launchpad_xgns_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_vote_with_launchpad_xgns_filetest.gno
@@ -40,7 +40,10 @@ var (
 
 func main(cur realm) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	println("[SCENARIO] 1. Check Initial gns and xgns Supply")
 	checkInitialGnsAndXgns(cur)

--- a/contract/r/scenario/gov/governance/governance_vote_with_smoothing_period_delegation_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_vote_with_smoothing_period_delegation_filetest.gno
@@ -47,7 +47,10 @@ var (
 
 func main(cur realm) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	// Calculate timing for delegation changes within smoothing period
 	smoothingPeriodBlocks := int64(config.VotingWeightSmoothingDuration) / currentBlockTime

--- a/contract/r/scenario/gov/staker/delegation_voting_power_transfer_filetest.gno
+++ b/contract/r/scenario/gov/staker/delegation_voting_power_transfer_filetest.gno
@@ -45,7 +45,10 @@ var (
 
 func main(cur realm) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 	votingWeightSmoothingDuration = int64(config.VotingWeightSmoothingDuration)
 
 	println("[SCENARIO] 1. Transfer GNS to alice for delegation")

--- a/contract/r/scenario/gov/staker/snapshot_cleanup_old_snapshots_filetest.gno
+++ b/contract/r/scenario/gov/staker/snapshot_cleanup_old_snapshots_filetest.gno
@@ -45,7 +45,10 @@ var (
 
 func main(cur realm) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 	maxSmoothingPeriod := governance.GetMaxSmoothingPeriod()
 	ufmt.Printf("[INFO] max smoothing period: %d seconds\n", maxSmoothingPeriod)
 

--- a/contract/r/scenario/gov/staker/snapshot_cleanup_with_active_proposal_filetest.gno
+++ b/contract/r/scenario/gov/staker/snapshot_cleanup_with_active_proposal_filetest.gno
@@ -47,7 +47,10 @@ var (
 
 func main(cur realm) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 	maxSmoothingPeriod := governance.GetMaxSmoothingPeriod()
 	ufmt.Printf("[INFO] max smoothing period: %d seconds\n", maxSmoothingPeriod)
 

--- a/contract/r/scenario/halt/emergency_mode_collect_paths_allowed_filetest.gno
+++ b/contract/r/scenario/halt/emergency_mode_collect_paths_allowed_filetest.gno
@@ -359,7 +359,10 @@ func setEmergencyModeForCollect(cur realm) {
 }
 
 func prepareGovernanceQuorumForEmergencyExecution(cur realm) {
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 	testing.SetRealm(adminRealm2)
 	governance.Reconfigure(cross(cur), config.VotingStartDelay, config.VotingPeriod, config.VotingWeightSmoothingDuration, 40, config.ProposalCreationThreshold, config.ExecutionDelay, config.ExecutionWindow)
 }
@@ -575,7 +578,10 @@ func testGovernanceProposeCommunityPoolSpendAllowed(cur realm) {
 }
 
 func testGovernanceProposeParameterChangeAllowed(cur realm) {
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 	executions := ufmt.Sprintf(
 		"gno.land/r/gnoswap/gov/governance*EXE*Reconfigure*EXE*%d,%d,%d,%d,%d,%d,%d",
 		config.VotingStartDelay,
@@ -594,7 +600,10 @@ func testGovernanceProposeParameterChangeAllowed(cur realm) {
 }
 
 func testGovernanceVoteAllowed(cur realm) {
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 	testing.SkipHeights(int64(config.VotingStartDelay) / collectCurrentBlockTime)
 	testing.SetRealm(aliceRealm2)
 	aliceVote := governance.Vote(cross(cur), parameterChangeProposalID, true)
@@ -609,7 +618,10 @@ func testGovernanceVoteAllowed(cur realm) {
 }
 
 func testGovernanceExecuteAllowed(cur realm) {
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 	testing.SkipHeights(int64(config.VotingPeriod) / collectCurrentBlockTime)
 	testing.SetRealm(bobRealm2)
 	executedID := governance.Execute(cross(cur), parameterChangeProposalID)
@@ -618,7 +630,10 @@ func testGovernanceExecuteAllowed(cur realm) {
 }
 
 func testGovernanceReconfigureAllowed(cur realm) {
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 	testing.SetRealm(adminRealm2)
 	version := governance.Reconfigure(cross(cur), config.VotingStartDelay, config.VotingPeriod, config.VotingWeightSmoothingDuration, config.Quorum, config.ProposalCreationThreshold, config.ExecutionDelay, config.ExecutionWindow+100)
 	ufmt.Printf("[EXPECTED] governance.Reconfigure version: %d\n", version)

--- a/contract/r/scenario/halt/emergency_mode_governance_and_withdraw_filetest.gno
+++ b/contract/r/scenario/halt/emergency_mode_governance_and_withdraw_filetest.gno
@@ -199,7 +199,11 @@ func initGovernancePoolAndTokens(cur realm) {
 }
 
 func setupProposalCreationXGns(cur realm) {
-	threshold := governance.GetLatestConfig().ProposalCreationThreshold
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
+	threshold := config.ProposalCreationThreshold
 	missingAmount := threshold - xgns.BalanceOf(aliceAddr)
 	if missingAmount <= 0 {
 		return
@@ -251,7 +255,10 @@ func createPoolAndPosition(cur realm) {
 	ufmt.Printf("[INFO] Position minted with ID: %d, Liquidity: %s\n", positionId, liquidity)
 
 	// Skip voting weight smoothing duration
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 	testing.SkipHeights(int64(config.VotingWeightSmoothingDuration) / currentBlockTime)
 }
 
@@ -359,7 +366,10 @@ func testGovernanceProposeTextWorks(cur realm) {
 func testGovernanceVoteTextWorks(cur realm) {
 	// Skip to voting start
 	testing.SetRealm(adminRealm)
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 	testing.SkipHeights(int64(config.VotingStartDelay) / currentBlockTime)
 
 	ufmt.Println("[INFO] Attempting to vote on TextProposal in Emergency Mode...")
@@ -384,7 +394,10 @@ func testGovernanceVoteTextWorks(cur realm) {
 func testTextProposalExecuteFails(cur realm) {
 	// Skip voting period for ready to execute
 	testing.SetRealm(adminRealm)
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 	testing.SkipHeights(int64(config.VotingPeriod) / currentBlockTime)
 
 	ufmt.Println("[INFO] Attempting to execute TextProposal in Emergency Mode (should fail)...")
@@ -419,7 +432,10 @@ func testGovernanceProposeParameterChangeWorks(cur realm) {
 func testGovernanceVoteParameterChangeWorks(cur realm) {
 	// Skip to voting start
 	testing.SetRealm(adminRealm)
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 	testing.SkipHeights(int64(config.VotingStartDelay) / currentBlockTime)
 
 	ufmt.Println("[INFO] Attempting to vote on ParameterChange proposal in Emergency Mode...")
@@ -444,7 +460,10 @@ func testGovernanceVoteParameterChangeWorks(cur realm) {
 func testParameterChangeProposalExecuteWorks(cur realm) {
 	// Skip voting period for ready to execute
 	testing.SetRealm(adminRealm)
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 	testing.SkipHeights(int64(config.VotingPeriod) / currentBlockTime)
 
 	ufmt.Println("[INFO] Attempting to execute ParameterChange proposal in Emergency Mode...")

--- a/contract/r/scenario/halt/emission_halt_does_not_block_governance_filetest.gno
+++ b/contract/r/scenario/halt/emission_halt_does_not_block_governance_filetest.gno
@@ -52,7 +52,10 @@ var (
 
 func main(cur realm) {
 	testing.SetRealm(adminRealm)
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	println("[SCENARIO] 1. Initialize governance and tokens")
 	initGovernanceAndTokens(cur)
@@ -114,7 +117,11 @@ func initGovernanceAndTokens(cur realm) {
 }
 
 func setupProposalCreationXGns(cur realm) {
-	threshold := governance.GetLatestConfig().ProposalCreationThreshold
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
+	threshold := config.ProposalCreationThreshold
 	missingAmount := threshold - xgns.BalanceOf(aliceAddr)
 	if missingAmount <= 0 {
 		return
@@ -140,7 +147,10 @@ func createAndVoteProposalWithEmissionEnabled(cur realm) {
 	ufmt.Printf("[EXPECTED] Proposal created successfully with ID: %d\n", proposalId)
 
 	// Skip to voting start
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 	testing.SkipHeights(int64(config.VotingStartDelay) / currentBlockTime)
 
 	// Vote on proposal
@@ -178,7 +188,10 @@ func setEmissionHalt(cur realm) {
 
 func createProposalWithEmissionHalted(cur realm) {
 	// Build a reconfigure execution with modified values to test parameter changes during emission halt
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	// Modify ExecutionWindow to verify the parameter change actually takes effect
 	newExecutionWindow := config.ExecutionWindow + 100
@@ -219,7 +232,10 @@ func voteOnProposalWithEmissionHalted(cur realm) {
 	println("[INFO] Voting on proposal with emission HALTED...")
 
 	// Wait for voting to start on the new proposal
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 	testing.SkipHeights(int64(config.VotingStartDelay) / currentBlockTime)
 
 	// Alice votes
@@ -241,19 +257,28 @@ func voteOnProposalWithEmissionHalted(cur realm) {
 
 func executeProposalWithEmissionHalted(cur realm) {
 	// Skip to voting end time by advancing blocks
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 	testing.SkipHeights(int64(config.VotingPeriod) / currentBlockTime)
 
 	ufmt.Println("[INFO] Executing proposal with emission HALTED...")
 
 	// Log config BEFORE Execute
-	configBefore := governance.GetLatestConfig()
+	configBefore, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 	ufmt.Printf("[INFO] Config BEFORE Execute - ExecutionWindow: %d\n", configBefore.ExecutionWindow)
 
 	testing.SetRealm(adminRealm)
 	governance.Execute(cross(cur), proposalId)
 
-	configAfter := governance.GetLatestConfig()
+	configAfter, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 	ufmt.Printf("[INFO] Config AFTER Execute - ExecutionWindow: %d\n", configAfter.ExecutionWindow)
 
 	// Verify the parameter change took effect
@@ -278,7 +303,10 @@ func resetProposalVotesWithEmissionHalted(cur realm) {
 	)
 
 	// Wait for voting start on the new proposal
-	config := governance.GetLatestConfig()
+	config, err := governance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 	testing.SkipHeights(int64(config.VotingStartDelay) / currentBlockTime)
 
 	// Vote on it

--- a/contract/r/scenario/staker/staker_emission_cache_sync_issue_filetest.gno
+++ b/contract/r/scenario/staker/staker_emission_cache_sync_issue_filetest.gno
@@ -122,7 +122,11 @@ func initSystem(cur realm) {
 	baz.Transfer(cross(cur), user1Addr, 1_000_000)
 
 	println("[EXPECTED] Initial distribution set to 75% for stakers")
-	ufmt.Printf("[EXPECTED] Current staker emission per second: %d\n", emission.GetStakerEmissionAmountPerSecond())
+	rate, err := emission.GetStakerEmissionAmountPerSecond()
+	if err != nil {
+		panic(err)
+	}
+	ufmt.Printf("[EXPECTED] Current staker emission per second: %d\n", rate)
 }
 
 func createPoolAndPosition(cur realm) {
@@ -189,7 +193,10 @@ func changeDistribution(cur realm) {
 	testing.SetRealm(adminRealm)
 
 	// Record emission rate before change
-	beforeRate := emission.GetStakerEmissionAmountPerSecond()
+	beforeRate, err := emission.GetStakerEmissionAmountPerSecond()
+	if err != nil {
+		panic(err)
+	}
 
 	// Change distribution to 50% for stakers
 	emission.ChangeDistributionPct(
@@ -201,7 +208,10 @@ func changeDistribution(cur realm) {
 	)
 
 	// Check emission rate after change
-	afterRate := emission.GetStakerEmissionAmountPerSecond()
+	afterRate, err := emission.GetStakerEmissionAmountPerSecond()
+	if err != nil {
+		panic(err)
+	}
 
 	ufmt.Printf("[EXPECTED] Emission rate before change: %d\n", beforeRate)
 	ufmt.Printf("[EXPECTED] Emission rate after change: %d\n", afterRate)

--- a/contract/r/scenario/upgrade/full_lifecycle_v2_valid_upgrade_filetest.gno
+++ b/contract/r/scenario/upgrade/full_lifecycle_v2_valid_upgrade_filetest.gno
@@ -1081,7 +1081,10 @@ func govStakerLifecycle(cur realm) {
 // ---------------------------------------------------------------------------
 
 func governanceLifecycle(cur realm) {
-	config := govGovernance.GetLatestConfig()
+	config, err := govGovernance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 	println("[EXPECTED] governance config version:", govGovernance.GetLatestConfigVersion())
 	println("[EXPECTED] voting period:", config.VotingPeriod, "quorum:", config.Quorum)
 
@@ -1376,6 +1379,10 @@ func captureSnapshot() upgradeSnapshot {
 	projectRecipient, _ := launchpad.GetProjectRecipient(launchpadProjectId)
 	projectTier30Total, _ := launchpad.GetProjectTierTotalDistributeAmount(launchpadProjectId, 30)
 	launchpadDepositAmount, _ := launchpad.GetDepositAmount(launchpadDepositId)
+	config, err := govGovernance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	return upgradeSnapshot{
 		poolLiquidity:      poolLiquidity,
@@ -1438,7 +1445,7 @@ func captureSnapshot() upgradeSnapshot {
 		textProposalState:  textStatus,
 		adminVoteWeight:    adminVoteWeight,
 		configVersion:      govGovernance.GetLatestConfigVersion(),
-		configVotingPeriod: govGovernance.GetLatestConfig().VotingPeriod,
+		configVotingPeriod: config.VotingPeriod,
 		projectCount:       launchpad.GetProjects().Size(),
 		projectActive:      projectActive,
 		projectRecipient:   projectRecipient,

--- a/contract/r/scenario/upgrade/gov_governance_upgrade_with_validate_data_filetest.gno
+++ b/contract/r/scenario/upgrade/gov_governance_upgrade_with_validate_data_filetest.gno
@@ -133,7 +133,11 @@ func main(cur realm) {
 func initialize(cur realm) {
 	testing.SetRealm(adminRealm)
 	govGovernance.UpgradeImpl(cross(cur), governanceV1Path)
-	config = govGovernance.GetLatestConfig()
+	var err error
+	config, err = govGovernance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	println("[EXPECTED] implementation:", govGovernance.GetImplementationPackagePath())
 	println("[EXPECTED] config version:", govGovernance.GetLatestConfigVersion())
@@ -232,7 +236,9 @@ func captureV1Snapshot() {
 	v1AdminVotedAt, _ = govGovernance.GetVotedAt(paramProposalId, adminAddr)
 	v1UserProposalCount = userProposalCount(adminAddr)
 	v1LatestConfigVer = govGovernance.GetLatestConfigVersion()
-	v1VotingPeriod = govGovernance.GetLatestConfig().VotingPeriod
+	config, err := govGovernance.GetLatestConfig()
+	uassert.NoError(t, err)
+	v1VotingPeriod = config.VotingPeriod
 
 	println("[EXPECTED] snapshot proposal count:", v1ProposalCount)
 	println("[EXPECTED] snapshot proposal ids:", len(v1ProposalIDs))
@@ -282,6 +288,8 @@ func validateSnapshot() {
 	uassert.NoError(t, err)
 	textStatus, err := govGovernance.GetProposalStatusByProposalId(textProposalId)
 	uassert.NoError(t, err)
+	latestConfig, err := govGovernance.GetLatestConfig()
+	uassert.NoError(t, err)
 	_, err = govGovernance.GetConfig(v1LatestConfigVer)
 	uassert.NoError(t, err)
 
@@ -306,7 +314,7 @@ func validateSnapshot() {
 	uassert.Equal(t, v1AdminVotedAt, votedAt)
 	uassert.Equal(t, v1UserProposalCount, userProposalCount(adminAddr))
 	uassert.Equal(t, v1LatestConfigVer, govGovernance.GetLatestConfigVersion())
-	uassert.Equal(t, v1VotingPeriod, govGovernance.GetLatestConfig().VotingPeriod)
+	uassert.Equal(t, v1VotingPeriod, latestConfig.VotingPeriod)
 	uassert.True(t, govGovernance.ExistsProposal(paramProposalId))
 	uassert.True(t, govGovernance.ExistsVotingInfo(paramProposalId, adminAddr))
 	uassert.False(t, govGovernance.ExistsVotingInfo(paramProposalId, aliceAddr))
@@ -351,12 +359,14 @@ func executeAndReconfigure(cur realm) {
 		config.ExecutionWindow,
 	)
 	testing.SkipHeights(1)
+	latestConfig, err := govGovernance.GetLatestConfig()
+	uassert.NoError(t, err)
 
 	println("[EXPECTED] config version after reconfigure:", newVersion)
-	println("[EXPECTED] latest config voting period:", govGovernance.GetLatestConfig().VotingPeriod)
+	println("[EXPECTED] latest config voting period:", latestConfig.VotingPeriod)
 
 	uassert.Equal(t, v1LatestConfigVer+1, newVersion)
-	uassert.Equal(t, v1VotingPeriod, govGovernance.GetLatestConfig().VotingPeriod)
+	uassert.Equal(t, v1VotingPeriod, latestConfig.VotingPeriod)
 }
 
 func assertAborts(cur realm, callback func(), logMessage string) {

--- a/contract/r/scenario/upgrade/gov_governance_v2_valid_upgrade_filetest.gno
+++ b/contract/r/scenario/upgrade/gov_governance_v2_valid_upgrade_filetest.gno
@@ -152,7 +152,10 @@ func setupVotingPower(cur realm) {
 
 	// Skip the voting weight smoothing duration so the proposal can snapshot
 	// a non-zero voting weight at creation time.
-	config := govGovernance.GetLatestConfig()
+	config, err := govGovernance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 	testing.SkipHeights(int64(config.VotingWeightSmoothingDuration) / currentBlockTime)
 
 	ufmt.Printf("[EXPECTED] gns delegated to admin (amount: %d)\n", delegatedAmount)
@@ -172,7 +175,10 @@ func createProposalV1(cur realm) int64 {
 	ufmt.Printf("[EXPECTED] v1 created proposal ID: %d\n", proposalID)
 
 	// Skip the voting start delay so the proposal becomes votable.
-	config := govGovernance.GetLatestConfig()
+	config, err := govGovernance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 	testing.SkipHeights(int64(config.VotingStartDelay) / currentBlockTime)
 	println("[INFO] current height:", runtime.ChainHeight())
 
@@ -224,7 +230,10 @@ func mutateProposalV2Valid(cur realm, proposalID int64) {
 // action status (sets executed=true). A direct-storage write under the upgraded
 // realm would abort with a readonly-taint panic here.
 func executeProposalV2Valid(cur realm, proposalID int64) {
-	config := govGovernance.GetLatestConfig()
+	config, err := govGovernance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 
 	// Advance past votingPeriod + executionDelay (relative to the already-passed
 	// voting start) so the proposal reaches the StatusExecutable window.
@@ -311,7 +320,10 @@ func cancelProposalV2Valid(cur realm, proposalID int64) {
 // proves the per-proposal vote tally / votes map allocated AFTER the upgrade is
 // also writable through the domain realm.
 func voteOnNewProposalV2Valid(cur realm, proposalID int64) {
-	config := govGovernance.GetLatestConfig()
+	config, err := govGovernance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 	testing.SkipHeights(int64(config.VotingStartDelay) / currentBlockTime)
 	println("[INFO] current height:", runtime.ChainHeight())
 
@@ -341,7 +353,10 @@ func reconfigureV2Valid(cur realm) {
 	)
 	ufmt.Printf("[EXPECTED] reconfigured: prev version %d -> new version %d (no taint panic)\n", prevVersion, newVersion)
 
-	cfg := govGovernance.GetLatestConfig()
+	cfg, err := govGovernance.GetLatestConfig()
+	if err != nil {
+		panic(err)
+	}
 	ufmt.Printf("[EXPECTED] latest config version: %d\n", govGovernance.GetLatestConfigVersion())
 	ufmt.Printf("[EXPECTED] latest config votingPeriod: %d\n", cfg.VotingPeriod)
 }

--- a/contract/r/scenario/upgrade/implements/mock/gov/governance/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/mock/gov/governance/test_impl.gno
@@ -80,7 +80,7 @@ func (t *TestGovernance) GetMaxSmoothingPeriod() int64 {
 }
 
 // Config getters
-func (t *TestGovernance) GetLatestConfig() governance.Config {
+func (t *TestGovernance) GetLatestConfig() (governance.Config, error) {
 	return t.instance.GetLatestConfig()
 }
 

--- a/contract/r/scenario/upgrade/implements/security/insecure_staker_callback/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/security/insecure_staker_callback/test_impl.gno
@@ -21,9 +21,11 @@ func NewInsecureStakerCallback(store staker.IStakerStore, poolAccessor staker.Po
 func init(cur realm) {
 	staker.RegisterInitializer(cross(cur), func(_ int, rlm realm, store staker.IStakerStore, poolAccessor staker.PoolAccessor, emissionAccessor staker.EmissionAccessor, nftAccessor staker.NFTAccessor) staker.IStaker {
 		instance := NewInsecureStakerCallback(store, poolAccessor, emissionAccessor, nftAccessor)
-		emissionAccessor.SetOnDistributionPctChangeCallback(0, rlm, func(_ int, callbackRealm realm, emissionAmountPerSecond int64) {
+		if err := emissionAccessor.SetOnDistributionPctChangeCallback(0, rlm, func(_ int, callbackRealm realm, emissionAmountPerSecond int64) {
 			gns.InitEmissionState(cross(callbackRealm), 0, 100)
-		})
+		}); err != nil {
+			panic(err)
+		}
 		return instance
 	})
 }

--- a/contract/r/scenario/upgrade/implements/v2_invalid/gov/governance/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v2_invalid/gov/governance/test_impl.gno
@@ -101,7 +101,7 @@ func (t *TestGovernance) GetMaxSmoothingPeriod() int64 {
 }
 
 // Config getters
-func (t *TestGovernance) GetLatestConfig() governance.Config {
+func (t *TestGovernance) GetLatestConfig() (governance.Config, error) {
 	return t.instance.GetLatestConfig()
 }
 

--- a/contract/r/scenario/upgrade/implements/v3_valid/gov/governance/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/gov/governance/test_impl.gno
@@ -67,7 +67,7 @@ func (t *TestGovernance) GetMaxSmoothingPeriod() int64 {
 }
 
 // Config getters
-func (t *TestGovernance) GetLatestConfig() governance.Config {
+func (t *TestGovernance) GetLatestConfig() (governance.Config, error) {
 	return t.instance.GetLatestConfig()
 }
 

--- a/contract/r/scenario/upgrade/upgrade_with_withdraw_and_halt_filetest.txt
+++ b/contract/r/scenario/upgrade/upgrade_with_withdraw_and_halt_filetest.txt
@@ -422,9 +422,12 @@ func updateRoleAddresses() {
 	updatedLaunchpadAddr, _ := access.GetAddress(prbac.ROLE_LAUNCHPAD.String())
 
 	testing.SetRealm(testing.NewUserRealm(stakerV2Addr))
-	emission.SetOnDistributionPctChangeCallback(cross, func(emissionAmountPerSecond int64) {
+	err := emission.SetOnDistributionPctChangeCallback(cross, func(emissionAmountPerSecond int64) {
 		ufmt.Printf("[INFO] emission amount per second should be %d\n", emissionAmountPerSecond)
 	})
+	if err != nil {
+		panic(err)
+	}
 
 	ufmt.Printf("[EXPECTED] community_pool should be changed %s to %s\n", previousCommunityPoolAddr, updatedCommunityPoolAddr)
 	ufmt.Printf("[EXPECTED] gov_governance should be changed %s to %s\n", previousGovGovernanceAddr, updatedGovGovernanceAddr)

--- a/contract/r/scenario/upgrade/upgrade_with_withdraw_filetest.txt
+++ b/contract/r/scenario/upgrade/upgrade_with_withdraw_filetest.txt
@@ -397,9 +397,12 @@ func updateRoleAddresses() {
 	updatedLaunchpadAddr, _ := access.GetAddress(prbac.ROLE_LAUNCHPAD.String())
 
 	testing.SetRealm(testing.NewUserRealm(stakerV2Addr))
-	emission.SetOnDistributionPctChangeCallback(cross, func(emissionAmountPerSecond int64) {
+	err := emission.SetOnDistributionPctChangeCallback(cross, func(emissionAmountPerSecond int64) {
 		ufmt.Printf("[INFO] emission amount per second should be %d\n", emissionAmountPerSecond)
 	})
+	if err != nil {
+		panic(err)
+	}
 
 	ufmt.Printf("[EXPECTED] community_pool should be changed %s to %s\n", previousCommunityPoolAddr, updatedCommunityPoolAddr)
 	ufmt.Printf("[EXPECTED] gov_governance should be changed %s to %s\n", previousGovGovernanceAddr, updatedGovGovernanceAddr)


### PR DESCRIPTION
## Summary
- Propagate getter errors through community pool, emission, governance, and dependent scenario consumers.
- Return liquidity-staker emission-rate lookup errors through the emission accessor and staker read-only reward getters.
- Abort `CollectReward` on a recoverable emission lookup error before applying staker reward updates; transaction-only tier/cache paths retain panic semantics.
- Update persisted `PoolTier` emission callbacks to return errors. This is an intentional breaking change with no migration or backward-compatibility path.
- Update scenario callers and governance upgrade fixtures for the fallible `GetLatestConfig()` API.
- Preserve gov-staker invalid-cast panic semantics; it is not treated as a recoverable getter error.
- Preserve router `DrySwap` validation in #1394; it is intentionally excluded.
- Stack this cross-module consumer layer on #1400.

## Testing
- `make test PKG=gno.land/r/gnoswap/emission`
- `make test PKG=gno.land/r/gnoswap/staker`
- `make test PKG=gno.land/r/gnoswap/staker/v1`
- `make test PKG=gno.land/r/gnoswap/scenario/staker`
- `make test PKG=gno.land/r/gnoswap/scenario/upgrade`
- `make test PKG=gno.land/r/gnoswap/test/fuzz`
- `make test PKG=gno.land/r/gnoswap/gov/staker/v1`
- `make test PKG=gno.land/r/gnoswap/scenario/gov/staker`
- `make test PKG=gno.land/r/gnoswap/scenario/getter`
- `make test PKG=gno.land/r/gnoswap/scenario/gov/governance`
- `make test PKG=gno.land/r/gnoswap/scenario/halt`

Local Docker integration could not run because `/Users/junghoon/.orbstack/run/docker.sock` was unavailable; GitHub CI remains the integration gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid or unavailable token, emission, governance, and reward data now returns explicit errors instead of triggering unexpected failures.
  * Reward calculations and collectible reward queries now propagate lookup and validation errors consistently.
  * Missing governance configuration now reports an error with a zero-valued configuration.

* **Documentation**
  * Updated emission API documentation and examples to demonstrate error handling.

* **Tests**
  * Expanded coverage for invalid targets, missing configuration, reward-calculation failures, and error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->