### PR TITLE
refactor(common)!: migrate token tellers off grc20 CallerTeller to RealmTeller

### DIFF
--- a/contract/r/gnoswap/common/README.md
+++ b/contract/r/gnoswap/common/README.md
@@ -4,7 +4,7 @@ Package common provides shared realm utilities for GnoSwap protocol contracts.
 
 ## Overview
 
-The common package contains helpers that must keep a realm boundary, including GRC20 token operations and native coin validation.
+The common package contains shared GRC20 token operations and native coin validation.
 
 ## Key Components
 
@@ -16,19 +16,14 @@ The common package contains helpers that must keep a realm boundary, including G
 
 ### GRC20 Registry Helpers
 
-The write helpers are crossing adapters and should be called as
-`common.Transfer(cross(cur), ...)`, `common.SafeGRC20Transfer(cross(cur), ...)`,
-and so on. They intentionally keep `cur realm` as the first parameter so the
-helper runs in common's crossing frame, then forward that live `cur` to
-`grc20.Teller` as `Transfer(0, cur, ...)`. Because `GetTokenTeller` returns a
-`CallerTeller`, the token actor is derived from `cur.Previous()`, which is the
-realm that crossed into common. Do not convert these helpers to
-`_ int, rlm realm`; that would remove the common crossing boundary and change
-which realm `CallerTeller` treats as the actor.
+The write helpers are called without crossing, for example
+`common.Transfer(0, cur, ...)` and `common.SafeGRC20Transfer(0, cur, ...)`.
+`GetTokenTeller` uses `RealmTeller` to bind the token actor to that current
+realm before forwarding the operation.
 
 **Token Operations:**
 - **GetToken**: Retrieves GRC20 token instance
-- **GetTokenTeller**: Gets a CallerTeller for token operations
+- **GetTokenTeller**: Gets a teller bound to the current realm
 - **IsRegistered**: Checks token registration status
 - **MustRegistered**: Validates multiple tokens are registered
 

--- a/contract/r/gnoswap/common/grc20reg_helper.gno
+++ b/contract/r/gnoswap/common/grc20reg_helper.gno
@@ -20,17 +20,18 @@ func GetToken(tokenKey string) *grc20.Token {
 	return grc20reg.MustGet(tokenKey)
 }
 
-// GetTokenTeller returns a CallerTeller for the specified tokenKey, panicking if not registered.
+// GetTokenTeller returns a teller bound to the current realm for the specified
+// tokenKey, panicking if not registered.
 //
 // Parameters:
+//   - rlm: current realm
 //   - tokenKey: GRC20 registry key
 //
-// Returns a grc20.Teller whose write methods derive the actor from the caller
-// realm.
+// Returns a grc20.Teller whose actor is the current realm.
 //
 // Panics if the token is not registered in grc20reg.
-func GetTokenTeller(tokenKey string) grc20.Teller {
-	return GetToken(tokenKey).CallerTeller()
+func GetTokenTeller(_ int, rlm realm, tokenKey string) grc20.Teller {
+	return GetToken(tokenKey).RealmTeller(0, rlm)
 }
 
 // IsRegistered checks if a token is registered in grc20reg, returning nil if registered or error if not.
@@ -112,100 +113,88 @@ func Allowance(tokenKey string, owner, spender address) int64 {
 	return GetToken(tokenKey).Allowance(owner, spender)
 }
 
-// Transfer crosses into common before forwarding to grc20.Teller.Transfer.
-// CallerTeller uses cur.Previous() as the token actor, so this helper must
-// remain a crossing adapter called with cross(cur).
+// Transfer forwards to a teller bound to the current realm.
 //
 // Parameters:
-//   - cur: current realm
+//   - rlm: current realm
 //   - tokenKey: GRC20 registry key
 //   - to: recipient address
 //   - amount: amount of tokens to transfer
 //
 // Returns an error if the transfer fails, nil otherwise.
-func Transfer(cur realm, tokenKey string, to address, amount int64) error {
-	return GetTokenTeller(tokenKey).Transfer(0, cur, to, amount)
+func Transfer(_ int, rlm realm, tokenKey string, to address, amount int64) error {
+	return GetTokenTeller(0, rlm, tokenKey).Transfer(0, rlm, to, amount)
 }
 
-// TransferFrom crosses into common before forwarding to grc20.Teller.TransferFrom.
-// CallerTeller uses cur.Previous() as the spender, so this helper must remain
-// a crossing adapter called with cross(cur).
+// TransferFrom forwards to a teller bound to the current realm.
 //
 // Parameters:
-//   - cur: current realm
+//   - rlm: current realm
 //   - tokenKey: GRC20 registry key
 //   - from: sender address
 //   - to: recipient address
 //   - amount: amount of tokens to transfer
 //
 // Returns an error if the transfer fails, nil otherwise.
-func TransferFrom(cur realm, tokenKey string, from, to address, amount int64) error {
-	return GetTokenTeller(tokenKey).TransferFrom(0, cur, from, to, amount)
+func TransferFrom(_ int, rlm realm, tokenKey string, from, to address, amount int64) error {
+	return GetTokenTeller(0, rlm, tokenKey).TransferFrom(0, rlm, from, to, amount)
 }
 
-// Approve crosses into common before forwarding to grc20.Teller.Approve.
-// CallerTeller uses cur.Previous() as the approver, so this helper must
-// remain a crossing adapter called with cross(cur).
+// Approve forwards to a teller bound to the current realm.
 //
 // Parameters:
-//   - cur: current realm
+//   - rlm: current realm
 //   - tokenKey: GRC20 registry key
 //   - spender: address allowed to spend the tokens
 //   - amount: amount of tokens to approve
 //
 // Returns an error if the approval fails, nil otherwise.
-func Approve(cur realm, tokenKey string, spender address, amount int64) error {
-	return GetTokenTeller(tokenKey).Approve(0, cur, spender, amount)
+func Approve(_ int, rlm realm, tokenKey string, spender address, amount int64) error {
+	return GetTokenTeller(0, rlm, tokenKey).Approve(0, rlm, spender, amount)
 }
 
-// SafeGRC20Transfer crosses into common, transfers tokens, and panics if it fails.
-// CallerTeller uses cur.Previous() as the token actor, so this helper must
-// remain a crossing adapter called with cross(cur).
+// SafeGRC20Transfer transfers tokens as the current realm and panics if it fails.
 //
 // Parameters:
-//   - cur: current realm
+//   - rlm: current realm
 //   - tokenKey: GRC20 registry key
 //   - to: recipient address
 //   - amount: amount of tokens to transfer
 //
 // Panics if the transfer fails.
-func SafeGRC20Transfer(cur realm, tokenKey string, to address, amount int64) {
-	if err := GetTokenTeller(tokenKey).Transfer(0, cur, to, amount); err != nil {
+func SafeGRC20Transfer(_ int, rlm realm, tokenKey string, to address, amount int64) {
+	if err := GetTokenTeller(0, rlm, tokenKey).Transfer(0, rlm, to, amount); err != nil {
 		panic(err)
 	}
 }
 
-// SafeGRC20TransferFrom crosses into common, transfers tokens, and panics if it fails.
-// CallerTeller uses cur.Previous() as the spender, so this helper must remain
-// a crossing adapter called with cross(cur).
+// SafeGRC20TransferFrom transfers tokens as the current realm and panics if it fails.
 //
 // Parameters:
-//   - cur: current realm
+//   - rlm: current realm
 //   - tokenKey: GRC20 registry key
 //   - from: sender address
 //   - to: recipient address
 //   - amount: amount of tokens to transfer
 //
 // Panics if the transfer fails.
-func SafeGRC20TransferFrom(cur realm, tokenKey string, from, to address, amount int64) {
-	if err := GetTokenTeller(tokenKey).TransferFrom(0, cur, from, to, amount); err != nil {
+func SafeGRC20TransferFrom(_ int, rlm realm, tokenKey string, from, to address, amount int64) {
+	if err := GetTokenTeller(0, rlm, tokenKey).TransferFrom(0, rlm, from, to, amount); err != nil {
 		panic(err)
 	}
 }
 
-// SafeGRC20Approve crosses into common, approves tokens, and panics if it fails.
-// CallerTeller uses cur.Previous() as the approver, so this helper must remain
-// a crossing adapter called with cross(cur).
+// SafeGRC20Approve approves tokens as the current realm and panics if it fails.
 //
 // Parameters:
-//   - cur: current realm
+//   - rlm: current realm
 //   - tokenKey: GRC20 registry key
 //   - spender: address allowed to spend the tokens
 //   - amount: amount of tokens to approve
 //
 // Panics if the approval fails.
-func SafeGRC20Approve(cur realm, tokenKey string, spender address, amount int64) {
-	if err := GetTokenTeller(tokenKey).Approve(0, cur, spender, amount); err != nil {
+func SafeGRC20Approve(_ int, rlm realm, tokenKey string, spender address, amount int64) {
+	if err := GetTokenTeller(0, rlm, tokenKey).Approve(0, rlm, spender, amount); err != nil {
 		panic(err)
 	}
 }

--- a/contract/r/gnoswap/common/grc20reg_helper_test.gno
+++ b/contract/r/gnoswap/common/grc20reg_helper_test.gno
@@ -110,7 +110,7 @@ func TestGrc20regHelper_TokenMethod(t *testing.T) {
 	})
 }
 
-func TestGrc20regHelper_GetTokenTeller(t *testing.T) {
+func TestGrc20regHelper_GetTokenTeller(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		path        string
@@ -135,14 +135,15 @@ func TestGrc20regHelper_GetTokenTeller(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
+			testing.SetRealm(testing.NewUserRealm(defaultHolder))
 			if tt.shouldPanic {
 				uassert.AbortsContains(t, cur, "unknown token", func() {
-					GetTokenTeller(tt.path)
+					GetTokenTeller(0, cur, tt.path)
 				})
 				return
 			}
 
-			teller := GetTokenTeller(tt.path)
+			teller := GetTokenTeller(0, cur, tt.path)
 			if teller == nil {
 				t.Error("Expected non-nil teller")
 			}
@@ -241,10 +242,10 @@ func TestGrc20regHelper_Transfer(cur realm, t *testing.T) {
 
 			if tt.shouldAbort {
 				uassert.AbortsContains(t, cur, tt.abortContains, func() {
-					Transfer(cross(cur), tt.path, tt.to, tt.amount)
+					Transfer(0, cur, tt.path, tt.to, tt.amount)
 				})
 			} else {
-				err := Transfer(cross(cur), tt.path, tt.to, tt.amount)
+				err := Transfer(0, cur, tt.path, tt.to, tt.amount)
 				if tt.expectedError {
 					uassert.Error(t, err)
 				} else {
@@ -348,7 +349,7 @@ func TestGrc20regHelper_TransferFrom(cur realm, t *testing.T) {
 			// Setup approval if needed - as the token owner (from address)
 			if tt.setupApproval {
 				testing.SetRealm(testing.NewUserRealm(tt.from))
-				err := Approve(cross(cur), tt.path, tt.caller, tt.approvalAmt)
+				err := Approve(0, cur, tt.path, tt.caller, tt.approvalAmt)
 				uassert.NoError(t, err)
 			}
 
@@ -364,10 +365,10 @@ func TestGrc20regHelper_TransferFrom(cur realm, t *testing.T) {
 
 			if tt.shouldAbort {
 				uassert.AbortsContains(t, cur, tt.abortContains, func() {
-					TransferFrom(cross(cur), tt.path, tt.from, tt.to, tt.amount)
+					TransferFrom(0, cur, tt.path, tt.from, tt.to, tt.amount)
 				})
 			} else {
-				err := TransferFrom(cross(cur), tt.path, tt.from, tt.to, tt.amount)
+				err := TransferFrom(0, cur, tt.path, tt.from, tt.to, tt.amount)
 				if tt.expectedError {
 					uassert.Error(t, err)
 				} else {
@@ -449,10 +450,10 @@ func TestGrc20regHelper_Approve(cur realm, t *testing.T) {
 
 			if tt.shouldAbort {
 				uassert.AbortsContains(t, cur, tt.abortContains, func() {
-					Approve(cross(cur), tt.path, tt.spender, tt.amount)
+					Approve(0, cur, tt.path, tt.spender, tt.amount)
 				})
 			} else {
-				err := Approve(cross(cur), tt.path, tt.spender, tt.amount)
+				err := Approve(0, cur, tt.path, tt.spender, tt.amount)
 				if tt.expectedError {
 					uassert.Error(t, err)
 				} else {
@@ -472,6 +473,7 @@ func TestGrc20regHelper_SafeGRC20Transfer(cur realm, t *testing.T) {
 		to            address
 		amount        int64
 		shouldAbort   bool
+		shouldPanic   bool
 		abortContains string
 	}{
 		{
@@ -488,7 +490,7 @@ func TestGrc20regHelper_SafeGRC20Transfer(cur realm, t *testing.T) {
 			path:          tokenPath,
 			to:            bob,
 			amount:        99999999999999,
-			shouldAbort:   true,
+			shouldPanic:   true,
 			abortContains: "insufficient balance",
 		},
 		{
@@ -497,7 +499,7 @@ func TestGrc20regHelper_SafeGRC20Transfer(cur realm, t *testing.T) {
 			path:          tokenPath,
 			to:            bob,
 			amount:        -100,
-			shouldAbort:   true,
+			shouldPanic:   true,
 			abortContains: "invalid amount",
 		},
 		{
@@ -517,15 +519,30 @@ func TestGrc20regHelper_SafeGRC20Transfer(cur realm, t *testing.T) {
 
 			if tt.shouldAbort {
 				uassert.AbortsContains(t, cur, tt.abortContains, func() {
-					SafeGRC20Transfer(cross(cur), tt.path, tt.to, tt.amount)
+					SafeGRC20Transfer(0, cur, tt.path, tt.to, tt.amount)
+				})
+			} else if tt.shouldPanic {
+				uassert.PanicsContains(t, cur, tt.abortContains, func() {
+					SafeGRC20Transfer(0, cur, tt.path, tt.to, tt.amount)
 				})
 			} else {
 				uassert.NotPanics(t, cur, func() {
-					SafeGRC20Transfer(cross(cur), tt.path, tt.to, tt.amount)
+					SafeGRC20Transfer(0, cur, tt.path, tt.to, tt.amount)
 				})
 			}
 		})
 	}
+}
+
+func TestGrc20regHelper_SafeGRC20TransferBindsCurrentRealm(cur realm, t *testing.T) {
+	testing.SetRealm(testing.NewUserRealm(defaultHolder))
+	beforeHolder := BalanceOf(tokenPath, defaultHolder)
+	beforeBob := BalanceOf(tokenPath, bob)
+
+	SafeGRC20Transfer(0, cur, tokenPath, bob, 100)
+
+	uassert.Equal(t, beforeHolder-100, BalanceOf(tokenPath, defaultHolder))
+	uassert.Equal(t, beforeBob+100, BalanceOf(tokenPath, bob))
 }
 
 func TestGrc20regHelper_SafeGRC20TransferFrom(cur realm, t *testing.T) {
@@ -539,6 +556,7 @@ func TestGrc20regHelper_SafeGRC20TransferFrom(cur realm, t *testing.T) {
 		setupApproval bool
 		approvalAmt   int64
 		shouldAbort   bool
+		shouldPanic   bool
 		abortContains string
 	}{
 		{
@@ -549,7 +567,7 @@ func TestGrc20regHelper_SafeGRC20TransferFrom(cur realm, t *testing.T) {
 			to:            alice,
 			amount:        100,
 			setupApproval: false,
-			shouldAbort:   true,
+			shouldPanic:   true,
 			abortContains: "insufficient allowance",
 		},
 		{
@@ -561,7 +579,7 @@ func TestGrc20regHelper_SafeGRC20TransferFrom(cur realm, t *testing.T) {
 			amount:        99999999999999,
 			setupApproval: true,
 			approvalAmt:   99999999999999,
-			shouldAbort:   true,
+			shouldPanic:   true,
 			abortContains: "insufficient balance",
 		},
 		{
@@ -592,7 +610,7 @@ func TestGrc20regHelper_SafeGRC20TransferFrom(cur realm, t *testing.T) {
 			// Setup approval if needed
 			if tt.setupApproval {
 				testing.SetRealm(testing.NewUserRealm(tt.from))
-				Approve(cross(cur), tt.path, tt.caller, tt.approvalAmt)
+				Approve(0, cur, tt.path, tt.caller, tt.approvalAmt)
 			}
 
 			// Now perform SafeGRC20TransferFrom as the caller
@@ -600,11 +618,15 @@ func TestGrc20regHelper_SafeGRC20TransferFrom(cur realm, t *testing.T) {
 
 			if tt.shouldAbort {
 				uassert.AbortsContains(t, cur, tt.abortContains, func() {
-					SafeGRC20TransferFrom(cross(cur), tt.path, tt.from, tt.to, tt.amount)
+					SafeGRC20TransferFrom(0, cur, tt.path, tt.from, tt.to, tt.amount)
+				})
+			} else if tt.shouldPanic {
+				uassert.PanicsContains(t, cur, tt.abortContains, func() {
+					SafeGRC20TransferFrom(0, cur, tt.path, tt.from, tt.to, tt.amount)
 				})
 			} else {
 				uassert.NotPanics(t, cur, func() {
-					SafeGRC20TransferFrom(cross(cur), tt.path, tt.from, tt.to, tt.amount)
+					SafeGRC20TransferFrom(0, cur, tt.path, tt.from, tt.to, tt.amount)
 				})
 			}
 		})
@@ -619,6 +641,7 @@ func TestGrc20regHelper_SafeGRC20Approve(cur realm, t *testing.T) {
 		spender       address
 		amount        int64
 		shouldAbort   bool
+		shouldPanic   bool
 		abortContains string
 	}{
 		{
@@ -635,7 +658,7 @@ func TestGrc20regHelper_SafeGRC20Approve(cur realm, t *testing.T) {
 			path:          tokenPath,
 			spender:       alice,
 			amount:        -100,
-			shouldAbort:   true,
+			shouldPanic:   true,
 			abortContains: "invalid amount",
 		},
 		{
@@ -663,11 +686,15 @@ func TestGrc20regHelper_SafeGRC20Approve(cur realm, t *testing.T) {
 
 			if tt.shouldAbort {
 				uassert.AbortsContains(t, cur, tt.abortContains, func() {
-					SafeGRC20Approve(cross(cur), tt.path, tt.spender, tt.amount)
+					SafeGRC20Approve(0, cur, tt.path, tt.spender, tt.amount)
+				})
+			} else if tt.shouldPanic {
+				uassert.PanicsContains(t, cur, tt.abortContains, func() {
+					SafeGRC20Approve(0, cur, tt.path, tt.spender, tt.amount)
 				})
 			} else {
 				uassert.NotPanics(t, cur, func() {
-					SafeGRC20Approve(cross(cur), tt.path, tt.spender, tt.amount)
+					SafeGRC20Approve(0, cur, tt.path, tt.spender, tt.amount)
 				})
 			}
 		})

--- a/contract/r/gnoswap/community_pool/community_pool.gno
+++ b/contract/r/gnoswap/community_pool/community_pool.gno
@@ -39,7 +39,7 @@ func TransferToken(cur realm, tokenPath string, to address, amount int64) {
 	caller := prevRealm.Address()
 	access.AssertIsAdminOrGovernance(caller)
 
-	common.SafeGRC20Transfer(cross(cur), tokenPath, to, amount)
+	common.SafeGRC20Transfer(0, cur, tokenPath, to, amount)
 
 	chain.Emit(
 		"TransferToken",

--- a/contract/r/gnoswap/gns/_helper_test.gno
+++ b/contract/r/gnoswap/gns/_helper_test.gno
@@ -27,7 +27,7 @@ func resetGnsTokenObject(cur realm, t *testing.T) {
 	t.Helper()
 
 	token, privateLedger = grc20.NewToken("Gnoswap", "GNS", 6, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(adminAddr, INITIAL_MINT_AMOUNT)
 }

--- a/contract/r/gnoswap/gns/gns.gno
+++ b/contract/r/gnoswap/gns/gns.gno
@@ -36,7 +36,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("Gnoswap", "GNS", 6, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	adminAddr := access.MustGetAddress(prabc.ROLE_ADMIN.String())
 	err := privateLedger.Mint(adminAddr, INITIAL_MINT_AMOUNT)

--- a/contract/r/gnoswap/gov/staker/v1/staker_reward.gno
+++ b/contract/r/gnoswap/gov/staker/v1/staker_reward.gno
@@ -419,7 +419,7 @@ func transferToken(
 		)
 	}
 
-	common.SafeGRC20Transfer(cross(rlm), tokenPath, to, amount)
+	common.SafeGRC20Transfer(0, rlm, tokenPath, to, amount)
 
 	return nil
 }

--- a/contract/r/gnoswap/launchpad/v1/_helper_test.gno
+++ b/contract/r/gnoswap/launchpad/v1/_helper_test.gno
@@ -256,7 +256,7 @@ func collectTestReward(cur realm, t *testing.T, lp *launchpadV1, userAddr addres
 	// Transfer reward to the depositor, mirroring CollectRewardByDepositId.
 	if rewardAmount > 0 {
 		testing.SetRealm(testing.NewCodeRealm(testLaunchpadPkgPath))
-		common.SafeGRC20Transfer(cross(cur), rewardTokenPath, deposit.Depositor(), rewardAmount)
+		common.SafeGRC20Transfer(0, cur, rewardTokenPath, deposit.Depositor(), rewardAmount)
 	}
 
 	return rewardAmount

--- a/contract/r/gnoswap/launchpad/v1/launchpad_project.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_project.gno
@@ -98,7 +98,7 @@ func (lp *launchpadV1) CreateProject(
 
 	// Interactions: transfer tokens
 	common.SafeGRC20TransferFrom(
-		cross(rlm),
+		0, rlm,
 		tokenPath,
 		caller,
 		launchpadAddr,
@@ -374,7 +374,7 @@ func (lp *launchpadV1) transferLeftFromProject(_ int, rlm realm, project *launch
 		}
 		project.SetTiers(updatedTiers)
 
-		common.SafeGRC20Transfer(cross(rlm), project.TokenPath(), recipient, projectRefundableAmount)
+		common.SafeGRC20Transfer(0, rlm, project.TokenPath(), recipient, projectRefundableAmount)
 	}
 
 	return projectRefundableAmount, nil

--- a/contract/r/gnoswap/launchpad/v1/launchpad_reward.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_reward.gno
@@ -44,7 +44,7 @@ func (lp *launchpadV1) CollectRewardByDepositId(_ int, rlm realm, depositID stri
 
 	// Transfer reward token to depositor
 	if rewardAmount > 0 {
-		common.SafeGRC20Transfer(cross(rlm), rewardTokenPath, deposit.Depositor(), rewardAmount)
+		common.SafeGRC20Transfer(0, rlm, rewardTokenPath, deposit.Depositor(), rewardAmount)
 	}
 
 	chain.Emit(

--- a/contract/r/gnoswap/launchpad/v1/launchpad_withdraw.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_withdraw.gno
@@ -67,7 +67,7 @@ func (lp *launchpadV1) CollectDepositGns(_ int, rlm realm, depositID string) (in
 
 	// Transfer reward token to depositor
 	if rewardAmount > 0 {
-		common.SafeGRC20Transfer(cross(rlm), rewardTokenPath, deposit.Depositor(), rewardAmount)
+		common.SafeGRC20Transfer(0, rlm, rewardTokenPath, deposit.Depositor(), rewardAmount)
 
 		chain.Emit(
 			"CollectRewardByDepositId",
@@ -80,7 +80,7 @@ func (lp *launchpadV1) CollectDepositGns(_ int, rlm realm, depositID string) (in
 	}
 
 	// Transfer the original GNS deposit back to the depositor
-	common.SafeGRC20Transfer(cross(rlm), GNS_TOKEN_KEY, deposit.Depositor(), withdrawalAmount)
+	common.SafeGRC20Transfer(0, rlm, GNS_TOKEN_KEY, deposit.Depositor(), withdrawalAmount)
 
 	chain.Emit(
 		"CollectDepositGns",

--- a/contract/r/gnoswap/pool/README.md
+++ b/contract/r/gnoswap/pool/README.md
@@ -116,11 +116,11 @@ func swapCallback(cur realm, amount0Delta, amount1Delta int64) error {
 
     if amount0Delta > 0 {
         // Transfer token0 to pool
-        common.SafeGRC20Transfer(cross, token0Path, poolAddr, amount0Delta)
+        common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
     }
     if amount1Delta > 0 {
         // Transfer token1 to pool
-        common.SafeGRC20Transfer(cross, token1Path, poolAddr, amount1Delta)
+        common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
     }
     return nil
 }

--- a/contract/r/gnoswap/pool/v1/README.md
+++ b/contract/r/gnoswap/pool/v1/README.md
@@ -116,11 +116,11 @@ func swapCallback(cur realm, amount0Delta, amount1Delta int64, _ *pool.CallbackM
 
     if amount0Delta > 0 {
         // Transfer token0 to pool
-        common.SafeGRC20Transfer(cross, token0Path, poolAddr, amount0Delta)
+        common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
     }
     if amount1Delta > 0 {
         // Transfer token1 to pool
-        common.SafeGRC20Transfer(cross, token1Path, poolAddr, amount1Delta)
+        common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
     }
     return nil
 }

--- a/contract/r/gnoswap/pool/v1/_helper_test.gno
+++ b/contract/r/gnoswap/pool/v1/_helper_test.gno
@@ -450,10 +450,10 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/gnoswap/pool/v1/dsl_test.gno
+++ b/contract/r/gnoswap/pool/v1/dsl_test.gno
@@ -169,9 +169,9 @@ func (e *PoolTestEnv) WhenSwapExecuted(cur realm, params SwapParams) (*u256.Uint
 	swapCallback := func(cur realm, amount0Delta int64, amount1Delta int64, _ *pl.CallbackMarker) error {
 		testing.SetRealm(adminRealm)
 		if params.zeroForOne {
-			common.SafeGRC20Transfer(cross(cur), params.token0, e.currentAddress, math.MaxInt64)
+			common.SafeGRC20Transfer(0, cur, params.token0, e.currentAddress, math.MaxInt64)
 		} else {
-			common.SafeGRC20Transfer(cross(cur), params.token1, e.currentAddress, math.MaxInt64)
+			common.SafeGRC20Transfer(0, cur, params.token1, e.currentAddress, math.MaxInt64)
 		}
 
 		return nil

--- a/contract/r/gnoswap/pool/v1/pool.gno
+++ b/contract/r/gnoswap/pool/v1/pool.gno
@@ -258,7 +258,7 @@ func (i *poolV1) Collect(
 
 		position.SetTokensOwed0(tokenOwed0)
 		pool.SetBalanceToken0(token0Balance)
-		common.SafeGRC20Approve(cross(rlm), pool.Token0Path(), positionAddr, amount0)
+		common.SafeGRC20Approve(0, rlm, pool.Token0Path(), positionAddr, amount0)
 	}
 	if amount1 > 0 {
 		tokenOwed1 := gnsmath.SafeSubInt64(position.TokensOwed1(), amount1)
@@ -269,7 +269,7 @@ func (i *poolV1) Collect(
 
 		position.SetTokensOwed1(tokenOwed1)
 		pool.SetBalanceToken1(token1Balance)
-		common.SafeGRC20Approve(cross(rlm), pool.Token1Path(), positionAddr, amount1)
+		common.SafeGRC20Approve(0, rlm, pool.Token1Path(), positionAddr, amount1)
 	}
 
 	setPosition(pool, positionKey, position)
@@ -378,8 +378,8 @@ func (i *poolV1) collectProtocol(
 		panic(err)
 	}
 
-	common.SafeGRC20Transfer(cross(rlm), pool.Token0Path(), recipient, amount0)
-	common.SafeGRC20Transfer(cross(rlm), pool.Token1Path(), recipient, amount1)
+	common.SafeGRC20Transfer(0, rlm, pool.Token0Path(), recipient, amount0)
+	common.SafeGRC20Transfer(0, rlm, pool.Token1Path(), recipient, amount1)
 
 	return utils.FormatInt(amount0), utils.FormatInt(amount1)
 }

--- a/contract/r/gnoswap/pool/v1/pool_test.gno
+++ b/contract/r/gnoswap/pool/v1/pool_test.gno
@@ -977,8 +977,8 @@ func approveTokensForPool(cur realm, t *testing.T, pool *pl.Pool) {
 	t.Helper()
 	testing.SetRealm(adminRealm)
 
-	common.SafeGRC20Approve(cross(cur), pool.Token0Path(), poolAddr, maxApprove)
-	common.SafeGRC20Approve(cross(cur), pool.Token1Path(), poolAddr, maxApprove)
+	common.SafeGRC20Approve(0, cur, pool.Token0Path(), poolAddr, maxApprove)
+	common.SafeGRC20Approve(0, cur, pool.Token1Path(), poolAddr, maxApprove)
 }
 
 func getTokenBalance(t *testing.T, tokenPath string, addr address) int64 {

--- a/contract/r/gnoswap/pool/v1/protocol_fee.gno
+++ b/contract/r/gnoswap/pool/v1/protocol_fee.gno
@@ -67,8 +67,8 @@ func (i *poolV1) HandleWithdrawalFee(
 
 	i.settleProtocolFee(0, rlm, token0Path, fee0Int64)
 	i.settleProtocolFee(0, rlm, token1Path, fee1Int64)
-	common.SafeGRC20Transfer(cross(rlm), token0Path, positionCaller, gnsmath.SafeConvertToInt64(amount0WithoutFee))
-	common.SafeGRC20Transfer(cross(rlm), token1Path, positionCaller, gnsmath.SafeConvertToInt64(amount1WithoutFee))
+	common.SafeGRC20Transfer(0, rlm, token0Path, positionCaller, gnsmath.SafeConvertToInt64(amount0WithoutFee))
+	common.SafeGRC20Transfer(0, rlm, token1Path, positionCaller, gnsmath.SafeConvertToInt64(amount1WithoutFee))
 
 	return fee0.ToString(), fee1.ToString(), amount0WithoutFee.ToString(), amount1WithoutFee.ToString()
 }
@@ -116,7 +116,7 @@ func (i *poolV1) settleProtocolFee(_ int, rlm realm, tokenPath string, amount in
 
 	if totalAmount > 0 {
 		protocolFeeAddr := access.MustGetAddress(prabc.ROLE_PROTOCOL_FEE.String())
-		common.SafeGRC20Approve(cross(rlm), tokenPath, protocolFeeAddr, totalAmount)
+		common.SafeGRC20Approve(0, rlm, tokenPath, protocolFeeAddr, totalAmount)
 
 		// AddToProtocolFee only reports an error for a halted realm, which is handled
 		// above. The branch keeps the amount pending should that ever change.

--- a/contract/r/gnoswap/pool/v1/protocol_fee_test.gno
+++ b/contract/r/gnoswap/pool/v1/protocol_fee_test.gno
@@ -694,10 +694,10 @@ func TestProtocolFeesDisabledWhenNotConfigured(cur realm, t *testing.T) {
 		testing.SetRealm(adminRealm)
 
 		if amount0Delta > 0 {
-			common.SafeGRC20Transfer(cross(cur), barPath, poolAddr, amount0Delta)
+			common.SafeGRC20Transfer(0, cur, barPath, poolAddr, amount0Delta)
 		}
 		if amount1Delta > 0 {
-			common.SafeGRC20Transfer(cross(cur), fooPath, poolAddr, amount1Delta)
+			common.SafeGRC20Transfer(0, cur, fooPath, poolAddr, amount1Delta)
 		}
 
 		return nil

--- a/contract/r/gnoswap/pool/v1/swap_paid_test.gno
+++ b/contract/r/gnoswap/pool/v1/swap_paid_test.gno
@@ -372,10 +372,10 @@ func swapPaidSwapCallback(
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil
@@ -412,11 +412,11 @@ func initSwapPaidSetFeeMintPosition(
 	testing.SetOriginSend(chain.Coins{})
 
 	if amount0Requested > 0 {
-		common.SafeGRC20Approve(cross(cur), token0Path, poolAddr, amount0Requested)
+		common.SafeGRC20Approve(0, cur, token0Path, poolAddr, amount0Requested)
 	}
 
 	if amount1Requested > 0 {
-		common.SafeGRC20Approve(cross(cur), token1Path, poolAddr, amount1Requested)
+		common.SafeGRC20Approve(0, cur, token1Path, poolAddr, amount1Requested)
 	}
 
 	sqrtPriceX96, _ := getMockInstance().GetSlot0SqrtPriceX96(GetPoolPath(token0Path, token1Path, feeTier))

--- a/contract/r/gnoswap/pool/v1/transfer.gno
+++ b/contract/r/gnoswap/pool/v1/transfer.gno
@@ -53,7 +53,7 @@ func (i *poolV1) safeTransfer(
 		panic(err)
 	}
 
-	common.SafeGRC20Transfer(cross(rlm), tokenPath, to, amountInt64)
+	common.SafeGRC20Transfer(0, rlm, tokenPath, to, amountInt64)
 
 	newBalance, err := updatePoolBalance(token0, token1, amountInt64, isToken0)
 	if err != nil {
@@ -111,7 +111,7 @@ func (i *poolV1) safeTransferFrom(
 	token := common.GetToken(tokenPath)
 	beforeBalance := token.BalanceOf(to)
 
-	common.SafeGRC20TransferFrom(cross(rlm), tokenPath, from, to, amountInt64)
+	common.SafeGRC20TransferFrom(0, rlm, tokenPath, from, to, amountInt64)
 
 	afterBalance := token.BalanceOf(to)
 	if gnsmath.SafeAddInt64(beforeBalance, amountInt64) != afterBalance {

--- a/contract/r/gnoswap/position/v1/_helper_test.gno
+++ b/contract/r/gnoswap/position/v1/_helper_test.gno
@@ -511,8 +511,8 @@ func mockInstanceMint(
 	amount1Int, _ := strconv.ParseInt(amount1Desired, 10, 64)
 
 	testing.SetRealm(testing.NewUserRealm(caller))
-	common.SafeGRC20Approve(cross(cur), token0, poolAddr, amount0Int)
-	common.SafeGRC20Approve(cross(cur), token1, poolAddr, amount1Int)
+	common.SafeGRC20Approve(0, cur, token0, poolAddr, amount0Int)
+	common.SafeGRC20Approve(0, cur, token1, poolAddr, amount1Int)
 
 	testing.SetRealm(testing.NewUserRealm(caller))
 	return position.Mint(cross(cur),
@@ -545,8 +545,8 @@ func mockInstanceIncreaseLiquidity(
 	amount1Int, _ := strconv.ParseInt(amount1DesiredStr, 10, 64)
 
 	testing.SetRealm(testing.NewUserRealm(caller))
-	common.SafeGRC20Approve(cross(cur), barPath, poolAddr, amount0Int)
-	common.SafeGRC20Approve(cross(cur), fooPath, poolAddr, amount1Int)
+	common.SafeGRC20Approve(0, cur, barPath, poolAddr, amount0Int)
+	common.SafeGRC20Approve(0, cur, fooPath, poolAddr, amount1Int)
 
 	testing.SetRealm(testing.NewUserRealm(caller))
 	return position.IncreaseLiquidity(cross(cur),
@@ -592,8 +592,8 @@ func mockInstanceReposition(
 	amount1Int, _ := strconv.ParseInt(amount1DesiredStr, 10, 64)
 
 	testing.SetRealm(testing.NewUserRealm(caller))
-	common.SafeGRC20Approve(cross(cur), barPath, poolAddr, amount0Int)
-	common.SafeGRC20Approve(cross(cur), fooPath, poolAddr, amount1Int)
+	common.SafeGRC20Approve(0, cur, barPath, poolAddr, amount0Int)
+	common.SafeGRC20Approve(0, cur, fooPath, poolAddr, amount1Int)
 
 	testing.SetRealm(testing.NewUserRealm(caller))
 	return position.Reposition(cross(cur),

--- a/contract/r/gnoswap/position/v1/burn.gno
+++ b/contract/r/gnoswap/position/v1/burn.gno
@@ -143,8 +143,8 @@ func (p *positionV1) decreaseLiquidity(_ int, rlm realm, params DecreaseLiquidit
 
 	p.mustUpdatePosition(0, rlm, params.positionId, *position)
 
-	common.SafeGRC20TransferFrom(cross(rlm), pToken0, poolAddr, caller, collectAmount0Int64)
-	common.SafeGRC20TransferFrom(cross(rlm), pToken1, poolAddr, caller, collectAmount1Int64)
+	common.SafeGRC20TransferFrom(0, rlm, pToken0, poolAddr, caller, collectAmount0Int64)
+	common.SafeGRC20TransferFrom(0, rlm, pToken1, poolAddr, caller, collectAmount1Int64)
 
 	return params.positionId, liquidityToRemove.ToString(), fee0Str, fee1Str, collect0, collect1, position.PoolKey(), nil
 }

--- a/contract/r/gnoswap/position/v1/mint_test.gno
+++ b/contract/r/gnoswap/position/v1/mint_test.gno
@@ -729,8 +729,8 @@ func TestMintInternal_TickBoundaries(cur realm, t *testing.T) {
 			amount1Int, _ := strconv.ParseInt(tt.params.amount1Desired.ToString(), 10, 64)
 
 			testing.SetRealm(testing.NewUserRealm(tt.params.caller))
-			common.SafeGRC20Approve(cross(cur), tt.params.token0, poolAddr, amount0Int)
-			common.SafeGRC20Approve(cross(cur), tt.params.token1, poolAddr, amount1Int)
+			common.SafeGRC20Approve(0, cur, tt.params.token0, poolAddr, amount0Int)
+			common.SafeGRC20Approve(0, cur, tt.params.token1, poolAddr, amount1Int)
 
 			if tt.expectPanic {
 				uassert.AbortsWithMessage(t, cur, tt.expectedMsg, func() {

--- a/contract/r/gnoswap/position/v1/position_test.gno
+++ b/contract/r/gnoswap/position/v1/position_test.gno
@@ -704,8 +704,8 @@ func TestMint(cur realm, t *testing.T) {
 				})
 			} else {
 				testing.SetRealm(adminRealm)
-				common.SafeGRC20Transfer(cross(cur), tc.token0, tc.caller, amount0Int)
-				common.SafeGRC20Transfer(cross(cur), tc.token1, tc.caller, amount1Int)
+				common.SafeGRC20Transfer(0, cur, tc.token0, tc.caller, amount0Int)
+				common.SafeGRC20Transfer(0, cur, tc.token1, tc.caller, amount1Int)
 
 				testing.SetRealm(testing.NewUserRealm(tc.caller))
 
@@ -801,16 +801,16 @@ func TestMint_ParticipantDerivationAndMintToValidation(cur realm, t *testing.T) 
 			}
 
 			testing.SetRealm(adminRealm)
-			common.SafeGRC20Transfer(cross(cur), barPath, caller, 1000000)
-			common.SafeGRC20Transfer(cross(cur), fooPath, caller, 1000000)
+			common.SafeGRC20Transfer(0, cur, barPath, caller, 1000000)
+			common.SafeGRC20Transfer(0, cur, fooPath, caller, 1000000)
 
 			if tt.callerCodePath != "" {
 				testing.SetRealm(testing.NewCodeRealm(tt.callerCodePath))
 			} else {
 				testing.SetRealm(testing.NewUserRealm(caller))
 			}
-			common.SafeGRC20Approve(cross(cur), barPath, poolAddr, 1000000)
-			common.SafeGRC20Approve(cross(cur), fooPath, poolAddr, 1000000)
+			common.SafeGRC20Approve(0, cur, barPath, poolAddr, 1000000)
+			common.SafeGRC20Approve(0, cur, fooPath, poolAddr, 1000000)
 
 			mint := func(cur realm) (uint64, string, string, string) {
 				if tt.callerCodePath != "" {

--- a/contract/r/gnoswap/protocol_fee/v1/protocol_fee.gno
+++ b/contract/r/gnoswap/protocol_fee/v1/protocol_fee.gno
@@ -243,7 +243,7 @@ func (pf *protocolFeeV1) AddToProtocolFee(_ int, rlm realm, tokenPath string, am
 
 	pf.reserveCollectedProtocolFee(0, rlm, tokenPath, amount)
 	protocolFeeAddr := access.MustGetAddress(prabc.ROLE_PROTOCOL_FEE.String())
-	common.SafeGRC20TransferFrom(cross(rlm), tokenPath, caller, protocolFeeAddr, amount)
+	common.SafeGRC20TransferFrom(0, rlm, tokenPath, caller, protocolFeeAddr, amount)
 
 	chain.Emit(
 		"AddToProtocolFee",

--- a/contract/r/gnoswap/protocol_fee/v1/protocol_fee_state.gno
+++ b/contract/r/gnoswap/protocol_fee/v1/protocol_fee_state.gno
@@ -59,7 +59,7 @@ func (pfs *protocolFeeState) distributeToDevOps(_ int, rlm realm, token string, 
 	if err := pfs.addActualDistributedToDevOps(0, rlm, token, amount); err != nil {
 		return err
 	}
-	common.SafeGRC20Transfer(cross(rlm), token, devOpsAddr, amount)
+	common.SafeGRC20Transfer(0, rlm, token, devOpsAddr, amount)
 
 	return nil
 }
@@ -72,7 +72,7 @@ func (pfs *protocolFeeState) distributeToGovStaker(_ int, rlm realm, token strin
 	if err := pfs.addActualDistributedToGovStaker(0, rlm, token, amount); err != nil {
 		return err
 	}
-	common.SafeGRC20Transfer(cross(rlm), token, govStakerAddr, amount)
+	common.SafeGRC20Transfer(0, rlm, token, govStakerAddr, amount)
 
 	return nil
 }

--- a/contract/r/gnoswap/protocol_fee/v1/protocol_fee_test.gno
+++ b/contract/r/gnoswap/protocol_fee/v1/protocol_fee_test.gno
@@ -298,7 +298,7 @@ func TestDistributeProtocolFeeByTokenPath_HaltScenario(cur realm, t *testing.T) 
 				}
 
 				testing.SetRealm(adminRealm)
-				common.SafeGRC20Transfer(cross(cur), "gno.land/r/onbloc/bar.BAR", protocolFeeAddr, 100)
+				common.SafeGRC20Transfer(0, cur, "gno.land/r/onbloc/bar.BAR", protocolFeeAddr, 100)
 			}
 
 			testing.SetRealm(govStakerRealm)
@@ -1278,7 +1278,7 @@ func TestDistributeProtocolFee_HaltScenario_SafeMode(cur realm, t *testing.T) {
 	}()
 
 	testing.SetRealm(adminRealm)
-	common.SafeGRC20Transfer(cross(cur), "gno.land/r/onbloc/bar.BAR", protocolFeeAddr, 100)
+	common.SafeGRC20Transfer(0, cur, "gno.land/r/onbloc/bar.BAR", protocolFeeAddr, 100)
 
 	testing.SetRealm(govStakerRealm)
 

--- a/contract/r/gnoswap/router/v1/base_test.gno
+++ b/contract/r/gnoswap/router/v1/base_test.gno
@@ -132,7 +132,7 @@ func TestProcessRoute(cur realm, t *testing.T) {
 	testing.SetRealm(adminRealm)
 	CreatePoolWithoutFee(cur, t)
 	MakeThirdMintPositionWithoutFee(cur, t)
-	common.SafeGRC20Approve(cross(cur), fooPath, routerAddr, 1000000)
+	common.SafeGRC20Approve(0, cur, fooPath, routerAddr, 1000000)
 	route := foobar500
 	toSwap := int64(1000)
 	swapType := ExactIn
@@ -159,8 +159,8 @@ func TestProcessRoutesWithRemainder(cur realm, t *testing.T) {
 	}
 
 	testing.SetRealm(adminRealm)
-	common.SafeGRC20Approve(cross(cur), fooPath, routerAddr, math.MaxInt64)
-	common.SafeGRC20Approve(cross(cur), barPath, routerAddr, math.MaxInt64)
+	common.SafeGRC20Approve(0, cur, fooPath, routerAddr, math.MaxInt64)
+	common.SafeGRC20Approve(0, cur, barPath, routerAddr, math.MaxInt64)
 	CreatePoolWithoutFee(cur, t)
 	MakeThirdMintPositionWithoutFee(cur, t)
 	MakeForthMintPositionWithoutFee(cur, t)

--- a/contract/r/gnoswap/router/v1/exact_in.gno
+++ b/contract/r/gnoswap/router/v1/exact_in.gno
@@ -178,7 +178,7 @@ func (r *routerV1) exactInSwapRoute(
 	previousRealm := rlm.Previous()
 	caller := previousRealm.Address()
 
-	common.SafeGRC20Transfer(cross(rlm), params.outputToken, caller, outputAmount)
+	common.SafeGRC20Transfer(0, rlm, params.outputToken, caller, outputAmount)
 
 	// handle referral registration
 	actualReferrer := referral.TryRegister(cross(rlm), caller, referrer)

--- a/contract/r/gnoswap/router/v1/exact_out.gno
+++ b/contract/r/gnoswap/router/v1/exact_out.gno
@@ -178,7 +178,7 @@ func (r *routerV1) exactOutSwapRoute(
 	previousRealm := rlm.Previous()
 	caller := previousRealm.Address()
 
-	common.SafeGRC20Transfer(cross(rlm), params.outputToken, caller, outputAmount)
+	common.SafeGRC20Transfer(0, rlm, params.outputToken, caller, outputAmount)
 
 	// handle referral registration
 	actualReferrer := referral.TryRegister(cross(rlm), caller, referrer)

--- a/contract/r/gnoswap/router/v1/protocol_fee_swap.gno
+++ b/contract/r/gnoswap/router/v1/protocol_fee_swap.gno
@@ -146,7 +146,7 @@ func (r *routerV1) settleProtocolFee(_ int, rlm realm, tokenPath string, amount 
 
 	if totalAmount > 0 {
 		protocolFeeAddr := access.MustGetAddress(prbac.ROLE_PROTOCOL_FEE.String())
-		common.SafeGRC20Approve(cross(rlm), tokenPath, protocolFeeAddr, totalAmount)
+		common.SafeGRC20Approve(0, rlm, tokenPath, protocolFeeAddr, totalAmount)
 
 		// AddToProtocolFee only reports an error for a halted realm, which is handled
 		// above. The branch keeps the amount pending should that ever change.

--- a/contract/r/gnoswap/router/v1/router_test.gno
+++ b/contract/r/gnoswap/router/v1/router_test.gno
@@ -901,7 +901,7 @@ func TestHandleMultiSwap(cur realm, t *testing.T) {
 
 			testing.SetRealm(adminRealm)
 
-			common.SafeGRC20Approve(cross(cur), tt.inputToken, routerAddr, math.MaxInt64)
+			common.SafeGRC20Approve(0, cur, tt.inputToken, routerAddr, math.MaxInt64)
 
 			amountSpecified := utils.SafeParseInt64(tt.amountSpecified)
 
@@ -1016,7 +1016,7 @@ func TestProcessRoute_MultiHops(cur realm, t *testing.T) {
 			toSwapAmount := utils.SafeParseInt64(tt.toSwap)
 			testing.SetRealm(adminRealm)
 
-			common.SafeGRC20Approve(cross(cur), barPath, routerAddr, math.MaxInt64)
+			common.SafeGRC20Approve(0, cur, barPath, routerAddr, math.MaxInt64)
 
 			router := mockRouter()
 			processRouteFn := func(cur realm) (int64, int64, error) {

--- a/contract/r/gnoswap/router/v1/swap_callback.gno
+++ b/contract/r/gnoswap/router/v1/swap_callback.gno
@@ -93,8 +93,8 @@ func (r *routerV1) transferToPool(_ int, rlm realm, token string, amount *u256.U
 	routerAddr := access.MustGetAddress(prbac.ROLE_ROUTER.String())
 
 	if payer == routerAddr {
-		common.SafeGRC20Transfer(cross(rlm), token, poolAddr, amount.Int64())
+		common.SafeGRC20Transfer(0, rlm, token, poolAddr, amount.Int64())
 	} else {
-		common.SafeGRC20TransferFrom(cross(rlm), token, payer, poolAddr, amount.Int64())
+		common.SafeGRC20TransferFrom(0, rlm, token, payer, poolAddr, amount.Int64())
 	}
 }

--- a/contract/r/gnoswap/router/v1/swap_multi_test.gno
+++ b/contract/r/gnoswap/router/v1/swap_multi_test.gno
@@ -88,8 +88,8 @@ func TestMultiSwap(cur realm, t *testing.T) {
 			// (cur.Previous()) resolves to user1 and the pool can pull the
 			// input token. Mirrors TestSingleSwap.
 			testing.SetRealm(testing.NewUserRealm(user1Addr))
-			common.Approve(cross(cur), tt.params.tokenIn, poolAddr, maxApprove)
-			common.Approve(cross(cur), tt.params.tokenOut, poolAddr, maxApprove)
+			common.Approve(0, cur, tt.params.tokenIn, poolAddr, maxApprove)
+			common.Approve(0, cur, tt.params.tokenOut, poolAddr, maxApprove)
 
 			firstAmountIn, lastAmountOut := multiSwapFn(cross(cur))
 

--- a/contract/r/gnoswap/router/v1/swap_single_test.gno
+++ b/contract/r/gnoswap/router/v1/swap_single_test.gno
@@ -84,8 +84,8 @@ func TestSingleSwap(cur realm, t *testing.T) {
 
 			user1Realm := testing.NewUserRealm(user1Addr)
 			testing.SetRealm(user1Realm)
-			common.Approve(cross(cur), tt.params.tokenIn, poolAddr, maxApprove)
-			common.Approve(cross(cur), tt.params.tokenOut, poolAddr, maxApprove)
+			common.Approve(0, cur, tt.params.tokenIn, poolAddr, maxApprove)
+			common.Approve(0, cur, tt.params.tokenOut, poolAddr, maxApprove)
 
 			amountIn, amountOut := singleSwapFn(cross(cur))
 

--- a/contract/r/gnoswap/staker/v1/external_incentive.gno
+++ b/contract/r/gnoswap/staker/v1/external_incentive.gno
@@ -60,12 +60,12 @@ func (s *stakerV1) CreateExternalIncentive(
 	stakerAddr := access.MustGetAddress(prbac.ROLE_STAKER.String())
 
 	// transfer reward token from user to staker
-	common.SafeGRC20TransferFrom(cross(rlm), rewardToken, caller, stakerAddr, rewardAmount)
+	common.SafeGRC20TransferFrom(0, rlm, rewardToken, caller, stakerAddr, rewardAmount)
 
 	depositGnsAmount := s.store.GetDepositGnsAmount()
 
 	// deposit gns amount
-	common.SafeGRC20TransferFrom(cross(rlm), GNS_TOKEN_KEY, caller, stakerAddr, depositGnsAmount)
+	common.SafeGRC20TransferFrom(0, rlm, GNS_TOKEN_KEY, caller, stakerAddr, depositGnsAmount)
 
 	currentHeight := runtime.ChainHeight()
 	incentiveId := s.store.NextIncentiveID(caller, currentTime)
@@ -209,10 +209,10 @@ func (s *stakerV1) EndExternalIncentive(_ int, rlm realm, targetPoolPath, incent
 	incentivesResolver.update(incentive)
 
 	// refund reward token to refundee
-	common.SafeGRC20Transfer(cross(rlm), incentiveResolver.RewardToken(), refundAddress, refund)
+	common.SafeGRC20Transfer(0, rlm, incentiveResolver.RewardToken(), refundAddress, refund)
 
 	// Transfer GNS deposit back to refundee
-	common.SafeGRC20Transfer(cross(rlm), GNS_TOKEN_KEY, refundAddress, incentiveResolver.DepositGnsAmount())
+	common.SafeGRC20Transfer(0, rlm, GNS_TOKEN_KEY, refundAddress, incentiveResolver.DepositGnsAmount())
 
 	previousRealm := rlm.Previous()
 	chain.Emit(
@@ -383,12 +383,12 @@ func (s *stakerV1) CancelExternalIncentive(_ int, rlm realm, targetPoolPath, inc
 
 	if refundAmount > 0 {
 		// transfer reward token back to creator
-		common.SafeGRC20Transfer(cross(rlm), rewardToken, creator, refundAmount)
+		common.SafeGRC20Transfer(0, rlm, rewardToken, creator, refundAmount)
 	}
 
 	if depositGnsAmount > 0 {
 		// transfer GNS deposit back to creator
-		common.SafeGRC20Transfer(cross(rlm), GNS_TOKEN_KEY, creator, depositGnsAmount)
+		common.SafeGRC20Transfer(0, rlm, GNS_TOKEN_KEY, creator, depositGnsAmount)
 	}
 
 	chain.Emit(
@@ -494,7 +494,7 @@ func (s *stakerV1) CollectExternalIncentivePenalty(
 	incentivesResolver.update(incentiveResolver.ExternalIncentive)
 
 	// Transfer penalty to refund address
-	common.SafeGRC20Transfer(cross(rlm), incentiveResolver.RewardToken(), refundAddress, penaltyAmount)
+	common.SafeGRC20Transfer(0, rlm, incentiveResolver.RewardToken(), refundAddress, penaltyAmount)
 
 	previousRealm := rlm.Previous()
 	chain.Emit(

--- a/contract/r/gnoswap/staker/v1/protocol_fee_unstaking.gno
+++ b/contract/r/gnoswap/staker/v1/protocol_fee_unstaking.gno
@@ -93,7 +93,7 @@ func (s *stakerV1) settleProtocolFee(_ int, rlm realm, tokenPath string, amount 
 
 	if totalAmount > 0 {
 		protocolFeeAddr := access.MustGetAddress(prbac.ROLE_PROTOCOL_FEE.String())
-		common.SafeGRC20Approve(cross(rlm), tokenPath, protocolFeeAddr, totalAmount)
+		common.SafeGRC20Approve(0, rlm, tokenPath, protocolFeeAddr, totalAmount)
 
 		// AddToProtocolFee only reports an error for a halted realm, which is handled
 		// above. The branch keeps the amount pending should that ever change.

--- a/contract/r/gnoswap/staker/v1/staker.gno
+++ b/contract/r/gnoswap/staker/v1/staker.gno
@@ -558,7 +558,7 @@ func (s *stakerV1) CollectReward(_ int, rlm realm, positionId uint64) (string, s
 		}
 
 		if toUser > 0 {
-			common.SafeGRC20Transfer(cross(rlm), rewardToken, deposit.Owner(), toUser)
+			common.SafeGRC20Transfer(0, rlm, rewardToken, deposit.Owner(), toUser)
 		}
 
 		chain.Emit(

--- a/contract/r/gnoswap/test/fuzz/exact_in_swap_route_test.gno
+++ b/contract/r/gnoswap/test/fuzz/exact_in_swap_route_test.gno
@@ -99,7 +99,7 @@ func runTestExactInSwapRoute(cur realm, ft *fuzz.T, params *exactInSwapRoutePara
 
 	// exact in swap route
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	common.SafeGRC20Approve(cross(cur), params.inputToken, routerAddr, math.MaxInt64)
+	common.SafeGRC20Approve(0, cur, params.inputToken, routerAddr, math.MaxInt64)
 
 	router.ExactInSwapRoute(
 		cross(cur),

--- a/contract/r/gnoswap/test/fuzz/exact_out_swap_route_test.gno
+++ b/contract/r/gnoswap/test/fuzz/exact_out_swap_route_test.gno
@@ -99,7 +99,7 @@ func runTestExactOutSwapRoute(cur realm, ft *fuzz.T, params *exactOutSwapRoutePa
 
 	// exact out swap route
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	common.SafeGRC20Approve(cross(cur), params.inputToken, routerAddr, math.MaxInt64)
+	common.SafeGRC20Approve(0, cur, params.inputToken, routerAddr, math.MaxInt64)
 
 	router.ExactOutSwapRoute(
 		cross(cur),

--- a/contract/r/gnoswap/test/fuzz/pool_swap_test.gno
+++ b/contract/r/gnoswap/test/fuzz/pool_swap_test.gno
@@ -130,8 +130,8 @@ func callPoolSwap(
 
 	// Approve tokens for swap
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
-	common.SafeGRC20Approve(cross(cur), token0Path, poolAddr, math.MaxInt64)
-	common.SafeGRC20Approve(cross(cur), token1Path, poolAddr, math.MaxInt64)
+	common.SafeGRC20Approve(0, cur, token0Path, poolAddr, math.MaxInt64)
+	common.SafeGRC20Approve(0, cur, token1Path, poolAddr, math.MaxInt64)
 
 	// Define swap callback
 	swapCallback := func(cur realm, amount0Delta, amount1Delta int64, _ *pool.CallbackMarker) error {
@@ -140,12 +140,12 @@ func callPoolSwap(
 
 			// Transfer token0 if needed
 			if amount0Delta > 0 {
-				common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+				common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 			}
 
 			// Transfer token1 if needed
 			if amount1Delta > 0 {
-				common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+				common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 			}
 		}(cross(cur))
 

--- a/contract/r/gnoswap/test/fuzz/pool_utils_test.gno
+++ b/contract/r/gnoswap/test/fuzz/pool_utils_test.gno
@@ -204,8 +204,8 @@ func setupMintPosition(
 	testing.SetRealm(testing.NewUserRealm(adminAddr))
 
 	poolAddr := access.MustGetAddress(prabc.ROLE_POOL.String())
-	common.SafeGRC20Approve(cross(cur), token0Path, poolAddr, amountDesired)
-	common.SafeGRC20Approve(cross(cur), token1Path, poolAddr, amountDesired)
+	common.SafeGRC20Approve(0, cur, token0Path, poolAddr, amountDesired)
+	common.SafeGRC20Approve(0, cur, token1Path, poolAddr, amountDesired)
 
 	return position.Mint(
 		cross(cur),

--- a/contract/r/gnoswap/test/fuzz/position_collect_fee_test.gno
+++ b/contract/r/gnoswap/test/fuzz/position_collect_fee_test.gno
@@ -184,8 +184,8 @@ func generateFeesWithSwap(cur realm, ft *fuzz.T, adminAddr, poolAddr address, po
 	}
 
 	// Approve tokens for swap
-	common.SafeGRC20Approve(cross(cur), token0Path, poolAddr, math.MaxInt64)
-	common.SafeGRC20Approve(cross(cur), token1Path, poolAddr, math.MaxInt64)
+	common.SafeGRC20Approve(0, cur, token0Path, poolAddr, math.MaxInt64)
+	common.SafeGRC20Approve(0, cur, token1Path, poolAddr, math.MaxInt64)
 
 	// Swap callback function
 	swapCallback := func(cur realm, amount0Delta, amount1Delta int64, _ *pool.CallbackMarker) error {
@@ -193,7 +193,7 @@ func generateFeesWithSwap(cur realm, ft *fuzz.T, adminAddr, poolAddr address, po
 		if amount0Delta > 0 {
 			func(cur realm) {
 				testing.SetRealm(testing.NewUserRealm(adminAddr))
-				common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+				common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 			}(cross(cur))
 		}
 
@@ -201,7 +201,7 @@ func generateFeesWithSwap(cur realm, ft *fuzz.T, adminAddr, poolAddr address, po
 		if amount1Delta > 0 {
 			func(cur realm) {
 				testing.SetRealm(testing.NewUserRealm(adminAddr))
-				common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+				common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 			}(cross(cur))
 		}
 

--- a/contract/r/gnoswap/test/fuzz/position_increase_liquidity_test.gno
+++ b/contract/r/gnoswap/test/fuzz/position_increase_liquidity_test.gno
@@ -46,8 +46,8 @@ func TestFuzzPositionIncreaseLiquidity_ValidParams_Stateless(cur realm, t *testi
 		mintTestToken(cur, token1Path, amount1Int64)
 
 		// Approve tokens
-		common.SafeGRC20Approve(cross(cur), token0Path, poolAddr, math.MaxInt64)
-		common.SafeGRC20Approve(cross(cur), token1Path, poolAddr, math.MaxInt64)
+		common.SafeGRC20Approve(0, cur, token0Path, poolAddr, math.MaxInt64)
+		common.SafeGRC20Approve(0, cur, token1Path, poolAddr, math.MaxInt64)
 
 		// when - increase liquidity
 		_, liquidity, amount0, amount1, _ := position.IncreaseLiquidity(
@@ -100,8 +100,8 @@ func TestFuzzPositionIncreaseLiquidity_RandomizedParams_Stateless(cur realm, t *
 		mintTestToken(cur, token1Path, amount1Int64)
 
 		// Approve tokens
-		common.SafeGRC20Approve(cross(cur), token0Path, poolAddr, math.MaxInt64)
-		common.SafeGRC20Approve(cross(cur), token1Path, poolAddr, math.MaxInt64)
+		common.SafeGRC20Approve(0, cur, token0Path, poolAddr, math.MaxInt64)
+		common.SafeGRC20Approve(0, cur, token1Path, poolAddr, math.MaxInt64)
 
 		// when - increase liquidity (may panic with invalid params)
 		position.IncreaseLiquidity(
@@ -142,8 +142,8 @@ func TestFuzzPositionIncreaseLiquidity_ValidParams_Stateful(cur realm, t *testin
 		mintTestToken(cur, token1Path, amount1Int64)
 
 		// Approve tokens
-		common.SafeGRC20Approve(cross(cur), token0Path, poolAddr, math.MaxInt64)
-		common.SafeGRC20Approve(cross(cur), token1Path, poolAddr, math.MaxInt64)
+		common.SafeGRC20Approve(0, cur, token0Path, poolAddr, math.MaxInt64)
+		common.SafeGRC20Approve(0, cur, token1Path, poolAddr, math.MaxInt64)
 
 		// Get current total liquidity before increase
 		prevTotalLiquidity := u256.MustFromDecimal(mustGetPositionLiquidity(tokenId))
@@ -204,8 +204,8 @@ func TestFuzzPositionIncreaseLiquidity_RandomizedParams_Stateful(cur realm, t *t
 		mintTestToken(cur, token1Path, amount1Int64)
 
 		// Approve tokens
-		common.SafeGRC20Approve(cross(cur), token0Path, poolAddr, math.MaxInt64)
-		common.SafeGRC20Approve(cross(cur), token1Path, poolAddr, math.MaxInt64)
+		common.SafeGRC20Approve(0, cur, token0Path, poolAddr, math.MaxInt64)
+		common.SafeGRC20Approve(0, cur, token1Path, poolAddr, math.MaxInt64)
 
 		// when - increase liquidity (may panic with invalid params)
 		//
@@ -265,8 +265,8 @@ func createTestPosition(cur realm, t *testing.T, adminAddr, poolAddr address) ui
 	}
 
 	// Approve tokens
-	common.SafeGRC20Approve(cross(cur), token0Path, poolAddr, math.MaxInt64)
-	common.SafeGRC20Approve(cross(cur), token1Path, poolAddr, math.MaxInt64)
+	common.SafeGRC20Approve(0, cur, token0Path, poolAddr, math.MaxInt64)
+	common.SafeGRC20Approve(0, cur, token1Path, poolAddr, math.MaxInt64)
 
 	amount0Int64, _ := strconv.ParseInt("10000000", 10, 64)
 	amount1Int64, _ := strconv.ParseInt("10000000", 10, 64)

--- a/contract/r/gnoswap/test/fuzz/position_mint_test.gno
+++ b/contract/r/gnoswap/test/fuzz/position_mint_test.gno
@@ -49,8 +49,8 @@ func TestFuzzPositionMint_ValidParams_Stateless(cur realm, t *testing.T) {
 		mintTestToken(cur, mintParams.token1Path, amount1Int64)
 
 		// Approve tokens
-		common.SafeGRC20Approve(cross(cur), mintParams.token0Path, poolAddr, math.MaxInt64)
-		common.SafeGRC20Approve(cross(cur), mintParams.token1Path, poolAddr, math.MaxInt64)
+		common.SafeGRC20Approve(0, cur, mintParams.token0Path, poolAddr, math.MaxInt64)
+		common.SafeGRC20Approve(0, cur, mintParams.token1Path, poolAddr, math.MaxInt64)
 
 		// when - mint position
 		tokenId, liquidity, amount0, amount1 := position.Mint(
@@ -116,8 +116,8 @@ func TestFuzzPositionMint_RandomizedParams_Stateless(cur realm, t *testing.T) {
 		}
 
 		// Approve tokens
-		common.SafeGRC20Approve(cross(cur), mintParams.token0Path, poolAddr, math.MaxInt64)
-		common.SafeGRC20Approve(cross(cur), mintParams.token1Path, poolAddr, math.MaxInt64)
+		common.SafeGRC20Approve(0, cur, mintParams.token0Path, poolAddr, math.MaxInt64)
+		common.SafeGRC20Approve(0, cur, mintParams.token1Path, poolAddr, math.MaxInt64)
 
 		// when - mint position (may panic with invalid params)
 		position.Mint(
@@ -174,8 +174,8 @@ func TestFuzzPositionMint_ValidParams_Stateful(cur realm, t *testing.T) {
 		mintTestToken(cur, mintParams.token1Path, amount1Int64)
 
 		// Approve tokens
-		common.SafeGRC20Approve(cross(cur), mintParams.token0Path, poolAddr, math.MaxInt64)
-		common.SafeGRC20Approve(cross(cur), mintParams.token1Path, poolAddr, math.MaxInt64)
+		common.SafeGRC20Approve(0, cur, mintParams.token0Path, poolAddr, math.MaxInt64)
+		common.SafeGRC20Approve(0, cur, mintParams.token1Path, poolAddr, math.MaxInt64)
 
 		// when - mint position
 		tokenId, liquidity, amount0, amount1 := position.Mint(
@@ -255,8 +255,8 @@ func TestFuzzPositionMint_RandomizedParams_Stateful(cur realm, t *testing.T) {
 		mintTestToken(cur, mintParams.token1Path, amount1Int64)
 
 		// Approve tokens
-		common.SafeGRC20Approve(cross(cur), mintParams.token0Path, poolAddr, math.MaxInt64)
-		common.SafeGRC20Approve(cross(cur), mintParams.token1Path, poolAddr, math.MaxInt64)
+		common.SafeGRC20Approve(0, cur, mintParams.token0Path, poolAddr, math.MaxInt64)
+		common.SafeGRC20Approve(0, cur, mintParams.token1Path, poolAddr, math.MaxInt64)
 
 		// when - mint position (may panic with invalid params)
 		tokenId, _, _, _ := position.Mint(

--- a/contract/r/gnoswap/test/fuzz/position_reposition_test.gno
+++ b/contract/r/gnoswap/test/fuzz/position_reposition_test.gno
@@ -58,8 +58,8 @@ func TestFuzzPositionReposition_ValidParams_Stateless(cur realm, t *testing.T) {
 		mintTestToken(cur, token1Path, amount1Int64)
 
 		// Approve tokens
-		common.SafeGRC20Approve(cross(cur), token0Path, poolAddr, math.MaxInt64)
-		common.SafeGRC20Approve(cross(cur), token1Path, poolAddr, math.MaxInt64)
+		common.SafeGRC20Approve(0, cur, token0Path, poolAddr, math.MaxInt64)
+		common.SafeGRC20Approve(0, cur, token1Path, poolAddr, math.MaxInt64)
 
 		// when - reposition
 		newTokenId, liquidityStr, tickLower, tickUpper, amount0, amount1 := position.Reposition(
@@ -138,8 +138,8 @@ func TestFuzzPositionReposition_RandomizedParams_Stateless(cur realm, t *testing
 		mintTestToken(cur, token1Path, amount1Int64)
 
 		// Approve tokens
-		common.SafeGRC20Approve(cross(cur), token0Path, poolAddr, math.MaxInt64)
-		common.SafeGRC20Approve(cross(cur), token1Path, poolAddr, math.MaxInt64)
+		common.SafeGRC20Approve(0, cur, token0Path, poolAddr, math.MaxInt64)
+		common.SafeGRC20Approve(0, cur, token1Path, poolAddr, math.MaxInt64)
 
 		// when - reposition (may panic with invalid params)
 		position.Reposition(
@@ -214,8 +214,8 @@ func TestFuzzPositionReposition_ValidParams_Stateful(cur realm, t *testing.T) {
 		mintTestToken(cur, token1Path, amount1Int64)
 
 		// Approve tokens
-		common.SafeGRC20Approve(cross(cur), token0Path, poolAddr, math.MaxInt64)
-		common.SafeGRC20Approve(cross(cur), token1Path, poolAddr, math.MaxInt64)
+		common.SafeGRC20Approve(0, cur, token0Path, poolAddr, math.MaxInt64)
+		common.SafeGRC20Approve(0, cur, token1Path, poolAddr, math.MaxInt64)
 
 		// when - reposition
 		returnedTokenId, liquidityStr, tickLower, tickUpper, amount0, amount1 := position.Reposition(
@@ -300,8 +300,8 @@ func TestFuzzPositionReposition_RandomizedParams_Stateful(cur realm, t *testing.
 			mintTestToken(cur, token1Path, amount1Int64)
 		}
 
-		common.SafeGRC20Approve(cross(cur), token0Path, poolAddr, math.MaxInt64)
-		common.SafeGRC20Approve(cross(cur), token1Path, poolAddr, math.MaxInt64)
+		common.SafeGRC20Approve(0, cur, token0Path, poolAddr, math.MaxInt64)
+		common.SafeGRC20Approve(0, cur, token1Path, poolAddr, math.MaxInt64)
 
 		position.Reposition(
 			cross(cur),

--- a/contract/r/gnoswap/test_token/bar/bar.gno
+++ b/contract/r/gnoswap/test_token/bar/bar.gno
@@ -22,7 +22,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("Bar", "BAR", 6, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(owner.Owner(), 100_000_000_000_000)
 	grc20reg.Register(cross(cur), token, "")

--- a/contract/r/gnoswap/test_token/baz/baz.gno
+++ b/contract/r/gnoswap/test_token/baz/baz.gno
@@ -22,7 +22,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("Baz", "BAZ", 6, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(owner.Owner(), 100_000_000_000_000)
 	grc20reg.Register(cross(cur), token, "")

--- a/contract/r/gnoswap/test_token/foo/foo.gno
+++ b/contract/r/gnoswap/test_token/foo/foo.gno
@@ -22,7 +22,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("Foo", "FOO", 6, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(owner.Owner(), 100_000_000_000_000)
 	grc20reg.Register(cross(cur), token, "")

--- a/contract/r/gnoswap/test_token/obl/obl.gno
+++ b/contract/r/gnoswap/test_token/obl/obl.gno
@@ -22,7 +22,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("Obl", "OBL", 6, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(owner.Owner(), 100_000_000_000_000)
 	grc20reg.Register(cross(cur), token, "")

--- a/contract/r/gnoswap/test_token/qux/qux.gno
+++ b/contract/r/gnoswap/test_token/qux/qux.gno
@@ -22,7 +22,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("Qux", "QUX", 6, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(owner.Owner(), 100_000_000_000_000)
 	grc20reg.Register(cross(cur), token, "")

--- a/contract/r/gnoswap/test_token/test_atom/atom.gno
+++ b/contract/r/gnoswap/test_token/test_atom/atom.gno
@@ -22,7 +22,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("Cosmos", "ATOM", 6, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(owner.Owner(), 300_000_000_000_000)
 	grc20reg.Register(cross(cur), token, "")

--- a/contract/r/gnoswap/test_token/test_atone/atone.gno
+++ b/contract/r/gnoswap/test_token/test_atone/atone.gno
@@ -22,7 +22,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("AtomOne", "ATONE", 6, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(owner.Owner(), 140_000_000_000_000)
 	grc20reg.Register(cross(cur), token, "")

--- a/contract/r/gnoswap/test_token/test_btc/btc.gno
+++ b/contract/r/gnoswap/test_token/test_btc/btc.gno
@@ -22,7 +22,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("Bitcoin", "BTC", 8, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(owner.Owner(), 2_100_000_000_000_000)
 	grc20reg.Register(cross(cur), token, "")

--- a/contract/r/gnoswap/test_token/test_dai/dai.gno
+++ b/contract/r/gnoswap/test_token/test_dai/dai.gno
@@ -22,7 +22,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("Dai", "DAI", 6, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(owner.Owner(), 5_000_000_000_000_000)
 	grc20reg.Register(cross(cur), token, "")

--- a/contract/r/gnoswap/test_token/test_eth/eth.gno
+++ b/contract/r/gnoswap/test_token/test_eth/eth.gno
@@ -22,7 +22,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("Ethereum", "ETH", 6, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(owner.Owner(), 120_000_000_000_000)
 	grc20reg.Register(cross(cur), token, "")

--- a/contract/r/gnoswap/test_token/test_photon/photon.gno
+++ b/contract/r/gnoswap/test_token/test_photon/photon.gno
@@ -22,7 +22,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("Photon", "PHOTON", 6, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(owner.Owner(), 10_000_000_000_000)
 	grc20reg.Register(cross(cur), token, "")

--- a/contract/r/gnoswap/test_token/test_sol/sol.gno
+++ b/contract/r/gnoswap/test_token/test_sol/sol.gno
@@ -22,7 +22,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("Solana", "SOL", 9, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(owner.Owner(), 600_000_000_000_000_000)
 	grc20reg.Register(cross(cur), token, "")

--- a/contract/r/gnoswap/test_token/test_trx/trx.gno
+++ b/contract/r/gnoswap/test_token/test_trx/trx.gno
@@ -22,7 +22,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("Tron", "TRX", 6, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(owner.Owner(), 100_000_000_000_000_000)
 	grc20reg.Register(cross(cur), token, "")

--- a/contract/r/gnoswap/test_token/test_usdc/usdc.gno
+++ b/contract/r/gnoswap/test_token/test_usdc/usdc.gno
@@ -22,7 +22,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("Usd Coin", "USDC", 6, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(owner.Owner(), 70_000_000_000_000_000)
 	grc20reg.Register(cross(cur), token, "")

--- a/contract/r/gnoswap/test_token/test_usdt/usdt.gno
+++ b/contract/r/gnoswap/test_token/test_usdt/usdt.gno
@@ -22,7 +22,7 @@ var (
 
 func init(cur realm) {
 	token, privateLedger = grc20.NewToken("Tether", "USDT", 6, tokenID, cur)
-	userTeller = token.CallerTeller()
+	userTeller = privateLedger.CallerTeller()
 
 	privateLedger.Mint(owner.Owner(), 200_000_000_000_000_000)
 	grc20reg.Register(cross(cur), token, "")

--- a/contract/r/scenario/gov/staker/collect_reward_delegation_multi_swap_fee_filetest.gno
+++ b/contract/r/scenario/gov/staker/collect_reward_delegation_multi_swap_fee_filetest.gno
@@ -116,8 +116,8 @@ func createPoolByAdmin(cur realm, token0, token1 string, fee int64) {
 func mintPositionByAdmin(cur realm, token0, token1 string, fee int64) {
 	testing.SetRealm(adminRealm)
 
-	common.SafeGRC20Approve(cross(cur), token0, poolAddr, math.MaxInt64)
-	common.SafeGRC20Approve(cross(cur), token1, poolAddr, math.MaxInt64)
+	common.SafeGRC20Approve(0, cur, token0, poolAddr, math.MaxInt64)
+	common.SafeGRC20Approve(0, cur, token1, poolAddr, math.MaxInt64)
 
 	positionId, liquidity, amount0, amount1 := position.Mint(
 		cross(cur),
@@ -150,7 +150,7 @@ func exactInSingleSwapRouteByAdmin(cur realm,
 ) {
 	testing.SetRealm(adminRealm)
 
-	common.SafeGRC20Approve(cross(cur), inputToken, routerAddr, math.MaxInt64)
+	common.SafeGRC20Approve(0, cur, inputToken, routerAddr, math.MaxInt64)
 
 	inputTokenAmount, outputTokenAmount := router.ExactInSingleSwapRoute(
 		cross(cur),

--- a/contract/r/scenario/gov/staker/collect_reward_delegation_multi_unstaking_fee_filetest.gno
+++ b/contract/r/scenario/gov/staker/collect_reward_delegation_multi_unstaking_fee_filetest.gno
@@ -143,8 +143,8 @@ func createPoolByAdmin(cur realm, token0, token1 string, fee int64) {
 func mintPositionByAdmin(cur realm, token0, token1 string, fee int64) {
 	testing.SetRealm(adminRealm)
 
-	common.SafeGRC20Approve(cross(cur), token0, poolAddr, math.MaxInt64)
-	common.SafeGRC20Approve(cross(cur), token1, poolAddr, math.MaxInt64)
+	common.SafeGRC20Approve(0, cur, token0, poolAddr, math.MaxInt64)
+	common.SafeGRC20Approve(0, cur, token1, poolAddr, math.MaxInt64)
 
 	positionId, liquidity, amount0, amount1 := position.Mint(
 		cross(cur),

--- a/contract/r/scenario/gov/staker/collect_reward_delegation_multi_withdrawal_fee_filetest.gno
+++ b/contract/r/scenario/gov/staker/collect_reward_delegation_multi_withdrawal_fee_filetest.gno
@@ -126,8 +126,8 @@ func createPoolByAdmin(cur realm, token0, token1 string, fee int64) {
 func mintPositionByAdmin(cur realm, token0, token1 string, fee int64) {
 	testing.SetRealm(adminRealm)
 
-	common.SafeGRC20Approve(cross(cur), token0, poolAddr, math.MaxInt64)
-	common.SafeGRC20Approve(cross(cur), token1, poolAddr, math.MaxInt64)
+	common.SafeGRC20Approve(0, cur, token0, poolAddr, math.MaxInt64)
+	common.SafeGRC20Approve(0, cur, token1, poolAddr, math.MaxInt64)
 
 	positionId, liquidity, amount0, amount1 := position.Mint(
 		cross(cur),
@@ -160,7 +160,7 @@ func exactInSingleSwapRouteByAdmin(cur realm,
 ) {
 	testing.SetRealm(adminRealm)
 
-	common.SafeGRC20Approve(cross(cur), inputToken, routerAddr, math.MaxInt64)
+	common.SafeGRC20Approve(0, cur, inputToken, routerAddr, math.MaxInt64)
 
 	inputTokenAmount, outputTokenAmount := router.ExactInSingleSwapRoute(
 		cross(cur),

--- a/contract/r/scenario/gov/staker/collect_reward_swap_route_fee_filetest.gno
+++ b/contract/r/scenario/gov/staker/collect_reward_swap_route_fee_filetest.gno
@@ -101,8 +101,8 @@ func createPoolByAdmin(cur realm, token0, token1 string, fee int64) {
 func mintPositionByAdmin(cur realm, token0, token1 string, fee int64) {
 	testing.SetRealm(adminRealm)
 
-	common.SafeGRC20Approve(cross(cur), token0, poolAddr, math.MaxInt64)
-	common.SafeGRC20Approve(cross(cur), token1, poolAddr, math.MaxInt64)
+	common.SafeGRC20Approve(0, cur, token0, poolAddr, math.MaxInt64)
+	common.SafeGRC20Approve(0, cur, token1, poolAddr, math.MaxInt64)
 
 	positionId, liquidity, amount0, amount1 := position.Mint(
 		cross(cur),
@@ -135,7 +135,7 @@ func exactInSingleSwapRouteByAdmin(cur realm,
 ) {
 	testing.SetRealm(adminRealm)
 
-	common.SafeGRC20Approve(cross(cur), inputToken, routerAddr, math.MaxInt64)
+	common.SafeGRC20Approve(0, cur, inputToken, routerAddr, math.MaxInt64)
 
 	// expected output token amount is -9955 (not handled amount is -9969, router fee is 14)
 	inputTokenAmount, outputTokenAmount := router.ExactInSingleSwapRoute(

--- a/contract/r/scenario/gov/staker/collect_reward_unstaking_fee_filetest.gno
+++ b/contract/r/scenario/gov/staker/collect_reward_unstaking_fee_filetest.gno
@@ -129,8 +129,8 @@ func createPoolByAdmin(cur realm, token0, token1 string, fee int64) {
 func mintPositionByAdmin(cur realm, token0, token1 string, fee int64) {
 	testing.SetRealm(adminRealm)
 
-	common.SafeGRC20Approve(cross(cur), token0, poolAddr, math.MaxInt64)
-	common.SafeGRC20Approve(cross(cur), token1, poolAddr, math.MaxInt64)
+	common.SafeGRC20Approve(0, cur, token0, poolAddr, math.MaxInt64)
+	common.SafeGRC20Approve(0, cur, token1, poolAddr, math.MaxInt64)
 
 	positionId, liquidity, amount0, amount1 := position.Mint(
 		cross(cur),

--- a/contract/r/scenario/gov/staker/collect_reward_withdrawal_fee_filetest.gno
+++ b/contract/r/scenario/gov/staker/collect_reward_withdrawal_fee_filetest.gno
@@ -113,8 +113,8 @@ func createPoolByAdmin(cur realm, token0, token1 string, fee int64) {
 func mintPositionByAdmin(cur realm, token0, token1 string, fee int64) {
 	testing.SetRealm(adminRealm)
 
-	common.SafeGRC20Approve(cross(cur), token0, poolAddr, math.MaxInt64)
-	common.SafeGRC20Approve(cross(cur), token1, poolAddr, math.MaxInt64)
+	common.SafeGRC20Approve(0, cur, token0, poolAddr, math.MaxInt64)
+	common.SafeGRC20Approve(0, cur, token1, poolAddr, math.MaxInt64)
 
 	positionId, liquidity, amount0, amount1 := position.Mint(
 		cross(cur),
@@ -147,7 +147,7 @@ func exactInSingleSwapRouteByAdmin(cur realm,
 ) {
 	testing.SetRealm(adminRealm)
 
-	common.SafeGRC20Approve(cross(cur), inputToken, routerAddr, math.MaxInt64)
+	common.SafeGRC20Approve(0, cur, inputToken, routerAddr, math.MaxInt64)
 
 	// expected output token amount is -9955 (not handled amount is -9969, router fee is 14)
 	inputTokenAmount, outputTokenAmount := router.ExactInSingleSwapRoute(

--- a/contract/r/scenario/halt/emergency_mode_collect_paths_allowed_filetest.gno
+++ b/contract/r/scenario/halt/emergency_mode_collect_paths_allowed_filetest.gno
@@ -311,10 +311,10 @@ func executeEmergencyCollectFeeSwaps(cur realm) {
 func emergencyCollectSwapCallback(cur realm, amount0Delta, amount1Delta int64) error {
 	testing.SetRealm(adminRealm2)
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), barPath2, poolAddr2, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, barPath2, poolAddr2, amount0Delta)
 	}
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), fooPath2, poolAddr2, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, fooPath2, poolAddr2, amount1Delta)
 	}
 	return nil
 }

--- a/contract/r/scenario/pool/dryswap2_filetest.gno
+++ b/contract/r/scenario/pool/dryswap2_filetest.gno
@@ -172,10 +172,10 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/pool/integrated_filetest.gno
+++ b/contract/r/scenario/pool/integrated_filetest.gno
@@ -362,10 +362,10 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/pool/multi_token_filetest.gno
+++ b/contract/r/scenario/pool/multi_token_filetest.gno
@@ -450,11 +450,11 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/pool/native_swap_filetest.gno
+++ b/contract/r/scenario/pool/native_swap_filetest.gno
@@ -205,9 +205,9 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if zeroForOne {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	} else {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/pool/oracle_twap_increased_cardinality_filetest.gno
+++ b/contract/r/scenario/pool/oracle_twap_increased_cardinality_filetest.gno
@@ -196,10 +196,10 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/pool/oracle_twap_multiple_swaps_filetest.gno
+++ b/contract/r/scenario/pool/oracle_twap_multiple_swaps_filetest.gno
@@ -244,10 +244,10 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/pool/oracle_twap_single_swap_filetest.gno
+++ b/contract/r/scenario/pool/oracle_twap_single_swap_filetest.gno
@@ -164,10 +164,10 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/pool/pool_dryswap_state_changes_filetest.gno
+++ b/contract/r/scenario/pool/pool_dryswap_state_changes_filetest.gno
@@ -197,12 +197,12 @@ func swap(cur realm, t *testing.T, zeroForOne bool, amountSpecified string) {
 
 			// Transfer token0 if needed
 			if amount0Delta > 0 {
-				common.SafeGRC20Transfer(cross(cur), barPath, poolAddr, amount0Delta)
+				common.SafeGRC20Transfer(0, cur, barPath, poolAddr, amount0Delta)
 			}
 
 			// Transfer token1 if needed
 			if amount1Delta > 0 {
-				common.SafeGRC20Transfer(cross(cur), fooPath, poolAddr, amount1Delta)
+				common.SafeGRC20Transfer(0, cur, fooPath, poolAddr, amount1Delta)
 			}
 		}(cross(cur))
 

--- a/contract/r/scenario/pool/pool_init_filetest.gno
+++ b/contract/r/scenario/pool/pool_init_filetest.gno
@@ -232,10 +232,10 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/pool/pool_limit_filetest.gno
+++ b/contract/r/scenario/pool/pool_limit_filetest.gno
@@ -163,10 +163,10 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/pool/pool_limit_order_negative_filetest.gno
+++ b/contract/r/scenario/pool/pool_limit_order_negative_filetest.gno
@@ -163,10 +163,10 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/pool/pool_limit_with_protocol_fee_fail_filetest.gno
+++ b/contract/r/scenario/pool/pool_limit_with_protocol_fee_fail_filetest.gno
@@ -168,10 +168,10 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/pool/pool_limit_with_protocol_fee_filetest.gno
+++ b/contract/r/scenario/pool/pool_limit_with_protocol_fee_filetest.gno
@@ -163,10 +163,10 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/pool/protocol_fee_tier_10000_filetest.gno
+++ b/contract/r/scenario/pool/protocol_fee_tier_10000_filetest.gno
@@ -167,11 +167,11 @@ func swapCallback(cur realm, amount0Delta, amount1Delta int64, _ *pool.CallbackM
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), barPath, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, barPath, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), fooPath, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, fooPath, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/pool/protocol_fee_tier_100_filetest.gno
+++ b/contract/r/scenario/pool/protocol_fee_tier_100_filetest.gno
@@ -167,11 +167,11 @@ func swapCallback(cur realm, amount0Delta, amount1Delta int64, _ *pool.CallbackM
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), barPath, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, barPath, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), fooPath, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, fooPath, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/pool/protocol_fee_tier_3000_filetest.gno
+++ b/contract/r/scenario/pool/protocol_fee_tier_3000_filetest.gno
@@ -167,11 +167,11 @@ func swapCallback(cur realm, amount0Delta, amount1Delta int64, _ *pool.CallbackM
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), barPath, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, barPath, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), fooPath, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, fooPath, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/pool/protocol_fee_tier_500_filetest.gno
+++ b/contract/r/scenario/pool/protocol_fee_tier_500_filetest.gno
@@ -167,11 +167,11 @@ func swapCallback(cur realm, amount0Delta, amount1Delta int64, _ *pool.CallbackM
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), barPath, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, barPath, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), fooPath, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, fooPath, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/pool/single_lp_filetest.gno
+++ b/contract/r/scenario/pool/single_lp_filetest.gno
@@ -398,11 +398,11 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/pool/swap_balance_extreme_filetest.gno
+++ b/contract/r/scenario/pool/swap_balance_extreme_filetest.gno
@@ -285,10 +285,10 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/pool/swap_balance_mixed_positions_filetest.gno
+++ b/contract/r/scenario/pool/swap_balance_mixed_positions_filetest.gno
@@ -260,10 +260,10 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/pool/swap_balance_single_in_range_filetest.gno
+++ b/contract/r/scenario/pool/swap_balance_single_in_range_filetest.gno
@@ -245,10 +245,10 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/pool/swap_complex_dryswap_verification_filetest.gno
+++ b/contract/r/scenario/pool/swap_complex_dryswap_verification_filetest.gno
@@ -359,10 +359,10 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/pool/swap_zero_amount_filetest.gno
+++ b/contract/r/scenario/pool/swap_zero_amount_filetest.gno
@@ -164,10 +164,10 @@ func zeroAmountSwapCallback(cur realm, token0Path string, token1Path string, amo
 	callbackAmount1Delta = amount1Delta
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/pool/tick_cross_oracle_update_filetest.gno
+++ b/contract/r/scenario/pool/tick_cross_oracle_update_filetest.gno
@@ -242,10 +242,10 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/pool/tick_transaction_filetest.gno
+++ b/contract/r/scenario/pool/tick_transaction_filetest.gno
@@ -173,10 +173,10 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/position/contract_owned_position_lifecycle_filetest.gno
+++ b/contract/r/scenario/position/contract_owned_position_lifecycle_filetest.gno
@@ -408,11 +408,11 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/position/position_balance_decrease_liquidity_filetest.gno
+++ b/contract/r/scenario/position/position_balance_decrease_liquidity_filetest.gno
@@ -231,11 +231,11 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/position/position_balance_reposition_filetest.gno
+++ b/contract/r/scenario/position/position_balance_reposition_filetest.gno
@@ -278,11 +278,11 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/position/position_collect_balance_revert_filetest.gno
+++ b/contract/r/scenario/position/position_collect_balance_revert_filetest.gno
@@ -197,10 +197,10 @@ func mockSwapCallback(cur realm, amount0Delta int64, amount1Delta int64) error {
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), barPath, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, barPath, poolAddr, amount0Delta)
 	}
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), fooPath, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, fooPath, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/position/position_collect_fee_filetest.gno
+++ b/contract/r/scenario/position/position_collect_fee_filetest.gno
@@ -239,11 +239,11 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/position/position_collect_fee_with_protocol_fee_filetest.gno
+++ b/contract/r/scenario/position/position_collect_fee_with_protocol_fee_filetest.gno
@@ -252,11 +252,11 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/position/position_decrease_increase_filetest.gno
+++ b/contract/r/scenario/position/position_decrease_increase_filetest.gno
@@ -233,11 +233,11 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/position/position_full_with_emission_filetest.gno
+++ b/contract/r/scenario/position/position_full_with_emission_filetest.gno
@@ -246,9 +246,9 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if zeroForOne {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	} else {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/position/position_increase_decrease_filetest.gno
+++ b/contract/r/scenario/position/position_increase_decrease_filetest.gno
@@ -233,11 +233,11 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/position/position_mint_gnot_grc20_range_filetest.gno
+++ b/contract/r/scenario/position/position_mint_gnot_grc20_range_filetest.gno
@@ -265,9 +265,9 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if zeroForOne {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	} else {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/position/position_mint_swap_burn_filetest.gno
+++ b/contract/r/scenario/position/position_mint_swap_burn_filetest.gno
@@ -247,11 +247,11 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/position/position_multi_user_fee_filetest.gno
+++ b/contract/r/scenario/position/position_multi_user_fee_filetest.gno
@@ -249,11 +249,11 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/position/position_native_token_filetest.gno
+++ b/contract/r/scenario/position/position_native_token_filetest.gno
@@ -219,9 +219,9 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if zeroForOne {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	} else {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/position/position_reposition_filetest.gno
+++ b/contract/r/scenario/position/position_reposition_filetest.gno
@@ -263,11 +263,11 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/position/position_reposition_tick_role_change_filetest.gno
+++ b/contract/r/scenario/position/position_reposition_tick_role_change_filetest.gno
@@ -218,9 +218,9 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if zeroForOne {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	} else {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/position/position_same_user_fee_distribution_filetest.gno
+++ b/contract/r/scenario/position/position_same_user_fee_distribution_filetest.gno
@@ -308,11 +308,11 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/position/position_swap_fee_distribution_filetest.gno
+++ b/contract/r/scenario/position/position_swap_fee_distribution_filetest.gno
@@ -200,11 +200,11 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/position/position_transfer_with_collect_fee_filetest.gno
+++ b/contract/r/scenario/position/position_transfer_with_collect_fee_filetest.gno
@@ -234,11 +234,11 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/position/position_unclaimed_fee_filetest.gno
+++ b/contract/r/scenario/position/position_unclaimed_fee_filetest.gno
@@ -292,11 +292,11 @@ func mockSwapCallback(cur realm, token0Path string, token1Path string, amount0De
 	testing.SetRealm(adminRealm)
 
 	if amount0Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token0Path, poolAddr, amount0Delta)
+		common.SafeGRC20Transfer(0, cur, token0Path, poolAddr, amount0Delta)
 	}
 
 	if amount1Delta > 0 {
-		common.SafeGRC20Transfer(cross(cur), token1Path, poolAddr, amount1Delta)
+		common.SafeGRC20Transfer(0, cur, token1Path, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/contract/r/scenario/router/dryswap_swap_consistency_filetest.gno
+++ b/contract/r/scenario/router/dryswap_swap_consistency_filetest.gno
@@ -225,7 +225,7 @@ func testExactIn_Small(cur realm) {
 	ufmt.Printf("[EXPECTED] DrySwap amountIn should be %s\n", dryIn)
 	ufmt.Printf("[EXPECTED] DrySwap amountOut should be %s\n", dryOut)
 
-	common.SafeGRC20Approve(cross(cur), barPath, routerAddr, 100000)
+	common.SafeGRC20Approve(0, cur, barPath, routerAddr, 100000)
 	actualIn, actualOut := router.ExactInSwapRoute(
 		cross(cur), barPath, fooPath, amount, route, "100", "1",
 		time.Now().Add(time.Hour).Unix(), "",
@@ -250,7 +250,7 @@ func testExactIn_Medium(cur realm) {
 	ufmt.Printf("[EXPECTED] DrySwap amountIn should be %s\n", dryIn)
 	ufmt.Printf("[EXPECTED] DrySwap amountOut should be %s\n", dryOut)
 
-	common.SafeGRC20Approve(cross(cur), barPath, routerAddr, 10000000)
+	common.SafeGRC20Approve(0, cur, barPath, routerAddr, 10000000)
 	actualIn, actualOut := router.ExactInSwapRoute(
 		cross(cur), barPath, fooPath, amount, route, "100", "1",
 		time.Now().Add(time.Hour).Unix(), "",
@@ -275,7 +275,7 @@ func testExactIn_Large(cur realm) {
 	ufmt.Printf("[EXPECTED] DrySwap amountIn should be %s\n", dryIn)
 	ufmt.Printf("[EXPECTED] DrySwap amountOut should be %s\n", dryOut)
 
-	common.SafeGRC20Approve(cross(cur), barPath, routerAddr, 1000000000)
+	common.SafeGRC20Approve(0, cur, barPath, routerAddr, 1000000000)
 	actualIn, actualOut := router.ExactInSwapRoute(
 		cross(cur), barPath, fooPath, amount, route, "100", "1",
 		time.Now().Add(time.Hour).Unix(), "",
@@ -300,7 +300,7 @@ func testExactIn_AlmostAll(cur realm) {
 	ufmt.Printf("[EXPECTED] DrySwap amountIn should be %s\n", dryIn)
 	ufmt.Printf("[EXPECTED] DrySwap amountOut should be %s\n", dryOut)
 
-	common.SafeGRC20Approve(cross(cur), fooPath, routerAddr, 100000000000)
+	common.SafeGRC20Approve(0, cur, fooPath, routerAddr, 100000000000)
 	actualIn, actualOut := router.ExactInSwapRoute(
 		cross(cur), fooPath, barPath, amount, route, "100", "1",
 		time.Now().Add(time.Hour).Unix(), "",
@@ -332,7 +332,7 @@ func testExactOut_Small(cur realm) {
 		return
 	}
 
-	common.SafeGRC20Approve(cross(cur), fooPath, routerAddr, 999999999999)
+	common.SafeGRC20Approve(0, cur, fooPath, routerAddr, 999999999999)
 	actualIn, actualOut := router.ExactOutSwapRoute(
 		cross(cur), fooPath, barPath, amount, route, "100", "999999999999",
 		time.Now().Add(time.Hour).Unix(), "",
@@ -362,7 +362,7 @@ func testExactOut_Medium(cur realm) {
 		return
 	}
 
-	common.SafeGRC20Approve(cross(cur), fooPath, routerAddr, 999999999999)
+	common.SafeGRC20Approve(0, cur, fooPath, routerAddr, 999999999999)
 	actualIn, actualOut := router.ExactOutSwapRoute(
 		cross(cur), fooPath, barPath, amount, route, "100", "999999999999",
 		time.Now().Add(time.Hour).Unix(), "",
@@ -392,7 +392,7 @@ func testExactOut_Large(cur realm) {
 		return
 	}
 
-	common.SafeGRC20Approve(cross(cur), fooPath, routerAddr, 999999999999)
+	common.SafeGRC20Approve(0, cur, fooPath, routerAddr, 999999999999)
 	actualIn, actualOut := router.ExactOutSwapRoute(
 		cross(cur), fooPath, barPath, amount, route, "100", "999999999999",
 		time.Now().Add(time.Hour).Unix(), "",
@@ -419,7 +419,7 @@ func testExactOut_BugScenario(cur realm) {
 	ufmt.Printf("[EXPECTED] DrySwap success should be %t\n", drySuccess)
 
 	if drySuccess {
-		common.SafeGRC20Approve(cross(cur), fooPath, routerAddr, 999999999999999)
+		common.SafeGRC20Approve(0, cur, fooPath, routerAddr, 999999999999999)
 		actualIn, actualOut := router.ExactOutSwapRoute(
 			cross(cur), fooPath, barPath, amount, route, "100", "999999999999999",
 			time.Now().Add(time.Hour).Unix(), "",
@@ -466,7 +466,7 @@ func testExactOut_JustAtOverflow(cur realm) {
 
 	if drySuccess {
 		ufmt.Println("[ERROR] DrySwap should have failed but succeeded!")
-		common.SafeGRC20Approve(cross(cur), fooPath, routerAddr, 999999999999999)
+		common.SafeGRC20Approve(0, cur, fooPath, routerAddr, 999999999999999)
 		uassert.AbortsWithMessage(t, cur, "[GNOSWAP-POOL-020] overflow", func() {
 			router.ExactOutSwapRoute(
 				cross(cur), fooPath, barPath, amount, route, "100", "999999999999999",
@@ -516,7 +516,7 @@ func testReverseDirection(cur realm) {
 		)
 		return rIn, rOut, rErr == nil
 	}(cross(cur))
-	common.SafeGRC20Approve(cross(cur), barPath, routerAddr, 1000000)
+	common.SafeGRC20Approve(0, cur, barPath, routerAddr, 1000000)
 	actualInFwd, actualOutFwd := router.ExactInSwapRoute(
 		cross(cur), barPath, fooPath, amount, "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:500", "100", "1",
 		time.Now().Add(time.Hour).Unix(), "",
@@ -532,7 +532,7 @@ func testReverseDirection(cur realm) {
 		return rIn, rOut, rErr == nil
 	}(cross(cur))
 
-	common.SafeGRC20Approve(cross(cur), fooPath, routerAddr, 1000000)
+	common.SafeGRC20Approve(0, cur, fooPath, routerAddr, 1000000)
 	actualInRev, actualOutRev := router.ExactInSwapRoute(
 		cross(cur), fooPath, barPath, amount, "gno.land/r/onbloc/foo.FOO:gno.land/r/onbloc/bar.BAR:500", "100", "1",
 		time.Now().Add(time.Hour).Unix(), "",
@@ -559,7 +559,7 @@ func testMaxSlippage(cur realm) {
 
 	if drySuccess {
 		// This means the swap would succeed, verify with actual swap
-		common.SafeGRC20Approve(cross(cur), barPath, routerAddr, 1000000)
+		common.SafeGRC20Approve(0, cur, barPath, routerAddr, 1000000)
 		actualIn, actualOut := router.ExactInSwapRoute(
 			cross(cur), barPath, fooPath, amount, "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:500", "100", "999999",
 			time.Now().Add(time.Hour).Unix(), "",
@@ -676,7 +676,7 @@ func testMultiHop_TwoHop_ExactIn_Success(cur realm) {
 	ufmt.Printf("[EXPECTED] DrySwap 2-hop - in=%s out=%s success=%t\n", dryIn, dryOut, drySuccess)
 
 	if drySuccess {
-		common.SafeGRC20Approve(cross(cur), barPath, routerAddr, 100000)
+		common.SafeGRC20Approve(0, cur, barPath, routerAddr, 100000)
 		actualIn, actualOut := router.ExactInSwapRoute(
 			cross(cur), barPath, fooPath, amount, route, quote, "1",
 			time.Now().Add(time.Hour).Unix(), "",
@@ -707,7 +707,7 @@ func testMultiHop_TwoHop_ExactOut_Success(cur realm) {
 	printExactOutTolerance(cur, amount, dryOut, 2)
 
 	if drySuccess {
-		common.SafeGRC20Approve(cross(cur), barPath, routerAddr, 999999999)
+		common.SafeGRC20Approve(0, cur, barPath, routerAddr, 999999999)
 		actualIn, actualOut := router.ExactOutSwapRoute(
 			cross(cur), barPath, fooPath, amount, route, quote, "999999999",
 			time.Now().Add(time.Hour).Unix(), "",
@@ -743,7 +743,7 @@ func testMultiHop_TwoHop_ExactOut_Fail(cur realm) {
 	printExactOutTolerance(cur, amount, dryOut, 2)
 
 	if drySuccess {
-		common.SafeGRC20Approve(cross(cur), barPath, routerAddr, 999999999)
+		common.SafeGRC20Approve(0, cur, barPath, routerAddr, 999999999)
 		actualIn, actualOut := router.ExactOutSwapRoute(
 			cross(cur), barPath, fooPath, amount, route, "100", amountLimit,
 			time.Now().Add(time.Hour).Unix(), "",
@@ -773,7 +773,7 @@ func testMultiHop_TwoRoute_TwoHop_ExactIn(cur realm) {
 	ufmt.Printf("[EXPECTED] DrySwap 2-hop two-route ExactIn - in=%s out=%s success=%t\n", dryIn, dryOut, drySuccess)
 
 	if drySuccess {
-		common.SafeGRC20Approve(cross(cur), barPath, routerAddr, 100000)
+		common.SafeGRC20Approve(0, cur, barPath, routerAddr, 100000)
 		actualIn, actualOut := router.ExactInSwapRoute(
 			cross(cur), barPath, fooPath, amount, route, quote, "1",
 			time.Now().Add(time.Hour).Unix(), "",
@@ -803,7 +803,7 @@ func testMultiHop_TwoRoute_TwoHop_ExactOut_Success(cur realm) {
 	printExactOutTolerance(cur, amount, dryOut, 4)
 
 	if drySuccess {
-		common.SafeGRC20Approve(cross(cur), barPath, routerAddr, 999999999)
+		common.SafeGRC20Approve(0, cur, barPath, routerAddr, 999999999)
 		actualIn, actualOut := router.ExactOutSwapRoute(
 			cross(cur), barPath, fooPath, amount, route, quote, "999999999",
 			time.Now().Add(time.Hour).Unix(), "",
@@ -840,7 +840,7 @@ func testMultiHop_TwoRoute_TwoHop_ExactOut_Fail(cur realm) {
 	printExactOutTolerance(cur, amount, dryOut, 4)
 
 	if drySuccess {
-		common.SafeGRC20Approve(cross(cur), barPath, routerAddr, 999999999)
+		common.SafeGRC20Approve(0, cur, barPath, routerAddr, 999999999)
 		actualIn, actualOut := router.ExactOutSwapRoute(
 			cross(cur), barPath, fooPath, amount, route, quote, amountLimit,
 			time.Now().Add(time.Hour).Unix(), "",
@@ -869,7 +869,7 @@ func testMultiHop_ThreeHop_ExactIn_Success(cur realm) {
 	ufmt.Printf("[EXPECTED] DrySwap 3-hop - in=%s out=%s success=%t\n", dryIn, dryOut, drySuccess)
 
 	if drySuccess {
-		common.SafeGRC20Approve(cross(cur), barPath, routerAddr, 10000)
+		common.SafeGRC20Approve(0, cur, barPath, routerAddr, 10000)
 		actualIn, actualOut := router.ExactInSwapRoute(
 			cross(cur), barPath, fooPath, amount, route, "100", "1",
 			time.Now().Add(time.Hour).Unix(), "",
@@ -898,7 +898,7 @@ func testMultiHop_ThreeHop_ExactOut_Success(cur realm) {
 	printExactOutTolerance(cur, amount, dryOut, 3)
 
 	if drySuccess {
-		common.SafeGRC20Approve(cross(cur), barPath, routerAddr, 999999999)
+		common.SafeGRC20Approve(0, cur, barPath, routerAddr, 999999999)
 		actualIn, actualOut := router.ExactOutSwapRoute(
 			cross(cur), barPath, quxPath, amount, route, "100", "999999999",
 			time.Now().Add(time.Hour).Unix(), "",
@@ -928,7 +928,7 @@ func testMultiHop_ThreeHop_ExactOut_Fail(cur realm) {
 	printExactOutTolerance(cur, amount, dryOut, 3)
 
 	if drySuccess {
-		common.SafeGRC20Approve(cross(cur), barPath, routerAddr, 999999999)
+		common.SafeGRC20Approve(0, cur, barPath, routerAddr, 999999999)
 		actualIn, actualOut := router.ExactOutSwapRoute(
 			cross(cur), barPath, quxPath, amount, route, "100", "999999999",
 			time.Now().Add(time.Hour).Unix(), "",
@@ -958,7 +958,7 @@ func testMultiHop_TwoRoute_ThreeHop_ExactIn(cur realm) {
 	ufmt.Printf("[EXPECTED] DrySwap 3-hop two-route ExactIn - in=%s out=%s success=%t\n", dryIn, dryOut, drySuccess)
 
 	if drySuccess {
-		common.SafeGRC20Approve(cross(cur), barPath, routerAddr, 10000)
+		common.SafeGRC20Approve(0, cur, barPath, routerAddr, 10000)
 		actualIn, actualOut := router.ExactInSwapRoute(
 			cross(cur), barPath, quxPath, amount, route, quote, "1",
 			time.Now().Add(time.Hour).Unix(), "",
@@ -988,7 +988,7 @@ func testMultiHop_TwoRoute_ThreeHop_ExactOut_Success(cur realm) {
 	printExactOutTolerance(cur, amount, dryOut, 4)
 
 	if drySuccess {
-		common.SafeGRC20Approve(cross(cur), barPath, routerAddr, 999999999)
+		common.SafeGRC20Approve(0, cur, barPath, routerAddr, 999999999)
 		actualIn, actualOut := router.ExactOutSwapRoute(
 			cross(cur), barPath, quxPath, amount, route, quote, "999999999",
 			time.Now().Add(time.Hour).Unix(), "",
@@ -1025,7 +1025,7 @@ func testMultiHop_TwoRoute_ThreeHop_ExactOut_Fail(cur realm) {
 	printExactOutTolerance(cur, amount, dryOut, 4)
 
 	if drySuccess {
-		common.SafeGRC20Approve(cross(cur), barPath, routerAddr, 999999999)
+		common.SafeGRC20Approve(0, cur, barPath, routerAddr, 999999999)
 		actualIn, actualOut := router.ExactOutSwapRoute(
 			cross(cur), barPath, quxPath, amount, route, quote, amountLimit,
 			time.Now().Add(time.Hour).Unix(), "",

--- a/contract/r/scenario/router/exact_in_swap_route_with_wrapped_native_output_token_filetest.gno
+++ b/contract/r/scenario/router/exact_in_swap_route_with_wrapped_native_output_token_filetest.gno
@@ -152,8 +152,8 @@ func mintPosition(cur realm, token0Path string, token1Path string, fee uint32, m
 	ufmt.Println("[INFO] Minting position")
 
 	testing.SetRealm(adminRealm)
-	common.Approve(cross(cur), token0Path, poolAddr, maxInt64)
-	common.Approve(cross(cur), token1Path, poolAddr, maxInt64)
+	common.Approve(0, cur, token0Path, poolAddr, maxInt64)
+	common.Approve(0, cur, token1Path, poolAddr, maxInt64)
 
 	positionId, liquidity, amount0, amount1 := pn.Mint(
 		cross(cur),
@@ -203,9 +203,9 @@ func exactInSwapRouteBy(cur realm,
 	specifiedAmountInt64, _ := strconv.ParseInt(specifiedAmount, 10, 64)
 
 	if inputToken == wugnotPath {
-		common.SafeGRC20Approve(cross(cur), wugnotPath, routerAddr, specifiedAmountInt64)
+		common.SafeGRC20Approve(0, cur, wugnotPath, routerAddr, specifiedAmountInt64)
 	} else {
-		common.SafeGRC20Approve(cross(cur), inputToken, routerAddr, specifiedAmountInt64)
+		common.SafeGRC20Approve(0, cur, inputToken, routerAddr, specifiedAmountInt64)
 	}
 	inputTokenAmount, outputTokenAmount := router.ExactInSwapRoute(
 		cross(cur),

--- a/contract/r/scenario/router/exact_out_swap_route_with_wrapped_native_output_token_filetest.gno
+++ b/contract/r/scenario/router/exact_out_swap_route_with_wrapped_native_output_token_filetest.gno
@@ -151,8 +151,8 @@ func mintPosition(cur realm, token0Path string, token1Path string, fee uint32, m
 	ufmt.Println("[INFO] Minting position")
 
 	testing.SetRealm(adminRealm)
-	common.Approve(cross(cur), token0Path, poolAddr, maxInt64)
-	common.Approve(cross(cur), token1Path, poolAddr, maxInt64)
+	common.Approve(0, cur, token0Path, poolAddr, maxInt64)
+	common.Approve(0, cur, token1Path, poolAddr, maxInt64)
 
 	positionId, liquidity, amount0, amount1 := pn.Mint(
 		cross(cur),
@@ -200,10 +200,10 @@ func exactOutSwapRouteBy(cur realm,
 
 	if inputToken == wugnotPath {
 		maxAmountInInt64, _ := strconv.ParseInt(maxAmountIn, 10, 64)
-		common.SafeGRC20Approve(cross(cur), wugnotPath, routerAddr, maxAmountInInt64)
+		common.SafeGRC20Approve(0, cur, wugnotPath, routerAddr, maxAmountInInt64)
 	} else {
 		maxAmountInInt64, _ := strconv.ParseInt(maxAmountIn, 10, 64)
-		common.SafeGRC20Approve(cross(cur), inputToken, routerAddr, maxAmountInInt64)
+		common.SafeGRC20Approve(0, cur, inputToken, routerAddr, maxAmountInInt64)
 	}
 	inputTokenAmount, outputTokenAmount := router.ExactOutSwapRoute(
 		cross(cur),

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_project.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_project.gno
@@ -91,7 +91,7 @@ func (lp *launchpadV1) CreateProject(
 	}
 
 	common.SafeGRC20TransferFrom(
-		cross(rlm),
+		0, rlm,
 		tokenPath,
 		caller,
 		launchpadAddr,
@@ -306,7 +306,7 @@ func (lp *launchpadV1) transferLeftFromProject(_ int, rlm realm, projectID strin
 	projectLeftReward := getProjectRemainingAmount(project)
 
 	if projectLeftReward > 0 {
-		common.SafeGRC20Transfer(cross(rlm), project.TokenPath(), recipient, projectLeftReward)
+		common.SafeGRC20Transfer(0, rlm, project.TokenPath(), recipient, projectLeftReward)
 	}
 
 	return projectLeftReward, nil

--- a/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_withdraw.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/launchpad/launchpad_withdraw.gno
@@ -47,7 +47,7 @@ func (lp *launchpadV1) CollectDepositGns(_ int, rlm realm, depositID string) (in
 	unStakeGovernance(0, rlm, recipient, withdrawalAmount)
 
 	// Transfer the original GNS deposit back to the depositor
-	common.SafeGRC20Transfer(cross(rlm), GNS_PATH, deposit.Depositor(), withdrawalAmount)
+	common.SafeGRC20Transfer(0, rlm, GNS_PATH, deposit.Depositor(), withdrawalAmount)
 
 	chain.Emit(
 		"CollectDepositGns",

--- a/contract/r/scenario/upgrade/protocol_fee_v2_valid_upgrade_filetest.gno
+++ b/contract/r/scenario/upgrade/protocol_fee_v2_valid_upgrade_filetest.gno
@@ -55,12 +55,6 @@ var (
 	adminRealm     = testing.NewUserRealm(adminAddr)
 	stakerRealm    = testing.NewCodeRealm("gno.land/r/gnoswap/staker")
 	govStakerRealm = testing.NewCodeRealm("gno.land/r/gnoswap/gov/staker")
-
-	// AddToProtocolFee performs SafeGRC20TransferFrom from the *implementation*
-	// realm, so the caller must approve whichever implementation realm is
-	// currently active (v1 before the upgrade, v2_valid after).
-	protocolFeeV1Realm      = testing.NewCodeRealm(protocolFeeV1Path)
-	protocolFeeV2ValidRealm = testing.NewCodeRealm(protocolFeeV2ValidPath)
 )
 
 const (
@@ -120,20 +114,16 @@ func setDataV1(cur realm) {
 	ufmt.Printf("[EXPECTED] DevOpsPct set to: %d\n", protocolFee.GetDevOpsPct())
 }
 
-// fundAndApproveBarFromStaker funds the staker realm with bar and approves both
-// the protocol_fee role address and the given implementation realm (the spender
-// inside AddToProtocolFee's TransferFrom).
-func fundAndApproveBarFromStaker(cur realm, implRealmAddr address, amount int64) {
+func fundAndApproveBarFromStaker(cur realm, amount int64) {
 	testing.SetRealm(adminRealm)
 	bar.Transfer(cross(cur), stakerRealm.Address(), amount)
 
 	testing.SetRealm(stakerRealm)
 	bar.Approve(cross(cur), protocolFeeAddr, amount)
-	bar.Approve(cross(cur), implRealmAddr, amount)
 }
 
 func addProtocolFeeV1(cur realm) {
-	fundAndApproveBarFromStaker(cur, protocolFeeV1Realm.Address(), 1000)
+	fundAndApproveBarFromStaker(cur, 1000)
 
 	testing.SetRealm(stakerRealm)
 	if err := protocolFee.AddToProtocolFee(cross(cur), barPath, 1000); err != nil {
@@ -167,8 +157,7 @@ func updateConfigV2Valid(cur realm) {
 }
 
 func addProtocolFeeV2Valid(cur realm) {
-	// Approve the v2_valid implementation realm this time (the new spender).
-	fundAndApproveBarFromStaker(cur, protocolFeeV2ValidRealm.Address(), 1000)
+	fundAndApproveBarFromStaker(cur, 1000)
 
 	testing.SetRealm(stakerRealm)
 	// Same token as v1: this RMWs the v1-created per-token BPTree entries.

--- a/tests/integration/testdata/pool/create_pool_and_mint.txtar
+++ b/tests/integration/testdata/pool/create_pool_and_mint.txtar
@@ -249,9 +249,9 @@ func handleSwapCallback(
 
 func transferToPool(cur realm, tokenPath string, amount int64, payer address) {
 	if payer == wrapperAddr {
-		common.SafeGRC20Transfer(cross(cur), tokenPath, poolAddr, amount)
+		common.SafeGRC20Transfer(0, cur, tokenPath, poolAddr, amount)
 		return
 	}
 
-	common.SafeGRC20TransferFrom(cross(cur), tokenPath, payer, poolAddr, amount)
+	common.SafeGRC20TransferFrom(0, cur, tokenPath, payer, poolAddr, amount)
 }

--- a/tests/integration/testdata/pool/direct_pool_swap_run_wrapper_callback.txtar
+++ b/tests/integration/testdata/pool/direct_pool_swap_run_wrapper_callback.txtar
@@ -138,9 +138,9 @@ func HandleSwapCallbackWithContext(
 
 	switch {
 	case amount0Delta > 0:
-		common.SafeGRC20TransferFrom(cross(cur), token0Path, payer, poolAddr, amount0Delta)
+		common.SafeGRC20TransferFrom(0, cur, token0Path, payer, poolAddr, amount0Delta)
 	case amount1Delta > 0:
-		common.SafeGRC20TransferFrom(cross(cur), token1Path, payer, poolAddr, amount1Delta)
+		common.SafeGRC20TransferFrom(0, cur, token1Path, payer, poolAddr, amount1Delta)
 	}
 
 	return nil

--- a/tests/integration/testdata/pool/swap_wugnot_gns_tokens.txtar
+++ b/tests/integration/testdata/pool/swap_wugnot_gns_tokens.txtar
@@ -220,9 +220,9 @@ func handleSwapCallback(
 
 func transferToPool(cur realm, tokenPath string, amount int64, payer address) {
 	if payer == wrapperAddr {
-		common.SafeGRC20Transfer(cross(cur), tokenPath, poolAddr, amount)
+		common.SafeGRC20Transfer(0, cur, tokenPath, poolAddr, amount)
 		return
 	}
 
-	common.SafeGRC20TransferFrom(cross(cur), tokenPath, payer, poolAddr, amount)
+	common.SafeGRC20TransferFrom(0, cur, tokenPath, payer, poolAddr, amount)
 }

--- a/tests/integration/testdata/position/reposition.txtar
+++ b/tests/integration/testdata/position/reposition.txtar
@@ -246,9 +246,9 @@ func handleSwapCallback(
 
 func transferToPool(cur realm, tokenPath string, amount int64, payer address) {
 	if payer == wrapperAddr {
-		common.SafeGRC20Transfer(cross(cur), tokenPath, poolAddr, amount)
+		common.SafeGRC20Transfer(0, cur, tokenPath, poolAddr, amount)
 		return
 	}
 
-	common.SafeGRC20TransferFrom(cross(cur), tokenPath, payer, poolAddr, amount)
+	common.SafeGRC20TransferFrom(0, cur, tokenPath, payer, poolAddr, amount)
 }


### PR DESCRIPTION
## Description

- Replace `CallerTeller` with `RealmTeller` in the shared GRC20 registry helpers.
- Bind token operations directly to the current realm instead of relying on a crossing call through `common`.
- Update all contract, scenario, fuzz, and integration-test call sites to use the new helper signatures.
- Add coverage verifying that transfers use the current realm as the token actor.

ref: https://github.com/gnolang/gno/commit/acd01fa29b6caa7afa0f270c606aa266bcad5fce

## API Mapping

| Previous API | New API |
| --- | --- |
| `GetTokenTeller(tokenKey)` | `GetTokenTeller(0, rlm, tokenKey)` |
| `Transfer(cross(rlm), tokenKey, to, amount)` | `Transfer(0, rlm, tokenKey, to, amount)` |
| `TransferFrom(cross(rlm), tokenKey, from, to, amount)` | `TransferFrom(0, rlm, tokenKey, from, to, amount)` |
| `Approve(cross(rlm), tokenKey, spender, amount)` | `Approve(0, rlm, tokenKey, spender, amount)` |
| `SafeGRC20Transfer(cross(rlm), tokenKey, to, amount)` | `SafeGRC20Transfer(0, rlm, tokenKey, to, amount)` |
| `SafeGRC20TransferFrom(cross(rlm), tokenKey, from, to, amount)` | `SafeGRC20TransferFrom(0, rlm, tokenKey, from, to, amount)` |
| `SafeGRC20Approve(cross(rlm), tokenKey, spender, amount)` | `SafeGRC20Approve(0, rlm, tokenKey, spender, amount)` |
| `token.CallerTeller()` | `token.RealmTeller(0, rlm)` |

## Behavior Change

The helpers are now same-realm functions. Callers pass the live realm explicitly, and `RealmTeller` uses that realm as the transfer or approval actor. This removes the extra `common` realm boundary while preserving the intended contract identity for token operations.

note: CI failed because gnoswap/gno is not in sync with the latest gno/master commit. It needs to be updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token transfer, approval, and transfer-from helpers now operate with an explicitly bound current realm.
  * Public token operations consistently use the private ledger context for balances, allowances, transfers, and approvals.

* **Bug Fixes**
  * Improved realm handling for swaps, liquidity operations, rewards, protocol fees, staking, and launchpad transfers.
  * Safe token operations preserve clear failure behavior for validation errors.

* **Documentation**
  * Updated helper and callback examples to reflect the current realm-based token operation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->