### PR TITLE
fix(staker): limit future incentive starts

### DIFF
--- a/contract/r/gnoswap/staker/v1/README.md
+++ b/contract/r/gnoswap/staker/v1/README.md
@@ -14,6 +14,7 @@ Staker manages distribution of internal (GNS emission) and external (user-provid
 - **Pool Tiers**: 1, 2, or 3 (assigned per pool)
 - **Warmup Schedule**: 30/50/70/100% over 30/60/90 days
 - **External Token Whitelist**: Approved reward tokens
+- **External Incentive Start**: UTC midnight, from the first eligible start (at least 24 hours after creation) through 7 days later
 
 ## Core Features
 

--- a/contract/r/gnoswap/staker/v1/assert.gno
+++ b/contract/r/gnoswap/staker/v1/assert.gno
@@ -17,6 +17,8 @@ const (
 	TIMESTAMP_180DAYS = int64(15552000)
 	TIMESTAMP_365DAYS = int64(31536000)
 
+	maxIncentiveStartDelay = 7 * 24 * time.Hour
+
 	MAX_UNIX_EPOCH_TIME = 253402300799 // 9999-12-31 23:59:59
 
 	maxUnstakingFee = uint64(1000) // 10%
@@ -177,7 +179,8 @@ func assertIsValidFeeRate(fee uint64) {
 	}
 }
 
-// assertIsValidIncentiveStartTime ensures the incentive starts at midnight at least 24 hours after creation.
+// assertIsValidIncentiveStartTime ensures the incentive starts at midnight no earlier than 24 hours after creation
+// and no later than 7 days after the first eligible midnight.
 func assertIsValidIncentiveStartTime(startTimestamp int64) {
 	// must be in seconds format, not milliseconds
 	// REF: https://stackoverflow.com/a/23982005
@@ -196,6 +199,14 @@ func assertIsValidIncentiveStartTime(startTimestamp int64) {
 		panic(makeErrorWithDetails(
 			errInvalidIncentiveStartTime,
 			ufmt.Sprintf("startTimestamp(%d) must be at least 24 hours later", startTimestamp),
+		))
+	}
+
+	maximumStartTimestamp := getMaximumIncentiveStartTimestamp()
+	if startTimestamp > maximumStartTimestamp {
+		panic(makeErrorWithDetails(
+			errInvalidIncentiveStartTime,
+			ufmt.Sprintf("startTimestamp(%d) exceeds the maximum start time policy", startTimestamp),
 		))
 	}
 
@@ -272,6 +283,18 @@ func assertIsNotStartedIncentive(incentiveResolver *ExternalIncentiveResolver, c
 // getMinimumIncentiveStartTimestamp returns after 24 hours from now.
 func getMinimumIncentiveStartTimestamp() int64 {
 	return time.Now().Add(24 * time.Hour).Unix()
+}
+
+// getMaximumIncentiveStartTimestamp returns 7 days after the first midnight that satisfies
+// the minimum 24-hour delay.
+func getMaximumIncentiveStartTimestamp() int64 {
+	minimumStartTimestamp := getMinimumIncentiveStartTimestamp()
+	firstEligibleMidnight := time.Unix(minimumStartTimestamp, 0).Truncate(24 * time.Hour)
+	if firstEligibleMidnight.Unix() < minimumStartTimestamp {
+		firstEligibleMidnight = firstEligibleMidnight.Add(24 * time.Hour)
+	}
+
+	return firstEligibleMidnight.Add(maxIncentiveStartDelay).Unix()
 }
 
 // assertIsValidIncentiveEndTime ensures the end timestamp is within valid epoch range.

--- a/contract/r/gnoswap/staker/v1/assert_test.gno
+++ b/contract/r/gnoswap/staker/v1/assert_test.gno
@@ -427,6 +427,7 @@ func TestAssertIsValidIncentiveStartTime(cur realm, t *testing.T) {
 	minimumStartTimestamp := getMinimumIncentiveStartTimestamp()
 	todayMidnight := now.Truncate(24 * time.Hour)
 	dayAfterTomorrowMidnight := now.AddDate(0, 0, 2).Truncate(24 * time.Hour)
+	maximumStartTimestamp := getMaximumIncentiveStartTimestamp()
 
 	tests := []struct {
 		name          string
@@ -459,10 +460,16 @@ func TestAssertIsValidIncentiveStartTime(cur realm, t *testing.T) {
 			expectedError: "must be midnight",
 		},
 		{
-			name:          "valid start time - far future midnight",
-			startTime:     time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC).Unix(),
+			name:          "valid start time - 7 days after first eligible midnight",
+			startTime:     maximumStartTimestamp,
 			expectPanic:   false,
 			expectedError: "",
+		},
+		{
+			name:          "invalid start time - more than 7 days after first eligible midnight",
+			startTime:     maximumStartTimestamp + int64(24*time.Hour/time.Second),
+			expectPanic:   true,
+			expectedError: "exceeds the maximum start time policy",
 		},
 		{
 			name:          "invalid start time - midnight before minimum",

--- a/contract/r/scenario/gov/governance/governance_proposal_execute_staker_cancel_external_incentive_filetest.gno
+++ b/contract/r/scenario/gov/governance/governance_proposal_execute_staker_cancel_external_incentive_filetest.gno
@@ -8,9 +8,9 @@
 // to cancel it passes, and executing the proposal refunds the reward tokens plus
 // the GNS deposit to the refund address and removes the incentive.
 //
-// The governance flow skips roughly three weeks of chain time between creation
-// and execution, so the incentive starts a year out to stay pending until the
-// proposal executes.
+// The default governance schedule takes longer than the maximum permitted
+// incentive lead time. This scenario first adopts a short schedule, then
+// exercises cancellation while the incentive remains pending.
 
 package main
 
@@ -85,24 +85,30 @@ func main(cur realm) {
 	delegateGnsToAdmin(cur)
 	println()
 
-	println("[SCENARIO] 2. Skip voting smoothing duration for create proposal")
+	println("[SCENARIO] 2. Skip voting smoothing duration")
 	testing.SkipHeights(int64(config.VotingWeightSmoothingDuration) / currentBlockTime)
 	ufmt.Printf("[INFO] current height: %d\n", runtime.ChainHeight())
 	println()
 
-	println("[SCENARIO] 3. Create pool and a pending external incentive")
+	println("[SCENARIO] 3. Adopt a short governance schedule")
+	proposalID := proposeShortVotingSchedule(cur)
+	voteAndExecuteShortSchedule(cur, proposalID, config)
+	config = governance.GetLatestConfig()
+	println()
+
+	println("[SCENARIO] 4. Create pool and a pending external incentive")
 	createPoolAndIncentive(cur)
 	println()
 
-	println("[SCENARIO] 4. Propose CancelExternalIncentive")
-	proposalID := proposeCancelExternalIncentive(cur)
+	println("[SCENARIO] 5. Propose CancelExternalIncentive")
+	proposalID = proposeCancelExternalIncentive(cur)
 	println()
 
-	println("[SCENARIO] 5. Vote and execute the proposal")
+	println("[SCENARIO] 6. Vote and execute the proposal")
 	voteAndExecute(cur, proposalID, config)
 	println()
 
-	println("[SCENARIO] 6. Verify the refund and the removal")
+	println("[SCENARIO] 7. Verify the refund and the removal")
 	verifyCancelled(cur)
 	println()
 }
@@ -134,14 +140,34 @@ func createPoolAndIncentive(cur realm) {
 
 	createTimestamp := time.Now().Unix()
 
-	// A year out, so the incentive is still pending when the proposal executes.
-	startTimestamp := ((createTimestamp / 86400) + 365) * 86400
+	// The first eligible midnight is at least one day after creation; this
+	// latest allowed start leaves the short governance proposal time to cancel.
+	startTimestamp := ((createTimestamp / 86400) + 8) * 86400
 	endTimestamp := startTimestamp + INCENTIVE_DURATION
 
 	incentiveID = ufmt.Sprintf("%s:%d:%d", adminAddr, createTimestamp, 1)
 	sr.CreateExternalIncentive(cross(cur), poolPath, barPath, REWARD_AMOUNT, startTimestamp, endTimestamp)
 
 	ufmt.Printf("[INFO] pending incentives for pool: %d\n", len(sr.GetExternalIncentiveByPoolPath(poolPath)))
+}
+
+func proposeShortVotingSchedule(cur realm) int64 {
+	testing.SetRealm(testing.NewUserRealm(adminAddr))
+	return governance.ProposeParameterChange(
+		cross(cur),
+		"governance",
+		"Adopt a short governance schedule",
+		1,
+		"gno.land/r/gnoswap/gov/governance*EXE*Reconfigure*EXE*8640,60480,86400,50,1000000000,0,2592000",
+	)
+}
+
+func voteAndExecuteShortSchedule(cur realm, proposalID int64, config governance.Config) {
+	testing.SetRealm(testing.NewUserRealm(adminAddr))
+	testing.SkipHeights(int64(config.VotingStartDelay)/currentBlockTime + 1)
+	governance.Vote(cross(cur), proposalID, true)
+	testing.SkipHeights(int64(config.VotingPeriod) / currentBlockTime)
+	governance.Execute(cross(cur), proposalID)
 }
 
 func proposeCancelExternalIncentive(cur realm) int64 {
@@ -163,7 +189,7 @@ func proposeCancelExternalIncentive(cur realm) int64 {
 func voteAndExecute(cur realm, proposalID int64, config governance.Config) {
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
 
-	testing.SkipHeights(int64(config.VotingStartDelay) / currentBlockTime)
+	testing.SkipHeights(int64(config.VotingStartDelay)/currentBlockTime + 1)
 	governance.Vote(cross(cur), proposalID, true)
 	ufmt.Printf("[INFO] Voted YES for proposal %d\n", proposalID)
 
@@ -187,20 +213,22 @@ func verifyCancelled(cur realm) {
 // [SCENARIO] 1. Delegate gns to admin
 // [INFO] gns delegated to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5 (amount: 1000000000)
 //
-// [SCENARIO] 2. Skip voting smoothing duration for create proposal
+// [SCENARIO] 2. Skip voting smoothing duration
 // [INFO] current height: 43323
 //
-// [SCENARIO] 3. Create pool and a pending external incentive
+// [SCENARIO] 3. Adopt a short governance schedule
+//
+// [SCENARIO] 4. Create pool and a pending external incentive
 // [INFO] pending incentives for pool: 1
 //
-// [SCENARIO] 4. Propose CancelExternalIncentive
-// [INFO] CancelExternalIncentive Proposal ID: 1
+// [SCENARIO] 5. Propose CancelExternalIncentive
+// [INFO] CancelExternalIncentive Proposal ID: 2
 //
-// [SCENARIO] 5. Vote and execute the proposal
-// [INFO] Voted YES for proposal 1
-// [EXPECTED] Proposal 1 executed successfully
+// [SCENARIO] 6. Vote and execute the proposal
+// [INFO] Voted YES for proposal 2
+// [EXPECTED] Proposal 2 executed successfully
 //
-// [SCENARIO] 6. Verify the refund and the removal
+// [SCENARIO] 7. Verify the refund and the removal
 // [EXPECTED] creator BAR refund delta: 1000000000
 // [EXPECTED] creator GNS refund delta: 100000000000
 // [EXPECTED] remaining incentives for pool: 0

--- a/contract/r/scenario/staker/full_internal_external_filetest.gno
+++ b/contract/r/scenario/staker/full_internal_external_filetest.gno
@@ -469,7 +469,7 @@ func createPoolExternalOnly(cur realm) {
 	baz.Approve(cross(cur), stakerAddr, 2_000_000_000)
 	gns.Approve(cross(cur), stakerAddr, depositGnsAmount)
 
-	startTime := int64(1244332800)
+	startTime := ((time.Now().Unix() / 86400) + 2) * 86400
 	endTime := startTime + TIMESTAMP_90DAYS
 
 	testing.SetRealm(adminRealm)

--- a/tests/integration/testdata/staker/collectable_reward_getters_read_only.txtar
+++ b/tests/integration/testdata/staker/collectable_reward_getters_read_only.txtar
@@ -94,7 +94,7 @@ gnokey maketx call -pkgpath gno.land/r/gnoswap/staker -func StakeToken -args 1 -
 # Create an incentive after staking. In the base implementation, the next
 # collectable getter lazily adds this ID to the deposit and advances its cursor.
 gnokey maketx call -pkgpath gno.land/r/gnoswap/gns -func Approve -args g1q6d4ns7zkr492rgl0pcgf5ajaf2dlz0nnptky3 -args 9223372036854775806 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" test1
-gnokey maketx call -pkgpath gno.land/r/gnoswap/staker -func CreateExternalIncentive -args "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:3000" -args "gno.land/r/onbloc/bar.BAR" -args 1000000000 -args 2773180800 -args 2780956800 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" test1
+gnokey maketx run test1 $WORK/run/create_external_incentive.gno -gas-fee 100000000ugnot -gas-wanted 1000000000 -broadcast -chainid=tendermint_test
 
 # Advance the chain beyond the creation timestamp so lazy discovery is reached.
 gnokey maketx call -pkgpath gno.land/r/onbloc/bar -func Transfer -args $test_admin_user_addr -args 1 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" test1
@@ -105,6 +105,27 @@ gnokey maketx call -pkgpath gno.land/r/onbloc/bar -func Transfer -args $test_adm
 # a regression assertion for the vulnerability fixed by this PR.
 gnokey maketx run test1 $WORK/run/collectable_reward_getters.gno -gas-fee 10000000ugnot -gas-wanted 1000000000 -broadcast -chainid=tendermint_test
 stdout 'collectable getters are read only'
+
+-- run/create_external_incentive.gno --
+package main
+
+import (
+	"time"
+
+	staker "gno.land/r/gnoswap/staker"
+)
+
+func main(cur realm) {
+	start := ((time.Now().Unix() / 86400) + 8) * 86400
+	staker.CreateExternalIncentive(
+		cross(cur),
+		"gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:3000",
+		"gno.land/r/onbloc/bar.BAR",
+		1000000000,
+		start,
+		start+90*24*60*60,
+	)
+}
 
 -- run/collectable_reward_getters.gno --
 package main

--- a/tests/integration/testdata/staker/end_non_existent_external_incentive_fail.txtar
+++ b/tests/integration/testdata/staker/end_non_existent_external_incentive_fail.txtar
@@ -95,7 +95,7 @@ gnokey maketx call -pkgpath gno.land/r/gnoswap/gns -func Approve -args g1q6d4ns7
 gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Approve -args g1q6d4ns7zkr492rgl0pcgf5ajaf2dlz0nnptky3 -args 9223372036854775806 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" test1
 
 gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Deposit -send "1000000000ugnot" -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" test1
-gnokey maketx call -pkgpath gno.land/r/gnoswap/staker -func CreateExternalIncentive -args "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:100" -args "gno.land/r/gnoland/wugnot.wugnot" -args 1000000000 -args 2773180800 -args 2780956800 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" test1
+gnokey maketx run test1 $WORK/run/create_external_incentive.gno -gas-fee 100000000ugnot -gas-wanted 1000000000 -broadcast -chainid=tendermint_test
 # stdout 'GAS USED:   3[0-9]{7}'
 # stdout 'STORAGE DELTA:  2[0-9]{4} bytes'
 # stdout 'TOTAL TX COST:  1[0-9]{8}ugnot'
@@ -104,5 +104,26 @@ gnokey maketx call -pkgpath gno.land/r/gnoswap/staker -func CreateExternalIncent
 gnokey query vm/qeval --data "gno.land/r/gnoswap/staker.GetExternalIncentiveByPoolPath(\"gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:100\")"
 
 ## End external incentive (not enough time -> should fail)
-! gnokey maketx call -pkgpath gno.land/r/gnoswap/staker -func EndExternalIncentive -args "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:100" -args "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5:2773180800:1" -args "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5" -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" test1
+! gnokey maketx call -pkgpath gno.land/r/gnoswap/staker -func EndExternalIncentive -args "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:100" -args "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5:1670457600:1" -args "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5" -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" test1
 stderr 'cannot end non existent incentive'
+
+-- run/create_external_incentive.gno --
+package main
+
+import (
+	"time"
+
+	staker "gno.land/r/gnoswap/staker"
+)
+
+func main(cur realm) {
+	start := ((time.Now().Unix() / 86400) + 8) * 86400
+	staker.CreateExternalIncentive(
+		cross(cur),
+		"gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:100",
+		"gno.land/r/gnoland/wugnot.wugnot",
+		1000000000,
+		start,
+		start+90*24*60*60,
+	)
+}

--- a/tests/integration/testdata/staker/staker_create_external_incentive.txtar
+++ b/tests/integration/testdata/staker/staker_create_external_incentive.txtar
@@ -101,7 +101,7 @@ gnokey maketx call -pkgpath gno.land/r/gnoswap/gns -func Approve -args g1q6d4ns7
 gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Approve -args g1q6d4ns7zkr492rgl0pcgf5ajaf2dlz0nnptky3 -args 9223372036854775806 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" test1
 
 gnokey maketx call -pkgpath gno.land/r/gnoland/wugnot -func Deposit -send "1000000000ugnot" -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" test1
-gnokey maketx call -pkgpath gno.land/r/gnoswap/staker -func CreateExternalIncentive -args "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:100" -args "gno.land/r/gnoland/wugnot.wugnot" -args 1000000000 -args 2773180800 -args 2780956800 -insecure-password-stdin=true -broadcast=true -chainid=tendermint_test -gas-fee 100000000ugnot -gas-wanted 1000000000 -memo "" test1
+gnokey maketx run test1 $WORK/run/create_external_incentive.gno -gas-fee 100000000ugnot -gas-wanted 1000000000 -broadcast -chainid=tendermint_test
 # stdout 'GAS USED:   3[0-9]{7}'
 # stdout 'STORAGE DELTA:  2[0-9]{4} bytes'
 # stdout 'TOTAL TX COST:  1[0-9]{8}ugnot'
@@ -119,3 +119,24 @@ gnokey query vm/qeval --data "gno.land/r/gnoswap/staker.GetExternalIncentiveByPo
 # stdout '\\"createdHeight\\":[0-9]+'
 # stdout '\\"depositGnsAmount\\":100000000000'
 # stdout '\\"refunded\\":false'
+
+-- run/create_external_incentive.gno --
+package main
+
+import (
+	"time"
+
+	staker "gno.land/r/gnoswap/staker"
+)
+
+func main(cur realm) {
+	start := ((time.Now().Unix() / 86400) + 8) * 86400
+	staker.CreateExternalIncentive(
+		cross(cur),
+		"gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:100",
+		"gno.land/r/gnoland/wugnot.wugnot",
+		1000000000,
+		start,
+		start+90*24*60*60,
+	)
+}


### PR DESCRIPTION
## Summary

This change prevents a creator from reserving a pool/reward-token pair with an external incentive whose start timestamp is far in the future.

## Start-Time Policy

An external incentive start timestamp is valid only when all of the following conditions hold:

1. It is expressed in seconds, not milliseconds.
2. It is at a UTC midnight.
3. It is no earlier than 24 hours after creation.
4. It is no later than seven days after the first midnight that satisfies condition 3.

| Creation time (UTC) | First eligible start | Latest eligible start |
| --- | --- | --- |
| Jan 1, 00:00 | Jan 2, 00:00 | Jan 9, 00:00 |
| Jan 1, 12:00 | Jan 3, 00:00 | Jan 10, 00:00 |
| Jan 1, 23:59 | Jan 3, 00:00 | Jan 10, 00:00 |

The maximum is calculated from the first eligible midnight, rather than directly from the creation timestamp. This preserves the existing 24-hour plus midnight scheduling rule while providing a full seven-day scheduling window.

A timestamp beyond this window is rejected with the invalid-incentive-start-time error and the detail `exceeds the maximum start time policy`.

## Changes

- add the maximum-start-time validation to external incentive creation
- cover the inclusive maximum boundary and the first timestamp beyond it
- document the schedule in the Staker README

## Test

- `make test PKG=gno.land/r/gnoswap/staker/v1 RUN=TestAssertIsValidIncentiveStartTime`