### PR TITLE
refactor(pool): expose uniswap v3 oracle surface

### DIFF
--- a/contract/r/gnoswap/pool/_mock_test.gno
+++ b/contract/r/gnoswap/pool/_mock_test.gno
@@ -312,17 +312,6 @@ func (m *MockPool) GetMaxLiquidityPerTick(poolPath string) (*u256.Uint, error) {
 	return res[0].(*u256.Uint), nil
 }
 
-func (m *MockPool) GetLastObservation(poolPath string) (tickCumulative int64, secondsPerLiquidityCumulativeX128 string, blockTimestamp int64, err error) {
-	res, ok := m.Response.Get("GetLastObservation")
-	if !ok {
-		return 0, "", 0, errors.New("not found")
-	}
-	if len(res) < 4 || res[3] == nil {
-		return res[0].(int64), res[1].(string), res[2].(int64), nil
-	}
-	return res[0].(int64), res[1].(string), res[2].(int64), res[3].(error)
-}
-
 func (m *MockPool) GetPoolCreationFee() int64 {
 	res, ok := m.Response.Get("GetPoolCreationFee")
 	if !ok {
@@ -449,6 +438,58 @@ func (m *MockPool) GetSlot0Unlocked(poolPath string) (bool, error) {
 	return res[0].(bool), nil
 }
 
+func (m *MockPool) GetSlot0(poolPath string) Slot0 {
+	res, ok := m.Response.Get("GetSlot0")
+	if !ok {
+		return NewSlot0(u256.Zero(), 0, 0, false)
+	}
+
+	return res[0].(Slot0)
+}
+
+func (m *MockPool) GetObservationAt(poolPath string, index uint16) (Observation, error) {
+	res, ok := m.Response.Get("GetObservationAt")
+	if !ok {
+		return Observation{}, errors.New("not found")
+	}
+
+	if len(res) < 2 || res[1] == nil {
+		return res[0].(Observation), nil
+	}
+
+	return res[0].(Observation), res[1].(error)
+}
+
+func (m *MockPool) Observe(poolPath string, secondsAgos []uint32) ([]int64, []string, error) {
+	res, ok := m.Response.Get("Observe")
+	if !ok {
+		return nil, nil, errors.New("not found")
+	}
+
+	if len(res) < 3 || res[2] == nil {
+		return res[0].([]int64), res[1].([]string), nil
+	}
+
+	return res[0].([]int64), res[1].([]string), res[2].(error)
+}
+
+func (m *MockPool) SnapshotCumulativesInside(
+	poolPath string,
+	tickLower int32,
+	tickUpper int32,
+) (int64, *u256.Uint, uint32, error) {
+	res, ok := m.Response.Get("SnapshotCumulativesInside")
+	if !ok {
+		return 0, nil, 0, errors.New("not found")
+	}
+
+	if len(res) < 4 || res[3] == nil {
+		return res[0].(int64), res[1].(*u256.Uint), res[2].(uint32), nil
+	}
+
+	return res[0].(int64), res[1].(*u256.Uint), res[2].(uint32), res[3].(error)
+}
+
 func (m *MockPool) GetTickCumulativeOutside(poolPath string, tick int32) (int64, error) {
 	res, ok := m.Response.Get("GetTickCumulativeOutside")
 	if !ok {
@@ -566,8 +607,8 @@ func (m *MockPool) GetWithdrawalFee() uint64 {
 	return res[0].(uint64)
 }
 
-func (m *MockPool) GetTWAP(poolPath string, secondsAgo uint32) (int32, *u256.Uint, error) {
-	res, ok := m.Response.Get("GetTWAP")
+func (m *MockPool) OracleConsult(poolPath string, secondsAgo uint32) (int32, *u256.Uint, error) {
+	res, ok := m.Response.Get("OracleConsult")
 	if !ok {
 		return 0, nil, errors.New("not found")
 	}
@@ -637,19 +678,6 @@ func (m *MockPool) GetTickBitmaps(poolPath string, wordPos int16) (string, error
 		return res[0].(string), nil
 	}
 	return res[0].(string), res[1].(error)
-}
-
-func (m *MockPool) GetObservationState(poolPath string) (*ObservationState, error) {
-	res, ok := m.Response.Get("GetObservationState")
-	if !ok {
-		return nil, errors.New("not found")
-	}
-
-	if len(res) < 2 || res[1] == nil {
-		return res[0].(*ObservationState), nil
-	}
-
-	return res[0].(*ObservationState), res[1].(error)
 }
 
 func newMockPool(version string) *MockPool {

--- a/contract/r/gnoswap/pool/getter.gno
+++ b/contract/r/gnoswap/pool/getter.gno
@@ -2,7 +2,6 @@ package pool
 
 import (
 	rotree "gno.land/p/nt/bptree/v0/rotree"
-	ufmt "gno.land/p/nt/ufmt/v0"
 )
 
 // GetPools returns a read-only view of every pool, keyed by pool path.
@@ -88,11 +87,6 @@ func GetLiquidity(poolPath string) (string, error) {
 		return "", err
 	}
 	return liquidity.ToString(), nil
-}
-
-// GetLastObservation returns the most recent observation data for calculating time-weighted averages.
-func GetLastObservation(poolPath string) (tickCumulative int64, secondsPerLiquidityCumulativeX128 string, blockTimestamp int64, err error) {
-	return getImplementation().GetLastObservation(poolPath)
 }
 
 // GetPoolCreationFee returns the current pool creation fee.
@@ -196,6 +190,67 @@ func GetSlot0Unlocked(poolPath string) (bool, error) {
 	return getImplementation().GetSlot0Unlocked(poolPath)
 }
 
+// GetSlot0 returns a safe copy of the pool's slot0 (sqrt price, tick,
+// protocol fee, lock state, and oracle cursor/capacity metadata).
+// The clone happens here, at the proxy boundary, so every implementation
+// version can return its internal Slot0 by value without each one having to
+// remember to defend against callers mutating the shared sqrtPriceX96.
+func GetSlot0(poolPath string) Slot0 {
+	slot0 := getImplementation().GetSlot0(poolPath)
+	return slot0.Clone()
+}
+
+// GetObservationAt returns a safe copy of the observation stored at index.
+// An in-range but uninitialized slot returns the zero observation, matching
+// Uniswap V3's fixed observation-array getter.
+//
+// ref: uniswap v3 IUniswapV3PoolState.observations(uint256 index)
+func GetObservationAt(poolPath string, index uint16) (Observation, error) {
+	observation, err := getImplementation().GetObservationAt(poolPath, index)
+	if err != nil {
+		return Observation{}, err
+	}
+
+	return *observation.Clone(), nil
+}
+
+// Observe returns the tick and seconds-per-liquidity cumulatives for each
+// requested lookback, matching Uniswap V3's observe(uint32[] secondsAgos).
+func Observe(poolPath string, secondsAgos []uint32) ([]int64, []string, error) {
+	tickCumulatives, secondsPerLiquidityCumulativeX128s, err := getImplementation().Observe(
+		poolPath,
+		cloneUint32Slice(secondsAgos),
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return cloneInt64Slice(tickCumulatives), cloneStringSlice(secondsPerLiquidityCumulativeX128s), nil
+}
+
+// SnapshotCumulativesInside returns the tick, seconds-per-liquidity, and
+// seconds cumulatives accrued while the pool price was inside
+// [tickLower, tickUpper). Both boundary ticks must be initialized.
+//
+// Snapshots are only comparable across an interval during which a position in
+// the range existed, matching Uniswap V3's snapshotCumulativesInside.
+func SnapshotCumulativesInside(
+	poolPath string,
+	tickLower int32,
+	tickUpper int32,
+) (int64, string, uint32, error) {
+	tickCumulativeInside, secondsPerLiquidityInsideX128, secondsInside, err := getImplementation().SnapshotCumulativesInside(
+		poolPath,
+		tickLower,
+		tickUpper,
+	)
+	if err != nil {
+		return 0, "", 0, err
+	}
+
+	return tickCumulativeInside, secondsPerLiquidityInsideX128.ToString(), secondsInside, nil
+}
+
 // GetTickCumulativeOutside returns the tick cumulative value outside a tick.
 func GetTickCumulativeOutside(poolPath string, tick int32) (int64, error) {
 	return getImplementation().GetTickCumulativeOutside(poolPath, tick)
@@ -270,10 +325,10 @@ func GetWithdrawalFee() uint64 {
 	return getImplementation().GetWithdrawalFee()
 }
 
-// GetTWAP returns the time-weighted average price for a pool.
-// Returns arithmetic mean tick and harmonic mean liquidity over the time period.
-func GetTWAP(poolPath string, secondsAgo uint32) (int32, string, error) {
-	tick, liquidity, err := getImplementation().GetTWAP(poolPath, secondsAgo)
+// OracleConsult returns the arithmetic mean tick and harmonic mean liquidity
+// over a lookback, following Uniswap V3 OracleLibrary's consult convention.
+func OracleConsult(poolPath string, secondsAgo uint32) (int32, string, error) {
+	tick, liquidity, err := getImplementation().OracleConsult(poolPath, secondsAgo)
 	if err != nil {
 		return 0, "", err
 	}
@@ -295,21 +350,6 @@ func GetTickInfo(poolPath string, tick int32) (TickInfo, error) {
 // GetTickBitmaps returns the tick bitmap for a given word position.
 func GetTickBitmaps(poolPath string, wordPos int16) (string, error) {
 	return getImplementation().GetTickBitmaps(poolPath, wordPos)
-}
-
-// GetObservationState returns the observation state for a given pool path.
-func GetObservationState(poolPath string) (*ObservationState, error) {
-	observationState, err := getImplementation().GetObservationState(poolPath)
-	if err != nil {
-		return nil, err
-	}
-
-	// Implementations may return nil without error after an upgrade.
-	if observationState == nil {
-		return nil, ufmt.Errorf("observation state not found for pool %s", poolPath)
-	}
-
-	return observationState.Clone(), nil
 }
 
 // GetPendingProtocolFees returns the pending protocol fee amount per token path.

--- a/contract/r/gnoswap/pool/getter_test.gno
+++ b/contract/r/gnoswap/pool/getter_test.gno
@@ -112,6 +112,80 @@ func TestMutablePoolGetterIsolation(cur realm, t *testing.T) {
 			},
 		},
 		{
+			name: "GetSlot0",
+			setup: func(m *MockPool) {
+				slot0 := NewSlot0(u256.MustFromDecimal("3000"), 12, 34, true)
+				slot0.SetObservationIndex(7)
+				slot0.SetObservationCardinality(8)
+				slot0.SetObservationCardinalityNext(9)
+				m.Response.Set("GetSlot0", slot0)
+			},
+			getter: func() any { return GetSlot0("foo:bar:500") },
+			assertGot: func(t *testing.T, result any) {
+				slot0 := result.(Slot0)
+				uassert.Equal(t, "3000", slot0.SqrtPriceX96().ToString())
+				uassert.Equal(t, int32(12), slot0.Tick())
+				uassert.Equal(t, uint8(34), slot0.FeeProtocol())
+				uassert.Equal(t, true, slot0.Unlocked())
+				uassert.Equal(t, uint16(7), slot0.ObservationIndex())
+				uassert.Equal(t, uint16(8), slot0.ObservationCardinality())
+				uassert.Equal(t, uint16(9), slot0.ObservationCardinalityNext())
+			},
+			mutate: func(result any) {
+				slot0 := result.(Slot0)
+				slot0.SetSqrtPriceX96(u256.MustFromDecimal("9000"))
+				slot0.SetObservationIndex(70)
+				slot0.SetObservationCardinality(80)
+				slot0.SetObservationCardinalityNext(90)
+			},
+			assertRaw: func(cur realm, t *testing.T) {
+				slot0 := implementation.(*MockPool).Response.responses["GetSlot0"][0].(Slot0)
+				uassert.Equal(t, "3000", slot0.SqrtPriceX96().ToString())
+				uassert.Equal(t, uint16(7), slot0.ObservationIndex())
+				uassert.Equal(t, uint16(8), slot0.ObservationCardinality())
+				uassert.Equal(t, uint16(9), slot0.ObservationCardinalityNext())
+			},
+		},
+		{
+			name: "Observe",
+			setup: func(m *MockPool) {
+				m.Response.Set("Observe", []int64{10, 20}, []string{"30", "40"}, error(nil))
+			},
+			getter: func() any {
+				tickCumulatives, secondsPerLiquidityCumulativeX128s, err := Observe(
+					"foo:bar:500",
+					[]uint32{60, 0},
+				)
+				uassert.NoError(t, err)
+				return []any{tickCumulatives, secondsPerLiquidityCumulativeX128s}
+			},
+			assertGot: func(t *testing.T, result any) {
+				values := result.([]any)
+				tickCumulatives := values[0].([]int64)
+				secondsPerLiquidityCumulativeX128s := values[1].([]string)
+				uassert.Equal(t, 2, len(tickCumulatives))
+				uassert.Equal(t, int64(10), tickCumulatives[0])
+				uassert.Equal(t, int64(20), tickCumulatives[1])
+				uassert.Equal(t, 2, len(secondsPerLiquidityCumulativeX128s))
+				uassert.Equal(t, "30", secondsPerLiquidityCumulativeX128s[0])
+				uassert.Equal(t, "40", secondsPerLiquidityCumulativeX128s[1])
+			},
+			mutate: func(result any) {
+				values := result.([]any)
+				values[0].([]int64)[0] = 100
+				values[1].([]string)[0] = "300"
+			},
+			assertRaw: func(cur realm, t *testing.T) {
+				values := implementation.(*MockPool).Response.responses["Observe"]
+				tickCumulatives := values[0].([]int64)
+				secondsPerLiquidityCumulativeX128s := values[1].([]string)
+				uassert.Equal(t, int64(10), tickCumulatives[0])
+				uassert.Equal(t, int64(20), tickCumulatives[1])
+				uassert.Equal(t, "30", secondsPerLiquidityCumulativeX128s[0])
+				uassert.Equal(t, "40", secondsPerLiquidityCumulativeX128s[1])
+			},
+		},
+		{
 			name:  "GetTickInfo",
 			setup: func(m *MockPool) { m.Response.Set("GetTickInfo", newTickInfoFixture(), nil) },
 			getter: func() any {
@@ -175,50 +249,17 @@ func TestMutablePoolGetterIsolation(cur realm, t *testing.T) {
 			},
 		},
 		{
-			name:  "GetTWAP",
-			setup: func(m *MockPool) { m.Response.Set("GetTWAP", int32(5), u256.MustFromDecimal("5000"), error(nil)) },
+			name:  "OracleConsult",
+			setup: func(m *MockPool) { m.Response.Set("OracleConsult", int32(5), u256.MustFromDecimal("5000"), error(nil)) },
 			getter: func() any {
-				_, liquidity, err := GetTWAP("foo:bar:500", 10)
+				_, liquidity, err := OracleConsult("foo:bar:500", 10)
 				uassert.NoError(t, err)
 				return liquidity
 			},
 			mutate: func(result any) {},
 			assertRaw: func(cur realm, t *testing.T) {
-				value := implementation.(*MockPool).Response.responses["GetTWAP"][1].(*u256.Uint)
+				value := implementation.(*MockPool).Response.responses["OracleConsult"][1].(*u256.Uint)
 				uassert.Equal(t, "5000", value.ToString())
-			},
-		},
-		{
-			name: "GetObservationState",
-			setup: func(m *MockPool) {
-				state := NewObservationState(100)
-				obs := NewObservation(123, 77, "2000", true)
-				state.Observations()[7] = obs
-				m.Response.Set("GetObservationState", state, error(nil))
-			},
-			getter: func() any {
-				state, err := GetObservationState("foo:bar:500")
-				uassert.NoError(t, err)
-				return state
-			},
-			assertGot: func(t *testing.T, result any) {
-				state := result.(*ObservationState)
-				uassert.Equal(t, 2, len(state.Observations()))
-				uassert.Equal(t, int64(100), state.Observations()[0].BlockTimestamp())
-				uassert.Equal(t, int64(123), state.Observations()[7].BlockTimestamp())
-			},
-			mutate: func(result any) {
-				state := result.(*ObservationState)
-				state.Observations()[8] = NewObservation(1, 2, "4", true)
-			},
-			assertRaw: func(cur realm, t *testing.T) {
-				state := implementation.(*MockPool).Response.responses["GetObservationState"][0].(*ObservationState)
-				uassert.Equal(t, int64(123), state.Observations()[7].BlockTimestamp())
-				uassert.Equal(t, int64(77), state.Observations()[7].TickCumulative())
-				uassert.Equal(t, "2000", state.Observations()[7].SecondsPerLiquidityCumulativeX128())
-				uassert.Equal(t, true, state.Observations()[7].Initialized())
-				_, ok := state.Observations()[8]
-				uassert.Equal(t, false, ok)
 			},
 		},
 	}

--- a/contract/r/gnoswap/pool/getter_utils.gno
+++ b/contract/r/gnoswap/pool/getter_utils.gno
@@ -10,6 +10,36 @@ func cloneInt32Slice(src []int32) []int32 {
 	return cloned
 }
 
+func cloneInt64Slice(src []int64) []int64 {
+	if src == nil {
+		return nil
+	}
+
+	cloned := make([]int64, len(src))
+	copy(cloned, src)
+	return cloned
+}
+
+func cloneStringSlice(src []string) []string {
+	if src == nil {
+		return nil
+	}
+
+	cloned := make([]string, len(src))
+	copy(cloned, src)
+	return cloned
+}
+
+func cloneUint32Slice(src []uint32) []uint32 {
+	if src == nil {
+		return nil
+	}
+
+	cloned := make([]uint32, len(src))
+	copy(cloned, src)
+	return cloned
+}
+
 func cloneFeeAmountTickSpacings(src map[uint32]int32) map[uint32]int32 {
 	if src == nil {
 		return nil

--- a/contract/r/gnoswap/pool/oracle.gno
+++ b/contract/r/gnoswap/pool/oracle.gno
@@ -19,7 +19,8 @@ func (os *ObservationState) SetObservations(observations map[uint16]*Observation
 	os.observations = observations
 }
 
-// ObservationAt returns the observation stored at index.
+// ObservationAt returns the observation stored at index, mirroring Uniswap
+// V3's observations(uint256 index) mapping getter.
 func (os *ObservationState) ObservationAt(index uint16) (*Observation, bool) {
 	observation, ok := os.observations[index]
 	return observation, ok

--- a/contract/r/gnoswap/pool/pool.gno
+++ b/contract/r/gnoswap/pool/pool.gno
@@ -211,9 +211,9 @@ func (p *Pool) IterateTicks(startTick int32, endTick int32, fn func(tick int32, 
 // caller reads, so copying the collections would walk the whole tick tree for
 // each entry on a page. Read them through their own lookups instead:
 // GetTickInfo / GetInitializedTicksInRange for ticks, GetTickBitmaps for the
-// bitmaps, GetPoolPositions for positions, and GetObservationState for the
-// oracle state. A caller that needs a working copy of a collection -- DrySwap
-// is the only one -- assembles it from those getters.
+// bitmaps, GetPoolPositions for positions, and GetSlot0 / GetObservationAt for
+// oracle metadata and entries. A caller that needs a working copy of a
+// collection -- DrySwap is the only one -- assembles it from those getters.
 func (p *Pool) Clone() *Pool {
 	if p == nil {
 		return nil
@@ -332,6 +332,7 @@ func (s *Slot0) Clone() Slot0 {
 		observationCardinalityNext: s.observationCardinalityNext,
 	}
 }
+
 func (s *Slot0) SetSqrtPriceX96(sqrtPriceX96 *u256.Uint) { s.sqrtPriceX96 = sqrtPriceX96.Clone() }
 func (s *Slot0) SetTick(tick int32)                      { s.tick = tick }
 func (s *Slot0) SetFeeProtocol(feeProtocol uint8)        { s.feeProtocol = feeProtocol }

--- a/contract/r/gnoswap/pool/types.gno
+++ b/contract/r/gnoswap/pool/types.gno
@@ -150,33 +150,33 @@ type IPoolSwap interface {
 // operation identifies its pool with poolPath, and uint values cross the public
 // boundary using GnoSwap types or decimal strings rather than the EVM ABI.
 //
-// ref: https://github.com/Uniswap/v3-core/blob/d0831dc6b8a318df3872b6d68f6de135c9f3ec29/contracts/interfaces/IUniswapV3PoolState.sol#L21-L32
-// ref: https://github.com/Uniswap/v3-core/blob/d0831dc6b8a318df3872b6d68f6de135c9f3ec29/contracts/interfaces/pool/IUniswapV3PoolDerivedState.sol#L18-L39
+// ref: https://github.com/Uniswap/v3-core/blob/e3589b192d0be27e100cd0daaf6c97204fdb1899/contracts/interfaces/pool/IUniswapV3PoolState.sol#L21-L32
+// ref: https://github.com/Uniswap/v3-core/blob/e3589b192d0be27e100cd0daaf6c97204fdb1899/contracts/interfaces/pool/IUniswapV3PoolDerivedState.sol#L18-L39
 type IPoolOracle interface {
 	// GetSlot0 returns a safe copy of a pool's price, tick, protocol-fee, lock,
 	// and oracle cursor/capacity state, corresponding to Uniswap V3 slot0().
 	//
-	// ref: https://github.com/Uniswap/v3-core/blob/d0831dc6b8a318df3872b6d68f6de135c9f3ec29/contracts/interfaces/IUniswapV3PoolState.sol#L21-L32
+	// ref: https://github.com/Uniswap/v3-core/blob/e3589b192d0be27e100cd0daaf6c97204fdb1899/contracts/interfaces/pool/IUniswapV3PoolState.sol#L21-L32
 	GetSlot0(poolPath string) Slot0
 
 	// GetObservationAt returns the observation stored at index, corresponding to
 	// Uniswap V3 observations(uint256). An in-range uninitialized slot returns a
 	// zero observation; an out-of-range index returns an error.
 	//
-	// ref: https://github.com/Uniswap/v3-core/blob/d0831dc6b8a318df3872b6d68f6de135c9f3ec29/contracts/interfaces/IUniswapV3PoolState.sol#L99-L115
+	// ref: https://github.com/Uniswap/v3-core/blob/e3589b192d0be27e100cd0daaf6c97204fdb1899/contracts/interfaces/pool/IUniswapV3PoolState.sol#L99-L115
 	GetObservationAt(poolPath string, index uint16) (Observation, error)
 
 	// Observe returns tick and seconds-per-liquidity cumulatives for every
 	// requested lookback, corresponding to Uniswap V3 observe(uint32[]).
 	//
-	// ref: https://github.com/Uniswap/v3-core/blob/d0831dc6b8a318df3872b6d68f6de135c9f3ec29/contracts/interfaces/pool/IUniswapV3PoolDerivedState.sol#L18-L21
+	// ref: https://github.com/Uniswap/v3-core/blob/e3589b192d0be27e100cd0daaf6c97204fdb1899/contracts/interfaces/pool/IUniswapV3PoolDerivedState.sol#L18-L21
 	Observe(poolPath string, secondsAgos []uint32) ([]int64, []string, error)
 
 	// SnapshotCumulativesInside returns accumulators accrued while the pool price
 	// was inside [tickLower, tickUpper), corresponding to Uniswap V3
 	// snapshotCumulativesInside(int24,int24).
 	//
-	// ref: https://github.com/Uniswap/v3-core/blob/d0831dc6b8a318df3872b6d68f6de135c9f3ec29/contracts/interfaces/pool/IUniswapV3PoolDerivedState.sol#L23-L39
+	// ref: https://github.com/Uniswap/v3-core/blob/e3589b192d0be27e100cd0daaf6c97204fdb1899/contracts/interfaces/pool/IUniswapV3PoolDerivedState.sol#L23-L39
 	SnapshotCumulativesInside(
 		poolPath string,
 		tickLower int32,
@@ -193,7 +193,7 @@ type IPoolOracle interface {
 	// observation buffer, corresponding to Uniswap V3
 	// increaseObservationCardinalityNext(uint16).
 	//
-	// ref: https://github.com/Uniswap/v3-core/blob/d0831dc6b8a318df3872b6d68f6de135c9f3ec29/contracts/interfaces/pool/IUniswapV3PoolActions.sol#L98-L102
+	// ref: https://github.com/Uniswap/v3-core/blob/e3589b192d0be27e100cd0daaf6c97204fdb1899/contracts/interfaces/pool/IUniswapV3PoolActions.sol#L98-L102
 	IncreaseObservationCardinalityNext(
 		_ int,
 		rlm realm,

--- a/contract/r/gnoswap/pool/types.gno
+++ b/contract/r/gnoswap/pool/types.gno
@@ -18,6 +18,7 @@ type IPool interface {
 	IPoolManager
 	IPoolPosition
 	IPoolSwap
+	IPoolOracle
 	IPoolGetter
 }
 
@@ -36,15 +37,6 @@ type IPoolManager interface {
 
 	// SetPoolCreationFee sets the pool creation fee.
 	SetPoolCreationFee(_ int, rlm realm, fee int64)
-
-	IncreaseObservationCardinalityNext(
-		_ int,
-		rlm realm,
-		token0Path string,
-		token1Path string,
-		fee uint32,
-		cardinalityNext uint16,
-	)
 }
 
 // IPoolPosition interface defines position management operations.
@@ -151,6 +143,32 @@ type IPoolSwap interface {
 	SetFeeProtocol(_ int, rlm realm, feeProtocol0, feeProtocol1 uint8)
 }
 
+// IPoolOracle interface defines the pool's Uniswap-V3-aligned oracle surface.
+type IPoolOracle interface {
+	GetSlot0(poolPath string) Slot0
+
+	GetObservationAt(poolPath string, index uint16) (Observation, error)
+
+	Observe(poolPath string, secondsAgos []uint32) ([]int64, []string, error)
+
+	SnapshotCumulativesInside(
+		poolPath string,
+		tickLower int32,
+		tickUpper int32,
+	) (int64, *u256.Uint, uint32, error)
+
+	OracleConsult(poolPath string, secondsAgo uint32) (int32, *u256.Uint, error)
+
+	IncreaseObservationCardinalityNext(
+		_ int,
+		rlm realm,
+		token0Path string,
+		token1Path string,
+		fee uint32,
+		cardinalityNext uint16,
+	)
+}
+
 // IPoolGetter interface defines data retrieval operations.
 // These methods provide read-only access to pool state and data.
 type IPoolGetter interface {
@@ -171,8 +189,6 @@ type IPoolGetter interface {
 	GetFeeGrowthGlobalX128(poolPath string) (*u256.Uint, *u256.Uint, error)
 
 	GetLiquidity(poolPath string) (*u256.Uint, error)
-
-	GetLastObservation(poolPath string) (tickCumulative int64, secondsPerLiquidityCumulativeX128 string, blockTimestamp int64, err error)
 
 	GetPendingProtocolFees() map[string]int64
 
@@ -228,8 +244,6 @@ type IPoolGetter interface {
 
 	GetWithdrawalFee() uint64
 
-	GetTWAP(poolPath string, secondsAgo uint32) (int32, *u256.Uint, error)
-
 	GetPools() *rotree.ReadOnlyTree
 	GetFeeAmountTickSpacings() map[uint32]int32
 
@@ -239,7 +253,6 @@ type IPoolGetter interface {
 
 	GetTickInfo(poolPath string, tick int32) (TickInfo, error)
 	GetTickBitmaps(poolPath string, wordPos int16) (string, error)
-	GetObservationState(poolPath string) (*ObservationState, error)
 }
 
 // IPoolStore interface defines the storage abstraction for pool data.

--- a/contract/r/gnoswap/pool/types.gno
+++ b/contract/r/gnoswap/pool/types.gno
@@ -143,22 +143,57 @@ type IPoolSwap interface {
 	SetFeeProtocol(_ int, rlm realm, feeProtocol0, feeProtocol1 uint8)
 }
 
-// IPoolOracle interface defines the pool's Uniswap-V3-aligned oracle surface.
+// IPoolOracle defines the pool's Uniswap V3-aligned oracle surface.
+//
+// Its public methods mirror the relevant Uniswap V3 pool-state, derived-state,
+// and action specifications, adapted for GnoSwap's singleton pool realm: every
+// operation identifies its pool with poolPath, and uint values cross the public
+// boundary using GnoSwap types or decimal strings rather than the EVM ABI.
+//
+// ref: https://github.com/Uniswap/v3-core/blob/d0831dc6b8a318df3872b6d68f6de135c9f3ec29/contracts/interfaces/IUniswapV3PoolState.sol#L21-L32
+// ref: https://github.com/Uniswap/v3-core/blob/d0831dc6b8a318df3872b6d68f6de135c9f3ec29/contracts/interfaces/pool/IUniswapV3PoolDerivedState.sol#L18-L39
 type IPoolOracle interface {
+	// GetSlot0 returns a safe copy of a pool's price, tick, protocol-fee, lock,
+	// and oracle cursor/capacity state, corresponding to Uniswap V3 slot0().
+	//
+	// ref: https://github.com/Uniswap/v3-core/blob/d0831dc6b8a318df3872b6d68f6de135c9f3ec29/contracts/interfaces/IUniswapV3PoolState.sol#L21-L32
 	GetSlot0(poolPath string) Slot0
 
+	// GetObservationAt returns the observation stored at index, corresponding to
+	// Uniswap V3 observations(uint256). An in-range uninitialized slot returns a
+	// zero observation; an out-of-range index returns an error.
+	//
+	// ref: https://github.com/Uniswap/v3-core/blob/d0831dc6b8a318df3872b6d68f6de135c9f3ec29/contracts/interfaces/IUniswapV3PoolState.sol#L99-L115
 	GetObservationAt(poolPath string, index uint16) (Observation, error)
 
+	// Observe returns tick and seconds-per-liquidity cumulatives for every
+	// requested lookback, corresponding to Uniswap V3 observe(uint32[]).
+	//
+	// ref: https://github.com/Uniswap/v3-core/blob/d0831dc6b8a318df3872b6d68f6de135c9f3ec29/contracts/interfaces/pool/IUniswapV3PoolDerivedState.sol#L18-L21
 	Observe(poolPath string, secondsAgos []uint32) ([]int64, []string, error)
 
+	// SnapshotCumulativesInside returns accumulators accrued while the pool price
+	// was inside [tickLower, tickUpper), corresponding to Uniswap V3
+	// snapshotCumulativesInside(int24,int24).
+	//
+	// ref: https://github.com/Uniswap/v3-core/blob/d0831dc6b8a318df3872b6d68f6de135c9f3ec29/contracts/interfaces/pool/IUniswapV3PoolDerivedState.sol#L23-L39
 	SnapshotCumulativesInside(
 		poolPath string,
 		tickLower int32,
 		tickUpper int32,
 	) (int64, *u256.Uint, uint32, error)
 
+	// OracleConsult returns the arithmetic mean tick and harmonic mean liquidity
+	// over secondsAgo, following Uniswap V3 periphery's OracleLibrary.consult.
+	//
+	// ref: https://github.com/Uniswap/v3-periphery/blob/0682387198a24c7cd63566a2c58398533860a5d1/contracts/libraries/OracleLibrary.sol#L16-L41
 	OracleConsult(poolPath string, secondsAgo uint32) (int32, *u256.Uint, error)
 
+	// IncreaseObservationCardinalityNext schedules growth of the circular
+	// observation buffer, corresponding to Uniswap V3
+	// increaseObservationCardinalityNext(uint16).
+	//
+	// ref: https://github.com/Uniswap/v3-core/blob/d0831dc6b8a318df3872b6d68f6de135c9f3ec29/contracts/interfaces/pool/IUniswapV3PoolActions.sol#L98-L102
 	IncreaseObservationCardinalityNext(
 		_ int,
 		rlm realm,

--- a/contract/r/gnoswap/pool/upgrade_test.gno
+++ b/contract/r/gnoswap/pool/upgrade_test.gno
@@ -1034,65 +1034,6 @@ func TestGetPositionFeeGrowthInsideLastX128(cur realm, t *testing.T) {
 	}
 }
 
-// TestGetLastObservation tests the GetLastObservation proxy function
-func TestGetLastObservation(cur realm, t *testing.T) {
-	tests := []struct {
-		name              string
-		setup             func(cur realm, t *testing.T)
-		poolPath          string
-		callerRealm       runtime.Realm
-		expectedTick      int64
-		expectedSqrt      string
-		expectedTimestamp int64
-	}{
-		{
-			name: "get last observation is success",
-			setup: func(cur realm, t *testing.T) {
-				testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/pool/v1"))
-				RegisterInitializer(cross(cur), makeMockInitializer("v1"))
-				testing.SetRealm(testing.NewUserRealm(adminAddr))
-				UpgradeImpl(cross(cur), "gno.land/r/gnoswap/pool/v1")
-			},
-			poolPath:          "mock_pool_path",
-			callerRealm:       testing.NewCodeRealm("gno.land/r/gnoswap/pool"),
-			expectedTick:      0,
-			expectedSqrt:      "0",
-			expectedTimestamp: 0,
-		},
-	}
-
-	for _, tt := range tests {
-		// Setup
-		resetTestState(t)
-
-		if tt.setup != nil {
-			tt.setup(cur, t)
-		}
-
-		mockPool := implementation.(*MockPool)
-		mockPool.Response.Set("GetLastObservation", tt.expectedTick, tt.expectedSqrt, tt.expectedTimestamp)
-
-		testing.SetRealm(tt.callerRealm)
-
-		// Action
-		tick, sqrt, timestamp, _ := GetLastObservation(tt.poolPath)
-
-		// Assert
-		if mockPool.Response.CallCount("GetLastObservation") != 1 {
-			t.Error("GetLastObservation was not called on the implementation")
-		}
-		if tick != tt.expectedTick {
-			t.Errorf("GetLastObservation() tick = %v, want %v", tick, tt.expectedTick)
-		}
-		if sqrt != tt.expectedSqrt {
-			t.Errorf("GetLastObservation() sqrt = %v, want %v", sqrt, tt.expectedSqrt)
-		}
-		if timestamp != tt.expectedTimestamp {
-			t.Errorf("GetLastObservation() timestamp = %v, want %v", timestamp, tt.expectedTimestamp)
-		}
-	}
-}
-
 // TestExistsPoolPath tests the ExistsPoolPath proxy function
 func TestExistsPoolPath(cur realm, t *testing.T) {
 	tests := []struct {
@@ -1142,15 +1083,55 @@ func TestExistsPoolPath(cur realm, t *testing.T) {
 	}
 }
 
-// TestGetTWAP tests the GetTWAP proxy function
-func TestGetTWAP(cur realm, t *testing.T) {
+// TestSnapshotCumulativesInside tests the SnapshotCumulativesInside proxy function.
+func TestSnapshotCumulativesInside(cur realm, t *testing.T) {
+	resetTestState(t)
+
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/pool/v1"))
+	RegisterInitializer(cross(cur), makeMockInitializer("v1"))
+	testing.SetRealm(testing.NewUserRealm(adminAddr))
+	UpgradeImpl(cross(cur), "gno.land/r/gnoswap/pool/v1")
+
+	mockPool := implementation.(*MockPool)
+	mockPool.Response.Set(
+		"SnapshotCumulativesInside",
+		int64(7),
+		u256.MustFromDecimal("8000"),
+		uint32(9),
+		nil,
+	)
+
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/pool"))
+
+	// Action
+	tickCumulativeInside, secondsPerLiquidityInsideX128, secondsInside, err := SnapshotCumulativesInside("mock_pool_path", -100, 100)
+	// Assert
+	if err != nil {
+		t.Fatalf("SnapshotCumulativesInside() error = %v", err)
+	}
+	if mockPool.Response.CallCount("SnapshotCumulativesInside") != 1 {
+		t.Error("SnapshotCumulativesInside was not called on the implementation")
+	}
+	if tickCumulativeInside != 7 {
+		t.Errorf("SnapshotCumulativesInside() tick = %v, want %v", tickCumulativeInside, int64(7))
+	}
+	if secondsPerLiquidityInsideX128 != "8000" {
+		t.Errorf("SnapshotCumulativesInside() secondsPerLiquidity = %v, want %v", secondsPerLiquidityInsideX128, "8000")
+	}
+	if secondsInside != 9 {
+		t.Errorf("SnapshotCumulativesInside() seconds = %v, want %v", secondsInside, uint32(9))
+	}
+}
+
+// TestOracleConsult tests the OracleConsult proxy function.
+func TestOracleConsult(cur realm, t *testing.T) {
 	tests := []struct {
 		name         string
 		setup        func(cur realm, t *testing.T)
 		poolPath     string
 		secondsAgo   uint32
 		callerRealm  runtime.Realm
-		expectedTWAP int32
+		expectedTick int32
 	}{
 		{
 			name: "api get twap is success",
@@ -1163,7 +1144,7 @@ func TestGetTWAP(cur realm, t *testing.T) {
 			poolPath:     "mock_pool_path",
 			secondsAgo:   3600,
 			callerRealm:  testing.NewCodeRealm("gno.land/r/gnoswap/pool"),
-			expectedTWAP: 0,
+			expectedTick: 0,
 		},
 	}
 
@@ -1176,19 +1157,19 @@ func TestGetTWAP(cur realm, t *testing.T) {
 		}
 
 		mockPool := implementation.(*MockPool)
-		mockPool.Response.Set("GetTWAP", tt.expectedTWAP, u256.Zero(), errors.New(""))
+		mockPool.Response.Set("OracleConsult", tt.expectedTick, u256.Zero(), errors.New(""))
 
 		testing.SetRealm(tt.callerRealm)
 
 		// Action
-		twap, _, _ := GetTWAP(tt.poolPath, tt.secondsAgo)
+		arithmeticMeanTick, _, _ := OracleConsult(tt.poolPath, tt.secondsAgo)
 
 		// Assert
-		if mockPool.Response.CallCount("GetTWAP") != 1 {
-			t.Error("GetTWAP was not called on the implementation")
+		if mockPool.Response.CallCount("OracleConsult") != 1 {
+			t.Error("OracleConsult was not called on the implementation")
 		}
-		if twap != tt.expectedTWAP {
-			t.Errorf("GetTWAP() = %v, want %v", twap, tt.expectedTWAP)
+		if arithmeticMeanTick != tt.expectedTick {
+			t.Errorf("OracleConsult() = %v, want %v", arithmeticMeanTick, tt.expectedTick)
 		}
 	}
 }

--- a/contract/r/gnoswap/pool/v1/getter.gno
+++ b/contract/r/gnoswap/pool/v1/getter.gno
@@ -2,6 +2,7 @@ package pool
 
 import (
 	"errors"
+	"time"
 
 	u256 "gno.land/p/gnoswap/uint256"
 	rotree "gno.land/p/nt/bptree/v0/rotree"
@@ -99,6 +100,77 @@ func (i *poolV1) GetSlot0Unlocked(poolPath string) (bool, error) {
 		return false, err
 	}
 	return pool.Slot0Unlocked(), nil
+}
+
+func (i *poolV1) GetSlot0(poolPath string) pl.Slot0 {
+	return i.mustGetPool(poolPath).Slot0()
+}
+
+func (i *poolV1) GetObservationAt(poolPath string, index uint16) (pl.Observation, error) {
+	pool, err := i.getPool(poolPath)
+	if err != nil {
+		return *pl.NewDefaultObservation(), err
+	}
+
+	// Uniswap's observations(uint256) getter is backed by a fixed-size array:
+	// an in-range but never-written slot returns the zero observation, while an
+	// out-of-range index reverts.
+	if index >= maxObservationCardinality {
+		return *pl.NewDefaultObservation(), makeErrorWithDetails(errDataNotFound, ufmt.Sprintf("observation index %d out of range", index))
+	}
+
+	observationState := pool.ObservationState()
+	if observationState == nil {
+		return *pl.NewDefaultObservation(), nil
+	}
+
+	observation, ok := observationState.ObservationAt(index)
+	if !ok || observation == nil {
+		return *pl.NewDefaultObservation(), nil
+	}
+
+	return *observation.Clone(), nil
+}
+
+// Observe returns the tick and seconds-per-liquidity cumulatives for each
+// requested lookback. It reads the current block timestamp once and never
+// writes an observation, matching Uniswap V3's view-only observe call.
+func (i *poolV1) Observe(poolPath string, secondsAgos []uint32) ([]int64, []string, error) {
+	pool, err := i.getPool(poolPath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	observationState := pool.ObservationState()
+	if observationState == nil {
+		return nil, nil, errors.New("observation state not initialized")
+	}
+
+	slot0 := pool.Slot0()
+	return observe(
+		observationState,
+		time.Now().Unix(),
+		secondsAgos,
+		slot0.Tick(),
+		slot0.ObservationIndex(),
+		pool.Liquidity(),
+		slot0.ObservationCardinality(),
+	)
+}
+
+// SnapshotCumulativesInside returns the oracle accumulators that accrued while
+// the pool price was inside [tickLower, tickUpper).
+func (i *poolV1) SnapshotCumulativesInside(
+	poolPath string,
+	tickLower int32,
+	tickUpper int32,
+) (int64, *u256.Uint, uint32, error) {
+	pool, err := i.getPool(poolPath)
+	if err != nil {
+		return 0, nil, 0, err
+	}
+
+	return snapshotCumulativesInside(pool, tickLower, tickUpper)
 }
 
 func (i *poolV1) GetFeeGrowthGlobal0X128(poolPath string) (*u256.Uint, error) {
@@ -419,20 +491,20 @@ func (i *poolV1) GetWithdrawalFee() uint64 {
 	return i.store.GetWithdrawalFeeBPS()
 }
 
-// GetTWAP returns the time-weighted average price for a pool over a specified period
+// OracleConsult returns the time-weighted average price for a pool over a specified period.
 //
 // Parameters:
 //   - poolPath: The path of the pool (e.g., "gno.land/r/demo/bar:gno.land/r/demo/foo:500")
 //   - secondsAgo: Number of seconds ago to calculate TWAP from
 //
-// Returns TWAP tick and error
-func (i *poolV1) GetTWAP(poolPath string, secondsAgo uint32) (int32, *u256.Uint, error) {
+// Returns the arithmetic mean tick and harmonic mean liquidity.
+func (i *poolV1) OracleConsult(poolPath string, secondsAgo uint32) (int32, *u256.Uint, error) {
 	pool, err := i.getPool(poolPath)
 	if err != nil {
 		return 0, nil, err
 	}
 
-	tick, liquidity, err := getTWAP(pool, secondsAgo)
+	tick, liquidity, err := oracleConsult(pool, secondsAgo)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -509,19 +581,4 @@ func (i *poolV1) GetTickBitmaps(poolPath string, wordPos int16) (string, error) 
 	}
 
 	return tickBitmap, nil
-}
-
-// GetObservationState returns the observation state for a pool.
-func (i *poolV1) GetObservationState(poolPath string) (*pl.ObservationState, error) {
-	pool, err := i.getPool(poolPath)
-	if err != nil {
-		return nil, err
-	}
-
-	observationState := pool.ObservationState()
-	if observationState == nil {
-		return nil, makeErrorWithDetails(errDataNotFound, ufmt.Sprintf("observation state not found for pool %s", poolPath))
-	}
-
-	return observationState, nil
 }

--- a/contract/r/gnoswap/pool/v1/getter.gno
+++ b/contract/r/gnoswap/pool/v1/getter.gno
@@ -454,35 +454,6 @@ func (i *poolV1) ExistsPoolPath(poolPath string) bool {
 	return pools.Has(poolPath)
 }
 
-func (i *poolV1) GetLastObservation(poolPath string) (
-	tickCumulative int64,
-	secondsPerLiquidityCumulativeX128 string,
-	blockTimestamp int64,
-	err error,
-) {
-	pool, err := i.getPool(poolPath)
-	if err != nil {
-		return 0, "", 0, err
-	}
-	observationState := pool.ObservationState()
-
-	if observationState == nil {
-		return 0, "0", 0, nil
-	}
-
-	slot0 := pool.Slot0()
-	lastObservation, err := observationAt(observationState, slot0.ObservationIndex())
-	if err != nil {
-		return 0, "0", 0, nil
-	}
-
-	tickCumulative = lastObservation.TickCumulative()
-	secondsPerLiquidityCumulativeX128 = lastObservation.SecondsPerLiquidityCumulativeX128()
-	blockTimestamp = lastObservation.BlockTimestamp()
-
-	return tickCumulative, secondsPerLiquidityCumulativeX128, blockTimestamp, nil
-}
-
 func (i *poolV1) GetPoolCreationFee() int64 {
 	return i.store.GetPoolCreationFee()
 }

--- a/contract/r/gnoswap/pool/v1/getter_test.gno
+++ b/contract/r/gnoswap/pool/v1/getter_test.gno
@@ -299,6 +299,54 @@ func TestGetters(cur realm, t *testing.T) {
 	})
 }
 
+func TestGetObservationAtReturnsDefaultForUninitializedSlot(cur realm, t *testing.T) {
+	testInitData(cur, t)
+
+	observation, err := getMockInstance().GetObservationAt("token0:token1:3000", 2)
+	uassert.NoError(t, err)
+	uassert.Equal(t, int64(0), observation.BlockTimestamp())
+	uassert.Equal(t, int64(0), observation.TickCumulative())
+	uassert.Equal(t, "0", observation.SecondsPerLiquidityCumulativeX128())
+	uassert.Equal(t, false, observation.Initialized())
+
+	_, err = getMockInstance().GetObservationAt("token0:token1:3000", maxObservationCardinality)
+	uassert.ErrorContains(t, err, "out of range")
+}
+
+func TestObserve(cur realm, t *testing.T) {
+	testInitData(cur, t)
+
+	pool := getMockInstance().mustGetPool("token0:token1:3000")
+	slot0Before := pool.Slot0()
+	observationBefore, err := observationAt(pool.ObservationState(), slot0Before.ObservationIndex())
+	uassert.NoError(t, err)
+	observationTimestampBefore := observationBefore.BlockTimestamp()
+	observationTickCumulativeBefore := observationBefore.TickCumulative()
+	observationSecondsPerLiquidityBefore := observationBefore.SecondsPerLiquidityCumulativeX128()
+
+	tickCumulatives, secondsPerLiquidityCumulativeX128s, err := getMockInstance().Observe(
+		"token0:token1:3000",
+		[]uint32{0, 0},
+	)
+	uassert.NoError(t, err)
+	uassert.Equal(t, 2, len(tickCumulatives))
+	uassert.Equal(t, 2, len(secondsPerLiquidityCumulativeX128s))
+	uassert.Equal(t, tickCumulatives[0], tickCumulatives[1])
+	uassert.Equal(t, secondsPerLiquidityCumulativeX128s[0], secondsPerLiquidityCumulativeX128s[1])
+
+	slot0After := pool.Slot0()
+	observationAfter, err := observationAt(pool.ObservationState(), slot0After.ObservationIndex())
+	uassert.NoError(t, err)
+	uassert.Equal(t, slot0Before.ObservationIndex(), slot0After.ObservationIndex())
+	uassert.Equal(t, slot0Before.ObservationCardinality(), slot0After.ObservationCardinality())
+	uassert.Equal(t, observationTimestampBefore, observationAfter.BlockTimestamp())
+	uassert.Equal(t, observationTickCumulativeBefore, observationAfter.TickCumulative())
+	uassert.Equal(t, observationSecondsPerLiquidityBefore, observationAfter.SecondsPerLiquidityCumulativeX128())
+
+	_, _, err = getMockInstance().Observe("missing:pool:3000", []uint32{0})
+	uassert.Error(t, err)
+}
+
 func TestPositionGetters(cur realm, t *testing.T) {
 	tests := []struct {
 		name                             string

--- a/contract/r/gnoswap/pool/v1/oracle.gno
+++ b/contract/r/gnoswap/pool/v1/oracle.gno
@@ -12,9 +12,9 @@ import (
 // maxObservationCardinality defines the maximum number of observations to store
 const maxObservationCardinality uint16 = 65535
 
-// GetTWAP calculates the time-weighted average price between two points in time
-// Returns the arithmetic mean tick and harmonic mean liquidity over the time period
-func getTWAP(p *pl.Pool, secondsAgo uint32) (int32, *u256.Uint, error) {
+// oracleConsult calculates the time-weighted average price between two points in time.
+// It returns the arithmetic mean tick and harmonic mean liquidity over the time period.
+func oracleConsult(p *pl.Pool, secondsAgo uint32) (int32, *u256.Uint, error) {
 	if secondsAgo == 0 {
 		return 0, nil, errors.New("secondsAgo must be greater than 0")
 	}
@@ -63,6 +63,76 @@ func getTWAP(p *pl.Pool, secondsAgo uint32) (int32, *u256.Uint, error) {
 	harmonicMeanLiquidity := u256.Zero().Div(secondsAgoX160, denominator)
 
 	return arithmeticMeanTick, harmonicMeanLiquidity, nil
+}
+
+// snapshotCumulativesInside returns the accumulators that accrued while the
+// current price was inside [tickLower, tickUpper), following Uniswap V3's
+// snapshotCumulativesInside flow.
+func snapshotCumulativesInside(
+	p *pl.Pool,
+	tickLower int32,
+	tickUpper int32,
+) (int64, *u256.Uint, uint32, error) {
+	if err := validateTicks(tickLower, tickUpper); err != nil {
+		return 0, nil, 0, err
+	}
+
+	lower := getTick(p, tickLower)
+	if !lower.Initialized() {
+		return 0, nil, 0, makeErrorWithDetails(errDataNotFound, "lower tick is not initialized")
+	}
+
+	upper := getTick(p, tickUpper)
+	if !upper.Initialized() {
+		return 0, nil, 0, makeErrorWithDetails(errDataNotFound, "upper tick is not initialized")
+	}
+
+	lowerSecondsPerLiquidityOutsideX128 := u256.MustFromDecimal(lower.SecondsPerLiquidityOutsideX128())
+	upperSecondsPerLiquidityOutsideX128 := u256.MustFromDecimal(upper.SecondsPerLiquidityOutsideX128())
+	slot0 := p.Slot0()
+
+	if slot0.Tick() < tickLower {
+		return lower.TickCumulativeOutside() - upper.TickCumulativeOutside(),
+			u256.Zero().Sub(lowerSecondsPerLiquidityOutsideX128, upperSecondsPerLiquidityOutsideX128),
+			lower.SecondsOutside() - upper.SecondsOutside(), nil
+	}
+
+	if slot0.Tick() < tickUpper {
+		observationState := p.ObservationState()
+		if observationState == nil {
+			return 0, nil, 0, errors.New("observation state not initialized")
+		}
+
+		currentTime := time.Now().Unix()
+		tickCumulative, secondsPerLiquidityCumulativeX128, err := observeSingle(
+			observationState,
+			currentTime,
+			0,
+			slot0.Tick(),
+			slot0.ObservationIndex(),
+			p.Liquidity(),
+			slot0.ObservationCardinality(),
+		)
+		if err != nil {
+			return 0, nil, 0, err
+		}
+
+		secondsPerLiquidityInsideX128 := u256.Zero().Sub(
+			u256.Zero().Sub(
+				u256.MustFromDecimal(secondsPerLiquidityCumulativeX128),
+				lowerSecondsPerLiquidityOutsideX128,
+			),
+			upperSecondsPerLiquidityOutsideX128,
+		)
+
+		return tickCumulative - lower.TickCumulativeOutside() - upper.TickCumulativeOutside(),
+			secondsPerLiquidityInsideX128,
+			uint32(currentTime) - lower.SecondsOutside() - upper.SecondsOutside(), nil
+	}
+
+	return upper.TickCumulativeOutside() - lower.TickCumulativeOutside(),
+		u256.Zero().Sub(upperSecondsPerLiquidityOutsideX128, lowerSecondsPerLiquidityOutsideX128),
+		upper.SecondsOutside() - lower.SecondsOutside(), nil
 }
 
 func transform(last *pl.Observation, blockTimestamp int64, tick int32, liquidity *u256.Uint) (*pl.Observation, error) {

--- a/contract/r/gnoswap/pool/v1/oracle_integration_test.gno
+++ b/contract/r/gnoswap/pool/v1/oracle_integration_test.gno
@@ -30,7 +30,7 @@ func TestOracle_SwapScenarios(cur realm, t *testing.T) {
 			},
 			verifyFn: func(t *testing.T, pool *pl.Pool, scenarios []swapScenario) {
 				// Now calculate TWAP from the beginning
-				// We can't use GetTWAP directly because it uses time.Now()
+				// We can't use OracleConsult directly because it uses time.Now()
 				// Instead, we'll test the observation data directly
 				observationState := pool.ObservationState()
 				slot0 := pool.Slot0()

--- a/contract/r/gnoswap/pool/v1/oracle_test.gno
+++ b/contract/r/gnoswap/pool/v1/oracle_test.gno
@@ -250,7 +250,7 @@ func TestPool_IncreaseObservationCardinalityNext(cur realm, t *testing.T) {
 }
 
 // Verify TWAP rounding for a variety of tickDelta/secondsAgo combinations
-func TestGetTWAP_RoundingTable(cur realm, t *testing.T) {
+func TestOracleConsult_RoundingTable(cur realm, t *testing.T) {
 	tests := []struct {
 		name       string
 		tickDelta  int64
@@ -300,16 +300,16 @@ func TestGetTWAP_RoundingTable(cur realm, t *testing.T) {
 			slot0.SetObservationCardinalityNext(2)
 			pool.SetSlot0(slot0)
 
-			twapTick, _, err := getTWAP(pool, tt.secondsAgo)
-			uassert.NoError(t, err, "getTWAP should succeed for configured observations")
+			twapTick, _, err := oracleConsult(pool, tt.secondsAgo)
+			uassert.NoError(t, err, "oracleConsult should succeed for configured observations")
 			uassert.Equal(t, tt.expected, twapTick, "unexpected TWAP tick")
 		})
 	}
 }
 
-// TestGetTWAP_HarmonicMeanLiquidity tests harmonic mean liquidity calculation
+// TestOracleConsult_HarmonicMeanLiquidity tests harmonic mean liquidity calculation.
 // Test cases from Uniswap V3 OracleLibrary.spec.ts
-func TestGetTWAP_HarmonicMeanLiquidity(cur realm, t *testing.T) {
+func TestOracleConsult_HarmonicMeanLiquidity(cur realm, t *testing.T) {
 	// Helper function to calculate expected harmonic mean liquidity
 	// Matches Uniswap's calculateHarmonicAvgLiq function
 	calculateHarmonicAvgLiq := func(period uint32, secondsPerLiq0, secondsPerLiq1 *u256.Uint) *u256.Uint {
@@ -368,8 +368,8 @@ func TestGetTWAP_HarmonicMeanLiquidity(cur realm, t *testing.T) {
 			slot0.SetObservationCardinalityNext(2)
 			pool.SetSlot0(slot0)
 
-			arithmeticMeanTick, harmonicMeanLiquidity, err := getTWAP(pool, tt.secondsAgo)
-			uassert.NoError(t, err, "getTWAP should succeed")
+			arithmeticMeanTick, harmonicMeanLiquidity, err := oracleConsult(pool, tt.secondsAgo)
+			uassert.NoError(t, err, "oracleConsult should succeed")
 
 			// Check arithmetic mean tick
 			uassert.Equal(t, tt.expectedArithmeticMeanTick, arithmeticMeanTick, "unexpected arithmetic mean tick")
@@ -388,8 +388,8 @@ func TestGetTWAP_HarmonicMeanLiquidity(cur realm, t *testing.T) {
 	}
 }
 
-// TestGetTWAP_ErrorCases tests error scenarios for TWAP calculation
-func TestGetTWAP_ErrorCases(cur realm, t *testing.T) {
+// TestOracleConsult_ErrorCases tests error scenarios for TWAP calculation.
+func TestOracleConsult_ErrorCases(cur realm, t *testing.T) {
 	tests := []struct {
 		name          string
 		setupPool     func() *pl.Pool
@@ -421,7 +421,7 @@ func TestGetTWAP_ErrorCases(cur realm, t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
 			pool := tt.setupPool()
-			_, _, err := getTWAP(pool, tt.secondsAgo)
+			_, _, err := oracleConsult(pool, tt.secondsAgo)
 			uassert.ErrorContains(t, err, tt.expectedError)
 		})
 	}

--- a/contract/r/gnoswap/pool/v1/snapshot_cumulatives_inside_test.gno
+++ b/contract/r/gnoswap/pool/v1/snapshot_cumulatives_inside_test.gno
@@ -1,0 +1,217 @@
+package pool
+
+import (
+	"testing"
+
+	"gno.land/p/gnoswap/consts"
+	u256 "gno.land/p/gnoswap/uint256"
+	uassert "gno.land/p/nt/uassert/v0"
+	pl "gno.land/r/gnoswap/pool"
+)
+
+type snapshotCumulativesInsideCase struct {
+	name                 string
+	currentTick          int32
+	lower                pl.TickInfo
+	upper                pl.TickInfo
+	observationTick      int64
+	observationLiquidity string
+	wantTick             int64
+	wantLiquidity        string
+	wantSeconds          uint32
+}
+
+func TestSnapshotCumulativesInside_RangePosition(cur realm, t *testing.T) {
+	tests := []snapshotCumulativesInsideCase{
+		{
+			name:                 "below range subtracts upper outside accumulators",
+			currentTick:          -20,
+			lower:                newSnapshotTickInfo(100, "900", 50, true),
+			upper:                newSnapshotTickInfo(40, "300", 20, true),
+			observationTick:      0,
+			observationLiquidity: "0",
+			wantTick:             60,
+			wantLiquidity:        "600",
+			wantSeconds:          30,
+		},
+		{
+			name:                 "inside range subtracts both outside accumulators from current",
+			currentTick:          0,
+			lower:                newSnapshotTickInfo(100, "1000", 10, true),
+			upper:                newSnapshotTickInfo(200, "2000", 20, true),
+			observationTick:      1000,
+			observationLiquidity: "5000",
+			wantTick:             700,
+			wantLiquidity:        "2000",
+			wantSeconds:          70,
+		},
+		{
+			name:                 "above range subtracts lower outside accumulators",
+			currentTick:          20,
+			lower:                newSnapshotTickInfo(40, "300", 20, true),
+			upper:                newSnapshotTickInfo(100, "900", 50, true),
+			observationTick:      0,
+			observationLiquidity: "0",
+			wantTick:             60,
+			wantLiquidity:        "600",
+			wantSeconds:          30,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
+			restoreContext := setOracleTestContext(100)
+			defer restoreContext()
+
+			pool := newSnapshotCumulativesInsidePool(
+				tt.currentTick,
+				-10,
+				10,
+				100,
+				tt.observationTick,
+				tt.observationLiquidity,
+				tt.lower,
+				tt.upper,
+			)
+
+			tickCumulativeInside, secondsPerLiquidityInsideX128, secondsInside, err := snapshotCumulativesInside(pool, -10, 10)
+			uassert.NoError(t, err)
+			uassert.Equal(t, tt.wantTick, tickCumulativeInside)
+			uassert.Equal(t, tt.wantLiquidity, secondsPerLiquidityInsideX128.ToString())
+			uassert.Equal(t, tt.wantSeconds, secondsInside)
+		})
+	}
+}
+
+func TestSnapshotCumulativesInside_UsesCounterfactualCurrentObservation(cur realm, t *testing.T) {
+	restoreContext := setOracleTestContext(100)
+	defer restoreContext()
+
+	pool := newSnapshotCumulativesInsidePool(
+		10,
+		-10,
+		20,
+		90,
+		900,
+		"0",
+		newSnapshotTickInfo(100, "0", 10, true),
+		newSnapshotTickInfo(200, "0", 20, true),
+	)
+	pool.SetLiquidity(u256.One())
+
+	observationBefore, ok := pool.ObservationState().ObservationAt(0)
+	uassert.True(t, ok)
+	beforeTimestamp := observationBefore.BlockTimestamp()
+	beforeTickCumulative := observationBefore.TickCumulative()
+	beforeSecondsPerLiquidity := observationBefore.SecondsPerLiquidityCumulativeX128()
+	slot0Before := pool.Slot0()
+
+	tickCumulativeInside, secondsPerLiquidityInsideX128, secondsInside, err := snapshotCumulativesInside(pool, -10, 20)
+	uassert.NoError(t, err)
+	uassert.Equal(t, int64(700), tickCumulativeInside)
+	uassert.Equal(t, u256.Zero().Mul(u256.NewUint(10), consts.Q128()).ToString(), secondsPerLiquidityInsideX128.ToString())
+	uassert.Equal(t, uint32(70), secondsInside)
+
+	observationAfter, ok := pool.ObservationState().ObservationAt(0)
+	uassert.True(t, ok)
+	uassert.Equal(t, beforeTimestamp, observationAfter.BlockTimestamp())
+	uassert.Equal(t, beforeTickCumulative, observationAfter.TickCumulative())
+	uassert.Equal(t, beforeSecondsPerLiquidity, observationAfter.SecondsPerLiquidityCumulativeX128())
+
+	slot0After := pool.Slot0()
+	uassert.Equal(t, slot0Before.ObservationIndex(), slot0After.ObservationIndex())
+	uassert.Equal(t, slot0Before.ObservationCardinality(), slot0After.ObservationCardinality())
+}
+
+func TestSnapshotCumulativesInside_ValidatesRangeAndTicks(cur realm, t *testing.T) {
+	pool := createTestPool()
+
+	tests := []struct {
+		name      string
+		tickLower int32
+		tickUpper int32
+		wantErr   string
+	}{
+		{
+			name:      "rejects an empty range",
+			tickLower: 0,
+			tickUpper: 0,
+			wantErr:   errInvalidTickRange,
+		},
+		{
+			name:      "rejects a lower tick below the minimum",
+			tickLower: MIN_TICK - 1,
+			tickUpper: 0,
+			wantErr:   errTickLowerInvalid,
+		},
+		{
+			name:      "rejects an upper tick above the maximum",
+			tickLower: 0,
+			tickUpper: MAX_TICK + 1,
+			wantErr:   errTickUpperInvalid,
+		},
+		{
+			name:      "requires initialized lower and upper ticks",
+			tickLower: -10,
+			tickUpper: 10,
+			wantErr:   errDataNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
+			_, _, _, err := snapshotCumulativesInside(pool, tt.tickLower, tt.tickUpper)
+			uassert.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func newSnapshotCumulativesInsidePool(
+	currentTick int32,
+	tickLower int32,
+	tickUpper int32,
+	observationTimestamp int64,
+	observationTickCumulative int64,
+	observationSecondsPerLiquidityX128 string,
+	lower pl.TickInfo,
+	upper pl.TickInfo,
+) *pl.Pool {
+	pool := createTestPool()
+	slot0 := pool.Slot0()
+	slot0.SetTick(currentTick)
+	slot0.SetObservationIndex(0)
+	slot0.SetObservationCardinality(1)
+	slot0.SetObservationCardinalityNext(1)
+	pool.SetSlot0(slot0)
+	pool.SetLiquidity(u256.One())
+
+	observationState := pl.NewObservationState(observationTimestamp)
+	observationState.SetObservation(0, pl.NewObservation(
+		observationTimestamp,
+		observationTickCumulative,
+		observationSecondsPerLiquidityX128,
+		true,
+	))
+	pool.SetObservationState(observationState)
+
+	ticks := pl.NewPoolTicksTree()
+	ticks.Set(pl.EncodeTickKey(tickLower), lower)
+	ticks.Set(pl.EncodeTickKey(tickUpper), upper)
+	pool.SetTicks(ticks)
+
+	return pool
+}
+
+func newSnapshotTickInfo(
+	tickCumulativeOutside int64,
+	secondsPerLiquidityOutsideX128 string,
+	secondsOutside uint32,
+	initialized bool,
+) pl.TickInfo {
+	tickInfo := pl.NewTickInfo()
+	tickInfo.SetTickCumulativeOutside(tickCumulativeOutside)
+	tickInfo.SetSecondsPerLiquidityOutsideX128(secondsPerLiquidityOutsideX128)
+	tickInfo.SetSecondsOutside(secondsOutside)
+	tickInfo.SetInitialized(initialized)
+	return tickInfo
+}

--- a/contract/r/gnoswap/pool/v1/twap_consistency_test.gno
+++ b/contract/r/gnoswap/pool/v1/twap_consistency_test.gno
@@ -182,7 +182,7 @@ func TestOracle_TWAPConsistencyCases(cur realm, t *testing.T) {
 			restoreContext := setOracleTestContext(tt.currentTime)
 			defer restoreContext()
 
-			got, _, err := getTWAP(newTwapConsistencyPool(tt), tt.secondsAgo)
+			got, _, err := oracleConsult(newTwapConsistencyPool(tt), tt.secondsAgo)
 			if tt.wantErr != "" {
 				uassert.ErrorContains(t, err, tt.wantErr)
 				return

--- a/contract/r/gnoswap/position/v1/position.gno
+++ b/contract/r/gnoswap/position/v1/position.gno
@@ -98,10 +98,7 @@ func (p *positionV1) Mint(
 	if err != nil {
 		panic(err)
 	}
-	tickCumulative, secondsPerLiquidityCumulativeX128, observationTimestamp, err := pl.GetLastObservation(processedInput.poolPath)
-	if err != nil {
-		panic(err)
-	}
+	tickCumulative, secondsPerLiquidityCumulativeX128, observationTimestamp := currentPoolObservation(processedInput.poolPath)
 
 	chain.Emit(
 		"Mint",
@@ -211,10 +208,7 @@ func (p *positionV1) IncreaseLiquidity(
 	if err != nil {
 		panic(err)
 	}
-	tickCumulative, secondsPerLiquidityCumulativeX128, observationTimestamp, err := pl.GetLastObservation(poolPath)
-	if err != nil {
-		panic(err)
-	}
+	tickCumulative, secondsPerLiquidityCumulativeX128, observationTimestamp := currentPoolObservation(poolPath)
 	chain.Emit(
 		"IncreaseLiquidity",
 		"prevAddr", previousRealm.Address().String(),
@@ -307,10 +301,7 @@ func (p *positionV1) DecreaseLiquidity(
 	if err != nil {
 		panic(err)
 	}
-	tickCumulative, secondsPerLiquidityCumulativeX128, observationTimestamp, err := pl.GetLastObservation(poolPath)
-	if err != nil {
-		panic(err)
-	}
+	tickCumulative, secondsPerLiquidityCumulativeX128, observationTimestamp := currentPoolObservation(poolPath)
 	chain.Emit(
 		"DecreaseLiquidity",
 		"prevAddr", previousRealm.Address().String(),

--- a/contract/r/gnoswap/position/v1/position.gno
+++ b/contract/r/gnoswap/position/v1/position.gno
@@ -98,7 +98,10 @@ func (p *positionV1) Mint(
 	if err != nil {
 		panic(err)
 	}
-	tickCumulative, secondsPerLiquidityCumulativeX128, observationTimestamp := currentPoolObservation(processedInput.poolPath)
+	tickCumulative, secondsPerLiquidityCumulativeX128, observationTimestamp, err := currentPoolObservation(processedInput.poolPath)
+	if err != nil {
+		panic(err)
+	}
 
 	chain.Emit(
 		"Mint",
@@ -208,7 +211,10 @@ func (p *positionV1) IncreaseLiquidity(
 	if err != nil {
 		panic(err)
 	}
-	tickCumulative, secondsPerLiquidityCumulativeX128, observationTimestamp := currentPoolObservation(poolPath)
+	tickCumulative, secondsPerLiquidityCumulativeX128, observationTimestamp, err := currentPoolObservation(poolPath)
+	if err != nil {
+		panic(err)
+	}
 	chain.Emit(
 		"IncreaseLiquidity",
 		"prevAddr", previousRealm.Address().String(),
@@ -301,7 +307,10 @@ func (p *positionV1) DecreaseLiquidity(
 	if err != nil {
 		panic(err)
 	}
-	tickCumulative, secondsPerLiquidityCumulativeX128, observationTimestamp := currentPoolObservation(poolPath)
+	tickCumulative, secondsPerLiquidityCumulativeX128, observationTimestamp, err := currentPoolObservation(poolPath)
+	if err != nil {
+		panic(err)
+	}
 	chain.Emit(
 		"DecreaseLiquidity",
 		"prevAddr", previousRealm.Address().String(),

--- a/contract/r/gnoswap/position/v1/reposition.gno
+++ b/contract/r/gnoswap/position/v1/reposition.gno
@@ -12,7 +12,6 @@ import (
 	"gno.land/r/gnoswap/common"
 	"gno.land/r/gnoswap/emission"
 	"gno.land/r/gnoswap/halt"
-	pl "gno.land/r/gnoswap/pool"
 )
 
 // Reposition adjusts the price range and liquidity of an existing position.
@@ -118,10 +117,7 @@ func (p *positionV1) Reposition(
 	if err != nil {
 		panic(err)
 	}
-	tickCumulative, secondsPerLiquidityCumulativeX128, observationTimestamp, err := pl.GetLastObservation(poolKey)
-	if err != nil {
-		panic(err)
-	}
+	tickCumulative, secondsPerLiquidityCumulativeX128, observationTimestamp := currentPoolObservation(poolKey)
 
 	chain.Emit(
 		"Reposition",

--- a/contract/r/gnoswap/position/v1/reposition.gno
+++ b/contract/r/gnoswap/position/v1/reposition.gno
@@ -117,7 +117,10 @@ func (p *positionV1) Reposition(
 	if err != nil {
 		panic(err)
 	}
-	tickCumulative, secondsPerLiquidityCumulativeX128, observationTimestamp := currentPoolObservation(poolKey)
+	tickCumulative, secondsPerLiquidityCumulativeX128, observationTimestamp, err := currentPoolObservation(poolKey)
+	if err != nil {
+		panic(err)
+	}
 
 	chain.Emit(
 		"Reposition",

--- a/contract/r/gnoswap/position/v1/utils.gno
+++ b/contract/r/gnoswap/position/v1/utils.gno
@@ -127,12 +127,12 @@ func isSlippageExceeded(amount0, amount1, amount0Min, amount1Min *u256.Uint) boo
 
 // currentPoolObservation derives the latest stored observation from the
 // Uniswap-V3-aligned Slot0 and observations surfaces.
-func currentPoolObservation(poolPath string) (int64, string, int64) {
+func currentPoolObservation(poolPath string) (int64, string, int64, error) {
 	slot0 := pl.GetSlot0(poolPath)
 	observation, err := pl.GetObservationAt(poolPath, slot0.ObservationIndex())
 	if err != nil {
-		return 0, "0", 0
+		return 0, "", 0, err
 	}
 
-	return observation.TickCumulative(), observation.SecondsPerLiquidityCumulativeX128(), observation.BlockTimestamp()
+	return observation.TickCumulative(), observation.SecondsPerLiquidityCumulativeX128(), observation.BlockTimestamp(), nil
 }

--- a/contract/r/gnoswap/position/v1/utils.gno
+++ b/contract/r/gnoswap/position/v1/utils.gno
@@ -124,3 +124,15 @@ func splitOf(poolKey string) (string, string, uint32) {
 func isSlippageExceeded(amount0, amount1, amount0Min, amount1Min *u256.Uint) bool {
 	return !(amount0.Gte(amount0Min) && amount1.Gte(amount1Min))
 }
+
+// currentPoolObservation derives the latest stored observation from the
+// Uniswap-V3-aligned Slot0 and observations surfaces.
+func currentPoolObservation(poolPath string) (int64, string, int64) {
+	slot0 := pl.GetSlot0(poolPath)
+	observation, err := pl.GetObservationAt(poolPath, slot0.ObservationIndex())
+	if err != nil {
+		return 0, "0", 0
+	}
+
+	return observation.TickCumulative(), observation.SecondsPerLiquidityCumulativeX128(), observation.BlockTimestamp()
+}

--- a/contract/r/scenario/getter/pool_getter_filetest.gno
+++ b/contract/r/scenario/getter/pool_getter_filetest.gno
@@ -123,10 +123,6 @@ func main(cur realm) {
 	getLiquidity(cur)
 	println()
 
-	println("[SCENARIO] 2.16. GetLastObservation")
-	getLastObservation(cur)
-	println()
-
 	println("[SCENARIO] 2.17. GetPoolCreationFee")
 	getPoolCreationFee(cur)
 	println()
@@ -255,8 +251,8 @@ func main(cur realm) {
 	getWithdrawalFee(cur)
 	println()
 
-	println("[SCENARIO] 2.50. GetTWAP")
-	getTWAP(cur)
+	println("[SCENARIO] 2.50. OracleConsult")
+	oracleConsult(cur)
 	println()
 
 	println("[SCENARIO] 2.51. GetPool")
@@ -275,8 +271,8 @@ func main(cur realm) {
 	getPosition(cur)
 	println()
 
-	println("[SCENARIO] 2.55. GetObservationState")
-	getObservationState(cur)
+	println("[SCENARIO] 2.55. Observe")
+	observe(cur)
 	println()
 }
 
@@ -480,16 +476,6 @@ func getLiquidity(cur realm) {
 
 	liquidity, _ := pl.GetLiquidity(poolPath)
 	println("[EXPECTED] liquidity:", liquidity)
-}
-
-func getLastObservation(cur realm) {
-	println("[INFO] Check GetLastObservation method")
-	testing.SetRealm(adminRealm)
-
-	tickCumulative, secondsPerLiquidityCumulativeX128, blockTimestamp, _ := pl.GetLastObservation(poolPath)
-	ufmt.Printf("[EXPECTED] tickCumulative: %d\n", tickCumulative)
-	println("[EXPECTED] secondsPerLiquidityCumulativeX128:", secondsPerLiquidityCumulativeX128)
-	ufmt.Printf("[EXPECTED] blockTimestamp: %d\n", blockTimestamp)
 }
 
 func getPoolCreationFee(cur realm) {
@@ -764,13 +750,13 @@ func getWithdrawalFee(cur realm) {
 	ufmt.Printf("[EXPECTED] withdrawal fee: %d\n", withdrawalFee)
 }
 
-func getTWAP(cur realm) {
-	println("[INFO] Check GetTWAP method")
+func oracleConsult(cur realm) {
+	println("[INFO] Check OracleConsult method")
 	testing.SetRealm(adminRealm)
 
-	arithmeticMeanTick, harmonicMeanLiquidity, err := pl.GetTWAP(poolPath, 0)
+	arithmeticMeanTick, harmonicMeanLiquidity, err := pl.OracleConsult(poolPath, 0)
 	if err != nil {
-		println("[EXPECTED] GetTWAP error:", err.Error())
+		println("[EXPECTED] OracleConsult error:", err.Error())
 	} else {
 		ufmt.Printf("[EXPECTED] arithmeticMeanTick: %d\n", arithmeticMeanTick)
 		println("[EXPECTED] harmonicMeanLiquidity:", harmonicMeanLiquidity)
@@ -839,20 +825,18 @@ func getPosition(cur realm) {
 	}
 }
 
-func getObservationState(cur realm) {
-	println("[INFO] Check GetObservationState method")
+func observe(cur realm) {
+	println("[INFO] Check Observe method")
 	testing.SetRealm(adminRealm)
 
-	observationState, err := pl.GetObservationState(poolPath)
+	tickCumulatives, secondsPerLiquidityCumulativeX128s, err := pl.Observe(poolPath, []uint32{0})
 	if err != nil {
-		println("[EXPECTED] GetObservationState error:", err.Error())
+		println("[EXPECTED] Observe error:", err.Error())
 		return
 	}
 
-	slot0 := pl.GetPools().Get(poolPath).(*pl.Pool).Slot0()
-	ufmt.Printf("[EXPECTED] observationState observations: %d\n", len(observationState.Observations()))
-	ufmt.Printf("[EXPECTED] slot0 observationIndex: %d\n", slot0.ObservationIndex())
-	ufmt.Printf("[EXPECTED] slot0 observationCardinality: %d\n", slot0.ObservationCardinality())
+	ufmt.Printf("[EXPECTED] tick cumulatives: %d\n", len(tickCumulatives))
+	ufmt.Printf("[EXPECTED] seconds per liquidity cumulatives: %d\n", len(secondsPerLiquidityCumulativeX128s))
 }
 
 // Output:
@@ -941,12 +925,6 @@ func getObservationState(cur realm) {
 // [SCENARIO] 2.14. GetLiquidity
 // [INFO] Check GetLiquidity method
 // [EXPECTED] liquidity: 100000000
-//
-// [SCENARIO] 2.16. GetLastObservation
-// [INFO] Check GetLastObservation method
-// [EXPECTED] tickCumulative: 0
-// [EXPECTED] secondsPerLiquidityCumulativeX128: 0
-// [EXPECTED] blockTimestamp: 1234567890
 //
 // [SCENARIO] 2.17. GetPoolCreationFee
 // [INFO] Check GetPoolCreationFee method
@@ -1085,9 +1063,9 @@ func getObservationState(cur realm) {
 // [INFO] Check GetWithdrawalFee method
 // [EXPECTED] withdrawal fee: 100
 //
-// [SCENARIO] 2.50. GetTWAP
-// [INFO] Check GetTWAP method
-// [EXPECTED] GetTWAP error: secondsAgo must be greater than 0
+// [SCENARIO] 2.50. OracleConsult
+// [INFO] Check OracleConsult method
+// [EXPECTED] OracleConsult error: secondsAgo must be greater than 0
 //
 // [SCENARIO] 2.51. GetPool
 // [INFO] Check GetPools entry
@@ -1116,8 +1094,8 @@ func getObservationState(cur realm) {
 // [EXPECTED] position tokensOwed0: 0
 // [EXPECTED] position tokensOwed1: 0
 //
-// [SCENARIO] 2.55. GetObservationState
-// [INFO] Check GetObservationState method
-// [EXPECTED] observationState observations: 1
-// [EXPECTED] slot0 observationIndex: 0
-// [EXPECTED] slot0 observationCardinality: 1
+// [SCENARIO] 2.55. Observe
+// [INFO] Check Observe method
+// [EXPECTED] tick cumulatives: 1
+// [EXPECTED] seconds per liquidity cumulatives: 1
+//

--- a/contract/r/scenario/pool/oracle_twap_increased_cardinality_filetest.gno
+++ b/contract/r/scenario/pool/oracle_twap_increased_cardinality_filetest.gno
@@ -176,15 +176,15 @@ func main(cur realm) {
 	println("[SCENARIO] 9. TWAP Queries at Different Intervals")
 	poolPath := barPath + ":" + fooPath + ":" + "500"
 
-	twapTick1h, twapLiquidity1h, _ := pool.GetTWAP(poolPath, quarterSeconds)
+	twapTick1h, twapLiquidity1h, _ := pool.OracleConsult(poolPath, quarterSeconds)
 	ufmt.Printf("[EXPECTED] TWAP for last 1 hour (3600s ago) - tick: %d, liquidity: %s\n", twapTick1h, twapLiquidity1h)
 	println()
 
-	twapTick2h, twapLiquidity2h, _ := pool.GetTWAP(poolPath, halfSeconds)
+	twapTick2h, twapLiquidity2h, _ := pool.OracleConsult(poolPath, halfSeconds)
 	ufmt.Printf("[EXPECTED] TWAP for last 2 hours (7200s ago) - tick: %d, liquidity: %s\n", twapTick2h, twapLiquidity2h)
 	println()
 
-	twapTick4h, twapLiquidity4h, _ := pool.GetTWAP(poolPath, totalSeconds)
+	twapTick4h, twapLiquidity4h, _ := pool.OracleConsult(poolPath, totalSeconds)
 	ufmt.Printf("[EXPECTED] TWAP for last 4 hours (14400s ago) - tick: %d, liquidity: %s\n", twapTick4h, twapLiquidity4h)
 	println()
 

--- a/contract/r/scenario/pool/oracle_twap_multiple_swaps_filetest.gno
+++ b/contract/r/scenario/pool/oracle_twap_multiple_swaps_filetest.gno
@@ -224,15 +224,15 @@ func main(cur realm) {
 	println("[SCENARIO] 12. TWAP Queries at Different Intervals")
 	poolPath := barPath + ":" + fooPath + ":" + "500"
 
-	twapTick1h, twapLiquidity1h, _ := pool.GetTWAP(poolPath, hourSeconds)
+	twapTick1h, twapLiquidity1h, _ := pool.OracleConsult(poolPath, hourSeconds)
 	ufmt.Printf("[EXPECTED] TWAP for last 1 hour (3600s ago) - tick: %d, liquidity: %s\n", twapTick1h, twapLiquidity1h)
 	println()
 
-	twapTick2h, twapLiquidity2h, _ := pool.GetTWAP(poolPath, halfSeconds)
+	twapTick2h, twapLiquidity2h, _ := pool.OracleConsult(poolPath, halfSeconds)
 	ufmt.Printf("[EXPECTED] TWAP for last 2 hours (7200s ago) - tick: %d, liquidity: %s\n", twapTick2h, twapLiquidity2h)
 	println()
 
-	twapTick4h, twapLiquidity4h, _ := pool.GetTWAP(poolPath, totalSeconds)
+	twapTick4h, twapLiquidity4h, _ := pool.OracleConsult(poolPath, totalSeconds)
 	ufmt.Printf("[EXPECTED] TWAP for last 4 hours (14400s ago, complete weighted average) - tick: %d, liquidity: %s\n", twapTick4h, twapLiquidity4h)
 	println()
 

--- a/contract/r/scenario/pool/oracle_twap_no_price_change_filetest.gno
+++ b/contract/r/scenario/pool/oracle_twap_no_price_change_filetest.gno
@@ -3,8 +3,9 @@
 package main
 
 import (
-	"gno.land/p/gnoswap/gnsmath"
 	"testing"
+
+	"gno.land/p/gnoswap/gnsmath"
 
 	ufmt "gno.land/p/nt/ufmt/v0"
 
@@ -95,7 +96,7 @@ func main(cur realm) {
 	// Get initial TWAP (should be current tick since no time has passed)
 	println("[SCENARIO] 3. Initial TWAP Query (0 seconds ago)")
 	poolPath := barPath + ":" + fooPath + ":" + "500"
-	twapTick, twapLiquidity, _ := pool.GetTWAP(poolPath, 0)
+	twapTick, twapLiquidity, _ := pool.OracleConsult(poolPath, 0)
 	ufmt.Printf("[EXPECTED] TWAP at 0 seconds ago - tick: %d, liquidity: %s\n", twapTick, twapLiquidity)
 	println()
 
@@ -108,15 +109,15 @@ func main(cur realm) {
 	// Query TWAP for different periods
 	println("[SCENARIO] 5. TWAP Queries After Time Passed")
 
-	twapTick1h, twapLiquidity1h, _ := pool.GetTWAP(poolPath, hourSeconds)
+	twapTick1h, twapLiquidity1h, _ := pool.OracleConsult(poolPath, hourSeconds)
 	ufmt.Printf("[EXPECTED] TWAP for last 1 hour (3600s ago) - tick: %d, liquidity: %s\n", twapTick1h, twapLiquidity1h)
 	println()
 
-	twapTick2h, twapLiquidity2h, _ := pool.GetTWAP(poolPath, halfSeconds)
+	twapTick2h, twapLiquidity2h, _ := pool.OracleConsult(poolPath, halfSeconds)
 	ufmt.Printf("[EXPECTED] TWAP for last 2 hours (7200s ago) - tick: %d, liquidity: %s\n", twapTick2h, twapLiquidity2h)
 	println()
 
-	twapTick4h, twapLiquidity4h, _ := pool.GetTWAP(poolPath, totalSeconds)
+	twapTick4h, twapLiquidity4h, _ := pool.OracleConsult(poolPath, totalSeconds)
 	ufmt.Printf("[EXPECTED] TWAP for last 4 hours (14400s ago) - tick: %d, liquidity: %s\n", twapTick4h, twapLiquidity4h)
 	println()
 

--- a/contract/r/scenario/pool/oracle_twap_single_swap_filetest.gno
+++ b/contract/r/scenario/pool/oracle_twap_single_swap_filetest.gno
@@ -144,15 +144,15 @@ func main(cur realm) {
 	println("[SCENARIO] 7. TWAP Queries After Price Change")
 	poolPath := barPath + ":" + fooPath + ":" + "500"
 
-	twapTick1h, twapLiquidity1h, _ := pool.GetTWAP(poolPath, hourSeconds)
+	twapTick1h, twapLiquidity1h, _ := pool.OracleConsult(poolPath, hourSeconds)
 	ufmt.Printf("[EXPECTED] TWAP for last 1 hour (3600s ago, recent price) - tick: %d, liquidity: %s\n", twapTick1h, twapLiquidity1h)
 	println()
 
-	twapTick2h, twapLiquidity2h, _ := pool.GetTWAP(poolPath, halfSeconds)
+	twapTick2h, twapLiquidity2h, _ := pool.OracleConsult(poolPath, halfSeconds)
 	ufmt.Printf("[EXPECTED] TWAP for last 2 hours (7200s ago, after price change) - tick: %d, liquidity: %s\n", twapTick2h, twapLiquidity2h)
 	println()
 
-	twapTick4h, twapLiquidity4h, _ := pool.GetTWAP(poolPath, totalSeconds)
+	twapTick4h, twapLiquidity4h, _ := pool.OracleConsult(poolPath, totalSeconds)
 	ufmt.Printf("[EXPECTED] TWAP for last 4 hours (14400s ago, weighted average of both periods) - tick: %d, liquidity: %s\n", twapTick4h, twapLiquidity4h)
 	println()
 

--- a/contract/r/scenario/upgrade/implements/mock/pool/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/mock/pool/test_impl.gno
@@ -440,6 +440,18 @@ func (t *TestPool) GetSlot0(poolPath string) pool.Slot0 {
 	).(pool.Slot0)
 }
 
+func (t *TestPool) GetObservationAt(poolPath string, index uint16) (pool.Observation, error) {
+	result := t.ExecuteFn(
+		"GetObservationAt",
+		func(args ...any) any {
+			observation, err := t.instance.GetObservationAt(args[0].(string), args[1].(uint16))
+			return []any{observation, err}
+		},
+		poolPath, index,
+	).([]any)
+	return result[0].(pool.Observation), result[1].(error)
+}
+
 func (t *TestPool) GetSlot0SqrtPriceX96(poolPath string) (*u256.Uint, error) {
 	result := t.ExecuteFn(
 		"GetSlot0SqrtPriceX96",

--- a/contract/r/scenario/upgrade/implements/mock/pool/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/mock/pool/test_impl.gno
@@ -317,18 +317,6 @@ func (t *TestPool) GetLiquidity(poolPath string) (*u256.Uint, error) {
 	return result[0].(*u256.Uint), result[1].(error)
 }
 
-func (t *TestPool) GetLastObservation(poolPath string) (int64, string, int64, error) {
-	result := t.ExecuteFn(
-		"GetLastObservation",
-		func(args ...any) any {
-			r1, r2, r3, r4 := t.instance.GetLastObservation(args[0].(string))
-			return []any{r1, r2, r3, r4}
-		},
-		poolPath,
-	).([]any)
-	return result[0].(int64), result[1].(string), result[2].(int64), result[3].(error)
-}
-
 func (t *TestPool) GetPoolCreationFee() int64 {
 	return t.ExecuteFn(
 		"GetPoolCreationFee",
@@ -442,6 +430,14 @@ func (t *TestPool) GetSlot0FeeProtocol(poolPath string) (uint8, error) {
 		poolPath,
 	).([]any)
 	return result[0].(uint8), result[1].(error)
+}
+
+func (t *TestPool) GetSlot0(poolPath string) pool.Slot0 {
+	return t.ExecuteFn(
+		"GetSlot0",
+		func(args ...any) any { return t.instance.GetSlot0(args[0].(string)) },
+		poolPath,
+	).(pool.Slot0)
 }
 
 func (t *TestPool) GetSlot0SqrtPriceX96(poolPath string) (*u256.Uint, error) {
@@ -631,16 +627,36 @@ func (t *TestPool) GetWithdrawalFee() uint64 {
 	).(uint64)
 }
 
-func (t *TestPool) GetTWAP(poolPath string, secondsAgo uint32) (int32, *u256.Uint, error) {
+func (t *TestPool) OracleConsult(poolPath string, secondsAgo uint32) (int32, *u256.Uint, error) {
 	result := t.ExecuteFn(
-		"GetTWAP",
+		"OracleConsult",
 		func(args ...any) any {
-			r1, r2, r3 := t.instance.GetTWAP(args[0].(string), args[1].(uint32))
+			r1, r2, r3 := t.instance.OracleConsult(args[0].(string), args[1].(uint32))
 			return []any{r1, r2, r3}
 		},
 		poolPath, secondsAgo,
 	).([]any)
 	return result[0].(int32), result[1].(*u256.Uint), result[2].(error)
+}
+
+func (t *TestPool) SnapshotCumulativesInside(
+	poolPath string,
+	tickLower int32,
+	tickUpper int32,
+) (int64, *u256.Uint, uint32, error) {
+	result := t.ExecuteFn(
+		"SnapshotCumulativesInside",
+		func(args ...any) any {
+			r1, r2, r3, r4 := t.instance.SnapshotCumulativesInside(args[0].(string), args[1].(int32), args[2].(int32))
+			return []any{r1, r2, r3, r4}
+		},
+		poolPath, tickLower, tickUpper,
+	).([]any)
+	if result[3] == nil {
+		return result[0].(int64), result[1].(*u256.Uint), result[2].(uint32), nil
+	}
+
+	return result[0].(int64), result[1].(*u256.Uint), result[2].(uint32), result[3].(error)
 }
 
 func (t *TestPool) GetPools() *rotree.ReadOnlyTree {
@@ -705,16 +721,20 @@ func (t *TestPool) GetTickBitmaps(poolPath string, wordPos int16) (string, error
 	return result[0].(string), result[1].(error)
 }
 
-func (t *TestPool) GetObservationState(poolPath string) (*pool.ObservationState, error) {
+func (t *TestPool) Observe(poolPath string, secondsAgos []uint32) ([]int64, []string, error) {
 	result := t.ExecuteFn(
-		"GetObservationState",
+		"Observe",
 		func(args ...any) any {
-			r1, r2 := t.instance.GetObservationState(args[0].(string))
-			return []any{r1, r2}
+			r1, r2, r3 := t.instance.Observe(args[0].(string), args[1].([]uint32))
+			return []any{r1, r2, r3}
 		},
-		poolPath,
+		poolPath, secondsAgos,
 	).([]any)
-	return result[0].(*pool.ObservationState), result[1].(error)
+	if result[2] == nil {
+		return result[0].([]int64), result[1].([]string), nil
+	}
+
+	return result[0].([]int64), result[1].([]string), result[2].(error)
 }
 
 func (t *TestPool) GetPendingProtocolFees() map[string]int64 {

--- a/contract/r/scenario/upgrade/implements/v2_invalid/pool/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v2_invalid/pool/test_impl.gno
@@ -288,6 +288,13 @@ func (t *TestPool) GetSlot0(poolPath string) pool.Slot0 {
 	return t.instance.GetSlot0(poolPath)
 }
 
+func (t *TestPool) GetObservationAt(poolPath string, index uint16) (pool.Observation, error) {
+	if !t.isActive("GetObservationAt") {
+		panic("test implementation: GetObservationAt not supported")
+	}
+	return t.instance.GetObservationAt(poolPath, index)
+}
+
 func (t *TestPool) GetSlot0SqrtPriceX96(poolPath string) (*u256.Uint, error) {
 	if !t.isActive("GetSlot0SqrtPriceX96") {
 		panic("test implementation: GetSlot0SqrtPriceX96 not supported")

--- a/contract/r/scenario/upgrade/implements/v2_invalid/pool/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v2_invalid/pool/test_impl.gno
@@ -211,13 +211,6 @@ func (t *TestPool) GetLiquidity(poolPath string) (*u256.Uint, error) {
 	return t.instance.GetLiquidity(poolPath)
 }
 
-func (t *TestPool) GetLastObservation(poolPath string) (int64, string, int64, error) {
-	if !t.isActive("GetLastObservation") {
-		panic("test implementation: GetLastObservation not supported")
-	}
-	return t.instance.GetLastObservation(poolPath)
-}
-
 func (t *TestPool) GetPoolCreationFee() int64 {
 	if !t.isActive("GetPoolCreationFee") {
 		panic("test implementation: GetPoolCreationFee not supported")
@@ -286,6 +279,13 @@ func (t *TestPool) GetSlot0FeeProtocol(poolPath string) (uint8, error) {
 		panic("test implementation: GetSlot0FeeProtocol not supported")
 	}
 	return t.instance.GetSlot0FeeProtocol(poolPath)
+}
+
+func (t *TestPool) GetSlot0(poolPath string) pool.Slot0 {
+	if !t.isActive("GetSlot0") {
+		panic("test implementation: GetSlot0 not supported")
+	}
+	return t.instance.GetSlot0(poolPath)
 }
 
 func (t *TestPool) GetSlot0SqrtPriceX96(poolPath string) (*u256.Uint, error) {
@@ -400,11 +400,22 @@ func (t *TestPool) GetWithdrawalFee() uint64 {
 	return t.instance.GetWithdrawalFee()
 }
 
-func (t *TestPool) GetTWAP(poolPath string, secondsAgo uint32) (int32, *u256.Uint, error) {
-	if !t.isActive("GetTWAP") {
-		panic("test implementation: GetTWAP not supported")
+func (t *TestPool) OracleConsult(poolPath string, secondsAgo uint32) (int32, *u256.Uint, error) {
+	if !t.isActive("OracleConsult") {
+		panic("test implementation: OracleConsult not supported")
 	}
-	return t.instance.GetTWAP(poolPath, secondsAgo)
+	return t.instance.OracleConsult(poolPath, secondsAgo)
+}
+
+func (t *TestPool) SnapshotCumulativesInside(
+	poolPath string,
+	tickLower int32,
+	tickUpper int32,
+) (int64, *u256.Uint, uint32, error) {
+	if !t.isActive("SnapshotCumulativesInside") {
+		panic("test implementation: SnapshotCumulativesInside not supported")
+	}
+	return t.instance.SnapshotCumulativesInside(poolPath, tickLower, tickUpper)
 }
 
 func (t *TestPool) GetPools() *rotree.ReadOnlyTree {
@@ -451,11 +462,11 @@ func (t *TestPool) GetTickBitmaps(poolPath string, wordPos int16) (string, error
 	return t.instance.GetTickBitmaps(poolPath, wordPos)
 }
 
-func (t *TestPool) GetObservationState(poolPath string) (*pool.ObservationState, error) {
-	if !t.isActive("GetObservationState") {
-		panic("test implementation: GetObservationState not supported")
+func (t *TestPool) Observe(poolPath string, secondsAgos []uint32) ([]int64, []string, error) {
+	if !t.isActive("Observe") {
+		panic("test implementation: Observe not supported")
 	}
-	return t.instance.GetObservationState(poolPath)
+	return t.instance.Observe(poolPath, secondsAgos)
 }
 
 func (t *TestPool) GetPendingProtocolFees() map[string]int64 {

--- a/contract/r/scenario/upgrade/implements/v3_valid/pool/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/pool/test_impl.gno
@@ -170,6 +170,10 @@ func (t *TestPool) GetSlot0(poolPath string) pool.Slot0 {
 	return t.instance.GetSlot0(poolPath)
 }
 
+func (t *TestPool) GetObservationAt(poolPath string, index uint16) (pool.Observation, error) {
+	return t.instance.GetObservationAt(poolPath, index)
+}
+
 func (t *TestPool) GetSlot0SqrtPriceX96(poolPath string) (*u256.Uint, error) {
 	return t.instance.GetSlot0SqrtPriceX96(poolPath)
 }

--- a/contract/r/scenario/upgrade/implements/v3_valid/pool/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/pool/test_impl.gno
@@ -126,10 +126,6 @@ func (t *TestPool) GetLiquidity(poolPath string) (*u256.Uint, error) {
 	return t.instance.GetLiquidity(poolPath)
 }
 
-func (t *TestPool) GetLastObservation(poolPath string) (int64, string, int64, error) {
-	return t.instance.GetLastObservation(poolPath)
-}
-
 func (t *TestPool) GetPoolCreationFee() int64 {
 	return t.instance.GetPoolCreationFee()
 }
@@ -168,6 +164,10 @@ func (t *TestPool) GetProtocolFeesToken1(poolPath string) (int64, error) {
 
 func (t *TestPool) GetSlot0FeeProtocol(poolPath string) (uint8, error) {
 	return t.instance.GetSlot0FeeProtocol(poolPath)
+}
+
+func (t *TestPool) GetSlot0(poolPath string) pool.Slot0 {
+	return t.instance.GetSlot0(poolPath)
 }
 
 func (t *TestPool) GetSlot0SqrtPriceX96(poolPath string) (*u256.Uint, error) {
@@ -234,8 +234,16 @@ func (t *TestPool) GetWithdrawalFee() uint64 {
 	return t.instance.GetWithdrawalFee()
 }
 
-func (t *TestPool) GetTWAP(poolPath string, secondsAgo uint32) (int32, *u256.Uint, error) {
-	return t.instance.GetTWAP(poolPath, secondsAgo)
+func (t *TestPool) OracleConsult(poolPath string, secondsAgo uint32) (int32, *u256.Uint, error) {
+	return t.instance.OracleConsult(poolPath, secondsAgo)
+}
+
+func (t *TestPool) SnapshotCumulativesInside(
+	poolPath string,
+	tickLower int32,
+	tickUpper int32,
+) (int64, *u256.Uint, uint32, error) {
+	return t.instance.SnapshotCumulativesInside(poolPath, tickLower, tickUpper)
 }
 
 func (t *TestPool) GetPools() *rotree.ReadOnlyTree {
@@ -264,8 +272,8 @@ func (t *TestPool) GetTickBitmaps(poolPath string, wordPos int16) (string, error
 	return t.instance.GetTickBitmaps(poolPath, wordPos)
 }
 
-func (t *TestPool) GetObservationState(poolPath string) (*pool.ObservationState, error) {
-	return t.instance.GetObservationState(poolPath)
+func (t *TestPool) Observe(poolPath string, secondsAgos []uint32) ([]int64, []string, error) {
+	return t.instance.Observe(poolPath, secondsAgos)
 }
 
 func (t *TestPool) GetPendingProtocolFees() map[string]int64 {


### PR DESCRIPTION
## Summary

Depends on #1407. This PR exposes the Uniswap V3-aligned oracle surface built on top of the Slot0 state refactor.

- Add `GetSlot0`, `GetObservationAt`, `Observe`, `SnapshotCumulativesInside`, and `OracleConsult`.
- Extend the proxy interface, mocks, upgrade fixtures, and getter scenarios for the new read APIs.
- Add coverage for observation lookup, cumulative snapshots, and oracle query behavior.
- Document the public interface with commit-pinned Uniswap references.

## Reference Surface

- [Uniswap V3 pool state: `slot0` and `observations`](https://github.com/Uniswap/v3-core/blob/e3589b192d0be27e100cd0daaf6c97204fdb1899/contracts/interfaces/pool/IUniswapV3PoolState.sol#L21-L32)
- [Uniswap V3 derived state: `observe` and `snapshotCumulativesInside`](https://github.com/Uniswap/v3-core/blob/e3589b192d0be27e100cd0daaf6c97204fdb1899/contracts/interfaces/pool/IUniswapV3PoolDerivedState.sol#L18-L39)
- [Uniswap V3 periphery `OracleLibrary.consult`](https://github.com/Uniswap/v3-periphery/blob/0682387198a24c7cd63566a2c58398533860a5d1/contracts/libraries/OracleLibrary.sol#L16-L41)

## Validation

- `make test PKG=gno.land/r/gnoswap/pool/v1`
- `make test PKG=gno.land/r/gnoswap/scenario/getter`
- `make test PKG=gno.land/r/gnoswap/scenario/pool`
- `make test PKG=gno.land/r/gnoswap/scenario/upgrade`