### PR TITLE
fix(gov/staker): preserve reward stake invariants

### DIFF
--- a/contract/r/gnoswap/gov/staker/v1/delegation.gno
+++ b/contract/r/gnoswap/gov/staker/v1/delegation.gno
@@ -115,7 +115,7 @@ func (r *DelegationResolver) processCollection(currentTime int64) (int64, error)
 
 func addToCollectedAmount(collectedAmount, amount int64) (int64, error) {
 	if amount < 0 {
-		return 0, errors.New("amount must be non-negative")
+		return 0, errors.New(errAmountMustBeNonNegative)
 	}
 	return gnsmath.SafeAddInt64(collectedAmount, amount), nil
 }

--- a/contract/r/gnoswap/gov/staker/v1/emission_reward_manager.gno
+++ b/contract/r/gnoswap/gov/staker/v1/emission_reward_manager.gno
@@ -149,6 +149,11 @@ func (self *EmissionRewardManagerResolver) removeStake(address string, amount in
 		return errors.New("amount must be non-negative")
 	}
 
+	currentTotalStakedAmount := self.GetTotalStakedAmount()
+	if amount > currentTotalStakedAmount {
+		return errors.New("remove amount exceeds total staked amount")
+	}
+
 	accumulatedReward := self.GetAccumulatedRewardX128PerStake()
 
 	rewardState, ok, err := self.GetRewardState(address)
@@ -169,11 +174,7 @@ func (self *EmissionRewardManagerResolver) removeStake(address string, amount in
 	// persist updated state
 	self.setRewardStates(address, rewardState)
 
-	updatedTotalStakedAmount := gnsmath.SafeSubInt64(self.GetTotalStakedAmount(), amount)
-	if updatedTotalStakedAmount < 0 {
-		updatedTotalStakedAmount = 0
-	}
-	self.SetTotalStakedAmount(updatedTotalStakedAmount)
+	self.SetTotalStakedAmount(gnsmath.SafeSubInt64(currentTotalStakedAmount, amount))
 
 	return nil
 }

--- a/contract/r/gnoswap/gov/staker/v1/emission_reward_manager.gno
+++ b/contract/r/gnoswap/gov/staker/v1/emission_reward_manager.gno
@@ -160,6 +160,10 @@ func (self *EmissionRewardManagerResolver) removeStake(address string, amount in
 	}
 
 	resolvedState := NewEmissionRewardStateResolver(rewardState)
+
+	if amount > resolvedState.GetStakedAmount() {
+		return errors.New("remove amount exceeds staked amount")
+	}
 	err = resolvedState.removeStakeWithUpdateRewardDebtX128(amount, accumulatedReward, currentTimestamp)
 	if err != nil {
 		return err

--- a/contract/r/gnoswap/gov/staker/v1/emission_reward_manager.gno
+++ b/contract/r/gnoswap/gov/staker/v1/emission_reward_manager.gno
@@ -161,9 +161,6 @@ func (self *EmissionRewardManagerResolver) removeStake(address string, amount in
 
 	resolvedState := NewEmissionRewardStateResolver(rewardState)
 
-	if amount > resolvedState.GetStakedAmount() {
-		return errors.New("remove amount exceeds staked amount")
-	}
 	err = resolvedState.removeStakeWithUpdateRewardDebtX128(amount, accumulatedReward, currentTimestamp)
 	if err != nil {
 		return err

--- a/contract/r/gnoswap/gov/staker/v1/emission_reward_manager.gno
+++ b/contract/r/gnoswap/gov/staker/v1/emission_reward_manager.gno
@@ -149,8 +149,8 @@ func (self *EmissionRewardManagerResolver) removeStake(address string, amount in
 		return errors.New("amount must be non-negative")
 	}
 
-	currentTotalStakedAmount := self.GetTotalStakedAmount()
-	if amount > currentTotalStakedAmount {
+	updatedTotalStakedAmount := gnsmath.SafeSubInt64(self.GetTotalStakedAmount(), amount)
+	if updatedTotalStakedAmount < 0 {
 		return errors.New("remove amount exceeds total staked amount")
 	}
 
@@ -174,7 +174,7 @@ func (self *EmissionRewardManagerResolver) removeStake(address string, amount in
 	// persist updated state
 	self.setRewardStates(address, rewardState)
 
-	self.SetTotalStakedAmount(gnsmath.SafeSubInt64(currentTotalStakedAmount, amount))
+	self.SetTotalStakedAmount(updatedTotalStakedAmount)
 
 	return nil
 }

--- a/contract/r/gnoswap/gov/staker/v1/emission_reward_manager.gno
+++ b/contract/r/gnoswap/gov/staker/v1/emission_reward_manager.gno
@@ -109,7 +109,7 @@ func (self *EmissionRewardManagerResolver) updateAccumulatedRewardX128PerStake(
 // Adds stake for specified address and updates reward calculations.
 func (self *EmissionRewardManagerResolver) addStake(address string, amount int64, currentTimestamp int64) error {
 	if amount < 0 {
-		return errors.New("amount must be non-negative")
+		return errors.New(errAmountMustBeNonNegative)
 	}
 
 	accumulatedReward := self.GetAccumulatedRewardX128PerStake()
@@ -132,7 +132,7 @@ func (self *EmissionRewardManagerResolver) addStake(address string, amount int64
 
 	currentTotal := self.GetTotalStakedAmount()
 	if amount > 0 && currentTotal > math.MaxInt64-amount {
-		return errors.New("total staked amount would overflow")
+		return errors.New(errTotalStakedAmountOverflow)
 	}
 	self.SetTotalStakedAmount(gnsmath.SafeAddInt64(currentTotal, amount))
 	return nil
@@ -143,12 +143,12 @@ func (self *EmissionRewardManagerResolver) addStake(address string, amount int64
 // Removes stake for specified address and updates reward calculations.
 func (self *EmissionRewardManagerResolver) removeStake(address string, amount int64, currentTimestamp int64) error {
 	if amount < 0 {
-		return errors.New("amount must be non-negative")
+		return errors.New(errAmountMustBeNonNegative)
 	}
 
 	updatedTotalStakedAmount := gnsmath.SafeSubInt64(self.GetTotalStakedAmount(), amount)
 	if updatedTotalStakedAmount < 0 {
-		return errors.New("remove amount exceeds total staked amount")
+		return errors.New(errRemoveAmountExceedsTotalStaked)
 	}
 
 	accumulatedReward := self.GetAccumulatedRewardX128PerStake()

--- a/contract/r/gnoswap/gov/staker/v1/emission_reward_manager_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/emission_reward_manager_test.gno
@@ -595,6 +595,11 @@ func TestEmissionRewardManager_removeStake_updatesPersistedState(cur realm, t *t
 	uassert.NoError(t, err)
 	uassert.Equal(t, resolver.GetTotalStakedAmount(), int64(1000))
 
+	createdState, exists, err := resolver.GetRewardState(addr)
+	uassert.NoError(t, err)
+	uassert.True(t, exists)
+	uassert.Equal(t, int64(1000), createdState.GetStakedAmount())
+
 	// When: remove part of the stake
 	err = resolver.removeStake(addr, 300, 100)
 	uassert.NoError(t, err)

--- a/contract/r/gnoswap/gov/staker/v1/emission_reward_manager_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/emission_reward_manager_test.gno
@@ -257,12 +257,12 @@ func TestEmissionRewardManager_removeStake(cur realm, t *testing.T) {
 			expectedHasError: true,
 		},
 		{
-			name:             "Remove excessive stake (clamps to zero)",
+			name:             "Remove excessive stake",
 			initialAmount:    200,
 			removeAmount:     300,
 			currentHeight:    500,
-			expectedAmount:   0, // Clamped to zero
-			expectedHasError: false,
+			expectedAmount:   200, // Rejected; state remains unchanged
+			expectedHasError: true,
 		},
 	}
 
@@ -346,7 +346,6 @@ func TestEmissionRewardManager_claimRewards(cur realm, t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestEmissionRewardManager_claimRewards_MultipleTimes(cur realm, t *testing.T) {
@@ -548,36 +547,21 @@ func TestEmissionRewardManager_updateAccumulatedRewardX128PerStake(cur realm, t 
 	}
 }
 
-// removeStake bug reproduction 1:
-// When removeStake is called for a new address (not present in the tree),
-// internally a NewEmissionRewardState(...) is created. If rewardStates.Set(...) is missing,
-// the new state is not persisted in the tree, and this was a bug.
-// With the fixed code, the state should be saved correctly.
-func TestEmissionRewardManager_removeStake_persistsStateForNewAddress(cur realm, t *testing.T) {
+// removeStake rejects removal from an unknown address before changing state.
+func TestEmissionRewardManager_removeStake_rejectsOverRemovalForNewAddress(cur realm, t *testing.T) {
 	manager := staker.NewEmissionRewardManager()
 	resolver := NewEmissionRewardManagerResolver(manager)
 
-	// Prepare: advance global accumulator once for safety
-	resolver.SetAccumulatedRewardX128PerStake(u256.NewUint(0))
-	resolver.updateAccumulatedRewardX128PerStake(0, 10)
-
-	// When: calling removeStake on an address that does not exist yet
 	addr := "user-new"
 	uassert.Equal(t, resolver.GetTotalStakedAmount(), int64(0))
 
 	err := resolver.removeStake(addr, 100, 20)
-	uassert.NoError(t, err)
+	uassert.Error(t, err)
+	uassert.Equal(t, resolver.GetTotalStakedAmount(), int64(0))
 
-	// Then: state should be persisted in the tree
-	// (this fails in the buggy version where Set was missing)
-	rs, ok, err := resolver.GetRewardState(addr)
+	_, ok, err := resolver.GetRewardState(addr)
 	uassert.NoError(t, err)
-	uassert.True(t, ok)
-
-	uassert.NotEqual(t, rs, nil)
-	uassert.Equal(t, rs.GetStakedAmount(), int64(0)) // clamped to 0, no negative values
-	// rewardDebtX128 should be a cloned snapshot
-	uassert.NotEqual(t, rs.GetRewardDebtX128(), nil)
+	uassert.False(t, ok)
 }
 
 // removeStake bug reproduction 2 (defensive check):
@@ -745,4 +729,24 @@ func TestEmissionRewardManager_ZeroStakeEdgeCases(cur realm, t *testing.T) {
 		// User should have earned rewards before removal
 		uassert.True(t, claimed >= 0)
 	})
+}
+
+func TestEmissionRewardManager_removeStake_preservesAggregateInvariantOnOverRemoval(cur realm, t *testing.T) {
+	manager := staker.NewEmissionRewardManager()
+	resolver := NewEmissionRewardManagerResolver(manager)
+
+	uassert.NoError(t, resolver.addStake("alice", 200, 10))
+	uassert.NoError(t, resolver.addStake("bob", 300, 10))
+	uassert.Error(t, resolver.removeStake("alice", 300, 20))
+
+	alice, aliceExists, err := resolver.GetRewardState("alice")
+	uassert.NoError(t, err)
+	uassert.True(t, aliceExists)
+	bob, bobExists, err := resolver.GetRewardState("bob")
+	uassert.NoError(t, err)
+	uassert.True(t, bobExists)
+
+	uassert.Equal(t, int64(200), alice.GetStakedAmount())
+	uassert.Equal(t, int64(300), bob.GetStakedAmount())
+	uassert.Equal(t, int64(500), resolver.GetTotalStakedAmount())
 }

--- a/contract/r/gnoswap/gov/staker/v1/emission_reward_manager_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/emission_reward_manager_test.gno
@@ -292,6 +292,22 @@ func TestEmissionRewardManager_removeStake(cur realm, t *testing.T) {
 	}
 }
 
+func TestEmissionRewardManager_removeStake_rejectsTotalUnderflow(cur realm, t *testing.T) {
+	manager := staker.NewEmissionRewardManager()
+	resolver := NewEmissionRewardManagerResolver(manager)
+
+	uassert.NoError(t, resolver.addStake("alice", 200, 10))
+	resolver.SetTotalStakedAmount(100)
+
+	uassert.Error(t, resolver.removeStake("alice", 200, 20))
+
+	alice, exists, err := resolver.GetRewardState("alice")
+	uassert.NoError(t, err)
+	uassert.True(t, exists)
+	uassert.Equal(t, int64(200), alice.GetStakedAmount())
+	uassert.Equal(t, int64(100), resolver.GetTotalStakedAmount())
+}
+
 // Test claimRewards
 func TestEmissionRewardManager_claimRewards(cur realm, t *testing.T) {
 	tests := []struct {

--- a/contract/r/gnoswap/gov/staker/v1/emission_reward_state.gno
+++ b/contract/r/gnoswap/gov/staker/v1/emission_reward_state.gno
@@ -100,7 +100,7 @@ func (self *EmissionRewardStateResolver) calculateClaimableRewards(
 //   - amount: amount of stake to add
 func (self *EmissionRewardStateResolver) addStake(amount int64) error {
 	if amount < 0 {
-		return errors.New("amount must be non-negative")
+		return errors.New(errAmountMustBeNonNegative)
 	}
 	self.SetStakedAmount(gnsmath.SafeAddInt64(self.GetStakedAmount(), amount))
 	return nil
@@ -113,10 +113,10 @@ func (self *EmissionRewardStateResolver) addStake(amount int64) error {
 //   - amount: amount of stake to remove
 func (self *EmissionRewardStateResolver) removeStake(amount int64) error {
 	if amount < 0 {
-		return errors.New("amount must be non-negative")
+		return errors.New(errAmountMustBeNonNegative)
 	}
 	if amount > self.GetStakedAmount() {
-		return errors.New("remove amount exceeds staked amount")
+		return errors.New(errRemoveAmountExceedsStaked)
 	}
 	self.SetStakedAmount(gnsmath.SafeSubInt64(self.GetStakedAmount(), amount))
 	return nil

--- a/contract/r/gnoswap/gov/staker/v1/emission_reward_state.gno
+++ b/contract/r/gnoswap/gov/staker/v1/emission_reward_state.gno
@@ -1,6 +1,8 @@
 package staker
 
 import (
+	"errors"
+
 	"gno.land/p/gnoswap/consts"
 	gnsmath "gno.land/p/gnoswap/gnsmath"
 	u256 "gno.land/p/gnoswap/uint256"
@@ -106,9 +108,6 @@ func (self *EmissionRewardStateResolver) addStake(amount int64) {
 // Parameters:
 //   - amount: amount of stake to remove
 func (self *EmissionRewardStateResolver) removeStake(amount int64) {
-	if amount > self.GetStakedAmount() {
-		panic("remove amount exceeds staked amount")
-	}
 	self.SetStakedAmount(gnsmath.SafeSubInt64(self.GetStakedAmount(), amount))
 }
 
@@ -193,6 +192,9 @@ func (self *EmissionRewardStateResolver) removeStakeWithUpdateRewardDebtX128(
 	accumulatedRewardX128PerStake *u256.Uint,
 	currentTimestamp int64,
 ) error {
+	if amount > self.GetStakedAmount() {
+		return errors.New("remove amount exceeds staked amount")
+	}
 	if err := self.updateRewardDebtX128(accumulatedRewardX128PerStake, currentTimestamp); err != nil {
 		return err
 	}

--- a/contract/r/gnoswap/gov/staker/v1/emission_reward_state.gno
+++ b/contract/r/gnoswap/gov/staker/v1/emission_reward_state.gno
@@ -97,7 +97,7 @@ func (self *EmissionRewardStateResolver) calculateClaimableRewards(
 // Parameters:
 //   - amount: amount of stake to add
 func (self *EmissionRewardStateResolver) addStake(amount int64) {
-	self.adjustStake(amount)
+	self.SetStakedAmount(gnsmath.SafeAddInt64(self.GetStakedAmount(), amount))
 }
 
 // removeStake decreases the staked amount for this address.
@@ -106,20 +106,10 @@ func (self *EmissionRewardStateResolver) addStake(amount int64) {
 // Parameters:
 //   - amount: amount of stake to remove
 func (self *EmissionRewardStateResolver) removeStake(amount int64) {
-	self.adjustStake(-amount)
-}
-
-// adjustStake is a small internal helper to centralize bound checks and math.
-func (self *EmissionRewardStateResolver) adjustStake(delta int64) {
-	if delta == 0 {
-		return
+	if amount > self.GetStakedAmount() {
+		panic("remove amount exceeds staked amount")
 	}
-	// clamp at zero on underflow
-	newAmt := gnsmath.SafeAddInt64(self.GetStakedAmount(), delta)
-	if newAmt < 0 {
-		newAmt = 0
-	}
-	self.SetStakedAmount(newAmt)
+	self.SetStakedAmount(gnsmath.SafeSubInt64(self.GetStakedAmount(), amount))
 }
 
 // claimRewards processes reward claiming and updates the claim state.

--- a/contract/r/gnoswap/gov/staker/v1/emission_reward_state.gno
+++ b/contract/r/gnoswap/gov/staker/v1/emission_reward_state.gno
@@ -98,8 +98,12 @@ func (self *EmissionRewardStateResolver) calculateClaimableRewards(
 //
 // Parameters:
 //   - amount: amount of stake to add
-func (self *EmissionRewardStateResolver) addStake(amount int64) {
+func (self *EmissionRewardStateResolver) addStake(amount int64) error {
+	if amount < 0 {
+		return errors.New("amount must be non-negative")
+	}
 	self.SetStakedAmount(gnsmath.SafeAddInt64(self.GetStakedAmount(), amount))
+	return nil
 }
 
 // removeStake decreases the staked amount for this address.
@@ -107,8 +111,15 @@ func (self *EmissionRewardStateResolver) addStake(amount int64) {
 //
 // Parameters:
 //   - amount: amount of stake to remove
-func (self *EmissionRewardStateResolver) removeStake(amount int64) {
+func (self *EmissionRewardStateResolver) removeStake(amount int64) error {
+	if amount < 0 {
+		return errors.New("amount must be non-negative")
+	}
+	if amount > self.GetStakedAmount() {
+		return errors.New("remove amount exceeds staked amount")
+	}
 	self.SetStakedAmount(gnsmath.SafeSubInt64(self.GetStakedAmount(), amount))
+	return nil
 }
 
 // claimRewards processes reward claiming and updates the claim state.
@@ -176,8 +187,7 @@ func (self *EmissionRewardStateResolver) addStakeWithUpdateRewardDebtX128(
 	if err := self.updateRewardDebtX128(accumulatedRewardX128PerStake, currentTimestamp); err != nil {
 		return err
 	}
-	self.addStake(amount)
-	return nil
+	return self.addStake(amount)
 }
 
 // removeStakeWithUpdateRewardDebtX128 removes stake and updates reward debt in one operation.
@@ -198,8 +208,7 @@ func (self *EmissionRewardStateResolver) removeStakeWithUpdateRewardDebtX128(
 	if err := self.updateRewardDebtX128(accumulatedRewardX128PerStake, currentTimestamp); err != nil {
 		return err
 	}
-	self.removeStake(amount)
-	return nil
+	return self.removeStake(amount)
 }
 
 // claimRewardsWithUpdateRewardDebtX128 claims rewards and updates reward debt in one operation.

--- a/contract/r/gnoswap/gov/staker/v1/emission_reward_state.gno
+++ b/contract/r/gnoswap/gov/staker/v1/emission_reward_state.gno
@@ -202,9 +202,6 @@ func (self *EmissionRewardStateResolver) removeStakeWithUpdateRewardDebtX128(
 	accumulatedRewardX128PerStake *u256.Uint,
 	currentTimestamp int64,
 ) error {
-	if amount > self.GetStakedAmount() {
-		return errors.New("remove amount exceeds staked amount")
-	}
 	if err := self.updateRewardDebtX128(accumulatedRewardX128PerStake, currentTimestamp); err != nil {
 		return err
 	}

--- a/contract/r/gnoswap/gov/staker/v1/emission_reward_state_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/emission_reward_state_test.gno
@@ -334,6 +334,17 @@ func TestEmissionRewardState_removeStake(cur realm, t *testing.T) {
 	}
 }
 
+func TestEmissionRewardState_removeStake_rejectsOverRemoval(cur realm, t *testing.T) {
+	state := staker.NewEmissionRewardState(u256.NewUint(0))
+	resolver := NewEmissionRewardStateResolver(state)
+	resolver.SetStakedAmount(100)
+
+	uassert.PanicsWithMessage(t, cur, "remove amount exceeds staked amount", func() {
+		resolver.removeStake(101)
+	})
+	uassert.Equal(t, resolver.GetStakedAmount(), int64(100))
+}
+
 // Test claimRewards including idempotent no-op cases.
 func TestEmissionRewardState_claimRewards(cur realm, t *testing.T) {
 	tests := []struct {

--- a/contract/r/gnoswap/gov/staker/v1/emission_reward_state_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/emission_reward_state_test.gno
@@ -288,12 +288,22 @@ func TestEmissionRewardState_addStake(cur realm, t *testing.T) {
 			resolver.SetStakedAmount(tt.initialStake)
 
 			// When: Add stake
-			resolver.addStake(tt.addAmount)
+			uassert.NoError(t, resolver.addStake(tt.addAmount))
 
 			// Then: Staked amount should be updated
 			uassert.Equal(t, resolver.GetStakedAmount(), tt.expectedStake)
 		})
 	}
+}
+
+func TestEmissionRewardState_rejectsNegativeStakeChanges(cur realm, t *testing.T) {
+	state := staker.NewEmissionRewardState(u256.Zero())
+	resolver := NewEmissionRewardStateResolver(state)
+	resolver.SetStakedAmount(100)
+
+	uassert.Error(t, resolver.addStake(-1))
+	uassert.Error(t, resolver.removeStake(-1))
+	uassert.Equal(t, int64(100), resolver.GetStakedAmount())
 }
 
 // Test removeStake
@@ -326,7 +336,7 @@ func TestEmissionRewardState_removeStake(cur realm, t *testing.T) {
 			resolver.SetStakedAmount(tt.initialStake)
 
 			// When: Remove stake
-			resolver.removeStake(tt.removeAmount)
+			uassert.NoError(t, resolver.removeStake(tt.removeAmount))
 
 			// Then: Staked amount should be updated
 			uassert.Equal(t, resolver.GetStakedAmount(), tt.expectedStake)

--- a/contract/r/gnoswap/gov/staker/v1/emission_reward_state_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/emission_reward_state_test.gno
@@ -339,9 +339,8 @@ func TestEmissionRewardState_removeStake_rejectsOverRemoval(cur realm, t *testin
 	resolver := NewEmissionRewardStateResolver(state)
 	resolver.SetStakedAmount(100)
 
-	uassert.PanicsWithMessage(t, cur, "remove amount exceeds staked amount", func() {
-		resolver.removeStake(101)
-	})
+	err := resolver.removeStakeWithUpdateRewardDebtX128(101, u256.Zero(), 0)
+	uassert.Error(t, err)
 	uassert.Equal(t, resolver.GetStakedAmount(), int64(100))
 }
 

--- a/contract/r/gnoswap/gov/staker/v1/errors.gno
+++ b/contract/r/gnoswap/gov/staker/v1/errors.gno
@@ -5,16 +5,25 @@ import (
 )
 
 const (
-	errDataNotFound           = "[GNOSWAP-GOV_STAKER-001] requested data not found"
-	errInvalidAmount          = "[GNOSWAP-GOV_STAKER-002] invalid amount"
-	errNoDelegatedAmount      = "[GNOSWAP-GOV_STAKER-003] zero delegated amount"
-	errNotEnoughDelegated     = "[GNOSWAP-GOV_STAKER-004] not enough delegated"
-	errInvalidAddress         = "[GNOSWAP-GOV_STAKER-005] invalid address"
-	errNotEnoughBalance       = "[GNOSWAP-GOV_STAKER-006] not enough balance"
-	errLessThanMinimum        = "[GNOSWAP-GOV_STAKER-007] cannot delegate less than minimum amount"
-	errInvalidSnapshotTime    = "[GNOSWAP-GOV_STAKER-008] invalid snapshot time"
-	errSameDelegatee          = "[GNOSWAP-GOV_STAKER-009] cannot redelegate to same address"
-	errWithdrawNotCollectable = "[GNOSWAP-GOV_STAKER-010] withdraw is not collectable"
+	errDataNotFound                   = "[GNOSWAP-GOV_STAKER-001] requested data not found"
+	errInvalidAmount                  = "[GNOSWAP-GOV_STAKER-002] invalid amount"
+	errNoDelegatedAmount              = "[GNOSWAP-GOV_STAKER-003] zero delegated amount"
+	errNotEnoughDelegated             = "[GNOSWAP-GOV_STAKER-004] not enough delegated"
+	errInvalidAddress                 = "[GNOSWAP-GOV_STAKER-005] invalid address"
+	errNotEnoughBalance               = "[GNOSWAP-GOV_STAKER-006] not enough balance"
+	errLessThanMinimum                = "[GNOSWAP-GOV_STAKER-007] cannot delegate less than minimum amount"
+	errInvalidSnapshotTime            = "[GNOSWAP-GOV_STAKER-008] invalid snapshot time"
+	errSameDelegatee                  = "[GNOSWAP-GOV_STAKER-009] cannot redelegate to same address"
+	errWithdrawNotCollectable         = "[GNOSWAP-GOV_STAKER-010] withdraw is not collectable"
+	errAmountMustBeNonNegative        = "[GNOSWAP-GOV_STAKER-011] amount must be non-negative"
+	errTotalStakedAmountOverflow      = "[GNOSWAP-GOV_STAKER-012] total staked amount would overflow"
+	errRemoveAmountExceedsTotalStaked = "[GNOSWAP-GOV_STAKER-013] remove amount exceeds total staked amount"
+	errRemoveAmountExceedsStaked      = "[GNOSWAP-GOV_STAKER-014] remove amount exceeds staked amount"
+	errAmountMustBePositive           = "[GNOSWAP-GOV_STAKER-015] amount must be positive"
+	errRewardDebtUpdateRequired       = "[GNOSWAP-GOV_STAKER-016] must update reward debt before claiming rewards"
+	errDelegatedAmountNegative        = "[GNOSWAP-GOV_STAKER-017] delegated amount cannot be negative"
+	errUndelegationAmountNegative     = "[GNOSWAP-GOV_STAKER-018] undelegation amount cannot be negative"
+	errDelegationNotFound             = "[GNOSWAP-GOV_STAKER-019] delegation not found"
 )
 
 func makeErrorWithDetails(message string, detail string) error {

--- a/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_manager.gno
+++ b/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_manager.gno
@@ -300,6 +300,10 @@ func (self *ProtocolFeeRewardManagerResolver) removeStake(address string, amount
 	}
 
 	resolvedState := NewProtocolFeeRewardStateResolver(rewardState)
+
+	if amount > resolvedState.GetStakedAmount() {
+		return errors.New("remove amount exceeds staked amount")
+	}
 	err = resolvedState.removeStakeWithUpdateRewardDebtX128(amount, self.GetAllAccumulatedProtocolFeeX128PerStake(), currentTimestamp)
 	if err != nil {
 		return err

--- a/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_manager.gno
+++ b/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_manager.gno
@@ -291,6 +291,11 @@ func (self *ProtocolFeeRewardManagerResolver) removeStake(address string, amount
 		return errors.New("amount must be non-negative")
 	}
 
+	currentTotalStakedAmount := self.GetTotalStakedAmount()
+	if amount > currentTotalStakedAmount {
+		return errors.New("remove amount exceeds total staked amount")
+	}
+
 	rewardState, ok, err := self.GetRewardState(address)
 	if err != nil {
 		return err
@@ -308,11 +313,7 @@ func (self *ProtocolFeeRewardManagerResolver) removeStake(address string, amount
 
 	self.setRewardState(address, rewardState)
 
-	updatedTotalStakedAmount := gnsmath.SafeSubInt64(self.GetTotalStakedAmount(), amount)
-	if updatedTotalStakedAmount < 0 {
-		updatedTotalStakedAmount = 0
-	}
-	self.SetTotalStakedAmount(updatedTotalStakedAmount)
+	self.SetTotalStakedAmount(gnsmath.SafeSubInt64(currentTotalStakedAmount, amount))
 
 	return nil
 }

--- a/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_manager.gno
+++ b/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_manager.gno
@@ -301,9 +301,6 @@ func (self *ProtocolFeeRewardManagerResolver) removeStake(address string, amount
 
 	resolvedState := NewProtocolFeeRewardStateResolver(rewardState)
 
-	if amount > resolvedState.GetStakedAmount() {
-		return errors.New("remove amount exceeds staked amount")
-	}
 	err = resolvedState.removeStakeWithUpdateRewardDebtX128(amount, self.GetAllAccumulatedProtocolFeeX128PerStake(), currentTimestamp)
 	if err != nil {
 		return err

--- a/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_manager.gno
+++ b/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_manager.gno
@@ -291,8 +291,8 @@ func (self *ProtocolFeeRewardManagerResolver) removeStake(address string, amount
 		return errors.New("amount must be non-negative")
 	}
 
-	currentTotalStakedAmount := self.GetTotalStakedAmount()
-	if amount > currentTotalStakedAmount {
+	updatedTotalStakedAmount := gnsmath.SafeSubInt64(self.GetTotalStakedAmount(), amount)
+	if updatedTotalStakedAmount < 0 {
 		return errors.New("remove amount exceeds total staked amount")
 	}
 
@@ -313,7 +313,7 @@ func (self *ProtocolFeeRewardManagerResolver) removeStake(address string, amount
 
 	self.setRewardState(address, rewardState)
 
-	self.SetTotalStakedAmount(gnsmath.SafeSubInt64(currentTotalStakedAmount, amount))
+	self.SetTotalStakedAmount(updatedTotalStakedAmount)
 
 	return nil
 }

--- a/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_manager.gno
+++ b/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_manager.gno
@@ -251,7 +251,7 @@ func (self *ProtocolFeeRewardManagerResolver) updateAccumulatedProtocolFeeX128Pe
 //   - currentTimestamp: current timestamp
 func (self *ProtocolFeeRewardManagerResolver) addStake(address string, amount int64, currentTimestamp int64) error {
 	if amount <= 0 {
-		return errors.New("amount must be positive")
+		return errors.New(errAmountMustBePositive)
 	}
 
 	rewardState, ok, err := self.GetRewardState(address)
@@ -266,7 +266,7 @@ func (self *ProtocolFeeRewardManagerResolver) addStake(address string, amount in
 
 	currentTotal := self.GetTotalStakedAmount()
 	if currentTotal > math.MaxInt64-amount {
-		return errors.New("total staked amount would overflow")
+		return errors.New(errTotalStakedAmountOverflow)
 	}
 	updatedTotalStakedAmount := gnsmath.SafeAddInt64(currentTotal, amount)
 
@@ -290,12 +290,12 @@ func (self *ProtocolFeeRewardManagerResolver) addStake(address string, amount in
 //   - currentTimestamp: current timestamp
 func (self *ProtocolFeeRewardManagerResolver) removeStake(address string, amount int64, currentTimestamp int64) error {
 	if amount < 0 {
-		return errors.New("amount must be non-negative")
+		return errors.New(errAmountMustBeNonNegative)
 	}
 
 	updatedTotalStakedAmount := gnsmath.SafeSubInt64(self.GetTotalStakedAmount(), amount)
 	if updatedTotalStakedAmount < 0 {
-		return errors.New("remove amount exceeds total staked amount")
+		return errors.New(errRemoveAmountExceedsTotalStaked)
 	}
 
 	rewardState, ok, err := self.GetRewardState(address)

--- a/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_manager_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_manager_test.gno
@@ -270,16 +270,16 @@ func TestProtocolFeeRewardManager_removeStake(cur realm, t *testing.T) {
 			initialAmount:    0,
 			removeAmount:     100,
 			currentTimestamp: 500,
-			expectedAmount:   0, // Clamps to zero
-			expectedHasError: false,
+			expectedAmount:   0, // Rejected; state remains unchanged
+			expectedHasError: true,
 		},
 		{
 			name:             "Remove stake with amount exceeding staked",
 			initialAmount:    100,
 			removeAmount:     200,
 			currentTimestamp: 600,
-			expectedAmount:   0, // Clamps to zero
-			expectedHasError: false,
+			expectedAmount:   100, // Rejected; state remains unchanged
+			expectedHasError: true,
 		},
 	}
 
@@ -307,6 +307,26 @@ func TestProtocolFeeRewardManager_removeStake(cur realm, t *testing.T) {
 			uassert.Equal(t, resolver.GetTotalStakedAmount(), tt.expectedAmount)
 		})
 	}
+}
+
+func TestProtocolFeeRewardManager_removeStake_preservesAggregateInvariantOnOverRemoval(cur realm, t *testing.T) {
+	manager := staker.NewProtocolFeeRewardManager()
+	resolver := NewProtocolFeeRewardManagerResolver(manager)
+
+	uassert.NoError(t, resolver.addStake("alice", 200, 10))
+	uassert.NoError(t, resolver.addStake("bob", 300, 10))
+	uassert.Error(t, resolver.removeStake("alice", 300, 20))
+
+	alice, aliceExists, err := resolver.GetRewardState("alice")
+	uassert.NoError(t, err)
+	uassert.True(t, aliceExists)
+	bob, bobExists, err := resolver.GetRewardState("bob")
+	uassert.NoError(t, err)
+	uassert.True(t, bobExists)
+
+	uassert.Equal(t, int64(200), alice.GetStakedAmount())
+	uassert.Equal(t, int64(300), bob.GetStakedAmount())
+	uassert.Equal(t, int64(500), resolver.GetTotalStakedAmount())
 }
 
 // Test claimRewards

--- a/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_manager_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_manager_test.gno
@@ -329,6 +329,22 @@ func TestProtocolFeeRewardManager_removeStake_preservesAggregateInvariantOnOverR
 	uassert.Equal(t, int64(500), resolver.GetTotalStakedAmount())
 }
 
+func TestProtocolFeeRewardManager_removeStake_rejectsTotalUnderflow(cur realm, t *testing.T) {
+	manager := staker.NewProtocolFeeRewardManager()
+	resolver := NewProtocolFeeRewardManagerResolver(manager)
+
+	uassert.NoError(t, resolver.addStake("alice", 200, 10))
+	resolver.SetTotalStakedAmount(100)
+
+	uassert.Error(t, resolver.removeStake("alice", 200, 20))
+
+	alice, exists, err := resolver.GetRewardState("alice")
+	uassert.NoError(t, err)
+	uassert.True(t, exists)
+	uassert.Equal(t, int64(200), alice.GetStakedAmount())
+	uassert.Equal(t, int64(100), resolver.GetTotalStakedAmount())
+}
+
 // Test claimRewards
 func TestProtocolFeeRewardManager_claimRewards(cur realm, t *testing.T) {
 	tests := []struct {

--- a/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_state.gno
+++ b/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_state.gno
@@ -156,7 +156,7 @@ func (p *ProtocolFeeRewardStateResolver) calculateClaimableRewardForToken(
 //   - amount: amount of stake to add
 func (p *ProtocolFeeRewardStateResolver) addStake(amount int64) error {
 	if amount < 0 {
-		return errors.New("amount must be non-negative")
+		return errors.New(errAmountMustBeNonNegative)
 	}
 	p.SetStakedAmount(gnsmath.SafeAddInt64(p.GetStakedAmount(), amount))
 	return nil
@@ -169,10 +169,10 @@ func (p *ProtocolFeeRewardStateResolver) addStake(amount int64) error {
 //   - amount: amount of stake to remove
 func (p *ProtocolFeeRewardStateResolver) removeStake(amount int64) error {
 	if amount < 0 {
-		return errors.New("amount must be non-negative")
+		return errors.New(errAmountMustBeNonNegative)
 	}
 	if amount > p.GetStakedAmount() {
-		return errors.New("remove amount exceeds staked amount")
+		return errors.New(errRemoveAmountExceedsStaked)
 	}
 	p.SetStakedAmount(gnsmath.SafeSubInt64(p.GetStakedAmount(), amount))
 	return nil
@@ -193,7 +193,7 @@ func (p *ProtocolFeeRewardStateResolver) claimRewards(currentTimestamp int64) (m
 	}
 
 	if p.GetAccumulatedTimestamp() < currentTimestamp {
-		return nil, errors.New("must update reward debt before claiming rewards")
+		return nil, errors.New(errRewardDebtUpdateRequired)
 	}
 
 	currentClaimedRewards := make(map[string]int64)

--- a/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_state.gno
+++ b/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_state.gno
@@ -154,8 +154,12 @@ func (p *ProtocolFeeRewardStateResolver) calculateClaimableRewardForToken(
 //
 // Parameters:
 //   - amount: amount of stake to add
-func (p *ProtocolFeeRewardStateResolver) addStake(amount int64) {
+func (p *ProtocolFeeRewardStateResolver) addStake(amount int64) error {
+	if amount < 0 {
+		return errors.New("amount must be non-negative")
+	}
 	p.SetStakedAmount(gnsmath.SafeAddInt64(p.GetStakedAmount(), amount))
+	return nil
 }
 
 // removeStake decreases the staked amount for this address.
@@ -163,8 +167,15 @@ func (p *ProtocolFeeRewardStateResolver) addStake(amount int64) {
 //
 // Parameters:
 //   - amount: amount of stake to remove
-func (p *ProtocolFeeRewardStateResolver) removeStake(amount int64) {
+func (p *ProtocolFeeRewardStateResolver) removeStake(amount int64) error {
+	if amount < 0 {
+		return errors.New("amount must be non-negative")
+	}
+	if amount > p.GetStakedAmount() {
+		return errors.New("remove amount exceeds staked amount")
+	}
 	p.SetStakedAmount(gnsmath.SafeSubInt64(p.GetStakedAmount(), amount))
+	return nil
 }
 
 // claimRewards processes reward claiming for all tokens and updates the claim state.
@@ -304,9 +315,7 @@ func (p *ProtocolFeeRewardStateResolver) addStakeWithUpdateRewardDebtX128(
 		return err
 	}
 
-	p.addStake(amount)
-
-	return nil
+	return p.addStake(amount)
 }
 
 // removeStakeWithUpdateRewardDebtX128 removes stake and updates reward debt in one operation.
@@ -329,9 +338,7 @@ func (p *ProtocolFeeRewardStateResolver) removeStakeWithUpdateRewardDebtX128(
 		return err
 	}
 
-	p.removeStake(amount)
-
-	return nil
+	return p.removeStake(amount)
 }
 
 // claimRewardsWithUpdateRewardDebtX128 claims rewards and updates reward debt in one operation.

--- a/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_state.gno
+++ b/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_state.gno
@@ -164,11 +164,7 @@ func (p *ProtocolFeeRewardStateResolver) addStake(amount int64) {
 // Parameters:
 //   - amount: amount of stake to remove
 func (p *ProtocolFeeRewardStateResolver) removeStake(amount int64) {
-	newAmount := gnsmath.SafeSubInt64(p.GetStakedAmount(), amount)
-	if newAmount < 0 {
-		newAmount = 0
-	}
-	p.SetStakedAmount(newAmount)
+	p.SetStakedAmount(gnsmath.SafeSubInt64(p.GetStakedAmount(), amount))
 }
 
 // claimRewards processes reward claiming for all tokens and updates the claim state.
@@ -325,6 +321,9 @@ func (p *ProtocolFeeRewardStateResolver) removeStakeWithUpdateRewardDebtX128(
 	accumulatedProtocolFeeX128PerStake map[string]*u256.Uint,
 	currentTimestamp int64,
 ) error {
+	if amount > p.GetStakedAmount() {
+		return errors.New("remove amount exceeds staked amount")
+	}
 	err := p.updateRewardDebtX128(accumulatedProtocolFeeX128PerStake, currentTimestamp)
 	if err != nil {
 		return err

--- a/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_state.gno
+++ b/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_state.gno
@@ -330,9 +330,6 @@ func (p *ProtocolFeeRewardStateResolver) removeStakeWithUpdateRewardDebtX128(
 	accumulatedProtocolFeeX128PerStake map[string]*u256.Uint,
 	currentTimestamp int64,
 ) error {
-	if amount > p.GetStakedAmount() {
-		return errors.New("remove amount exceeds staked amount")
-	}
 	err := p.updateRewardDebtX128(accumulatedProtocolFeeX128PerStake, currentTimestamp)
 	if err != nil {
 		return err

--- a/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_state.gno
+++ b/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_state.gno
@@ -352,7 +352,9 @@ func (p *ProtocolFeeRewardStateResolver) claimRewardsWithUpdateRewardDebtX128(
 	accumulatedProtocolFeeX128PerStake map[string]*u256.Uint,
 	currentTimestamp int64,
 ) (map[string]int64, error) {
-	p.updateRewardDebtX128(accumulatedProtocolFeeX128PerStake, currentTimestamp)
+	if err := p.updateRewardDebtX128(accumulatedProtocolFeeX128PerStake, currentTimestamp); err != nil {
+		return nil, err
+	}
 
 	return p.claimRewards(currentTimestamp)
 }

--- a/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_state_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_state_test.gno
@@ -257,12 +257,22 @@ func TestProtocolFeeRewardState_addStake(cur realm, t *testing.T) {
 			resolver.SetStakedAmount(tt.initialStake)
 
 			// When: Add stake
-			resolver.addStake(tt.addAmount)
+			uassert.NoError(t, resolver.addStake(tt.addAmount))
 
 			// Then: Staked amount should be updated
 			uassert.Equal(t, resolver.GetStakedAmount(), tt.expectedStake)
 		})
 	}
+}
+
+func TestProtocolFeeRewardState_rejectsNegativeStakeChanges(cur realm, t *testing.T) {
+	state := staker.NewProtocolFeeRewardState(make(map[string]*u256.Uint))
+	resolver := NewProtocolFeeRewardStateResolver(state)
+	resolver.SetStakedAmount(100)
+
+	uassert.Error(t, resolver.addStake(-1))
+	uassert.Error(t, resolver.removeStake(-1))
+	uassert.Equal(t, int64(100), resolver.GetStakedAmount())
 }
 
 // Test removeStake
@@ -301,7 +311,7 @@ func TestProtocolFeeRewardState_removeStake(cur realm, t *testing.T) {
 			resolver.SetStakedAmount(tt.initialStake)
 
 			// When: Remove stake
-			resolver.removeStake(tt.removeAmount)
+			uassert.NoError(t, resolver.removeStake(tt.removeAmount))
 
 			// Then: Staked amount should be updated
 			uassert.Equal(t, resolver.GetStakedAmount(), tt.expectedStake)

--- a/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_state_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/protocol_fee_reward_state_test.gno
@@ -309,6 +309,16 @@ func TestProtocolFeeRewardState_removeStake(cur realm, t *testing.T) {
 	}
 }
 
+func TestProtocolFeeRewardState_removeStake_rejectsOverRemoval(cur realm, t *testing.T) {
+	state := staker.NewProtocolFeeRewardState(make(map[string]*u256.Uint))
+	resolver := NewProtocolFeeRewardStateResolver(state)
+	resolver.SetStakedAmount(100)
+
+	err := resolver.removeStakeWithUpdateRewardDebtX128(101, make(map[string]*u256.Uint), 0)
+	uassert.Error(t, err)
+	uassert.Equal(t, resolver.GetStakedAmount(), int64(100))
+}
+
 // Test claimRewards including idempotent no-op cases.
 func TestProtocolFeeRewardState_claimRewards(cur realm, t *testing.T) {
 	tests := []struct {
@@ -794,20 +804,15 @@ func TestProtocolFeeRewardState_BoundaryConditions(cur realm, t *testing.T) {
 		uassert.True(t, didPanic)
 	})
 
-	t.Run("RemoveStake boundary - clamping to zero", func(cur realm, t *testing.T) {
-		// given: protocol fee reward state with some staked amount
+	t.Run("RemoveStake boundary - reject over-removal", func(cur realm, t *testing.T) {
 		state := staker.NewProtocolFeeRewardState(make(map[string]*u256.Uint))
 		resolver := NewProtocolFeeRewardStateResolver(state)
-
 		state.SetStakedAmount(1000)
 
-		// when: remove more than available (uses safeSubInt64 with clamping)
-		accumulatedFees := make(map[string]*u256.Uint)
-		err := resolver.removeStakeWithUpdateRewardDebtX128(2000, accumulatedFees, 1000)
+		err := resolver.removeStakeWithUpdateRewardDebtX128(2000, make(map[string]*u256.Uint), 1000)
 
-		// then: should clamp to zero
-		uassert.NoError(t, err)
-		uassert.Equal(t, state.GetStakedAmount(), int64(0))
+		uassert.Error(t, err)
+		uassert.Equal(t, state.GetStakedAmount(), int64(1000))
 	})
 
 	t.Run("ClaimRewards boundary - exact subtraction", func(cur realm, t *testing.T) {

--- a/contract/r/gnoswap/gov/staker/v1/staker_delegate.gno
+++ b/contract/r/gnoswap/gov/staker/v1/staker_delegate.gno
@@ -342,10 +342,16 @@ func (gs *govStakerV1) delegate(
 		return nil, errors.New("delegated amount cannot be negative")
 	}
 
-	gs.addDelegation(0, rlm, delegationID, delegation)
+	if err := gs.addDelegation(0, rlm, delegationID, delegation); err != nil {
+		return nil, err
+	}
 	gs.addDelegationRecord(0, rlm, to, delegatedAmount, currentTimestamp)
-	gs.addStakeEmissionReward(0, rlm, from.String(), amount, currentTimestamp)
-	gs.addStakeProtocolFeeReward(0, rlm, from.String(), amount, currentTimestamp)
+	if err := gs.addStakeEmissionReward(0, rlm, from.String(), amount, currentTimestamp); err != nil {
+		return nil, err
+	}
+	if err := gs.addStakeProtocolFeeReward(0, rlm, from.String(), amount, currentTimestamp); err != nil {
+		return nil, err
+	}
 
 	return delegation, nil
 }
@@ -389,7 +395,9 @@ func (gs *govStakerV1) unDelegate(
 	for _, delegation := range delegations {
 		resolver := NewDelegationResolver(delegation)
 		if resolver.IsEmpty() {
-			gs.removeDelegation(0, rlm, delegation.ID())
+			if err := gs.removeDelegation(0, rlm, delegation.ID()); err != nil {
+				return 0, err
+			}
 			continue
 		}
 
@@ -410,10 +418,16 @@ func (gs *govStakerV1) unDelegate(
 			lockupPeriod,
 		)
 
-		gs.setDelegation(0, rlm, delegation.ID(), delegation)
+		if err := gs.setDelegation(0, rlm, delegation.ID(), delegation); err != nil {
+			return 0, err
+		}
 		gs.addDelegationRecord(0, rlm, delegatee, -currentUnDelegationAmount, currentTimestamp)
-		gs.removeStakeEmissionReward(0, rlm, delegator.String(), currentUnDelegationAmount, currentTimestamp)
-		gs.removeStakeProtocolFeeReward(0, rlm, delegator.String(), currentUnDelegationAmount, currentTimestamp)
+		if err := gs.removeStakeEmissionReward(0, rlm, delegator.String(), currentUnDelegationAmount, currentTimestamp); err != nil {
+			return 0, err
+		}
+		if err := gs.removeStakeProtocolFeeReward(0, rlm, delegator.String(), currentUnDelegationAmount, currentTimestamp); err != nil {
+			return 0, err
+		}
 
 		unDelegationAmount = gnsmath.SafeSubInt64(unDelegationAmount, currentUnDelegationAmount)
 		if unDelegationAmount <= 0 {
@@ -462,7 +476,9 @@ func (gs *govStakerV1) unDelegateWithoutLockup(
 	for _, delegation := range delegations {
 		resolver := NewDelegationResolver(delegation)
 		if resolver.IsEmpty() {
-			gs.removeDelegation(0, rlm, delegation.ID())
+			if err := gs.removeDelegation(0, rlm, delegation.ID()); err != nil {
+				return 0, err
+			}
 			continue
 		}
 
@@ -479,13 +495,19 @@ func (gs *govStakerV1) unDelegateWithoutLockup(
 		)
 
 		if resolver.IsEmpty() {
-			gs.removeDelegation(0, rlm, delegation.ID())
-		} else {
-			gs.setDelegation(0, rlm, delegation.ID(), delegation)
+			if err := gs.removeDelegation(0, rlm, delegation.ID()); err != nil {
+				return 0, err
+			}
+		} else if err := gs.setDelegation(0, rlm, delegation.ID(), delegation); err != nil {
+			return 0, err
 		}
 		gs.addDelegationRecord(0, rlm, delegatee, -currentUnDelegationAmount, currentTime)
-		gs.removeStakeEmissionReward(0, rlm, delegator.String(), currentUnDelegationAmount, currentTime)
-		gs.removeStakeProtocolFeeReward(0, rlm, delegator.String(), currentUnDelegationAmount, currentTime)
+		if err := gs.removeStakeEmissionReward(0, rlm, delegator.String(), currentUnDelegationAmount, currentTime); err != nil {
+			return 0, err
+		}
+		if err := gs.removeStakeProtocolFeeReward(0, rlm, delegator.String(), currentUnDelegationAmount, currentTime); err != nil {
+			return 0, err
+		}
 
 		unDelegationAmount = gnsmath.SafeSubInt64(unDelegationAmount, currentUnDelegationAmount)
 		if unDelegationAmount <= 0 {
@@ -590,19 +612,24 @@ func (gs *govStakerV1) collectDelegations(_ int, rlm realm, user address, curren
 			if resolver.IsEmpty() {
 				idsToRemove = append(idsToRemove, delegation.ID())
 			} else {
-				gs.setDelegation(0, rlm, delegation.ID(), delegation)
+				if iErr := gs.setDelegation(0, rlm, delegation.ID(), delegation); iErr != nil {
+					err = iErr
+					return true
+				}
 			}
 		}
 
 		return false
 	})
 
-	for _, id := range idsToRemove {
-		gs.removeDelegation(0, rlm, id)
-	}
-
 	if err != nil {
 		return totalCollectedAmount, makeErrorWithDetails(errInvalidAmount, err.Error())
+	}
+
+	for _, id := range idsToRemove {
+		if err := gs.removeDelegation(0, rlm, id); err != nil {
+			return totalCollectedAmount, err
+		}
 	}
 
 	return totalCollectedAmount, nil

--- a/contract/r/gnoswap/gov/staker/v1/staker_delegate.gno
+++ b/contract/r/gnoswap/gov/staker/v1/staker_delegate.gno
@@ -339,7 +339,7 @@ func (gs *govStakerV1) delegate(
 	delegationResolver := NewDelegationResolver(delegation)
 	delegatedAmount := delegationResolver.DelegatedAmount()
 	if delegatedAmount < 0 {
-		return nil, errors.New("delegated amount cannot be negative")
+		return nil, errors.New(errDelegatedAmountNegative)
 	}
 
 	if err := gs.addDelegation(0, rlm, delegationID, delegation); err != nil {
@@ -408,7 +408,7 @@ func (gs *govStakerV1) unDelegate(
 		}
 
 		if currentUnDelegationAmount < 0 {
-			return 0, errors.New("undelegation amount cannot be negative")
+			return 0, errors.New(errUndelegationAmountNegative)
 		}
 
 		if currentUnDelegationAmount == 0 {

--- a/contract/r/gnoswap/gov/staker/v1/staker_delegate_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/staker_delegate_test.gno
@@ -1051,7 +1051,9 @@ func setupStakerDelegateTestDelegation(cur realm, t *testing.T, gs *govStakerV1,
 
 	testing.SetRealm(testing.NewUserRealm(from))
 	func(cur realm) {
-		gs.addDelegation(0, cur, delegationID, delegation)
+		if err := gs.addDelegation(0, cur, delegationID, delegation); err != nil {
+			panic(err)
+		}
 	}(cross(cur))
 
 	testing.SetRealm(testing.NewUserRealm(from))
@@ -1076,7 +1078,9 @@ func setupStakerDelegateTestCollectableAmount(cur realm, t *testing.T, gs *govSt
 
 	testing.SetRealm(testing.NewUserRealm(user))
 	func(cur realm) {
-		gs.addDelegation(0, cur, delegationID, delegation)
+		if err := gs.addDelegation(0, cur, delegationID, delegation); err != nil {
+			panic(err)
+		}
 	}(cross(cur))
 
 	testing.SetRealm(testing.NewUserRealm(user))
@@ -1187,7 +1191,9 @@ func TestStakerDelegate_collectDelegations_MultipleDelegations(cur realm, t *tes
 
 				testing.SetRealm(testing.NewUserRealm(user))
 				func(cur realm) {
-					gs.addDelegation(0, cur, delegationID, delegation)
+					if err := gs.addDelegation(0, cur, delegationID, delegation); err != nil {
+						panic(err)
+					}
 				}(cross(cur))
 
 				mintXgnsForTest(cur, user, totalAmount)
@@ -1237,7 +1243,9 @@ func TestStakerDelegate_collectDelegations_NoCollectableAmount(cur realm, t *tes
 
 				testing.SetRealm(testing.NewUserRealm(user))
 				func(cur realm) {
-					gs.addDelegation(0, cur, delegationID, delegation)
+					if err := gs.addDelegation(0, cur, delegationID, delegation); err != nil {
+						panic(err)
+					}
 				}(cross(cur))
 
 				mintXgnsForTest(cur, user, minimumAmount)
@@ -1257,7 +1265,9 @@ func TestStakerDelegate_collectDelegations_NoCollectableAmount(cur realm, t *tes
 
 				testing.SetRealm(testing.NewUserRealm(user))
 				func(cur realm) {
-					gs.addDelegation(0, cur, delegationID, delegation)
+					if err := gs.addDelegation(0, cur, delegationID, delegation); err != nil {
+						panic(err)
+					}
 				}(cross(cur))
 
 				return user

--- a/contract/r/gnoswap/gov/staker/v1/staker_reward_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/staker_reward_test.gno
@@ -313,7 +313,7 @@ func TestStakerReward_SetAmountByProjectWallet(cur realm, t *testing.T) {
 			amount:        0,
 			add:           true,
 			expectPanic:   true,
-			expectedError: "amount must be positive",
+			expectedError: errAmountMustBePositive,
 			setupMocks: func(cur realm, _ *govStakerV1) {
 				cleanupStakerRewardTest(cur, t)
 			},

--- a/contract/r/gnoswap/gov/staker/v1/staker_reward_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/staker_reward_test.gno
@@ -870,7 +870,7 @@ func setupStakerRewardTestLaunchpadDeposit(cur realm, t *testing.T, gs *govStake
 	launchpadRewardID := gs.makeLaunchpadRewardID(addr.String())
 	testing.SetRealm(adminRealm)
 	func(cur realm) {
-		gs.setLaunchpadProjectDeposit(0, cur, launchpadRewardID, amount)
+		uassert.NoError(t, gs.setLaunchpadProjectDeposit(0, cur, launchpadRewardID, amount))
 	}(cross(cur))
 }
 

--- a/contract/r/gnoswap/gov/staker/v1/state.gno
+++ b/contract/r/gnoswap/gov/staker/v1/state.gno
@@ -95,7 +95,7 @@ func (g *govStakerV1) addDelegation(_ int, rlm realm, delegationID int64, delega
 func (g *govStakerV1) removeDelegation(_ int, rlm realm, delegationID int64) error {
 	delegation := g.getDelegation(delegationID)
 	if delegation == nil {
-		return errors.New("delegation not found")
+		return errors.New(errDelegationNotFound)
 	}
 
 	if err := g.store.RemoveDelegation(0, rlm, delegationID); err != nil {

--- a/contract/r/gnoswap/gov/staker/v1/state.gno
+++ b/contract/r/gnoswap/gov/staker/v1/state.gno
@@ -1,6 +1,7 @@
 package staker
 
 import (
+	"errors"
 	"math"
 
 	gnsmath "gno.land/p/gnoswap/gnsmath"
@@ -55,28 +56,24 @@ func (g *govStakerV1) getDelegation(delegationID int64) *staker.Delegation {
 //   - delegation: delegation instance to store
 //
 // Returns:
-//   - bool: true if successfully stored
-func (g *govStakerV1) setDelegation(_ int, rlm realm, delegationID int64, delegation *staker.Delegation) bool {
-	if err := g.store.SetDelegation(0, rlm, delegationID, delegation); err != nil {
-		return false
-	}
-	return true
+//   - error: nil on success, otherwise the storage write error
+func (g *govStakerV1) setDelegation(_ int, rlm realm, delegationID int64, delegation *staker.Delegation) error {
+	return g.store.SetDelegation(0, rlm, delegationID, delegation)
 }
 
 // addDelegation adds a new delegation to storage and updates the delegation manager.
 //
 // Parameters:
-//   - delegationID: unique identifier of the delegation
+//   - delegationID: unique identifier of the delegation to add
 //   - delegation: delegation instance to add
 //
 // Returns:
-//   - bool: true if successfully added
-func (g *govStakerV1) addDelegation(_ int, rlm realm, delegationID int64, delegation *staker.Delegation) bool {
-	if ok := g.setDelegation(0, rlm, delegationID, delegation); !ok {
-		return false
+//   - error: nil on success, otherwise the delegation or manager storage error
+func (g *govStakerV1) addDelegation(_ int, rlm realm, delegationID int64, delegation *staker.Delegation) error {
+	if err := g.setDelegation(0, rlm, delegationID, delegation); err != nil {
+		return err
 	}
 
-	// Update delegation manager
 	delegationManager := g.store.GetDelegationManager()
 	resolvedManager := NewDelegationManagerResolver(delegationManager)
 	resolvedManager.addDelegation(
@@ -84,11 +81,8 @@ func (g *govStakerV1) addDelegation(_ int, rlm realm, delegationID int64, delega
 		delegation.DelegateTo(),
 		delegationID,
 	)
-	if err := g.store.SetDelegationManager(0, rlm, delegationManager); err != nil {
-		return false
-	}
 
-	return true
+	return g.store.SetDelegationManager(0, rlm, delegationManager)
 }
 
 // removeDelegation removes a delegation from storage and updates the delegation manager.
@@ -97,19 +91,17 @@ func (g *govStakerV1) addDelegation(_ int, rlm realm, delegationID int64, delega
 //   - delegationID: unique identifier of the delegation to remove
 //
 // Returns:
-//   - bool: true if successfully removed
-func (g *govStakerV1) removeDelegation(_ int, rlm realm, delegationID int64) bool {
+//   - error: nil on success, otherwise an error when the delegation is absent or storage fails
+func (g *govStakerV1) removeDelegation(_ int, rlm realm, delegationID int64) error {
 	delegation := g.getDelegation(delegationID)
 	if delegation == nil {
-		return false
+		return errors.New("delegation not found")
 	}
 
-	// Remove from store
 	if err := g.store.RemoveDelegation(0, rlm, delegationID); err != nil {
-		return false
+		return err
 	}
 
-	// Update delegation manager
 	delegationManager := g.store.GetDelegationManager()
 	resolvedManager := NewDelegationManagerResolver(delegationManager)
 	resolvedManager.removeDelegation(
@@ -117,11 +109,8 @@ func (g *govStakerV1) removeDelegation(_ int, rlm realm, delegationID int64) boo
 		delegation.DelegateTo(),
 		delegationID,
 	)
-	if err := g.store.SetDelegationManager(0, rlm, delegationManager); err != nil {
-		return false
-	}
 
-	return true
+	return g.store.SetDelegationManager(0, rlm, delegationManager)
 }
 
 // getUserDelegations retrieves all delegations for a specific user.
@@ -569,15 +558,13 @@ func (g *govStakerV1) getLaunchpadProjectDeposit(ownerAddress string) (int64, bo
 //   - deposit: deposit amount to set
 //
 // Returns:
-//   - bool: true if successfully set
-func (g *govStakerV1) setLaunchpadProjectDeposit(_ int, rlm realm, ownerAddress string, deposit int64) bool {
+//   - error: nil on success, otherwise the storage write error
+func (g *govStakerV1) setLaunchpadProjectDeposit(_ int, rlm realm, ownerAddress string, deposit int64) error {
 	launchpadDeposits := g.store.GetLaunchpadProjectDeposits()
 	resolvedDeposits := NewLaunchpadProjectDepositsResolver(launchpadDeposits)
 	resolvedDeposits.setLaunchpadProjectDeposit(ownerAddress, deposit)
-	if err := g.store.SetLaunchpadProjectDeposits(0, rlm, launchpadDeposits); err != nil {
-		return false
-	}
-	return true
+
+	return g.store.SetLaunchpadProjectDeposits(0, rlm, launchpadDeposits)
 }
 
 // addStakeFromLaunchpad adds stake for a launchpad project and updates reward tracking.
@@ -605,7 +592,9 @@ func (g *govStakerV1) addStakeFromLaunchpad(_ int, rlm realm, address string, am
 	}
 
 	deposit = gnsmath.SafeAddInt64(deposit, amount)
-	g.setLaunchpadProjectDeposit(0, rlm, launchpadRewardID, deposit)
+	if err := g.setLaunchpadProjectDeposit(0, rlm, launchpadRewardID, deposit); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -639,7 +628,9 @@ func (g *govStakerV1) removeStakeFromLaunchpad(_ int, rlm realm, address string,
 		deposit = 0
 	}
 
-	g.setLaunchpadProjectDeposit(0, rlm, launchpadRewardID, deposit)
+	if err := g.setLaunchpadProjectDeposit(0, rlm, launchpadRewardID, deposit); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/contract/r/gnoswap/gov/staker/v1/state_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/state_test.gno
@@ -31,6 +31,18 @@ func countDelegationIDs(tree *bptree.BPTree) int {
 	return total
 }
 
+func mustAddDelegation(gs *govStakerV1, cur realm, delegationID int64, delegation *staker.Delegation) {
+	if err := gs.addDelegation(0, cur, delegationID, delegation); err != nil {
+		panic(err)
+	}
+}
+
+func mustSetLaunchpadProjectDeposit(gs *govStakerV1, cur realm, ownerAddress string, deposit int64) {
+	if err := gs.setLaunchpadProjectDeposit(0, cur, ownerAddress, deposit); err != nil {
+		panic(err)
+	}
+}
+
 // Test lockup period management
 func TestUnDelegationLockupPeriod(cur realm, t *testing.T) {
 	tests := []struct {
@@ -111,11 +123,11 @@ func TestDelegationManagement(cur realm, t *testing.T) {
 			)
 
 			// When: Add delegation
-			result := gs.addDelegation(0, cur, delegationID, delegation)
+			err := gs.addDelegation(0, cur, delegationID, delegation)
 
 			// Then: Should succeed
 			if tt.expectSuccess {
-				uassert.True(t, result)
+				uassert.NoError(t, err)
 
 				// Verify delegation was stored
 				storedDelegation := gs.getDelegation(delegationID)
@@ -124,7 +136,7 @@ func TestDelegationManagement(cur realm, t *testing.T) {
 				uassert.Equal(t, storedDelegation.DelegateTo(), tt.delegateTo)
 				uassert.Equal(t, storedDelegation.TotalDelegatedAmount(), tt.delegateAmount)
 			} else {
-				uassert.False(t, result)
+				uassert.Error(t, err)
 			}
 		})
 	}
@@ -154,7 +166,7 @@ func TestGetUserDelegations(cur realm, t *testing.T) {
 						100,
 						100,
 					)
-					gs.addDelegation(0, cur, delegationID, delegation)
+					uassert.NoError(t, gs.addDelegation(0, cur, delegationID, delegation))
 					delegationIDs = append(delegationIDs, delegationID)
 				}
 				return user, delegationIDs
@@ -226,7 +238,7 @@ func TestRemoveDelegation(cur realm, t *testing.T) {
 					100,
 					100,
 				)
-				gs.addDelegation(0, cur, delegationID, delegation)
+				uassert.NoError(t, gs.addDelegation(0, cur, delegationID, delegation))
 				return delegationID
 			},
 			expectSuccess: true,
@@ -249,10 +261,14 @@ func TestRemoveDelegation(cur realm, t *testing.T) {
 			delegationID := tt.setupState(gs)
 
 			// When: Remove delegation
-			result := gs.removeDelegation(0, cur, delegationID)
+			err := gs.removeDelegation(0, cur, delegationID)
 
 			// Then: Should return expected result
-			uassert.Equal(t, result, tt.expectSuccess)
+			if tt.expectSuccess {
+				uassert.NoError(t, err)
+			} else {
+				uassert.Error(t, err)
+			}
 
 			if tt.expectSuccess {
 				// Verify delegation was removed
@@ -414,10 +430,14 @@ func TestLaunchpadProjectDeposits(cur realm, t *testing.T) {
 			gs := createTestGovStaker()
 
 			// When: Set launchpad project deposit
-			result := gs.setLaunchpadProjectDeposit(0, cur, tt.ownerAddress, tt.depositAmount)
+			err := gs.setLaunchpadProjectDeposit(0, cur, tt.ownerAddress, tt.depositAmount)
 
 			// Then: Should succeed
-			uassert.Equal(t, result, tt.expectSuccess)
+			if tt.expectSuccess {
+				uassert.NoError(t, err)
+			} else {
+				uassert.Error(t, err)
+			}
 
 			if tt.expectSuccess {
 				// Verify deposit was stored
@@ -515,7 +535,7 @@ func TestLaunchpadStakeOperations(cur realm, t *testing.T) {
 			launchpadRewardID := gs.makeLaunchpadRewardID(tt.address)
 			testing.SetRealm(adminRealm)
 			func(cur realm) {
-				gs.setLaunchpadProjectDeposit(0, cur, launchpadRewardID, tt.amount)
+				mustSetLaunchpadProjectDeposit(gs, cur, launchpadRewardID, tt.amount)
 			}(cross(cur))
 
 			// Then: Should create deposit record
@@ -549,7 +569,7 @@ func TestRemoveLaunchpadProjectDeposit(cur realm, t *testing.T) {
 				ownerAddress := "g1projectowner9876543210abcdefghijklm"
 				testing.SetRealm(adminRealm)
 				func(cur realm) {
-					gs.setLaunchpadProjectDeposit(0, cur, ownerAddress, 3000)
+					mustSetLaunchpadProjectDeposit(gs, cur, ownerAddress, 3000)
 				}(cross(cur))
 				return ownerAddress
 			},
@@ -646,7 +666,7 @@ func TestGetUserDelegationsWithDelegatee(cur realm, t *testing.T) {
 						100,
 						100,
 					)
-					gs.addDelegation(0, cur, delegationID, delegation)
+					mustAddDelegation(gs, cur, delegationID, delegation)
 					delegationIDs = append(delegationIDs, delegationID)
 				}
 				return user, delegatee, delegationIDs
@@ -673,7 +693,7 @@ func TestGetUserDelegationsWithDelegatee(cur realm, t *testing.T) {
 						100,
 						100,
 					)
-					gs.addDelegation(0, cur, delegationID, delegation)
+					mustAddDelegation(gs, cur, delegationID, delegation)
 					delegationIDs = append(delegationIDs, delegationID)
 				}
 
@@ -688,7 +708,7 @@ func TestGetUserDelegationsWithDelegatee(cur realm, t *testing.T) {
 						100,
 						100,
 					)
-					gs.addDelegation(0, cur, delegationID, delegation)
+					mustAddDelegation(gs, cur, delegationID, delegation)
 				}
 
 				delegationID := gs.nextDelegationID()
@@ -700,7 +720,7 @@ func TestGetUserDelegationsWithDelegatee(cur realm, t *testing.T) {
 					100,
 					100,
 				)
-				gs.addDelegation(0, cur, delegationID, delegation)
+				mustAddDelegation(gs, cur, delegationID, delegation)
 
 				return user, targetDelegatee, delegationIDs
 			},
@@ -723,7 +743,7 @@ func TestGetUserDelegationsWithDelegatee(cur realm, t *testing.T) {
 					100,
 					100,
 				)
-				gs.addDelegation(0, cur, delegationID, delegation)
+				mustAddDelegation(gs, cur, delegationID, delegation)
 
 				return user, targetDelegatee, []int64{}
 			},
@@ -756,7 +776,7 @@ func TestGetUserDelegationsWithDelegatee(cur realm, t *testing.T) {
 						100,
 						100,
 					)
-					gs.addDelegation(0, cur, delegationID, delegation)
+					mustAddDelegation(gs, cur, delegationID, delegation)
 					delegationIDs = append(delegationIDs, delegationID)
 				}
 				return user, delegatee, delegationIDs
@@ -780,7 +800,7 @@ func TestGetUserDelegationsWithDelegatee(cur realm, t *testing.T) {
 					100,
 					100,
 				)
-				gs.addDelegation(0, cur, delegationID1, delegation1)
+				mustAddDelegation(gs, cur, delegationID1, delegation1)
 				delegationIDs = append(delegationIDs, delegationID1)
 
 				// Add delegation with small amount
@@ -793,7 +813,7 @@ func TestGetUserDelegationsWithDelegatee(cur realm, t *testing.T) {
 					100,
 					100,
 				)
-				gs.addDelegation(0, cur, delegationID2, delegation2)
+				mustAddDelegation(gs, cur, delegationID2, delegation2)
 				delegationIDs = append(delegationIDs, delegationID2)
 
 				// Add delegation with large amount
@@ -806,7 +826,7 @@ func TestGetUserDelegationsWithDelegatee(cur realm, t *testing.T) {
 					100,
 					100,
 				)
-				gs.addDelegation(0, cur, delegationID3, delegation3)
+				mustAddDelegation(gs, cur, delegationID3, delegation3)
 				delegationIDs = append(delegationIDs, delegationID3)
 
 				return user, delegatee, delegationIDs

--- a/contract/r/gnoswap/gov/staker/v1/state_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/state_test.gno
@@ -499,7 +499,7 @@ func TestLaunchpadStakeOperations(cur realm, t *testing.T) {
 		currentHeight int64
 	}{
 		{
-			name:          "Add stake from launchpad",
+			name:          "Reject launchpad removal without matching stake",
 			address:       "g1projectowner1234567890abcdefghijklm",
 			amount:        2000,
 			currentHeight: 100,
@@ -523,14 +523,15 @@ func TestLaunchpadStakeOperations(cur realm, t *testing.T) {
 			uassert.True(t, exists)
 			uassert.Equal(t, deposit, tt.amount)
 
-			// When: Clear deposit via production launchpad path
+			// Removing an orphaned deposit must not silently corrupt reward accounting.
 			testing.SetRealm(testing.NewCodeRealm(GOV_STAKER_PKG_PATH))
 			testing.SetRealm(testing.NewUserRealm(launchpadAddr))
-			staker.SetAmountByProjectWallet(cross(cur), address(tt.address), tt.amount, false)
+			uassert.AbortsWithMessage(t, cur, "remove amount exceeds staked amount", func() {
+				staker.SetAmountByProjectWallet(cross(cur), address(tt.address), tt.amount, false)
+			})
 
-			// Then:
-			launchpadDepositAmount, _ := staker.GetLaunchpadProjectDeposit(tt.address)
-			uassert.Equal(t, launchpadDepositAmount, int64(0))
+			launchpadDepositAmount, _ := gs.getLaunchpadProjectDeposit(launchpadRewardID)
+			uassert.Equal(t, launchpadDepositAmount, tt.amount)
 		})
 	}
 }

--- a/contract/r/gnoswap/gov/staker/v1/state_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/state_test.gno
@@ -546,7 +546,7 @@ func TestLaunchpadStakeOperations(cur realm, t *testing.T) {
 			// Removing an orphaned deposit must not silently corrupt reward accounting.
 			testing.SetRealm(testing.NewCodeRealm(GOV_STAKER_PKG_PATH))
 			testing.SetRealm(testing.NewUserRealm(launchpadAddr))
-			uassert.AbortsWithMessage(t, cur, "remove amount exceeds staked amount", func() {
+			uassert.AbortsWithMessage(t, cur, errRemoveAmountExceedsStaked, func() {
 				staker.SetAmountByProjectWallet(cross(cur), address(tt.address), tt.amount, false)
 			})
 

--- a/contract/r/gnoswap/gov/staker/v1/state_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/state_test.gno
@@ -31,13 +31,13 @@ func countDelegationIDs(tree *bptree.BPTree) int {
 	return total
 }
 
-func mustAddDelegation(gs *govStakerV1, rlm realm, delegationID int64, delegation *staker.Delegation) {
+func mustAddDelegation(_ int, rlm realm, gs *govStakerV1, delegationID int64, delegation *staker.Delegation) {
 	if err := gs.addDelegation(0, rlm, delegationID, delegation); err != nil {
 		panic(err)
 	}
 }
 
-func mustSetLaunchpadProjectDeposit(gs *govStakerV1, rlm realm, ownerAddress string, deposit int64) {
+func mustSetLaunchpadProjectDeposit(_ int, rlm realm, gs *govStakerV1, ownerAddress string, deposit int64) {
 	if err := gs.setLaunchpadProjectDeposit(0, rlm, ownerAddress, deposit); err != nil {
 		panic(err)
 	}
@@ -535,7 +535,7 @@ func TestLaunchpadStakeOperations(cur realm, t *testing.T) {
 			launchpadRewardID := gs.makeLaunchpadRewardID(tt.address)
 			testing.SetRealm(adminRealm)
 			func(cur realm) {
-				mustSetLaunchpadProjectDeposit(gs, cur, launchpadRewardID, tt.amount)
+				mustSetLaunchpadProjectDeposit(0, cur, gs, launchpadRewardID, tt.amount)
 			}(cross(cur))
 
 			// Then: Should create deposit record
@@ -569,7 +569,7 @@ func TestRemoveLaunchpadProjectDeposit(cur realm, t *testing.T) {
 				ownerAddress := "g1projectowner9876543210abcdefghijklm"
 				testing.SetRealm(adminRealm)
 				func(cur realm) {
-					mustSetLaunchpadProjectDeposit(gs, cur, ownerAddress, 3000)
+					mustSetLaunchpadProjectDeposit(0, cur, gs, ownerAddress, 3000)
 				}(cross(cur))
 				return ownerAddress
 			},
@@ -666,7 +666,7 @@ func TestGetUserDelegationsWithDelegatee(cur realm, t *testing.T) {
 						100,
 						100,
 					)
-					mustAddDelegation(gs, cur, delegationID, delegation)
+					mustAddDelegation(0, cur, gs, delegationID, delegation)
 					delegationIDs = append(delegationIDs, delegationID)
 				}
 				return user, delegatee, delegationIDs
@@ -693,7 +693,7 @@ func TestGetUserDelegationsWithDelegatee(cur realm, t *testing.T) {
 						100,
 						100,
 					)
-					mustAddDelegation(gs, cur, delegationID, delegation)
+					mustAddDelegation(0, cur, gs, delegationID, delegation)
 					delegationIDs = append(delegationIDs, delegationID)
 				}
 
@@ -708,7 +708,7 @@ func TestGetUserDelegationsWithDelegatee(cur realm, t *testing.T) {
 						100,
 						100,
 					)
-					mustAddDelegation(gs, cur, delegationID, delegation)
+					mustAddDelegation(0, cur, gs, delegationID, delegation)
 				}
 
 				delegationID := gs.nextDelegationID()
@@ -720,7 +720,7 @@ func TestGetUserDelegationsWithDelegatee(cur realm, t *testing.T) {
 					100,
 					100,
 				)
-				mustAddDelegation(gs, cur, delegationID, delegation)
+				mustAddDelegation(0, cur, gs, delegationID, delegation)
 
 				return user, targetDelegatee, delegationIDs
 			},
@@ -743,7 +743,7 @@ func TestGetUserDelegationsWithDelegatee(cur realm, t *testing.T) {
 					100,
 					100,
 				)
-				mustAddDelegation(gs, cur, delegationID, delegation)
+				mustAddDelegation(0, cur, gs, delegationID, delegation)
 
 				return user, targetDelegatee, []int64{}
 			},
@@ -776,7 +776,7 @@ func TestGetUserDelegationsWithDelegatee(cur realm, t *testing.T) {
 						100,
 						100,
 					)
-					mustAddDelegation(gs, cur, delegationID, delegation)
+					mustAddDelegation(0, cur, gs, delegationID, delegation)
 					delegationIDs = append(delegationIDs, delegationID)
 				}
 				return user, delegatee, delegationIDs
@@ -800,7 +800,7 @@ func TestGetUserDelegationsWithDelegatee(cur realm, t *testing.T) {
 					100,
 					100,
 				)
-				mustAddDelegation(gs, cur, delegationID1, delegation1)
+				mustAddDelegation(0, cur, gs, delegationID1, delegation1)
 				delegationIDs = append(delegationIDs, delegationID1)
 
 				// Add delegation with small amount
@@ -813,7 +813,7 @@ func TestGetUserDelegationsWithDelegatee(cur realm, t *testing.T) {
 					100,
 					100,
 				)
-				mustAddDelegation(gs, cur, delegationID2, delegation2)
+				mustAddDelegation(0, cur, gs, delegationID2, delegation2)
 				delegationIDs = append(delegationIDs, delegationID2)
 
 				// Add delegation with large amount
@@ -826,7 +826,7 @@ func TestGetUserDelegationsWithDelegatee(cur realm, t *testing.T) {
 					100,
 					100,
 				)
-				mustAddDelegation(gs, cur, delegationID3, delegation3)
+				mustAddDelegation(0, cur, gs, delegationID3, delegation3)
 				delegationIDs = append(delegationIDs, delegationID3)
 
 				return user, delegatee, delegationIDs

--- a/contract/r/gnoswap/gov/staker/v1/state_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/state_test.gno
@@ -31,14 +31,14 @@ func countDelegationIDs(tree *bptree.BPTree) int {
 	return total
 }
 
-func mustAddDelegation(gs *govStakerV1, cur realm, delegationID int64, delegation *staker.Delegation) {
-	if err := gs.addDelegation(0, cur, delegationID, delegation); err != nil {
+func mustAddDelegation(gs *govStakerV1, rlm realm, delegationID int64, delegation *staker.Delegation) {
+	if err := gs.addDelegation(0, rlm, delegationID, delegation); err != nil {
 		panic(err)
 	}
 }
 
-func mustSetLaunchpadProjectDeposit(gs *govStakerV1, cur realm, ownerAddress string, deposit int64) {
-	if err := gs.setLaunchpadProjectDeposit(0, cur, ownerAddress, deposit); err != nil {
+func mustSetLaunchpadProjectDeposit(gs *govStakerV1, rlm realm, ownerAddress string, deposit int64) {
+	if err := gs.setLaunchpadProjectDeposit(0, rlm, ownerAddress, deposit); err != nil {
 		panic(err)
 	}
 }

--- a/contract/r/gnoswap/launchpad/v1/launchpad_withdraw_test.gno
+++ b/contract/r/gnoswap/launchpad/v1/launchpad_withdraw_test.gno
@@ -10,6 +10,7 @@ import (
 	uassert "gno.land/p/nt/uassert/v0"
 	"gno.land/r/gnoswap/access"
 	"gno.land/r/gnoswap/gns"
+	gov_staker "gno.land/r/gnoswap/gov/staker"
 	"gno.land/r/gnoswap/gov/xgns"
 	"gno.land/r/gnoswap/launchpad"
 	"gno.land/r/onbloc/obl"
@@ -1063,12 +1064,13 @@ func initLaunchpadWithdrawTestWithTier(cur realm, t *testing.T, depositor addres
 	testing.SetOriginCaller(depositor)
 	lp.depositGns(0, cur, project, tierDuration, depositAmount, depositor)
 
-	govStakerAddr, _ := access.GetAddress(prbac.ROLE_GOV_STAKER.String())
-	govStakerRealm := testing.NewUserRealm(govStakerAddr)
-	testing.SetRealm(govStakerRealm)
-
-	launchpadAddr, _ := access.GetAddress(prbac.ROLE_LAUNCHPAD.String())
-	xgns.Mint(cross(cur), launchpadAddr, depositAmount)
+	// depositGns is an internal helper and intentionally does not stake the
+	// corresponding governance amount. Mirror the public DepositGns path so
+	// withdrawal removes an existing reward stake.
+	func(cur realm) {
+		testing.SetRealm(testing.NewCodeRealm("gno.land/r/gnoswap/launchpad"))
+		gov_staker.SetAmountByProjectWallet(cross(cur), project.Recipient(), depositAmount, true)
+	}(cross(cur))
 
 	projectTier, _ := getProjectTier(project, tierDuration)
 	testing.SetHeight(projectTier.EndTime() + 1)


### PR DESCRIPTION
## Summary
- Reject invalid reward-stake removals instead of silently clamping balances to zero.

## Context
- Independent clamping of per-address and aggregate stake could violate the aggregate stake invariant when a removal exceeded the address stake or an inconsistent aggregate total.

## Changes
- Validate non-negative removal amounts, per-address stake, and aggregate stake before persisting a removal.
- Preserve exact subtraction after validation for emission and protocol-fee reward states.
- Cover over-removal, aggregate-total underflow, unknown-address removal, and new-state persistence.

## Behavior Changes
- Invalid removals now return an error and leave reward states and aggregate stake unchanged.

## Verification
- `make test PKG=gno.land/r/gnoswap/gov/staker/v1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stake removals exceeding account or aggregate balances are rejected without changing state.
  * Negative stake changes and invalid delegation or deposit updates now fail safely.
  * Failed operations preserve balances, reward debt, deposits, and aggregate totals.
  * Reward and fee updates now report errors consistently and handle no-stake distributions correctly.
  * Stake updates apply reward calculations before changing balances.

* **Tests**
  * Expanded coverage for invalid changes, state preservation, cursor advancement, and aggregate staking invariants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->