### PR TITLE
fix(pool): validate int128 lower bound

### DIFF
--- a/contract/r/gnoswap/pool/v1/utils.gno
+++ b/contract/r/gnoswap/pool/v1/utils.gno
@@ -10,6 +10,7 @@ const (
 	MAX_UINT64  string = "18446744073709551615"
 	MAX_INT64   string = "9223372036854775807"
 	MAX_INT128  string = "170141183460469231731687303715884105727"
+	MIN_INT128  string = "-170141183460469231731687303715884105728"
 	MAX_UINT128 string = "340282366920938463463374607431768211455"
 	MAX_INT256  string = "57896044618658097711785492504343953926634992332820282019728792003956564819967"
 
@@ -26,6 +27,7 @@ const (
 
 var (
 	maxInt128FromDecimal  = i256.MustFromDecimal(MAX_INT128)
+	minInt128FromDecimal  = i256.MustFromDecimal(MIN_INT128)
 	maxUint128FromDecimal = u256.MustFromDecimal(MAX_UINT128)
 	q128FromDecimal       = u256.MustFromDecimal(Q128)
 )
@@ -93,10 +95,11 @@ func u256Min(num1, num2 *u256.Uint) *u256.Uint {
 
 // checkOverFlowInt128 checks if the value overflows the int128 range.
 func checkOverFlowInt128(value *i256.Int) {
-	if value.Gt(maxInt128FromDecimal) {
+	if value.Gt(maxInt128FromDecimal) || value.Lt(minInt128FromDecimal) {
 		panic(ufmt.Sprintf(
 			"%v: amount(%s) overflows int128 range",
-			errOverflow, value.ToString()))
+			errOverflow, value.ToString(),
+		))
 	}
 }
 

--- a/contract/r/gnoswap/pool/v1/utils_test.gno
+++ b/contract/r/gnoswap/pool/v1/utils_test.gno
@@ -379,14 +379,15 @@ func TestCheckOverFlowInt128_BoundaryValues(cur realm, t *testing.T) {
 		},
 		// Negative values
 		{
-			name:        "negative MAX_INT128",
-			input:       "-170141183460469231731687303715884105727",
+			name:        "MIN_INT128 exact",
+			input:       MIN_INT128,
 			shouldPanic: false,
 		},
 		{
-			name:        "negative MAX_INT128 - 1",
-			input:       "-170141183460469231731687303715884105728",
-			shouldPanic: false,
+			name:        "MIN_INT128 - 1",
+			input:       "-170141183460469231731687303715884105729",
+			shouldPanic: true,
+			errorMsg:    "[GNOSWAP-POOL-020] overflow: amount(-170141183460469231731687303715884105729) overflows int128 range",
 		},
 		// Q values
 		{
@@ -775,6 +776,17 @@ func TestCheckOverFlowInt128(cur realm, t *testing.T) {
 			input:       new(i256.Int).Add(i256.MustFromDecimal(MAX_INT128), i256.One()),
 			shouldPanic: true,
 			errorMsg:    "[GNOSWAP-POOL-020] overflow: amount(170141183460469231731687303715884105728) overflows int128 range",
+		},
+		{
+			name:        "min int128",
+			input:       i256.MustFromDecimal(MIN_INT128),
+			shouldPanic: false,
+		},
+		{
+			name:        "min int128 - 1",
+			input:       new(i256.Int).Sub(i256.MustFromDecimal(MIN_INT128), i256.One()),
+			shouldPanic: true,
+			errorMsg:    "[GNOSWAP-POOL-020] overflow: amount(-170141183460469231731687303715884105729) overflows int128 range",
 		},
 		{
 			name:        "very large value",


### PR DESCRIPTION
## Summary
- validate both lower and upper bounds before storing `liquidityNet` as an int128-equivalent value
- add regression coverage for `MIN_INT128` and `MIN_INT128 - 1`

## Reference
Uniswap V3 computes `liquidityNet ± liquidityDelta` as `int256` and converts it through `SafeCast.toInt128()`, which rejects both overflow and underflow:
- https://github.com/Uniswap/v3-core/blob/d0831dc6b8a318df3872b6d68f6de135c9f3ec29/contracts/libraries/Tick.sol#L135-L138
- https://github.com/Uniswap/v3-core/blob/d0831dc6b8a318df3872b6d68f6de135c9f3ec29/contracts/libraries/SafeCast.sol#L12-L17

## Test
- `make test PKG=gno.land/r/gnoswap/pool/v1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for signed 128-bit values to correctly reject numbers below the supported minimum.
  * Preserved support for the exact minimum and maximum supported values.
  * Prevented invalid out-of-range values from being processed, improving reliability for pool-related operations.

* **Tests**
  * Added coverage for minimum-boundary and below-minimum input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->