### PR TITLE
fix: skip zero withdrawal records for pending delegations

### DIFF
--- a/contract/r/gnoswap/gov/staker/v1/staker_delegate.gno
+++ b/contract/r/gnoswap/gov/staker/v1/staker_delegate.gno
@@ -403,6 +403,10 @@ func (gs *govStakerV1) unDelegate(
 			return 0, errors.New("undelegation amount cannot be negative")
 		}
 
+		if currentUnDelegationAmount == 0 {
+			continue
+		}
+
 		resolver.UnDelegate(
 			currentUnDelegationAmount,
 			currentHeight,
@@ -470,6 +474,10 @@ func (gs *govStakerV1) unDelegateWithoutLockup(
 
 		if currentUnDelegationAmount > resolver.DelegatedAmount() {
 			currentUnDelegationAmount = resolver.DelegatedAmount()
+		}
+
+		if currentUnDelegationAmount == 0 {
+			continue
 		}
 
 		resolver.UnDelegateWithoutLockup(

--- a/contract/r/gnoswap/gov/staker/v1/staker_delegate_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/staker_delegate_test.gno
@@ -309,6 +309,27 @@ func TestStakerDelegate_UndelegateMultipleDelegations(cur realm, t *testing.T) {
 	}
 }
 
+func TestStakerDelegate_UndelegateSkipsZeroAmountWithdrawals(cur realm, t *testing.T) {
+	setupStakerDelegateTestGNSBalance(cur, t)
+
+	user := testutils.TestAddress("alice")
+	validator := testutils.TestAddress("zero_w_val")
+	testing.SetRealm(testing.NewUserRealm(user))
+
+	callStakerDelegate(cur, validator, minimumAmount, "")
+	firstDelegationID := staker.GetUserDelegationIDs(user, validator)[0]
+	callStakerUndelegate(cur, validator, minimumAmount)
+	uassert.Equal(t, staker.GetDelegationWithdrawCount(firstDelegationID), 1)
+
+	callStakerDelegate(cur, validator, minimumAmount, "")
+	callStakerUndelegate(cur, validator, minimumAmount)
+
+	delegationIDs := staker.GetUserDelegationIDs(user, validator)
+	uassert.Equal(t, len(delegationIDs), 2)
+	uassert.Equal(t, staker.GetDelegationWithdrawCount(firstDelegationID), 1)
+	uassert.Equal(t, staker.GetDelegationWithdrawCount(delegationIDs[1]), 1)
+}
+
 // Test Undelegate edge cases with multiple delegations
 func TestStakerDelegate_UndelegateMultipleDelegations_EdgeCases(cur realm, t *testing.T) {
 	tests := []struct {

--- a/contract/r/gnoswap/gov/staker/v1/staker_delegate_test.gno
+++ b/contract/r/gnoswap/gov/staker/v1/staker_delegate_test.gno
@@ -494,6 +494,32 @@ func TestStakerDelegate_Redelegate(cur realm, t *testing.T) {
 	}
 }
 
+func TestStakerDelegate_RedelegateSkipsPendingUndelegation(cur realm, t *testing.T) {
+	setupStakerDelegateTestGNSBalance(cur, t)
+
+	user := testutils.TestAddress("alice")
+	previousValidator := testutils.TestAddress("zero_re_val1")
+	newValidator := testutils.TestAddress("zero_re_val2")
+	testing.SetRealm(testing.NewUserRealm(user))
+
+	callStakerDelegate(cur, previousValidator, minimumAmount, "")
+	firstDelegationID := staker.GetUserDelegationIDs(user, previousValidator)[0]
+	callStakerUndelegate(cur, previousValidator, minimumAmount)
+	uassert.Equal(t, staker.GetDelegationWithdrawCount(firstDelegationID), 1)
+
+	callStakerDelegate(cur, previousValidator, minimumAmount, "")
+	result := callStakerRedelegate(cur, previousValidator, newValidator, minimumAmount)
+
+	uassert.Equal(t, result, int64(minimumAmount))
+	uassert.Equal(t, staker.GetDelegationWithdrawCount(firstDelegationID), 1)
+
+	previousDelegationIDs := staker.GetUserDelegationIDs(user, previousValidator)
+	newDelegationIDs := staker.GetUserDelegationIDs(user, newValidator)
+	uassert.Equal(t, len(previousDelegationIDs), 1)
+	uassert.Equal(t, previousDelegationIDs[0], firstDelegationID)
+	uassert.Equal(t, len(newDelegationIDs), 1)
+}
+
 func TestStakerDelegate_RedelegatePreservesTotalLockedAmount(cur realm, t *testing.T) {
 	setupStakerDelegateTestGNSBalance(cur, t)
 

--- a/contract/r/scenario/gov/staker/undelegate_zero_withdraw_filetest.gno
+++ b/contract/r/scenario/gov/staker/undelegate_zero_withdraw_filetest.gno
@@ -43,23 +43,23 @@ func main(cur realm) {
 	fundAndApprove(cur)
 	println()
 
-	println("[SCENARIO] 2. Fully undelegate the first delegation")
+	println("[SCENARIO] 2. Create delegation A, then fully undelegate it")
 	fullyUndelegateFirstDelegation(cur)
 	println()
 
-	println("[SCENARIO] 3. Delegate and undelegate again before the first lockup expires")
+	println("[SCENARIO] 3. Create delegation B while A is lockup-pending, then undelegate B")
 	undelegateSecondDelegation(cur)
 	println()
 
-	println("[SCENARIO] 4. Verify no zero withdrawal was added to the first delegation")
+	println("[SCENARIO] 4. Inspect the Undelegate path")
 	verifyWithdrawalCounts(cur)
 	println()
 
-	println("[SCENARIO] 5. Redelegate past a lockup-pending delegation")
+	println("[SCENARIO] 5. Create pending delegation C, then redelegate active delegation D")
 	redelegatePastPendingUndelegation(cur)
 	println()
 
-	println("[SCENARIO] 6. Verify redelegation preserved the pending withdrawal")
+	println("[SCENARIO] 6. Inspect the Redelegate path")
 	verifyRedelegation(cur)
 	println()
 }
@@ -82,7 +82,7 @@ func fullyUndelegateFirstDelegation(cur realm) {
 
 	testing.SetRealm(delegatorRealm)
 	staker.Undelegate(cross(cur), validatorAddr, delegateAmount)
-	ufmt.Printf("[INFO] first delegation ID: %d, withdrawal count: %d\n", firstDelegationID, staker.GetDelegationWithdrawCount(firstDelegationID))
+	ufmt.Printf("[INFO] delegation A is lockup-pending: id=%d, active=0, withdrawals=%d\n", firstDelegationID, staker.GetDelegationWithdrawCount(firstDelegationID))
 }
 
 func undelegateSecondDelegation(cur realm) {
@@ -104,8 +104,9 @@ func verifyWithdrawalCounts(cur realm) {
 		panic("zero amount withdrawal was recorded")
 	}
 
-	ufmt.Printf("[EXPECTED] first delegation withdrawal count remains 1: %t\n", firstCount == 1)
-	ufmt.Printf("[EXPECTED] second delegation withdrawal count is 1: %t\n", secondCount == 1)
+	ufmt.Printf("[STATE] A (lockup-pending): active=0, withdrawals=%d\n", firstCount)
+	ufmt.Printf("[STATE] B (fully undelegated): active=0, withdrawals=%d\n", secondCount)
+	ufmt.Printf("[EXPECTED] Undelegate skips A instead of appending a zero withdrawal: %t\n", firstCount == 1)
 }
 
 func redelegatePastPendingUndelegation(cur realm) {
@@ -120,7 +121,6 @@ func redelegatePastPendingUndelegation(cur realm) {
 	staker.Delegate(cross(cur), redelegateFrom, delegateAmount, "")
 	staker.Redelegate(cross(cur), redelegateFrom, redelegateTo, delegateAmount)
 
-	testing.SetRealm(govStakerRealm)
 	if staker.GetDelegationWithdrawCount(firstRedelegationID) != 1 {
 		panic("zero amount withdrawal was recorded during redelegation")
 	}
@@ -134,25 +134,34 @@ func verifyRedelegation(cur realm) {
 		panic("redelegation records are inconsistent")
 	}
 
-	ufmt.Printf("[EXPECTED] pending delegation remains at previous validator: %t\n", len(previousDelegationIDs) == 1)
-	ufmt.Printf("[EXPECTED] redelegated delegation exists at new validator: %t\n", len(newDelegationIDs) == 1)
+	pendingWithdrawalCount := staker.GetDelegationWithdrawCount(previousDelegationIDs[0])
+	redelegatedWithdrawalCount := staker.GetDelegationWithdrawCount(newDelegationIDs[0])
+	if pendingWithdrawalCount != 1 || redelegatedWithdrawalCount != 0 {
+		panic("redelegation withdrawal records are inconsistent")
+	}
+
+	ufmt.Printf("[STATE] C (lockup-pending): delegation records=%d, withdrawals=%d\n", len(previousDelegationIDs), pendingWithdrawalCount)
+	ufmt.Printf("[STATE] D (redelegated target): delegation records=%d, withdrawals=%d\n", len(newDelegationIDs), redelegatedWithdrawalCount)
+	ufmt.Printf("[EXPECTED] Redelegate skips C instead of appending a zero withdrawal: %t\n", pendingWithdrawalCount == 1)
 }
 
 // Output:
 // [SCENARIO] 1. Fund and approve the delegator
 // [INFO] approved 4000000 GNS for delegation
 //
-// [SCENARIO] 2. Fully undelegate the first delegation
-// [INFO] first delegation ID: 1, withdrawal count: 1
+// [SCENARIO] 2. Create delegation A, then fully undelegate it
+// [INFO] delegation A is lockup-pending: id=1, active=0, withdrawals=1
 //
-// [SCENARIO] 3. Delegate and undelegate again before the first lockup expires
+// [SCENARIO] 3. Create delegation B while A is lockup-pending, then undelegate B
 //
-// [SCENARIO] 4. Verify no zero withdrawal was added to the first delegation
-// [EXPECTED] first delegation withdrawal count remains 1: true
-// [EXPECTED] second delegation withdrawal count is 1: true
+// [SCENARIO] 4. Inspect the Undelegate path
+// [STATE] A (lockup-pending): active=0, withdrawals=1
+// [STATE] B (fully undelegated): active=0, withdrawals=1
+// [EXPECTED] Undelegate skips A instead of appending a zero withdrawal: true
 //
-// [SCENARIO] 5. Redelegate past a lockup-pending delegation
+// [SCENARIO] 5. Create pending delegation C, then redelegate active delegation D
 //
-// [SCENARIO] 6. Verify redelegation preserved the pending withdrawal
-// [EXPECTED] pending delegation remains at previous validator: true
-// [EXPECTED] redelegated delegation exists at new validator: true
+// [SCENARIO] 6. Inspect the Redelegate path
+// [STATE] C (lockup-pending): delegation records=1, withdrawals=1
+// [STATE] D (redelegated target): delegation records=1, withdrawals=0
+// [EXPECTED] Redelegate skips C instead of appending a zero withdrawal: true

--- a/contract/r/scenario/gov/staker/undelegate_zero_withdraw_filetest.gno
+++ b/contract/r/scenario/gov/staker/undelegate_zero_withdraw_filetest.gno
@@ -1,0 +1,112 @@
+// zero amount undelegation withdrawal
+
+// PKGPATH: gno.land/r/gnoswap/v1/main
+
+package main
+
+import (
+	"testing"
+
+	testutils "gno.land/p/nt/testutils/v0"
+	ufmt "gno.land/p/nt/ufmt/v0"
+
+	prbac "gno.land/p/gnoswap/rbac"
+	_ "gno.land/r/gnoswap/rbac"
+
+	_ "gno.land/r/gnoswap/protocol_fee"
+	_ "gno.land/r/gnoswap/protocol_fee/v1"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/gns"
+	"gno.land/r/gnoswap/gov/staker"
+	_ "gno.land/r/gnoswap/gov/staker/v1"
+)
+
+var (
+	adminAddr      = access.MustGetAddress(prbac.ROLE_ADMIN.String())
+	adminRealm     = testing.NewUserRealm(adminAddr)
+	govStakerAddr  = access.MustGetAddress(prbac.ROLE_GOV_STAKER.String())
+	govStakerRealm = testing.NewCodeRealm("gno.land/r/gnoswap/gov/staker")
+
+	delegatorAddr  = testutils.TestAddress("zero_withdraw")
+	delegatorRealm = testing.NewUserRealm(delegatorAddr)
+	validatorAddr  = testutils.TestAddress("zero_validator")
+
+	delegateAmount    = int64(1_000_000)
+	firstDelegationID int64
+)
+
+func main(cur realm) {
+	println("[SCENARIO] 1. Fund and approve the delegator")
+	fundAndApprove(cur)
+	println()
+
+	println("[SCENARIO] 2. Fully undelegate the first delegation")
+	fullyUndelegateFirstDelegation(cur)
+	println()
+
+	println("[SCENARIO] 3. Delegate and undelegate again before the first lockup expires")
+	undelegateSecondDelegation(cur)
+	println()
+
+	println("[SCENARIO] 4. Verify no zero withdrawal was added to the first delegation")
+	verifyWithdrawalCounts(cur)
+	println()
+}
+
+func fundAndApprove(cur realm) {
+	testing.SetRealm(adminRealm)
+	gns.Transfer(cross(cur), delegatorAddr, delegateAmount*2)
+
+	testing.SetRealm(delegatorRealm)
+	gns.Approve(cross(cur), govStakerAddr, delegateAmount*2)
+	ufmt.Printf("[INFO] approved %d GNS for delegation\n", delegateAmount*2)
+}
+
+func fullyUndelegateFirstDelegation(cur realm) {
+	testing.SetRealm(delegatorRealm)
+	staker.Delegate(cross(cur), validatorAddr, delegateAmount, "")
+
+	testing.SetRealm(govStakerRealm)
+	firstDelegationID = staker.GetUserDelegationIDs(delegatorAddr, validatorAddr)[0]
+
+	testing.SetRealm(delegatorRealm)
+	staker.Undelegate(cross(cur), validatorAddr, delegateAmount)
+	ufmt.Printf("[INFO] first delegation ID: %d, withdrawal count: %d\n", firstDelegationID, staker.GetDelegationWithdrawCount(firstDelegationID))
+}
+
+func undelegateSecondDelegation(cur realm) {
+	testing.SetRealm(delegatorRealm)
+	staker.Delegate(cross(cur), validatorAddr, delegateAmount, "")
+	staker.Undelegate(cross(cur), validatorAddr, delegateAmount)
+}
+
+func verifyWithdrawalCounts(cur realm) {
+	testing.SetRealm(govStakerRealm)
+	delegationIDs := staker.GetUserDelegationIDs(delegatorAddr, validatorAddr)
+	if len(delegationIDs) != 2 {
+		panic("expected two delegation records")
+	}
+
+	firstCount := staker.GetDelegationWithdrawCount(firstDelegationID)
+	secondCount := staker.GetDelegationWithdrawCount(delegationIDs[1])
+	if firstCount != 1 || secondCount != 1 {
+		panic("zero amount withdrawal was recorded")
+	}
+
+	ufmt.Printf("[EXPECTED] first delegation withdrawal count remains 1: %t\n", firstCount == 1)
+	ufmt.Printf("[EXPECTED] second delegation withdrawal count is 1: %t\n", secondCount == 1)
+}
+
+// Output:
+// [SCENARIO] 1. Fund and approve the delegator
+// [INFO] approved 2000000 GNS for delegation
+//
+// [SCENARIO] 2. Fully undelegate the first delegation
+// [INFO] first delegation ID: 1, withdrawal count: 1
+//
+// [SCENARIO] 3. Delegate and undelegate again before the first lockup expires
+//
+// [SCENARIO] 4. Verify no zero withdrawal was added to the first delegation
+// [EXPECTED] first delegation withdrawal count remains 1: true
+// [EXPECTED] second delegation withdrawal count is 1: true

--- a/contract/r/scenario/gov/staker/undelegate_zero_withdraw_filetest.gno
+++ b/contract/r/scenario/gov/staker/undelegate_zero_withdraw_filetest.gno
@@ -34,8 +34,11 @@ var (
 	redelegateFrom = testutils.TestAddress("zero_re_val1")
 	redelegateTo   = testutils.TestAddress("zero_re_val2")
 
-	delegateAmount    = int64(1_000_000)
-	firstDelegationID int64
+	delegateAmount = int64(1_000_000)
+
+	firstDelegationID                      int64
+	firstWithdrawalsBeforeSecondUndelegate int
+	firstWithdrawalsBeforeRedelegate       int
 )
 
 func main(cur realm) {
@@ -82,7 +85,8 @@ func fullyUndelegateFirstDelegation(cur realm) {
 
 	testing.SetRealm(delegatorRealm)
 	staker.Undelegate(cross(cur), validatorAddr, delegateAmount)
-	ufmt.Printf("[INFO] delegation A is lockup-pending: id=%d, active=0, withdrawals=%d\n", firstDelegationID, staker.GetDelegationWithdrawCount(firstDelegationID))
+	firstWithdrawalsBeforeSecondUndelegate = staker.GetDelegationWithdrawCount(firstDelegationID)
+	ufmt.Printf("[INFO] A is fully undelegated and has %d pending withdrawal\n", firstWithdrawalsBeforeSecondUndelegate)
 }
 
 func undelegateSecondDelegation(cur realm) {
@@ -100,13 +104,13 @@ func verifyWithdrawalCounts(cur realm) {
 
 	firstCount := staker.GetDelegationWithdrawCount(firstDelegationID)
 	secondCount := staker.GetDelegationWithdrawCount(delegationIDs[1])
-	if firstCount != 1 || secondCount != 1 {
+	if firstWithdrawalsBeforeSecondUndelegate != 1 || firstCount != firstWithdrawalsBeforeSecondUndelegate || secondCount != 1 {
 		panic("zero amount withdrawal was recorded")
 	}
 
-	ufmt.Printf("[STATE] A (lockup-pending): active=0, withdrawals=%d\n", firstCount)
-	ufmt.Printf("[STATE] B (fully undelegated): active=0, withdrawals=%d\n", secondCount)
-	ufmt.Printf("[EXPECTED] Undelegate skips A instead of appending a zero withdrawal: %t\n", firstCount == 1)
+	ufmt.Printf("[CHECK] A withdrawals: before B undelegation=%d, after=%d\n", firstWithdrawalsBeforeSecondUndelegate, firstCount)
+	ufmt.Printf("[CHECK] B withdrawals after its undelegation=%d\n", secondCount)
+	println("[RESULT] PASS: B's undelegation did not append a zero withdrawal to A")
 }
 
 func redelegatePastPendingUndelegation(cur realm) {
@@ -118,10 +122,11 @@ func redelegatePastPendingUndelegation(cur realm) {
 
 	testing.SetRealm(delegatorRealm)
 	staker.Undelegate(cross(cur), redelegateFrom, delegateAmount)
+	firstWithdrawalsBeforeRedelegate = staker.GetDelegationWithdrawCount(firstRedelegationID)
 	staker.Delegate(cross(cur), redelegateFrom, delegateAmount, "")
 	staker.Redelegate(cross(cur), redelegateFrom, redelegateTo, delegateAmount)
 
-	if staker.GetDelegationWithdrawCount(firstRedelegationID) != 1 {
+	if firstWithdrawalsBeforeRedelegate != 1 || staker.GetDelegationWithdrawCount(firstRedelegationID) != firstWithdrawalsBeforeRedelegate {
 		panic("zero amount withdrawal was recorded during redelegation")
 	}
 }
@@ -136,13 +141,13 @@ func verifyRedelegation(cur realm) {
 
 	pendingWithdrawalCount := staker.GetDelegationWithdrawCount(previousDelegationIDs[0])
 	redelegatedWithdrawalCount := staker.GetDelegationWithdrawCount(newDelegationIDs[0])
-	if pendingWithdrawalCount != 1 || redelegatedWithdrawalCount != 0 {
+	if pendingWithdrawalCount != firstWithdrawalsBeforeRedelegate || redelegatedWithdrawalCount != 0 {
 		panic("redelegation withdrawal records are inconsistent")
 	}
 
-	ufmt.Printf("[STATE] C (lockup-pending): delegation records=%d, withdrawals=%d\n", len(previousDelegationIDs), pendingWithdrawalCount)
-	ufmt.Printf("[STATE] D (redelegated target): delegation records=%d, withdrawals=%d\n", len(newDelegationIDs), redelegatedWithdrawalCount)
-	ufmt.Printf("[EXPECTED] Redelegate skips C instead of appending a zero withdrawal: %t\n", pendingWithdrawalCount == 1)
+	ufmt.Printf("[CHECK] C withdrawals: before redelegation=%d, after=%d\n", firstWithdrawalsBeforeRedelegate, pendingWithdrawalCount)
+	ufmt.Printf("[CHECK] D target withdrawal count=%d\n", redelegatedWithdrawalCount)
+	println("[RESULT] PASS: redelegation did not append a zero withdrawal to C")
 }
 
 // Output:
@@ -150,18 +155,18 @@ func verifyRedelegation(cur realm) {
 // [INFO] approved 4000000 GNS for delegation
 //
 // [SCENARIO] 2. Create delegation A, then fully undelegate it
-// [INFO] delegation A is lockup-pending: id=1, active=0, withdrawals=1
+// [INFO] A is fully undelegated and has 1 pending withdrawal
 //
 // [SCENARIO] 3. Create delegation B while A is lockup-pending, then undelegate B
 //
 // [SCENARIO] 4. Inspect the Undelegate path
-// [STATE] A (lockup-pending): active=0, withdrawals=1
-// [STATE] B (fully undelegated): active=0, withdrawals=1
-// [EXPECTED] Undelegate skips A instead of appending a zero withdrawal: true
+// [CHECK] A withdrawals: before B undelegation=1, after=1
+// [CHECK] B withdrawals after its undelegation=1
+// [RESULT] PASS: B's undelegation did not append a zero withdrawal to A
 //
 // [SCENARIO] 5. Create pending delegation C, then redelegate active delegation D
 //
 // [SCENARIO] 6. Inspect the Redelegate path
-// [STATE] C (lockup-pending): delegation records=1, withdrawals=1
-// [STATE] D (redelegated target): delegation records=1, withdrawals=0
-// [EXPECTED] Redelegate skips C instead of appending a zero withdrawal: true
+// [CHECK] C withdrawals: before redelegation=1, after=1
+// [CHECK] D target withdrawal count=0
+// [RESULT] PASS: redelegation did not append a zero withdrawal to C

--- a/contract/r/scenario/gov/staker/undelegate_zero_withdraw_filetest.gno
+++ b/contract/r/scenario/gov/staker/undelegate_zero_withdraw_filetest.gno
@@ -31,6 +31,8 @@ var (
 	delegatorAddr  = testutils.TestAddress("zero_withdraw")
 	delegatorRealm = testing.NewUserRealm(delegatorAddr)
 	validatorAddr  = testutils.TestAddress("zero_validator")
+	redelegateFrom = testutils.TestAddress("zero_re_val1")
+	redelegateTo   = testutils.TestAddress("zero_re_val2")
 
 	delegateAmount    = int64(1_000_000)
 	firstDelegationID int64
@@ -52,15 +54,23 @@ func main(cur realm) {
 	println("[SCENARIO] 4. Verify no zero withdrawal was added to the first delegation")
 	verifyWithdrawalCounts(cur)
 	println()
+
+	println("[SCENARIO] 5. Redelegate past a lockup-pending delegation")
+	redelegatePastPendingUndelegation(cur)
+	println()
+
+	println("[SCENARIO] 6. Verify redelegation preserved the pending withdrawal")
+	verifyRedelegation(cur)
+	println()
 }
 
 func fundAndApprove(cur realm) {
 	testing.SetRealm(adminRealm)
-	gns.Transfer(cross(cur), delegatorAddr, delegateAmount*2)
+	gns.Transfer(cross(cur), delegatorAddr, delegateAmount*4)
 
 	testing.SetRealm(delegatorRealm)
-	gns.Approve(cross(cur), govStakerAddr, delegateAmount*2)
-	ufmt.Printf("[INFO] approved %d GNS for delegation\n", delegateAmount*2)
+	gns.Approve(cross(cur), govStakerAddr, delegateAmount*4)
+	ufmt.Printf("[INFO] approved %d GNS for delegation\n", delegateAmount*4)
 }
 
 func fullyUndelegateFirstDelegation(cur realm) {
@@ -98,9 +108,39 @@ func verifyWithdrawalCounts(cur realm) {
 	ufmt.Printf("[EXPECTED] second delegation withdrawal count is 1: %t\n", secondCount == 1)
 }
 
+func redelegatePastPendingUndelegation(cur realm) {
+	testing.SetRealm(delegatorRealm)
+	staker.Delegate(cross(cur), redelegateFrom, delegateAmount, "")
+
+	testing.SetRealm(govStakerRealm)
+	firstRedelegationID := staker.GetUserDelegationIDs(delegatorAddr, redelegateFrom)[0]
+
+	testing.SetRealm(delegatorRealm)
+	staker.Undelegate(cross(cur), redelegateFrom, delegateAmount)
+	staker.Delegate(cross(cur), redelegateFrom, delegateAmount, "")
+	staker.Redelegate(cross(cur), redelegateFrom, redelegateTo, delegateAmount)
+
+	testing.SetRealm(govStakerRealm)
+	if staker.GetDelegationWithdrawCount(firstRedelegationID) != 1 {
+		panic("zero amount withdrawal was recorded during redelegation")
+	}
+}
+
+func verifyRedelegation(cur realm) {
+	testing.SetRealm(govStakerRealm)
+	previousDelegationIDs := staker.GetUserDelegationIDs(delegatorAddr, redelegateFrom)
+	newDelegationIDs := staker.GetUserDelegationIDs(delegatorAddr, redelegateTo)
+	if len(previousDelegationIDs) != 1 || len(newDelegationIDs) != 1 {
+		panic("redelegation records are inconsistent")
+	}
+
+	ufmt.Printf("[EXPECTED] pending delegation remains at previous validator: %t\n", len(previousDelegationIDs) == 1)
+	ufmt.Printf("[EXPECTED] redelegated delegation exists at new validator: %t\n", len(newDelegationIDs) == 1)
+}
+
 // Output:
 // [SCENARIO] 1. Fund and approve the delegator
-// [INFO] approved 2000000 GNS for delegation
+// [INFO] approved 4000000 GNS for delegation
 //
 // [SCENARIO] 2. Fully undelegate the first delegation
 // [INFO] first delegation ID: 1, withdrawal count: 1
@@ -110,3 +150,9 @@ func verifyWithdrawalCounts(cur realm) {
 // [SCENARIO] 4. Verify no zero withdrawal was added to the first delegation
 // [EXPECTED] first delegation withdrawal count remains 1: true
 // [EXPECTED] second delegation withdrawal count is 1: true
+//
+// [SCENARIO] 5. Redelegate past a lockup-pending delegation
+//
+// [SCENARIO] 6. Verify redelegation preserved the pending withdrawal
+// [EXPECTED] pending delegation remains at previous validator: true
+// [EXPECTED] redelegated delegation exists at new validator: true


### PR DESCRIPTION
## Summary

- Skip delegation mutations when a multi-record undelegation resolves to zero for an older lockup-pending delegation.
- Apply the guard to both `Undelegate` and `Redelegate` paths.
- Add unit and golden-scenario regression coverage for both paths.

## Root cause

A fully undelegated delegation remains stored until its lockup withdrawal is collected. Its active delegated amount is zero, but it is not empty because its locked amount remains positive. When a later delegation to the same validator is undelegated or redelegated, the iteration clamps the older record's applied amount to zero and previously still appended a zero `DelegationWithdraw` through `unDelegate`.

## Why a pending delegation cannot be removed

`DelegatedAmount` is `TotalDelegatedAmount - UnDelegatedAmount`, so zero means the stake no longer earns rewards; it does **not** mean the asset has been paid out. [Source](https://github.com/gnoswap-labs/gnoswap/blob/d8eed1199b2129144231bcba5d1fecbbb131eb05/contract/r/gnoswap/gov/staker/v1/delegation.gno#L25-L34)

The lockup `UnDelegate` path records the amount as a `DelegationWithdraw` with the unlock schedule. [Source](https://github.com/gnoswap-labs/gnoswap/blob/d8eed1199b2129144231bcba5d1fecbbb131eb05/contract/r/gnoswap/gov/staker/v1/delegation.gno#L46-L60) The record remains non-empty until `CollectedAmount` reaches `TotalDelegatedAmount`; collection processes matured withdrawals and then removes only empty delegations. [Collection](https://github.com/gnoswap-labs/gnoswap/blob/d8eed1199b2129144231bcba5d1fecbbb131eb05/contract/r/gnoswap/gov/staker/v1/staker_delegate.gno#L578-L602)

Deleting the delegation at undelegation time would discard the pending withdrawal and make a later `Collect` unable to return the user’s tokens. The zero-amount guard therefore preserves the required lockup lifecycle while avoiding a second, zero-valued withdrawal record.

## Reproduction on main

The regression filetest was run unchanged against `main` (`b2c1611f`). It fails with:

```text
[REPRO] A withdrawals: before B undelegation=1, after=2; B withdrawals=1
unexpected panic: zero amount withdrawal was recorded
```

## Validation

```text
make test WORKDIR=tmp PKG=gno.land/r/gnoswap/gov/staker/v1 RUN=TestStakerDelegate_
make test WORKDIR=tmp PKG=gno.land/r/gnoswap/scenario/gov/staker
```

Both pass on this branch. The scenario suite includes `undelegate_zero_withdraw_filetest.gno`, which verifies the `Undelegate` and `Redelegate` paths.