### PR TITLE
test: cover inactive-liquidity recovery scenarios

### DIFF
--- a/contract/r/gnoswap/pool/v1/swap_test.gno
+++ b/contract/r/gnoswap/pool/v1/swap_test.gno
@@ -436,8 +436,8 @@ func TestDrySwap_ValidationAndFailures(cur realm, t *testing.T) {
 			riskAssessment: "Protect system resources",
 		},
 		{
-			name:        "insufficient_balance_protection",
-			description: "Protect against insufficient balance",
+			name:        "dry_swap_does_not_require_caller_balance",
+			description: "Allow quote generation without caller balance",
 			swapBuilder: func() SwapParams {
 				return NewSwapBuilder().
 					InPool(barTokenPath, bazTokenPath, FeeTier100).
@@ -446,9 +446,9 @@ func TestDrySwap_ValidationAndFailures(cur realm, t *testing.T) {
 					WithPriceLimit(MAX_PRICE_IMPACT).
 					Build()
 			},
-			expectSuccess:  false,
-			failureReason:  "Block transactions exceeding user balance",
-			riskAssessment: "Protect user assets and prevent transaction failure",
+			expectSuccess:  true,
+			failureReason:  "DrySwap does not transfer caller tokens",
+			riskAssessment: "Allow quote generation before a user funds a swap",
 		},
 	}
 

--- a/contract/r/scenario/pool/exact_in_swap_return_from_terminal_tick_filetest.gno
+++ b/contract/r/scenario/pool/exact_in_swap_return_from_terminal_tick_filetest.gno
@@ -1,0 +1,157 @@
+// PKGPATH: gno.land/r/gnoswap/scenario/pool/swap_return_from_terminal_tick
+
+package swap_return_from_terminal_tick
+
+import (
+	"testing"
+
+	"gno.land/p/gnoswap/gnsmath"
+	prbac "gno.land/p/gnoswap/rbac"
+	ufmt "gno.land/p/nt/ufmt/v0"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/common"
+	"gno.land/r/gnoswap/gns"
+	pl "gno.land/r/gnoswap/pool"
+	pn "gno.land/r/gnoswap/position"
+
+	_ "gno.land/r/gnoswap/pool/v1"
+	_ "gno.land/r/gnoswap/position/v1"
+	_ "gno.land/r/gnoswap/protocol_fee/v1"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/baz"
+)
+
+const (
+	fee       uint32 = 100
+	maxApprove int64  = 9223372036854775807
+	minPrice          = "4295128740"
+	maxPrice          = "1461446703485210103287273052203988822378723970341"
+)
+
+var (
+	adminAddr, _ = access.GetAddress(prbac.ROLE_ADMIN.String())
+	adminRealm   = testing.NewUserRealm(adminAddr)
+	poolAddr, _  = access.GetAddress(prbac.ROLE_POOL.String())
+	routerRealm  = testing.NewCodeRealm("gno.land/r/gnoswap/router")
+
+	barPath  = "gno.land/r/onbloc/bar.BAR"
+	bazPath  = "gno.land/r/onbloc/baz.BAZ"
+	poolPath = "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/baz.BAZ:100"
+)
+
+// This drives Pool.Swap directly.  The callback only settles the token owed
+// to the pool; no router swap logic participates in the state transition.
+func main(cur realm) {
+	println("[SCENARIO] Pool returns from terminal tick without full-range liquidity")
+	println()
+	println("[STEP 1] Initialize pool with a single narrow position")
+	setup(cur)
+
+	println("[STEP 2] Move the pool to the lower terminal tick")
+	println("[ACTION] Call Pool.Swap directly with bar -> baz ExactIn input=100000")
+	testing.SetRealm(routerRealm)
+	forward0, forward1 := pl.Swap(cross(cur), barPath, bazPath, fee, adminAddr, true, "100000", minPrice, settleSwap)
+	ufmt.Printf("[RESULT] Forward swap: amount0=%s amount1=%s\n", forward0, forward1)
+	assertTick(-887272, "lower")
+
+	println()
+	println("[STEP 3] Recover from the lower terminal tick")
+	println("[ACTION] Call Pool.Swap directly with baz -> bar ExactIn input=1000")
+	testing.SetRealm(routerRealm)
+	reverse0, reverse1 := pl.Swap(cross(cur), barPath, bazPath, fee, adminAddr, false, "1000", maxPrice, settleSwap)
+	ufmt.Printf("[RESULT] Recovery swap: amount0=%s amount1=%s\n", reverse0, reverse1)
+	assertTickInRange(-50, 50, "lower")
+	println("[SUCCESS] Returned to the active [-50, 50] range")
+
+	println()
+	println("[STEP 4] Move the pool to the upper terminal tick")
+	println("[ACTION] Call Pool.Swap directly with baz -> bar ExactIn input=100000")
+	testing.SetRealm(routerRealm)
+	forward0, forward1 = pl.Swap(cross(cur), barPath, bazPath, fee, adminAddr, false, "100000", maxPrice, settleSwap)
+	ufmt.Printf("[RESULT] Forward swap: amount0=%s amount1=%s\n", forward0, forward1)
+	assertTick(887271, "upper")
+
+	println()
+	println("[STEP 5] Recover from the upper terminal tick")
+	println("[ACTION] Call Pool.Swap directly with bar -> baz ExactIn input=1000")
+	testing.SetRealm(routerRealm)
+	reverse0, reverse1 = pl.Swap(cross(cur), barPath, bazPath, fee, adminAddr, true, "1000", minPrice, settleSwap)
+	ufmt.Printf("[RESULT] Recovery swap: amount0=%s amount1=%s\n", reverse0, reverse1)
+	assertTickInRange(-50, 50, "upper")
+	println("[SUCCESS] Returned to the active [-50, 50] range")
+
+	println("[RESULT] Pool returned from both terminal ticks to active liquidity")
+}
+
+func setup(cur realm) {
+	testing.SetRealm(adminRealm)
+	println("[INFO] Set pool creation fee to 0")
+	gns.Approve(cross(cur), poolAddr, pl.GetPoolCreationFee())
+	pl.SetPoolCreationFee(cross(cur), 0)
+	println("[INFO] Create bar:baz:100 pool at tick 0")
+	pl.CreatePool(cross(cur), barPath, bazPath, fee, gnsmath.TickMathGetSqrtRatioAtTick(0).ToString())
+
+	bar.Approve(cross(cur), poolAddr, maxApprove)
+	baz.Approve(cross(cur), poolAddr, maxApprove)
+	pn.Mint(cross(cur), barPath, bazPath, fee, -50, 50, "10000", "10000", "1", "1", 9999999999, adminAddr, "")
+	println("[SUCCESS] Minted the only position in range [-50, 50]")
+}
+
+func settleSwap(cur realm, amount0Delta, amount1Delta int64, _ *pl.CallbackMarker) error {
+	testing.SetRealm(adminRealm)
+	if amount0Delta > 0 {
+		common.SafeGRC20Transfer(cross(cur), barPath, poolAddr, amount0Delta)
+	}
+	if amount1Delta > 0 {
+		common.SafeGRC20Transfer(cross(cur), bazPath, poolAddr, amount1Delta)
+	}
+	return nil
+}
+
+func assertTick(want int32, terminal string) {
+	got, _ := pl.GetSlot0Tick(poolPath)
+	ufmt.Printf("[EXPECTED] Tick after %s terminal swap: %d\n", terminal, got)
+	if got != want {
+		panic(ufmt.Sprintf("expected terminal tick %d, got %d", want, got))
+	}
+}
+
+func assertTickInRange(lower, upper int32, terminal string) {
+	got, _ := pl.GetSlot0Tick(poolPath)
+	ufmt.Printf("[EXPECTED] Tick after %s recovery swap: %d\n", terminal, got)
+	if got < lower || got > upper {
+		panic(ufmt.Sprintf("expected tick in [%d, %d], got %d", lower, upper, got))
+	}
+}
+
+// Output:
+// [SCENARIO] Pool returns from terminal tick without full-range liquidity
+//
+// [STEP 1] Initialize pool with a single narrow position
+// [INFO] Set pool creation fee to 0
+// [INFO] Create bar:baz:100 pool at tick 0
+// [SUCCESS] Minted the only position in range [-50, 50]
+// [STEP 2] Move the pool to the lower terminal tick
+// [ACTION] Call Pool.Swap directly with bar -> baz ExactIn input=100000
+// [RESULT] Forward swap: amount0=10028 amount1=-9999
+// [EXPECTED] Tick after lower terminal swap: -887272
+//
+// [STEP 3] Recover from the lower terminal tick
+// [ACTION] Call Pool.Swap directly with baz -> bar ExactIn input=1000
+// [RESULT] Recovery swap: amount0=-1003 amount1=1000
+// [EXPECTED] Tick after lower recovery swap: -45
+// [SUCCESS] Returned to the active [-50, 50] range
+//
+// [STEP 4] Move the pool to the upper terminal tick
+// [ACTION] Call Pool.Swap directly with baz -> bar ExactIn input=100000
+// [RESULT] Forward swap: amount0=-19021 amount1=19030
+// [EXPECTED] Tick after upper terminal swap: 887271
+//
+// [STEP 5] Recover from the upper terminal tick
+// [ACTION] Call Pool.Swap directly with bar -> baz ExactIn input=1000
+// [RESULT] Recovery swap: amount0=1000 amount1=-1003
+// [EXPECTED] Tick after upper recovery swap: 44
+// [SUCCESS] Returned to the active [-50, 50] range
+// [RESULT] Pool returned from both terminal ticks to active liquidity

--- a/contract/r/scenario/pool/exact_out_swap_return_from_terminal_tick_filetest.gno
+++ b/contract/r/scenario/pool/exact_out_swap_return_from_terminal_tick_filetest.gno
@@ -1,0 +1,156 @@
+// PKGPATH: gno.land/r/gnoswap/scenario/pool/exact_out_swap_return_from_terminal_tick
+
+package exact_out_swap_return_from_terminal_tick
+
+import (
+	"testing"
+
+	"gno.land/p/gnoswap/gnsmath"
+	prbac "gno.land/p/gnoswap/rbac"
+	ufmt "gno.land/p/nt/ufmt/v0"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/common"
+	"gno.land/r/gnoswap/gns"
+	pl "gno.land/r/gnoswap/pool"
+	pn "gno.land/r/gnoswap/position"
+
+	_ "gno.land/r/gnoswap/pool/v1"
+	_ "gno.land/r/gnoswap/position/v1"
+	_ "gno.land/r/gnoswap/protocol_fee/v1"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/baz"
+)
+
+const (
+	fee       uint32 = 100
+	maxApprove int64  = 9223372036854775807
+	minPrice          = "4295128740"
+	maxPrice          = "1461446703485210103287273052203988822378723970341"
+)
+
+var (
+	adminAddr, _ = access.GetAddress(prbac.ROLE_ADMIN.String())
+	adminRealm   = testing.NewUserRealm(adminAddr)
+	poolAddr, _  = access.GetAddress(prbac.ROLE_POOL.String())
+	routerRealm  = testing.NewCodeRealm("gno.land/r/gnoswap/router")
+
+	barPath  = "gno.land/r/onbloc/bar.BAR"
+	bazPath  = "gno.land/r/onbloc/baz.BAZ"
+	poolPath = "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/baz.BAZ:100"
+)
+
+// Pool.Swap uses a negative amountSpecified for ExactOut.  The callback only
+// settles the amount owed to the pool, keeping router behavior out of this test.
+func main(cur realm) {
+	println("[SCENARIO] Pool ExactOut returns from terminal ticks without full-range liquidity")
+	println()
+	println("[STEP 1] Initialize pool with a single narrow position")
+	setup(cur)
+
+	println("[STEP 2] Move the pool to the lower terminal tick")
+	println("[ACTION] Call Pool.Swap directly with bar -> baz ExactIn input=100000")
+	testing.SetRealm(routerRealm)
+	forward0, forward1 := pl.Swap(cross(cur), barPath, bazPath, fee, adminAddr, true, "100000", minPrice, settleSwap)
+	ufmt.Printf("[RESULT] Forward swap: amount0=%s amount1=%s\n", forward0, forward1)
+	assertTick(-887272, "lower terminal")
+
+	println()
+	println("[STEP 3] Recover from the lower terminal tick with ExactOut")
+	println("[ACTION] Request 1000 bar by calling Pool.Swap directly")
+	testing.SetRealm(routerRealm)
+	in0, out1 := pl.Swap(cross(cur), barPath, bazPath, fee, adminAddr, false, "-1000", maxPrice, settleSwap)
+	ufmt.Printf("[RESULT] Recovery swap: amount0=%s amount1=%s\n", in0, out1)
+	assertInRange("lower ExactOut reverse")
+	println("[SUCCESS] Returned to the active [-50, 50] range")
+
+	println()
+	println("[STEP 4] Move the pool to the upper terminal tick")
+	println("[ACTION] Call Pool.Swap directly with baz -> bar ExactIn input=100000")
+	testing.SetRealm(routerRealm)
+	forward0, forward1 = pl.Swap(cross(cur), barPath, bazPath, fee, adminAddr, false, "100000", maxPrice, settleSwap)
+	ufmt.Printf("[RESULT] Forward swap: amount0=%s amount1=%s\n", forward0, forward1)
+	assertTick(887271, "upper terminal")
+
+	println()
+	println("[STEP 5] Recover from the upper terminal tick with ExactOut")
+	println("[ACTION] Request 1000 baz by calling Pool.Swap directly")
+	testing.SetRealm(routerRealm)
+	in0, out1 = pl.Swap(cross(cur), barPath, bazPath, fee, adminAddr, true, "-1000", minPrice, settleSwap)
+	ufmt.Printf("[RESULT] Recovery swap: amount0=%s amount1=%s\n", in0, out1)
+	assertInRange("upper ExactOut reverse")
+	println("[SUCCESS] Returned to the active [-50, 50] range")
+
+	println("[RESULT] Pool ExactOut returned from both terminal ticks")
+}
+
+func setup(cur realm) {
+	testing.SetRealm(adminRealm)
+	println("[INFO] Set pool creation fee to 0")
+	gns.Approve(cross(cur), poolAddr, pl.GetPoolCreationFee())
+	pl.SetPoolCreationFee(cross(cur), 0)
+	println("[INFO] Create bar:baz:100 pool at tick 0")
+	pl.CreatePool(cross(cur), barPath, bazPath, fee, gnsmath.TickMathGetSqrtRatioAtTick(0).ToString())
+	bar.Approve(cross(cur), poolAddr, maxApprove)
+	baz.Approve(cross(cur), poolAddr, maxApprove)
+	pn.Mint(cross(cur), barPath, bazPath, fee, -50, 50, "10000", "10000", "1", "1", 9999999999, adminAddr, "")
+	println("[SUCCESS] Minted the only position in range [-50, 50]")
+}
+
+func settleSwap(cur realm, amount0Delta, amount1Delta int64, _ *pl.CallbackMarker) error {
+	testing.SetRealm(adminRealm)
+	if amount0Delta > 0 {
+		common.SafeGRC20Transfer(cross(cur), barPath, poolAddr, amount0Delta)
+	}
+	if amount1Delta > 0 {
+		common.SafeGRC20Transfer(cross(cur), bazPath, poolAddr, amount1Delta)
+	}
+	return nil
+}
+
+func assertTick(want int32, label string) {
+	got, _ := pl.GetSlot0Tick(poolPath)
+	ufmt.Printf("[EXPECTED] Tick after %s: %d\n", label, got)
+	if got != want {
+		panic(ufmt.Sprintf("expected %s tick %d, got %d", label, want, got))
+	}
+}
+
+func assertInRange(label string) {
+	got, _ := pl.GetSlot0Tick(poolPath)
+	ufmt.Printf("[EXPECTED] Tick after %s: %d\n", label, got)
+	if got < -50 || got > 50 {
+		panic(ufmt.Sprintf("expected %s to return to [-50, 50], got %d", label, got))
+	}
+}
+
+// Output:
+// [SCENARIO] Pool ExactOut returns from terminal ticks without full-range liquidity
+//
+// [STEP 1] Initialize pool with a single narrow position
+// [INFO] Set pool creation fee to 0
+// [INFO] Create bar:baz:100 pool at tick 0
+// [SUCCESS] Minted the only position in range [-50, 50]
+// [STEP 2] Move the pool to the lower terminal tick
+// [ACTION] Call Pool.Swap directly with bar -> baz ExactIn input=100000
+// [RESULT] Forward swap: amount0=10028 amount1=-9999
+// [EXPECTED] Tick after lower terminal: -887272
+//
+// [STEP 3] Recover from the lower terminal tick with ExactOut
+// [ACTION] Request 1000 bar by calling Pool.Swap directly
+// [RESULT] Recovery swap: amount0=-1000 amount1=997
+// [EXPECTED] Tick after lower ExactOut reverse: -46
+// [SUCCESS] Returned to the active [-50, 50] range
+//
+// [STEP 4] Move the pool to the upper terminal tick
+// [ACTION] Call Pool.Swap directly with baz -> bar ExactIn input=100000
+// [RESULT] Forward swap: amount0=-19024 amount1=19034
+// [EXPECTED] Tick after upper terminal: 887271
+//
+// [STEP 5] Recover from the upper terminal tick with ExactOut
+// [ACTION] Request 1000 baz by calling Pool.Swap directly
+// [RESULT] Recovery swap: amount0=997 amount1=-1000
+// [EXPECTED] Tick after upper ExactOut reverse: 45
+// [SUCCESS] Returned to the active [-50, 50] range
+// [RESULT] Pool ExactOut returned from both terminal ticks

--- a/contract/r/scenario/position/position_balance_reposition_filetest.gno
+++ b/contract/r/scenario/position/position_balance_reposition_filetest.gno
@@ -323,20 +323,20 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 // [EXPECTED] Swap amount0 should be 0
 // [EXPECTED] Swap amount1 should be 0
 // [INFO] Repositioning to new range (9000~13000)
-// [EXPECTED] New liquidity should be 432601712
+// [EXPECTED] New liquidity should be 144008520
 // [EXPECTED] New tick range should be [9000, 13000]
-// [EXPECTED] User BAR balance after reposition should be 99999949999899
-// [EXPECTED] User FOO balance after reposition should be 99999999999999
-// [EXPECTED] Final position liquidity should be 432601712
+// [EXPECTED] User BAR balance after reposition should be 99999999999899
+// [EXPECTED] User FOO balance after reposition should be 99999949999999
+// [EXPECTED] Final position liquidity should be 144008520
 // [EXPECTED] Final position tick range should be [9000, 13000]
-// [EXPECTED] Final position token0 balance should be 49999999
-// [EXPECTED] Final position token1 balance should be 0
-// [EXPECTED] Final pool balance change should be 50000000
+// [EXPECTED] Final position token0 balance should be 0
+// [EXPECTED] Final position token1 balance should be 49999999
 // [EXPECTED] Final pool balance change should be 0
-// [EXPECTED] Final pool token0 balance should be 50000002
-// [EXPECTED] Final pool token1 balance should be 1
+// [EXPECTED] Final pool balance change should be 50000000
+// [EXPECTED] Final pool token0 balance should be 2
+// [EXPECTED] Final pool token1 balance should be 50000001
 // [EXPECTED] Final pool liquidity should be 0
-// [EXPECTED] Final pool tick should be 8031
-// [EXPECTED] Total BAR change during reposition: 11605209
-// [EXPECTED] Total FOO change during reposition: -756515
+// [EXPECTED] Final pool tick should be 887271
+// [EXPECTED] Total BAR change during reposition: -38394791
+// [EXPECTED] Total FOO change during reposition: 49243485
 // [EXPECTED] Reposition balance validation passed

--- a/contract/r/scenario/position/position_decrease_increase_filetest.gno
+++ b/contract/r/scenario/position/position_decrease_increase_filetest.gno
@@ -284,12 +284,12 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 //
 // [SCENARIO] 7. Increase position liquidity
 // [INFO] Increasing position liquidity
-// [EXPECTED] Added liquidity should be 318704392
-// [EXPECTED] Amount0 added should be 18394892
-// [EXPECTED] Amount1 added should be 50000000
+// [EXPECTED] Added liquidity should be 411504506
+// [EXPECTED] Amount0 added should be 50000000
+// [EXPECTED] Amount1 added should be 0
 //
 // [SCENARIO] 8. Check final position state
-// [EXPECTED] Final position liquidity should be 318704392
+// [EXPECTED] Final position liquidity should be 411504506
 // [EXPECTED] Position tickLower should be unchanged at 8000
 // [EXPECTED] Position tickUpper should be unchanged at 12000
 // [EXPECTED] Final fee0 should be 0

--- a/contract/r/scenario/router/exact_in_swap_return_from_terminal_tick_filetest.gno
+++ b/contract/r/scenario/router/exact_in_swap_return_from_terminal_tick_filetest.gno
@@ -1,0 +1,147 @@
+// PKGPATH: gno.land/r/gnoswap/scenario/router/swap_return_from_terminal_tick
+
+package swap_return_from_terminal_tick
+
+import (
+	"testing"
+
+	"gno.land/p/gnoswap/gnsmath"
+	prbac "gno.land/p/gnoswap/rbac"
+	ufmt "gno.land/p/nt/ufmt/v0"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/gns"
+	pl "gno.land/r/gnoswap/pool"
+	pn "gno.land/r/gnoswap/position"
+	rt "gno.land/r/gnoswap/router"
+
+	_ "gno.land/r/gnoswap/pool/v1"
+	_ "gno.land/r/gnoswap/position/v1"
+	_ "gno.land/r/gnoswap/protocol_fee/v1"
+	_ "gno.land/r/gnoswap/router/v1"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/baz"
+)
+
+const (
+	fee       uint32 = 100
+	maxApprove int64  = 9223372036854775807
+	deadline   int64  = 9999999999
+)
+
+var (
+	adminAddr, _ = access.GetAddress(prbac.ROLE_ADMIN.String())
+	adminRealm   = testing.NewUserRealm(adminAddr)
+	poolAddr, _  = access.GetAddress(prbac.ROLE_POOL.String())
+	routerAddr, _ = access.GetAddress(prbac.ROLE_ROUTER.String())
+
+	barPath  = "gno.land/r/onbloc/bar.BAR"
+	bazPath  = "gno.land/r/onbloc/baz.BAZ"
+	poolPath = "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/baz.BAZ:100"
+	forwardRoute = "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/baz.BAZ:100"
+	reverseRoute = "gno.land/r/onbloc/baz.BAZ:gno.land/r/onbloc/bar.BAR:100"
+)
+
+// This is intentionally a single narrow position.  There is no full-range
+// liquidity to mask a failure to leave a terminal, inactive-liquidity state.
+func main(cur realm) {
+	println("[SCENARIO] Router returns from terminal tick without full-range liquidity")
+	println()
+	println("[STEP 1] Initialize pool with a single narrow position")
+	setup(cur)
+
+	println("[STEP 2] Move the pool to the lower terminal tick")
+	println("[ACTION] Execute bar -> baz ExactIn swap with input=100000")
+	forwardIn, forwardOut := rt.ExactInSwapRoute(cross(cur), barPath, bazPath, "100000", forwardRoute, "100", "0", deadline, "")
+	ufmt.Printf("[RESULT] Forward swap: in=%s out=%s\n", forwardIn, forwardOut)
+	assertTick(poolPath, -887271, "lower")
+
+	println()
+	println("[STEP 3] Recover from the lower terminal tick")
+	println("[ACTION] Execute baz -> bar ExactIn swap with input=1000")
+	reverseIn, reverseOut := rt.ExactInSwapRoute(cross(cur), bazPath, barPath, "1000", reverseRoute, "100", "0", deadline, "")
+	ufmt.Printf("[RESULT] Recovery swap: in=%s out=%s\n", reverseIn, reverseOut)
+	assertTickInRange(poolPath, -50, 50, "lower")
+	println("[SUCCESS] Returned to the active [-50, 50] range")
+
+	println()
+	println("[STEP 4] Move the pool to the upper terminal tick")
+	println("[ACTION] Execute baz -> bar ExactIn swap with input=100000")
+	forwardIn, forwardOut = rt.ExactInSwapRoute(cross(cur), bazPath, barPath, "100000", reverseRoute, "100", "0", deadline, "")
+	ufmt.Printf("[RESULT] Forward swap: in=%s out=%s\n", forwardIn, forwardOut)
+	assertTick(poolPath, 887270, "upper")
+
+	println()
+	println("[STEP 5] Recover from the upper terminal tick")
+	println("[ACTION] Execute bar -> baz ExactIn swap with input=1000")
+	reverseIn, reverseOut = rt.ExactInSwapRoute(cross(cur), barPath, bazPath, "1000", forwardRoute, "100", "0", deadline, "")
+	ufmt.Printf("[RESULT] Recovery swap: in=%s out=%s\n", reverseIn, reverseOut)
+	assertTickInRange(poolPath, -50, 50, "upper")
+	println("[SUCCESS] Returned to the active [-50, 50] range")
+
+	println("[RESULT] Router returned from both terminal ticks to active liquidity")
+}
+
+func setup(cur realm) {
+	testing.SetRealm(adminRealm)
+	println("[INFO] Set pool creation fee to 0")
+	gns.Approve(cross(cur), poolAddr, pl.GetPoolCreationFee())
+	pl.SetPoolCreationFee(cross(cur), 0)
+	println("[INFO] Create bar:baz:100 pool at tick 0")
+	pl.CreatePool(cross(cur), barPath, bazPath, fee, gnsmath.TickMathGetSqrtRatioAtTick(0).ToString())
+
+	bar.Approve(cross(cur), poolAddr, maxApprove)
+	baz.Approve(cross(cur), poolAddr, maxApprove)
+	bar.Approve(cross(cur), routerAddr, maxApprove)
+	baz.Approve(cross(cur), routerAddr, maxApprove)
+
+	pn.Mint(cross(cur), barPath, bazPath, fee, -50, 50, "10000", "10000", "1", "1", deadline, adminAddr, "")
+	println("[SUCCESS] Minted the only position in range [-50, 50]")
+}
+
+func assertTick(path string, want int32, terminal string) {
+	got, _ := pl.GetSlot0Tick(path)
+	ufmt.Printf("[EXPECTED] Tick after %s terminal swap: %d\n", terminal, got)
+	if got != want {
+		panic(ufmt.Sprintf("expected terminal tick %d, got %d", want, got))
+	}
+}
+
+func assertTickInRange(path string, lower, upper int32, terminal string) {
+	got, _ := pl.GetSlot0Tick(path)
+	ufmt.Printf("[EXPECTED] Tick after %s recovery swap: %d\n", terminal, got)
+	if got < lower || got > upper {
+		panic(ufmt.Sprintf("expected tick in [%d, %d], got %d", lower, upper, got))
+	}
+}
+
+// Output:
+// [SCENARIO] Router returns from terminal tick without full-range liquidity
+//
+// [STEP 1] Initialize pool with a single narrow position
+// [INFO] Set pool creation fee to 0
+// [INFO] Create bar:baz:100 pool at tick 0
+// [SUCCESS] Minted the only position in range [-50, 50]
+// [STEP 2] Move the pool to the lower terminal tick
+// [ACTION] Execute bar -> baz ExactIn swap with input=100000
+// [RESULT] Forward swap: in=10028 out=-9985
+// [EXPECTED] Tick after lower terminal swap: -887271
+//
+// [STEP 3] Recover from the lower terminal tick
+// [ACTION] Execute baz -> bar ExactIn swap with input=1000
+// [RESULT] Recovery swap: in=1000 out=-1002
+// [EXPECTED] Tick after lower recovery swap: -45
+// [SUCCESS] Returned to the active [-50, 50] range
+//
+// [STEP 4] Move the pool to the upper terminal tick
+// [ACTION] Execute baz -> bar ExactIn swap with input=100000
+// [RESULT] Forward swap: in=19030 out=-18993
+// [EXPECTED] Tick after upper terminal swap: 887270
+//
+// [STEP 5] Recover from the upper terminal tick
+// [ACTION] Execute bar -> baz ExactIn swap with input=1000
+// [RESULT] Recovery swap: in=1000 out=-1002
+// [EXPECTED] Tick after upper recovery swap: 44
+// [SUCCESS] Returned to the active [-50, 50] range
+// [RESULT] Router returned from both terminal ticks to active liquidity

--- a/contract/r/scenario/router/exact_out_swap_return_from_terminal_tick_filetest.gno
+++ b/contract/r/scenario/router/exact_out_swap_return_from_terminal_tick_filetest.gno
@@ -1,0 +1,145 @@
+// PKGPATH: gno.land/r/gnoswap/scenario/router/exact_out_swap_return_from_terminal_tick
+
+package exact_out_swap_return_from_terminal_tick
+
+import (
+	"testing"
+
+	"gno.land/p/gnoswap/gnsmath"
+	prbac "gno.land/p/gnoswap/rbac"
+	ufmt "gno.land/p/nt/ufmt/v0"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/gns"
+	pl "gno.land/r/gnoswap/pool"
+	pn "gno.land/r/gnoswap/position"
+	rt "gno.land/r/gnoswap/router"
+
+	_ "gno.land/r/gnoswap/pool/v1"
+	_ "gno.land/r/gnoswap/position/v1"
+	_ "gno.land/r/gnoswap/protocol_fee/v1"
+	_ "gno.land/r/gnoswap/router/v1"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/baz"
+)
+
+const (
+	fee       uint32 = 100
+	maxApprove int64  = 9223372036854775807
+	deadline   int64  = 9999999999
+)
+
+var (
+	adminAddr, _ = access.GetAddress(prbac.ROLE_ADMIN.String())
+	adminRealm   = testing.NewUserRealm(adminAddr)
+	poolAddr, _  = access.GetAddress(prbac.ROLE_POOL.String())
+	routerAddr, _ = access.GetAddress(prbac.ROLE_ROUTER.String())
+
+	barPath      = "gno.land/r/onbloc/bar.BAR"
+	bazPath      = "gno.land/r/onbloc/baz.BAZ"
+	poolPath     = "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/baz.BAZ:100"
+	forwardRoute = "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/baz.BAZ:100"
+	reverseRoute = "gno.land/r/onbloc/baz.BAZ:gno.land/r/onbloc/bar.BAR:100"
+)
+
+// The forward swaps intentionally exhaust the only [-50, 50] liquidity range.
+// Each reverse is ExactOut: it requests 1,000 output tokens at a bounded max input.
+func main(cur realm) {
+	println("[SCENARIO] Router ExactOut returns from terminal ticks without full-range liquidity")
+	println()
+	println("[STEP 1] Initialize pool with a single narrow position")
+	setup(cur)
+
+	println("[STEP 2] Move the pool to the lower terminal tick")
+	println("[ACTION] Execute bar -> baz ExactIn swap with input=100000")
+	forwardIn, forwardOut := rt.ExactInSwapRoute(cross(cur), barPath, bazPath, "100000", forwardRoute, "100", "0", deadline, "")
+	ufmt.Printf("[RESULT] Forward swap: in=%s out=%s\n", forwardIn, forwardOut)
+	assertTick(-887271, "lower terminal")
+
+	println()
+	println("[STEP 3] Recover from the lower terminal tick with ExactOut")
+	println("[ACTION] Request 1000 bar with bounded max input=10000")
+	in, out := rt.ExactOutSwapRoute(cross(cur), bazPath, barPath, "1000", reverseRoute, "100", "10000", deadline, "")
+	ufmt.Printf("[RESULT] Recovery swap: in=%s out=%s\n", in, out)
+	assertInRange("lower ExactOut reverse")
+	println("[SUCCESS] Returned to the active [-50, 50] range")
+
+	println()
+	println("[STEP 4] Move the pool to the upper terminal tick")
+	println("[ACTION] Execute baz -> bar ExactIn swap with input=100000")
+	forwardIn, forwardOut = rt.ExactInSwapRoute(cross(cur), bazPath, barPath, "100000", reverseRoute, "100", "0", deadline, "")
+	ufmt.Printf("[RESULT] Forward swap: in=%s out=%s\n", forwardIn, forwardOut)
+	assertTick(887270, "upper terminal")
+
+	println()
+	println("[STEP 5] Recover from the upper terminal tick with ExactOut")
+	println("[ACTION] Request 1000 baz with bounded max input=10000")
+	in, out = rt.ExactOutSwapRoute(cross(cur), barPath, bazPath, "1000", forwardRoute, "100", "10000", deadline, "")
+	ufmt.Printf("[RESULT] Recovery swap: in=%s out=%s\n", in, out)
+	assertInRange("upper ExactOut reverse")
+	println("[SUCCESS] Returned to the active [-50, 50] range")
+
+	println("[RESULT] Router ExactOut returned from both terminal ticks")
+}
+
+func setup(cur realm) {
+	testing.SetRealm(adminRealm)
+	println("[INFO] Set pool creation fee to 0")
+	gns.Approve(cross(cur), poolAddr, pl.GetPoolCreationFee())
+	pl.SetPoolCreationFee(cross(cur), 0)
+	println("[INFO] Create bar:baz:100 pool at tick 0")
+	pl.CreatePool(cross(cur), barPath, bazPath, fee, gnsmath.TickMathGetSqrtRatioAtTick(0).ToString())
+	bar.Approve(cross(cur), poolAddr, maxApprove)
+	baz.Approve(cross(cur), poolAddr, maxApprove)
+	bar.Approve(cross(cur), routerAddr, maxApprove)
+	baz.Approve(cross(cur), routerAddr, maxApprove)
+	pn.Mint(cross(cur), barPath, bazPath, fee, -50, 50, "10000", "10000", "1", "1", deadline, adminAddr, "")
+	println("[SUCCESS] Minted the only position in range [-50, 50]")
+}
+
+func assertTick(want int32, label string) {
+	got, _ := pl.GetSlot0Tick(poolPath)
+	ufmt.Printf("[EXPECTED] Tick after %s: %d\n", label, got)
+	if got != want {
+		panic(ufmt.Sprintf("expected %s tick %d, got %d", label, want, got))
+	}
+}
+
+func assertInRange(label string) {
+	got, _ := pl.GetSlot0Tick(poolPath)
+	ufmt.Printf("[EXPECTED] Tick after %s: %d\n", label, got)
+	if got < -50 || got > 50 {
+		panic(ufmt.Sprintf("expected %s to return to [-50, 50], got %d", label, got))
+	}
+}
+
+// Output:
+// [SCENARIO] Router ExactOut returns from terminal ticks without full-range liquidity
+//
+// [STEP 1] Initialize pool with a single narrow position
+// [INFO] Set pool creation fee to 0
+// [INFO] Create bar:baz:100 pool at tick 0
+// [SUCCESS] Minted the only position in range [-50, 50]
+// [STEP 2] Move the pool to the lower terminal tick
+// [ACTION] Execute bar -> baz ExactIn swap with input=100000
+// [RESULT] Forward swap: in=10028 out=-9985
+// [EXPECTED] Tick after lower terminal: -887271
+//
+// [STEP 3] Recover from the lower terminal tick with ExactOut
+// [ACTION] Request 1000 bar with bounded max input=10000
+// [RESULT] Recovery swap: in=998 out=-1000
+// [EXPECTED] Tick after lower ExactOut reverse: -46
+// [SUCCESS] Returned to the active [-50, 50] range
+//
+// [STEP 4] Move the pool to the upper terminal tick
+// [ACTION] Execute baz -> bar ExactIn swap with input=100000
+// [RESULT] Forward swap: in=19033 out=-18995
+// [EXPECTED] Tick after upper terminal: 887270
+//
+// [STEP 5] Recover from the upper terminal tick with ExactOut
+// [ACTION] Request 1000 baz with bounded max input=10000
+// [RESULT] Recovery swap: in=998 out=-1000
+// [EXPECTED] Tick after upper ExactOut reverse: 45
+// [SUCCESS] Returned to the active [-50, 50] range
+// [RESULT] Router ExactOut returned from both terminal ticks

--- a/contract/r/scenario/router/inactive_liquidity_callback_and_recovery_filetest.gno
+++ b/contract/r/scenario/router/inactive_liquidity_callback_and_recovery_filetest.gno
@@ -1,0 +1,206 @@
+// PKGPATH: gno.land/r/gnoswap/scenario/router/inactive_liquidity_callback_and_recovery
+
+package inactive_liquidity_callback_and_recovery
+
+import (
+	"testing"
+
+	"gno.land/p/gnoswap/gnsmath"
+	prbac "gno.land/p/gnoswap/rbac"
+	ufmt "gno.land/p/nt/ufmt/v0"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/gns"
+	pl "gno.land/r/gnoswap/pool"
+	pn "gno.land/r/gnoswap/position"
+	rt "gno.land/r/gnoswap/router"
+
+	_ "gno.land/r/gnoswap/pool/v1"
+	_ "gno.land/r/gnoswap/position/v1"
+	_ "gno.land/r/gnoswap/protocol_fee/v1"
+	_ "gno.land/r/gnoswap/router/v1"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/baz"
+)
+
+const (
+	fee       uint32 = 100
+	maxApprove int64  = 9223372036854775807
+	deadline   int64  = 9999999999
+)
+
+var (
+	adminAddr, _ = access.GetAddress(prbac.ROLE_ADMIN.String())
+	adminRealm   = testing.NewUserRealm(adminAddr)
+	poolAddr, _  = access.GetAddress(prbac.ROLE_POOL.String())
+	routerAddr, _ = access.GetAddress(prbac.ROLE_ROUTER.String())
+
+	barPath      = "gno.land/r/onbloc/bar.BAR"
+	bazPath      = "gno.land/r/onbloc/baz.BAZ"
+	poolPath     = "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/baz.BAZ:100"
+	forwardRoute = "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/baz.BAZ:100"
+	reverseRoute = "gno.land/r/onbloc/baz.BAZ:gno.land/r/onbloc/bar.BAR:100"
+	middleLiquidity string
+)
+
+func main(cur realm) {
+	println("[SCENARIO] Router inactive-liquidity callback and recovery")
+	println()
+	println("[STEP 1] Initialize pool at tick 0")
+	setup(cur)
+
+	println()
+	println("[STEP 2] Mint active and out-of-range positions")
+	println("[INFO] Active range: [-50, 50], out-of-range: [100, 200]")
+	mintMiddleAndOutOfRangeLiquidity(cur)
+	assertActiveLiquidity(false, "minting the middle position")
+
+	println()
+	println("[STEP 3] Remove the active middle position")
+	println("[ACTION] Decrease all liquidity from position ID=1")
+	removeMiddleLiquidity(cur)
+	assertActiveLiquidity(true, "removing the middle position")
+
+	// There is no initialized liquidity below tick 0. Pool.Swap calls the router
+	// callback with zero deltas, and router SwapCallback must abort with the
+	// insufficient-liquidity error. The failed callback is caught with revive;
+	// the pool has already traversed the inactive interval to the lower terminal.
+	println()
+	println("[STEP 4] Swap toward the empty lower side")
+	println("[ACTION] Execute bar -> baz ExactIn swap with input=100000")
+	assertCallbackPanicTowardEmptySide(cur)
+	assertTick(-887271, "tick after empty-side callback abort")
+
+	// The opposite direction first crosses inactive ticks, enters [100, 200],
+	// consumes that liquidity, then reaches the upper terminal tick.
+	println()
+	println("[STEP 5] Cross remaining [100, 200] liquidity and reach the upper terminal")
+	println("[ACTION] Execute baz -> bar ExactIn swap with input=100000")
+	moveTowardOutOfRangeLiquidityAndTerminal(cur)
+	assertTick(887270, "tick after crossing out-of-range liquidity")
+
+	// The middle position stays removed. A bounded reverse swap must re-enter
+	// the remaining [100, 200] position and reactivate its liquidity.
+	println()
+	println("[STEP 6] Recover from the upper terminal")
+	println("[ACTION] Execute bar -> baz ExactIn swap with input=1000")
+	recoverToOutOfRangeLiquidity(cur)
+	assertTickInRange(100, 200, "tick after recovery swap")
+	assertActiveLiquidity(false, "re-entering the out-of-range position")
+	println("[SUCCESS] Re-entered and reactivated the [100, 200] position")
+
+	println("[RESULT] Router callback panic and inactive-liquidity recovery verified")
+}
+
+func setup(cur realm) {
+	testing.SetRealm(adminRealm)
+	println("[INFO] Set pool creation fee to 0")
+	gns.Approve(cross(cur), poolAddr, pl.GetPoolCreationFee())
+	pl.SetPoolCreationFee(cross(cur), 0)
+	println("[INFO] Create bar:baz:100 pool")
+	pl.CreatePool(cross(cur), barPath, bazPath, fee, gnsmath.TickMathGetSqrtRatioAtTick(0).ToString())
+	bar.Approve(cross(cur), poolAddr, maxApprove)
+	baz.Approve(cross(cur), poolAddr, maxApprove)
+	bar.Approve(cross(cur), routerAddr, maxApprove)
+	baz.Approve(cross(cur), routerAddr, maxApprove)
+}
+
+func mintMiddleAndOutOfRangeLiquidity(cur realm) {
+	testing.SetRealm(adminRealm)
+	_, middleLiquidity, _, _ = pn.Mint(cross(cur), barPath, bazPath, fee, -50, 50, "10000", "10000", "1", "1", deadline, adminAddr, "")
+	_, outLiquidity, _, _ := pn.Mint(cross(cur), barPath, bazPath, fee, 100, 200, "10000", "10000", "0", "0", deadline, adminAddr, "")
+	ufmt.Printf("[SUCCESS] Minted middle liquidity=%s, out-of-range liquidity=%s\n", middleLiquidity, outLiquidity)
+}
+
+func removeMiddleLiquidity(cur realm) {
+	testing.SetRealm(adminRealm)
+	_, removed, _, _, _, _, _ := pn.DecreaseLiquidity(cross(cur), 1, middleLiquidity, "0", "0", deadline)
+	ufmt.Printf("[RESULT] Removed middle liquidity: %s\n", removed)
+	if removed != middleLiquidity {
+		panic("middle position liquidity must be fully removed")
+	}
+}
+
+func assertCallbackPanicTowardEmptySide(cur realm) {
+	testing.SetRealm(adminRealm)
+	r := revive(func() {
+		rt.ExactInSwapRoute(cross(cur), barPath, bazPath, "100000", forwardRoute, "100", "0", deadline, "")
+	})
+	if r == nil {
+		panic("expected router callback to abort in the empty direction")
+	}
+	ufmt.Printf("[RESULT] Empty-side swap aborted as expected: %v\n", r)
+}
+
+func moveTowardOutOfRangeLiquidityAndTerminal(cur realm) {
+	testing.SetRealm(adminRealm)
+	in, out := rt.ExactInSwapRoute(cross(cur), bazPath, barPath, "100000", reverseRoute, "100", "0", deadline, "")
+	ufmt.Printf("[RESULT] Forward swap: in=%s out=%s\n", in, out)
+}
+
+func recoverToOutOfRangeLiquidity(cur realm) {
+	testing.SetRealm(adminRealm)
+	in, out := rt.ExactInSwapRoute(cross(cur), barPath, bazPath, "1000", forwardRoute, "100", "0", deadline, "")
+	ufmt.Printf("[RESULT] Recovery swap: in=%s out=%s\n", in, out)
+}
+
+func assertTick(want int32, label string) {
+	got, _ := pl.GetSlot0Tick(poolPath)
+	ufmt.Printf("[EXPECTED] %s: %d\n", label, got)
+	if got != want {
+		panic(ufmt.Sprintf("expected tick %d, got %d", want, got))
+	}
+}
+
+func assertTickInRange(lower, upper int32, label string) {
+	got, _ := pl.GetSlot0Tick(poolPath)
+	ufmt.Printf("[EXPECTED] %s: %d\n", label, got)
+	if got < lower || got > upper {
+		panic(ufmt.Sprintf("expected tick in [%d, %d], got %d", lower, upper, got))
+	}
+}
+
+func assertActiveLiquidity(wantZero bool, label string) {
+	p, _ := pl.GetPools().Get(poolPath).(*pl.Pool)
+	zero := p.Liquidity().IsZero()
+	ufmt.Printf("[EXPECTED] Active liquidity is zero after %s: %t\n", label, zero)
+	if zero != wantZero {
+		panic(ufmt.Sprintf("unexpected active liquidity state: zero=%t", zero))
+	}
+}
+
+// Output:
+// [SCENARIO] Router inactive-liquidity callback and recovery
+//
+// [STEP 1] Initialize pool at tick 0
+// [INFO] Set pool creation fee to 0
+// [INFO] Create bar:baz:100 pool
+//
+// [STEP 2] Mint active and out-of-range positions
+// [INFO] Active range: [-50, 50], out-of-range: [100, 200]
+// [SUCCESS] Minted middle liquidity=4005202, out-of-range liquidity=2015154
+// [EXPECTED] Active liquidity is zero after minting the middle position: false
+//
+// [STEP 3] Remove the active middle position
+// [ACTION] Decrease all liquidity from position ID=1
+// [RESULT] Removed middle liquidity: 4005202
+// [EXPECTED] Active liquidity is zero after removing the middle position: true
+//
+// [STEP 4] Swap toward the empty lower side
+// [ACTION] Execute bar -> baz ExactIn swap with input=100000
+// [RESULT] Empty-side swap aborted as expected: [GNOSWAP-ROUTER-020] insufficient liquidity for swap || swap entirely within 0-liquidity region
+// [EXPECTED] tick after empty-side callback abort: -887271
+//
+// [STEP 5] Cross remaining [100, 200] liquidity and reach the upper terminal
+// [ACTION] Execute baz -> bar ExactIn swap with input=100000
+// [RESULT] Forward swap: in=10154 out=-9985
+// [EXPECTED] tick after crossing out-of-range liquidity: 887270
+//
+// [STEP 6] Recover from the upper terminal
+// [ACTION] Execute bar -> baz ExactIn swap with input=1000
+// [RESULT] Recovery swap: in=1000 out=-1017
+// [EXPECTED] tick after recovery swap: 189
+// [EXPECTED] Active liquidity is zero after re-entering the out-of-range position: false
+// [SUCCESS] Re-entered and reactivated the [100, 200] position
+// [RESULT] Router callback panic and inactive-liquidity recovery verified

--- a/contract/r/scenario/staker/position_inrange_change_by_swap_external_filetest.gno
+++ b/contract/r/scenario/staker/position_inrange_change_by_swap_external_filetest.gno
@@ -106,6 +106,7 @@ func main(cur realm) {
 
 	println("[SCENARIO] 10. Collect external reward after returning to in-range")
 	collectExternalRewardAfterReturningInRange(cur)
+	println()
 }
 
 func initAndSetup(cur realm) {
@@ -273,8 +274,8 @@ func performSwapToMovePrice(cur realm) {
 	currentTickAfter, _ := pl.GetSlot0Tick(poolPath)
 	ufmt.Printf("[EXPECTED] tick after swap: %d\n", currentTickAfter)
 
-	// Position should now be out of range (tick > 50)
-	if currentTickAfter <= 50 {
+	// Position should now be out of range (tick < -50).
+	if currentTickAfter >= -50 {
 		println("[WARNING] swap might not have moved price far enough")
 		// Try another swap to move further
 		println("[INFO] perform additional swap")
@@ -328,7 +329,7 @@ func performReverseSwap(cur realm) {
 
 	println("[INFO] perform reverse swap to move price back into range")
 	// Swap baz for bar to move tick back down
-	reverseSwapAmount := "50000"
+	reverseSwapAmount := "1000"
 
 	println("[INFO] swap baz for bar to move tick down")
 
@@ -457,9 +458,6 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 // [INFO] swap bar for baz to move tick up
 // [INFO] swapped 100000 bar for -9985 baz
 // [EXPECTED] tick after swap: -887271
-// [WARNING] swap might not have moved price far enough
-// [INFO] perform additional swap
-// [EXPECTED] final tick after additional swap: -887271
 //
 // [SCENARIO] 8. Collect external reward while out-of-range
 // [INFO] skip blocks to accumulate external rewards while out-of-range
@@ -471,16 +469,15 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 // [INFO] tick before reverse swap: -887271
 // [INFO] perform reverse swap to move price back into range
 // [INFO] swap baz for bar to move tick down
-// [INFO] swapped 50000 baz for 0 bar
-// [EXPECTED] tick after reverse swap: -887271
-// [WARNING] position might still be out-of-range
-// [INFO] position range: -50 to 50, current tick: -887271
+// [INFO] swapped 1000 baz for -1002 bar
+// [EXPECTED] tick after reverse swap: -45
+// [INFO] position is back in-range
 //
 // [SCENARIO] 10. Collect external reward after returning to in-range
 // [INFO] skip blocks to accumulate external rewards after returning to in-range
 // [INFO] collect external reward after position returned to in-range
-// [EXPECTED] external reward after returning to in-range: 0
-// [INFO] final tick: -887271
-// [INFO] position is still out-of-range, no external rewards as expected
+// [EXPECTED] external reward after returning to in-range: 190972
+// [INFO] final tick: -45
+// [INFO] confirmed: external rewards resumed when position returned to in-range
 // [INFO] position in-range change by swap (external rewards) scenario completed successfully
 // [INFO] confirmed: external rewards are only distributed when positions are in-range

--- a/contract/r/scenario/staker/position_inrange_change_by_swap_internal_filetest.gno
+++ b/contract/r/scenario/staker/position_inrange_change_by_swap_internal_filetest.gno
@@ -99,6 +99,8 @@ func main(cur realm) {
 
 	println("[SCENARIO] 9. Collect reward after returning to in-range")
 	collectRewardAfterReturningInRange(cur)
+	println()
+
 }
 
 func initAndSetup(cur realm) {
@@ -244,8 +246,8 @@ func performSwapToMovePrice(cur realm) {
 	currentTickAfter, _ := pl.GetSlot0Tick(poolPath)
 	ufmt.Printf("[EXPECTED] tick after swap: %d\n", currentTickAfter)
 
-	// Position should now be out of range (tick > 50)
-	if currentTickAfter <= 50 {
+	// Position should now be out of range (tick < -50).
+	if currentTickAfter >= -50 {
 		println("[WARNING] swap might not have moved price far enough")
 		// Try another swap to move further
 		println("[INFO] perform additional swap")
@@ -298,7 +300,7 @@ func performReverseSwap(cur realm) {
 
 	println("[INFO] perform reverse swap to move price back into range")
 	// Swap baz for bar to move tick back down
-	reverseSwapAmount := "50000"
+	reverseSwapAmount := "1000"
 
 	var amountOut string = "0"
 
@@ -422,9 +424,6 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 // [INFO] swap bar for baz to move tick up
 // [INFO] swapped 100000 bar for -9985 baz
 // [EXPECTED] tick after swap: -887271
-// [WARNING] swap might not have moved price far enough
-// [INFO] perform additional swap
-// [EXPECTED] final tick after additional swap: -887271
 //
 // [SCENARIO] 7. Collect reward while out-of-range
 // [INFO] skip blocks to accumulate rewards while out-of-range
@@ -436,16 +435,15 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 // [INFO] tick before reverse swap: -887271
 // [INFO] perform reverse swap to move price back into range
 // [INFO] swap baz for bar to move tick down
-// [INFO] swapped 50000 baz for 0 bar
-// [EXPECTED] tick after reverse swap: -887271
-// [WARNING] position might still be out-of-range
-// [INFO] position range: -50 to 50, current tick: -887271
+// [INFO] swapped 1000 baz for -1002 bar
+// [EXPECTED] tick after reverse swap: -45
+// [INFO] position is back in-range
 //
 // [SCENARIO] 9. Collect reward after returning to in-range
 // [INFO] skip blocks to accumulate rewards after returning to in-range
 // [INFO] collect reward after position returned to in-range
-// [EXPECTED] reward after returning to in-range: 0
-// [INFO] final tick: -887271
-// [INFO] position is still out-of-range, no rewards as expected
+// [EXPECTED] reward after returning to in-range: 44145964
+// [INFO] final tick: -45
+// [INFO] confirmed: rewards resumed when position returned to in-range
 // [INFO] position in-range change by swap scenario completed successfully
 // [INFO] confirmed: rewards are only distributed when positions are in-range


### PR DESCRIPTION
## Summary

Extends swap regression coverage for pools that traverse inactive-liquidity ranges. The PR preserves the existing staker recovery scenario, updates affected expectations, and adds focused Router and Pool tests for terminal-tick and callback recovery behavior.

## Background

After inactive-liquidity traversal was enabled, existing scenarios could reach a terminal tick instead of stopping at the first inactive range. Their expectations and retry condition no longer reflected the reachable swap path.

## Changes

### Existing scenario alignment

- Correct the staker retry condition so an additional same-direction swap is made only when the lower bound has not yet been crossed.
- Keep the original narrow position range `[-50, 50]` and forward input `100000`.
- Use a bounded reverse ExactIn input of `1000`, allowing the position to re-enter its active range and resume rewards.
- Update the affected position filetest goldens.
- Align the `DrySwap` test with its quote-only behavior; it does not consume or validate the callers token balance.

### Terminal-tick recovery coverage

Add dedicated filetests for both Router and direct `Pool.Swap` paths:

- ExactIn recovery from lower and upper terminal ticks.
- ExactOut recovery from lower and upper terminal ticks.
- No full-range liquidity: each pool contains only one narrow `[-50, 50]` position.

Verified ExactIn recovery:

| Path | Lower terminal -> recovery | Upper terminal -> recovery |
| --- | --- | --- |
| Router | `-887271 -> -45` | `887270 -> 44` |
| Pool.Swap | `-887272 -> -45` | `887271 -> 44` |

The one-tick terminal boundary difference is expected because Router and direct Pool calls use different price-limit boundaries.

### Inactive-liquidity callback recovery coverage

Add a Router scenario with an active `[-50, 50]` position and an out-of-range `[100, 200]` position:

1. Remove the active middle position, leaving zero active liquidity at tick `0`.
2. Verify an empty-side swap aborts through the Router callback with `GNOSWAP-ROUTER-020`.
3. Traverse toward the remaining initialized liquidity and reach the opposite terminal tick.
4. Reverse with a bounded swap and verify the tick returns to `[100, 200]` and active liquidity is restored.

## Validation

- `make test PKG=gno.land/r/gnoswap/pool/v1`
- `gno test --update-golden-tests ./gno.land/r/gnoswap/scenario/staker`
- `gno test ./gno.land/r/gnoswap/scenario/staker`
- `gno test --update-golden-tests ./gno.land/r/gnoswap/scenario/position`
- `gno test --update-golden-tests ./gno.land/r/gnoswap/scenario/router`
- `gno test ./gno.land/r/gnoswap/scenario/router`
- `gno test --update-golden-tests ./gno.land/r/gnoswap/scenario/pool`
- `gno test ./gno.land/r/gnoswap/scenario/pool`