### PR TITLE
refactor(pool): store oracle observations separately

### DIFF
--- a/contract/p/gnoswap/utils/codec.gno
+++ b/contract/p/gnoswap/utils/codec.gno
@@ -1,6 +1,6 @@
 package utils
 
-import ufmt "gno.land/p/nt/ufmt/v0"
+import "gno.land/p/nt/ufmt/v0"
 
 // EncodeUint16 converts a uint16 into a fixed-width 2-byte big-endian string.
 func EncodeUint16(value uint16) string {

--- a/contract/p/gnoswap/utils/codec.gno
+++ b/contract/p/gnoswap/utils/codec.gno
@@ -2,6 +2,22 @@ package utils
 
 import ufmt "gno.land/p/nt/ufmt/v0"
 
+// EncodeUint16 converts a uint16 into a fixed-width 2-byte big-endian string.
+func EncodeUint16(value uint16) string {
+	var buf [2]byte
+	buf[0] = byte(value >> 8)
+	buf[1] = byte(value)
+	return string(buf[:])
+}
+
+// DecodeUint16 converts a fixed-width 2-byte big-endian string into a uint16.
+func DecodeUint16(key string) uint16 {
+	if len(key) != 2 {
+		panic(ufmt.Sprintf("invalid uint16 key length: %d", len(key)))
+	}
+	return uint16(key[0])<<8 | uint16(key[1])
+}
+
 // EncodeUint64 converts a uint64 into a fixed-width 8-byte big-endian string.
 func EncodeUint64(value uint64) string {
 	var buf [8]byte

--- a/contract/p/gnoswap/utils/codec_test.gno
+++ b/contract/p/gnoswap/utils/codec_test.gno
@@ -7,6 +7,36 @@ import (
 	uassert "gno.land/p/nt/uassert/v0"
 )
 
+func TestUint16Codec(cur realm, t *testing.T) {
+	tests := []struct {
+		value uint16
+		want  [2]byte
+	}{
+		{0, [2]byte{0, 0}},
+		{1, [2]byte{0, 1}},
+		{255, [2]byte{0, 255}},
+		{256, [2]byte{1, 0}},
+		{65535, [2]byte{255, 255}},
+	}
+
+	previous := ""
+	for _, tt := range tests {
+		encoded := EncodeUint16(tt.value)
+		uassert.Equal(t, 2, len(encoded))
+		uassert.Equal(t, tt.want[0], encoded[0])
+		uassert.Equal(t, tt.want[1], encoded[1])
+		uassert.Equal(t, tt.value, DecodeUint16(encoded))
+		if previous != "" && !(previous < encoded) {
+			t.Errorf("encoded keys are not lexicographically ordered: %d", tt.value)
+		}
+		previous = encoded
+	}
+
+	uassert.PanicsWithMessage(t, cur, "invalid uint16 key length: 1", func() {
+		DecodeUint16("x")
+	})
+}
+
 func TestEncodeUint64(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/contract/r/gnoswap/mock/pool_store.gno
+++ b/contract/r/gnoswap/mock/pool_store.gno
@@ -8,6 +8,7 @@ import (
 
 type MockPoolStore struct {
 	pools                *bptree.BPTree
+	observations         *bptree.BPTree
 	feeAmountTickSpacing map[uint32]int32
 	slot0FeeProtocol     uint8
 	poolCreationFee      int64
@@ -32,6 +33,19 @@ func (s *MockPoolStore) GetPools() *bptree.BPTree {
 // SetPools stores the map containing all pool data.
 func (s *MockPoolStore) SetPools(_ int, rlm realm, pools *bptree.BPTree) error {
 	s.pools = pools
+	return nil
+}
+
+func (s *MockPoolStore) HasObservations() bool {
+	return s.observations != nil
+}
+
+func (s *MockPoolStore) GetObservations() *bptree.BPTree {
+	return s.observations
+}
+
+func (s *MockPoolStore) SetObservations(_ int, rlm realm, observations *bptree.BPTree) error {
+	s.observations = observations
 	return nil
 }
 
@@ -188,6 +202,7 @@ func NewMockPoolStoreWithHook(
 
 	return &MockPoolStore{
 		pools:                pool.NewPoolsTree(),
+		observations:         pool.NewObservationsTree(),
 		feeAmountTickSpacing: feeAmountTickSpacing,
 		slot0FeeProtocol:     0,
 		poolCreationFee:      100_000_000,

--- a/contract/r/gnoswap/pool/oracle.gno
+++ b/contract/r/gnoswap/pool/oracle.gno
@@ -1,8 +1,8 @@
 package pool
 
 import (
-	utils "gno.land/p/gnoswap/utils"
-	bptree "gno.land/p/nt/bptree/v0"
+	"gno.land/p/gnoswap/utils"
+	"gno.land/p/nt/bptree/v0"
 )
 
 type Observation struct {

--- a/contract/r/gnoswap/pool/oracle.gno
+++ b/contract/r/gnoswap/pool/oracle.gno
@@ -1,6 +1,9 @@
 package pool
 
-import bptree "gno.land/p/nt/bptree/v0"
+import (
+	utils "gno.land/p/gnoswap/utils"
+	bptree "gno.land/p/nt/bptree/v0"
+)
 
 type Observation struct {
 	blockTimestamp                    int64  // timestamp of the observation
@@ -77,7 +80,7 @@ func NewObservationTree() *ObservationTree {
 }
 
 func (t *ObservationTree) Get(index uint16) (*Observation, bool) {
-	value := t.tree.Get(EncodeObservationKey(index))
+	value := t.tree.Get(utils.EncodeUint16(index))
 	if value == nil {
 		return nil, false
 	}
@@ -86,11 +89,11 @@ func (t *ObservationTree) Get(index uint16) (*Observation, bool) {
 }
 
 func (t *ObservationTree) Set(index uint16, observation *Observation) {
-	t.tree.Set(EncodeObservationKey(index), observation)
+	t.tree.Set(utils.EncodeUint16(index), observation)
 }
 
 func (t *ObservationTree) Has(index uint16) bool {
-	return t.tree.Has(EncodeObservationKey(index))
+	return t.tree.Has(utils.EncodeUint16(index))
 }
 
 // NewObservationsTree creates the pool-path index for oracle observation trees.

--- a/contract/r/gnoswap/pool/oracle.gno
+++ b/contract/r/gnoswap/pool/oracle.gno
@@ -52,7 +52,7 @@ func NewDefaultObservation() *Observation {
 	)
 }
 
-// ObservationTree is a pool-local, sparse oracle ring buffer keyed by index.
+// ObservationTree is a pool-local oracle ring buffer keyed by index.
 // It owns the B+tree key encoding so oracle code works with uint16 indices.
 type ObservationTree struct {
 	tree *bptree.BPTree

--- a/contract/r/gnoswap/pool/oracle.gno
+++ b/contract/r/gnoswap/pool/oracle.gno
@@ -1,42 +1,6 @@
 package pool
 
-// ObservationState manages only the oracle's circular observation buffer.
-// The active index and buffer capacities are part of Pool.Slot0 so there is
-// one authoritative copy of the oracle cursor state.
-type ObservationState struct {
-	observations map[uint16]*Observation // circular buffer of observations
-}
-
-// ObservationState Getters methods
-func (os *ObservationState) Observations() map[uint16]*Observation { return os.observations }
-
-// ObservationState Setters methods
-func (os *ObservationState) SetObservation(index uint16, observation *Observation) {
-	os.observations[index] = observation
-}
-
-func (os *ObservationState) SetObservations(observations map[uint16]*Observation) {
-	os.observations = observations
-}
-
-// ObservationAt returns the observation stored at index, mirroring Uniswap
-// V3's observations(uint256 index) mapping getter.
-func (os *ObservationState) ObservationAt(index uint16) (*Observation, bool) {
-	observation, ok := os.observations[index]
-	return observation, ok
-}
-
-func (os *ObservationState) Clone() *ObservationState {
-	observations := make(map[uint16]*Observation)
-
-	for index, observation := range os.observations {
-		observations[index] = observation.Clone()
-	}
-
-	return &ObservationState{
-		observations: observations,
-	}
-}
+import bptree "gno.land/p/nt/bptree/v0"
 
 type Observation struct {
 	blockTimestamp                    int64  // timestamp of the observation
@@ -79,21 +43,6 @@ func (o *Observation) Clone() *Observation {
 	}
 }
 
-func NewObservationState(currentTime int64) *ObservationState {
-	state := &ObservationState{
-		observations: make(map[uint16]*Observation),
-	}
-
-	state.observations[0] = NewObservation(
-		currentTime,
-		0,
-		"0",
-		true,
-	)
-
-	return state
-}
-
 func NewObservation(
 	blockTimestamp int64,
 	tickCumulative int64,
@@ -115,4 +64,48 @@ func NewDefaultObservation() *Observation {
 		"0",
 		false,
 	)
+}
+
+// ObservationTree is a pool-local, sparse oracle ring buffer keyed by index.
+// It owns the B+tree key encoding so oracle code works with uint16 indices.
+type ObservationTree struct {
+	tree *bptree.BPTree
+}
+
+func NewObservationTree() *ObservationTree {
+	return &ObservationTree{tree: bptree.NewBPTreeN(32)}
+}
+
+func (t *ObservationTree) Get(index uint16) (*Observation, bool) {
+	value := t.tree.Get(EncodeObservationKey(index))
+	if value == nil {
+		return nil, false
+	}
+	observation, ok := value.(*Observation)
+	return observation, ok
+}
+
+func (t *ObservationTree) Set(index uint16, observation *Observation) {
+	t.tree.Set(EncodeObservationKey(index), observation)
+}
+
+func (t *ObservationTree) Has(index uint16) bool {
+	return t.tree.Has(EncodeObservationKey(index))
+}
+
+// NewObservationsTree creates the pool-path index for oracle observation trees.
+func NewObservationsTree() *bptree.BPTree {
+	return bptree.NewBPTreeN(32)
+}
+
+// NewPoolObservationsTree creates a pool's circular observation buffer.
+func NewPoolObservationsTree(currentTime int64) *ObservationTree {
+	observations := NewObservationTree()
+	observations.Set(0, NewObservation(
+		currentTime,
+		0,
+		"0",
+		true,
+	))
+	return observations
 }

--- a/contract/r/gnoswap/pool/oracle.gno
+++ b/contract/r/gnoswap/pool/oracle.gno
@@ -20,23 +20,6 @@ func (o *Observation) SecondsPerLiquidityCumulativeX128() string {
 }
 func (o *Observation) Initialized() bool { return o.initialized }
 
-// Observation Setters methods
-func (o *Observation) SetBlockTimestamp(blockTimestamp int64) {
-	o.blockTimestamp = blockTimestamp
-}
-
-func (o *Observation) SetTickCumulative(tickCumulative int64) {
-	o.tickCumulative = tickCumulative
-}
-
-func (o *Observation) SetSecondsPerLiquidityCumulativeX128(secondsPerLiquidityCumulativeX128 string) {
-	o.secondsPerLiquidityCumulativeX128 = secondsPerLiquidityCumulativeX128
-}
-
-func (o *Observation) SetInitialized(initialized bool) {
-	o.initialized = initialized
-}
-
 func (o *Observation) Clone() *Observation {
 	return &Observation{
 		blockTimestamp:                    o.blockTimestamp,
@@ -80,6 +63,9 @@ func NewObservationTree() *ObservationTree {
 }
 
 func (t *ObservationTree) Get(index uint16) (*Observation, bool) {
+	if t == nil || t.tree == nil {
+		return nil, false
+	}
 	value := t.tree.Get(utils.EncodeUint16(index))
 	if value == nil {
 		return nil, false
@@ -89,10 +75,16 @@ func (t *ObservationTree) Get(index uint16) (*Observation, bool) {
 }
 
 func (t *ObservationTree) Set(index uint16, observation *Observation) {
+	if t == nil || t.tree == nil {
+		panic("observation tree is not initialized")
+	}
 	t.tree.Set(utils.EncodeUint16(index), observation)
 }
 
 func (t *ObservationTree) Has(index uint16) bool {
+	if t == nil || t.tree == nil {
+		return false
+	}
 	return t.tree.Has(utils.EncodeUint16(index))
 }
 

--- a/contract/r/gnoswap/pool/pool.gno
+++ b/contract/r/gnoswap/pool/pool.gno
@@ -1,8 +1,6 @@
 package pool
 
 import (
-	"time"
-
 	bptree "gno.land/p/nt/bptree/v0"
 	ufmt "gno.land/p/nt/ufmt/v0"
 
@@ -26,9 +24,6 @@ type Pool struct {
 	ticks                *bptree.BPTree   // tick(int32) -> TickInfo
 	tickBitmaps          map[int16]string // tick(wordPos)(int16) -> bitMap(tickWord ^ mask)(string)
 	positions            *bptree.BPTree   // maps the key (caller, lower tick, upper tick) to a unique position
-
-	// Oracle observation buffer; its cursor and capacity live in slot0.
-	observationState *ObservationState
 }
 
 // Pool Getters methods
@@ -54,7 +49,6 @@ func (p *Pool) Liquidity() *u256.Uint               { return p.liquidity }
 func (p *Pool) Ticks() *bptree.BPTree               { return p.ticks }
 func (p *Pool) TickBitmaps() map[int16]string       { return p.tickBitmaps }
 func (p *Pool) Positions() *bptree.BPTree           { return p.positions }
-func (p *Pool) ObservationState() *ObservationState { return p.observationState }
 
 // GetPosition returns the position information for key.
 func (p *Pool) GetPosition(key string) (PositionInfo, error) {
@@ -153,10 +147,6 @@ func (p *Pool) SetPosition(posKey string, positionInfo PositionInfo) {
 	p.positions.Set(posKey, positionInfo)
 }
 
-func (p *Pool) SetObservationState(observationState *ObservationState) {
-	p.observationState = observationState
-}
-
 func (p *Pool) HasTick(tick int32) bool {
 	tickKey := EncodeTickKey(tick)
 	return p.ticks.Has(tickKey)
@@ -233,7 +223,6 @@ func (p *Pool) Clone() *Pool {
 		ticks:                nil,
 		tickBitmaps:          nil,
 		positions:            nil,
-		observationState:     nil,
 	}
 }
 
@@ -262,7 +251,6 @@ func NewPool(
 		ticks:                bptree.NewBPTreeN(32),
 		tickBitmaps:          make(map[int16]string),
 		positions:            bptree.NewBPTreeN(16),
-		observationState:     NewObservationState(time.Now().Unix()),
 	}
 }
 

--- a/contract/r/gnoswap/pool/pool.gno
+++ b/contract/r/gnoswap/pool/pool.gno
@@ -195,7 +195,7 @@ func (p *Pool) IterateTicks(startTick int32, endTick int32, fn func(tick int32, 
 }
 
 // Clone copies a pool's own fields and leaves its collections nil: ticks,
-// tickBitmaps, positions, and observationState are not copied.
+// tickBitmaps, positions, and observations are not copied.
 //
 // The copy is shallow because the read-only pool view clones every entry a
 // caller reads, so copying the collections would walk the whole tick tree for

--- a/contract/r/gnoswap/pool/pool.gno
+++ b/contract/r/gnoswap/pool/pool.gno
@@ -27,28 +27,28 @@ type Pool struct {
 }
 
 // Pool Getters methods
-func (p *Pool) PoolPath() string                    { return GetPoolPath(p.token0Path, p.token1Path, p.fee) }
-func (p *Pool) Token0Path() string                  { return p.token0Path }
-func (p *Pool) Token1Path() string                  { return p.token1Path }
-func (p *Pool) Fee() uint32                         { return p.fee }
-func (p *Pool) Balances() TokenPair                 { return p.balances }
-func (p *Pool) BalanceToken0() int64                { return p.balances.token0 }
-func (p *Pool) BalanceToken1() int64                { return p.balances.token1 }
-func (p *Pool) TickSpacing() int32                  { return p.tickSpacing }
-func (p *Pool) Slot0() Slot0                        { return p.slot0 }
-func (p *Pool) Slot0SqrtPriceX96() *u256.Uint       { return p.slot0.sqrtPriceX96 }
-func (p *Pool) Slot0Tick() int32                    { return p.slot0.tick }
-func (p *Pool) Slot0FeeProtocol() uint8             { return p.slot0.feeProtocol }
-func (p *Pool) Slot0Unlocked() bool                 { return p.slot0.unlocked }
-func (p *Pool) FeeGrowthGlobal0X128() *u256.Uint    { return p.feeGrowthGlobal0X128 }
-func (p *Pool) FeeGrowthGlobal1X128() *u256.Uint    { return p.feeGrowthGlobal1X128 }
-func (p *Pool) ProtocolFees() TokenPair             { return p.protocolFees }
-func (p *Pool) ProtocolFeesToken0() int64           { return p.protocolFees.token0 }
-func (p *Pool) ProtocolFeesToken1() int64           { return p.protocolFees.token1 }
-func (p *Pool) Liquidity() *u256.Uint               { return p.liquidity }
-func (p *Pool) Ticks() *bptree.BPTree               { return p.ticks }
-func (p *Pool) TickBitmaps() map[int16]string       { return p.tickBitmaps }
-func (p *Pool) Positions() *bptree.BPTree           { return p.positions }
+func (p *Pool) PoolPath() string                 { return GetPoolPath(p.token0Path, p.token1Path, p.fee) }
+func (p *Pool) Token0Path() string               { return p.token0Path }
+func (p *Pool) Token1Path() string               { return p.token1Path }
+func (p *Pool) Fee() uint32                      { return p.fee }
+func (p *Pool) Balances() TokenPair              { return p.balances }
+func (p *Pool) BalanceToken0() int64             { return p.balances.token0 }
+func (p *Pool) BalanceToken1() int64             { return p.balances.token1 }
+func (p *Pool) TickSpacing() int32               { return p.tickSpacing }
+func (p *Pool) Slot0() Slot0                     { return p.slot0 }
+func (p *Pool) Slot0SqrtPriceX96() *u256.Uint    { return p.slot0.sqrtPriceX96 }
+func (p *Pool) Slot0Tick() int32                 { return p.slot0.tick }
+func (p *Pool) Slot0FeeProtocol() uint8          { return p.slot0.feeProtocol }
+func (p *Pool) Slot0Unlocked() bool              { return p.slot0.unlocked }
+func (p *Pool) FeeGrowthGlobal0X128() *u256.Uint { return p.feeGrowthGlobal0X128 }
+func (p *Pool) FeeGrowthGlobal1X128() *u256.Uint { return p.feeGrowthGlobal1X128 }
+func (p *Pool) ProtocolFees() TokenPair          { return p.protocolFees }
+func (p *Pool) ProtocolFeesToken0() int64        { return p.protocolFees.token0 }
+func (p *Pool) ProtocolFeesToken1() int64        { return p.protocolFees.token1 }
+func (p *Pool) Liquidity() *u256.Uint            { return p.liquidity }
+func (p *Pool) Ticks() *bptree.BPTree            { return p.ticks }
+func (p *Pool) TickBitmaps() map[int16]string    { return p.tickBitmaps }
+func (p *Pool) Positions() *bptree.BPTree        { return p.positions }
 
 // GetPosition returns the position information for key.
 func (p *Pool) GetPosition(key string) (PositionInfo, error) {
@@ -195,7 +195,8 @@ func (p *Pool) IterateTicks(startTick int32, endTick int32, fn func(tick int32, 
 }
 
 // Clone copies a pool's own fields and leaves its collections nil: ticks,
-// tickBitmaps, positions, and observations are not copied.
+// tickBitmaps, and positions are not copied. Oracle observations are stored
+// separately from Pool.
 //
 // The copy is shallow because the read-only pool view clones every entry a
 // caller reads, so copying the collections would walk the whole tick tree for

--- a/contract/r/gnoswap/pool/store.gno
+++ b/contract/r/gnoswap/pool/store.gno
@@ -18,6 +18,7 @@ func (s StoreKey) String() string {
 const (
 	// Pool data storage keys
 	StoreKeyPools                StoreKey = "pools"                // Map containing all pools
+	StoreKeyObservations         StoreKey = "observations"         // poolPath -> observation B+tree
 	StoreKeyFeeAmountTickSpacing StoreKey = "feeAmountTickSpacing" // Fee tier to tick spacing mapping
 	StoreKeySlot0FeeProtocol     StoreKey = "slot0FeeProtocol"     // Protocol fee percentage
 
@@ -69,6 +70,31 @@ func (s *poolStore) SetPools(_ int, rlm realm, pools *bptree.BPTree) error {
 	}
 
 	return s.kvStore.Set(0, rlm, StoreKeyPools.String(), pools)
+}
+
+func (s *poolStore) HasObservations() bool {
+	return s.kvStore.Has(StoreKeyObservations.String())
+}
+
+func (s *poolStore) GetObservations() *bptree.BPTree {
+	observations, err := s.kvStore.GetBPTree(StoreKeyObservations.String())
+	if err != nil {
+		panic(err)
+	}
+	if observations == nil {
+		panic("observations is nil")
+	}
+	return observations
+}
+
+func (s *poolStore) SetObservations(_ int, rlm realm, observations *bptree.BPTree) error {
+	if !rlm.IsCurrent() {
+		return errors.New(ErrSpoofedRealm)
+	}
+	if observations == nil {
+		panic("observations is nil")
+	}
+	return s.kvStore.Set(0, rlm, StoreKeyObservations.String(), observations)
 }
 
 func (s *poolStore) HasFeeAmountTickSpacing() bool {

--- a/contract/r/gnoswap/pool/store.gno
+++ b/contract/r/gnoswap/pool/store.gno
@@ -2,6 +2,7 @@ package pool
 
 import (
 	"errors"
+
 	"gno.land/p/gnoswap/store"
 	bptree "gno.land/p/nt/bptree/v0"
 	ufmt "gno.land/p/nt/ufmt/v0"

--- a/contract/r/gnoswap/pool/types.gno
+++ b/contract/r/gnoswap/pool/types.gno
@@ -301,6 +301,10 @@ type IPoolStore interface {
 	GetPools() *bptree.BPTree
 	SetPools(_ int, rlm realm, pools *bptree.BPTree) error
 
+	HasObservations() bool
+	GetObservations() *bptree.BPTree
+	SetObservations(_ int, rlm realm, observations *bptree.BPTree) error
+
 	HasFeeAmountTickSpacing() bool
 	GetFeeAmountTickSpacing() map[uint32]int32
 	SetFeeAmountTickSpacing(_ int, rlm realm, feeAmountTickSpacing map[uint32]int32) error

--- a/contract/r/gnoswap/pool/utils.gno
+++ b/contract/r/gnoswap/pool/utils.gno
@@ -37,6 +37,14 @@ func EncodePositionKey(tickLower, tickUpper int32) string {
 	return string(buf[:])
 }
 
+// EncodeObservationKey encodes an observation index into a fixed-width key.
+func EncodeObservationKey(index uint16) string {
+	var buf [2]byte
+	buf[0] = byte(index >> 8)
+	buf[1] = byte(index)
+	return string(buf[:])
+}
+
 func encodeTickKeyToBuffer(dst []byte, tick int32) {
 	adjustTick := tick + ENCODED_TICK_OFFSET
 	if adjustTick < 0 {

--- a/contract/r/gnoswap/pool/utils.gno
+++ b/contract/r/gnoswap/pool/utils.gno
@@ -37,14 +37,6 @@ func EncodePositionKey(tickLower, tickUpper int32) string {
 	return string(buf[:])
 }
 
-// EncodeObservationKey encodes an observation index into a fixed-width key.
-func EncodeObservationKey(index uint16) string {
-	var buf [2]byte
-	buf[0] = byte(index >> 8)
-	buf[1] = byte(index)
-	return string(buf[:])
-}
-
 func encodeTickKeyToBuffer(dst []byte, tick int32) {
 	adjustTick := tick + ENCODED_TICK_OFFSET
 	if adjustTick < 0 {

--- a/contract/r/gnoswap/pool/v1/_helper_test.gno
+++ b/contract/r/gnoswap/pool/v1/_helper_test.gno
@@ -2,7 +2,6 @@ package pool
 
 import (
 	"chain"
-	"errors"
 	"testing"
 
 	"gno.land/r/gnoswap/gns"
@@ -52,6 +51,8 @@ var (
 	// define addresses to use in tests
 	addr01 = testutils.TestAddress("addr01")
 	addr02 = testutils.TestAddress("addr02")
+
+	testObservationTrees = make(map[string]*pl.ObservationTree)
 )
 
 // mustGetPositionByPool returns the position info for a given key.
@@ -464,6 +465,11 @@ func initPoolTest(cur realm, t *testing.T) {
 	t.Helper()
 	const mockPoolPath = "gno.land/r/gnoswap/pool/mock"
 
+	// Observation trees are stored independently from pools. Reset the
+	// test-only fixture registry with the mock implementation so no tree from
+	// an earlier test can be reused for a pool path in a new fixture.
+	testObservationTrees = make(map[string]*pl.ObservationTree)
+
 	if !initializedPool {
 		initializedPool = true
 		testing.SetRealm(testing.NewCodeRealm(mockPoolPath))
@@ -505,7 +511,7 @@ type createMockPoolParams struct {
 	ticks                *bptree.BPTree
 	tickBitmaps          map[int16]string
 	positions            *bptree.BPTree
-	observationState     *pl.ObservationState
+	observations     *pl.ObservationTree
 }
 
 func makeMockPool(params createMockPoolParams) *pl.Pool {
@@ -566,8 +572,10 @@ func makeMockPool(params createMockPoolParams) *pl.Pool {
 	if params.positions != nil {
 		pool.SetPositions(params.positions)
 	}
-	if params.observationState != nil {
-		pool.SetObservationState(params.observationState)
+	if params.observations != nil {
+		setObservationsForTest(pool, params.observations)
+	} else {
+		setObservationsForTest(pool, pl.NewPoolObservationsTree(0))
 	}
 
 	return pool
@@ -584,7 +592,7 @@ func testObservationSlot0(index, cardinality, cardinalityNext uint16) pl.Slot0 {
 // writeObservationWithSlot0 keeps unit-test setup concise while production
 // callers use writeObservation's Uniswap-shaped cursor input/output directly.
 func writeObservationWithSlot0(
-	observations *pl.ObservationState,
+	observations *pl.ObservationTree,
 	slot0 *pl.Slot0,
 	currentTime int64,
 	tick int32,
@@ -608,10 +616,7 @@ func writeObservationWithSlot0(
 }
 
 func increaseObservationCardinalityNextForTest(p *pl.Pool, cardinalityNext uint16) error {
-	observations := p.ObservationState()
-	if observations == nil {
-		return errors.New("observation state not initialized")
-	}
+	observations := observationsForTest(p)
 	slot0 := p.Slot0()
 	cardinalityNextNew, err := grow(observations, slot0.ObservationCardinalityNext(), cardinalityNext)
 	if err != nil {
@@ -622,13 +627,53 @@ func increaseObservationCardinalityNextForTest(p *pl.Pool, cardinalityNext uint1
 	return nil
 }
 
+func observationsForTest(pool *pl.Pool) *pl.ObservationTree {
+	observations, ok := testObservationTrees[pool.PoolPath()]
+	if ok && observations != nil {
+		return observations
+	}
+
+	if mockInstance != nil {
+		value := mockInstance.store.GetObservations().Get(pool.PoolPath())
+		if observations, ok := value.(*pl.ObservationTree); ok && observations != nil {
+			testObservationTrees[pool.PoolPath()] = observations
+			return observations
+		}
+	}
+
+	observations = pl.NewPoolObservationsTree(0)
+	setObservationsForTest(pool, observations)
+	return observations
+}
+
+func mustObservation(observations *pl.ObservationTree, index uint16) *pl.Observation {
+	observation, ok := observations.Get(index)
+	if !ok {
+		panic("missing observation test fixture")
+	}
+	return observation
+}
+
+func setObservationsForTest(pool *pl.Pool, observations *pl.ObservationTree) {
+	if observations == nil {
+		delete(testObservationTrees, pool.PoolPath())
+		if mockInstance != nil {
+			mockInstance.store.GetObservations().Remove(pool.PoolPath())
+		}
+		return
+	}
+	testObservationTrees[pool.PoolPath()] = observations
+	if mockInstance != nil {
+		mockInstance.store.GetObservations().Set(pool.PoolPath(), observations)
+	}
+}
+
 func getMockInstance() *poolV1 {
 	if mockInstance == nil {
 		mockInstance = &poolV1{
 			store: mock.NewMockPoolStore(),
 		}
 	}
-
 	return mockInstance
 }
 

--- a/contract/r/gnoswap/pool/v1/_helper_test.gno
+++ b/contract/r/gnoswap/pool/v1/_helper_test.gno
@@ -511,7 +511,7 @@ type createMockPoolParams struct {
 	ticks                *bptree.BPTree
 	tickBitmaps          map[int16]string
 	positions            *bptree.BPTree
-	observations     *pl.ObservationTree
+	observations         *pl.ObservationTree
 }
 
 func makeMockPool(params createMockPoolParams) *pl.Pool {

--- a/contract/r/gnoswap/pool/v1/getter.gno
+++ b/contract/r/gnoswap/pool/v1/getter.gno
@@ -107,8 +107,7 @@ func (i *poolV1) GetSlot0(poolPath string) pl.Slot0 {
 }
 
 func (i *poolV1) GetObservationAt(poolPath string, index uint16) (pl.Observation, error) {
-	pool, err := i.getPool(poolPath)
-	if err != nil {
+	if _, err := i.getPool(poolPath); err != nil {
 		return *pl.NewDefaultObservation(), err
 	}
 
@@ -119,12 +118,12 @@ func (i *poolV1) GetObservationAt(poolPath string, index uint16) (pl.Observation
 		return *pl.NewDefaultObservation(), makeErrorWithDetails(errDataNotFound, ufmt.Sprintf("observation index %d out of range", index))
 	}
 
-	observationState := pool.ObservationState()
-	if observationState == nil {
-		return *pl.NewDefaultObservation(), nil
+	observations, err := i.getObservations(poolPath)
+	if err != nil {
+		return *pl.NewDefaultObservation(), err
 	}
 
-	observation, ok := observationState.ObservationAt(index)
+	observation, ok := observations.Get(index)
 	if !ok || observation == nil {
 		return *pl.NewDefaultObservation(), nil
 	}
@@ -141,14 +140,14 @@ func (i *poolV1) Observe(poolPath string, secondsAgos []uint32) ([]int64, []stri
 		return nil, nil, err
 	}
 
-	observationState := pool.ObservationState()
-	if observationState == nil {
-		return nil, nil, errors.New("observation state not initialized")
+	observations, err := i.getObservations(poolPath)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	slot0 := pool.Slot0()
 	return observe(
-		observationState,
+		observations,
 		time.Now().Unix(),
 		secondsAgos,
 		slot0.Tick(),
@@ -170,7 +169,12 @@ func (i *poolV1) SnapshotCumulativesInside(
 		return 0, nil, 0, err
 	}
 
-	return snapshotCumulativesInside(pool, tickLower, tickUpper)
+	observations, err := i.getObservations(poolPath)
+	if err != nil {
+		return 0, nil, 0, err
+	}
+
+	return snapshotCumulativesInside(pool, observations, tickLower, tickUpper)
 }
 
 func (i *poolV1) GetFeeGrowthGlobal0X128(poolPath string) (*u256.Uint, error) {

--- a/contract/r/gnoswap/pool/v1/getter.gno
+++ b/contract/r/gnoswap/pool/v1/getter.gno
@@ -475,7 +475,12 @@ func (i *poolV1) OracleConsult(poolPath string, secondsAgo uint32) (int32, *u256
 		return 0, nil, err
 	}
 
-	tick, liquidity, err := oracleConsult(pool, secondsAgo)
+	observations, err := i.getObservations(poolPath)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	tick, liquidity, err := oracleConsult(pool, observations, secondsAgo)
 	if err != nil {
 		return 0, nil, err
 	}

--- a/contract/r/gnoswap/pool/v1/getter_test.gno
+++ b/contract/r/gnoswap/pool/v1/getter_test.gno
@@ -313,6 +313,18 @@ func TestGetObservationAtReturnsDefaultForUninitializedSlot(cur realm, t *testin
 	uassert.ErrorContains(t, err, "out of range")
 }
 
+func TestGetLastObservationPropagatesLookupError(cur realm, t *testing.T) {
+	testInitData(cur, t)
+
+	observations := getMockInstance().store.GetObservations()
+	observations.Remove("token0:token1:3000")
+	uassert.NoError(t, getMockInstance().store.SetObservations(0, cur, observations))
+
+	_, secondsPerLiquidity, _, err := getMockInstance().GetLastObservation("token0:token1:3000")
+	uassert.Error(t, err)
+	uassert.Equal(t, "0", secondsPerLiquidity)
+}
+
 func TestObserve(cur realm, t *testing.T) {
 	testInitData(cur, t)
 

--- a/contract/r/gnoswap/pool/v1/getter_test.gno
+++ b/contract/r/gnoswap/pool/v1/getter_test.gno
@@ -313,18 +313,6 @@ func TestGetObservationAtReturnsDefaultForUninitializedSlot(cur realm, t *testin
 	uassert.ErrorContains(t, err, "out of range")
 }
 
-func TestGetLastObservationPropagatesLookupError(cur realm, t *testing.T) {
-	testInitData(cur, t)
-
-	observations := getMockInstance().store.GetObservations()
-	observations.Remove("token0:token1:3000")
-	uassert.NoError(t, getMockInstance().store.SetObservations(0, cur, observations))
-
-	_, secondsPerLiquidity, _, err := getMockInstance().GetLastObservation("token0:token1:3000")
-	uassert.Error(t, err)
-	uassert.Equal(t, "0", secondsPerLiquidity)
-}
-
 func TestObserve(cur realm, t *testing.T) {
 	testInitData(cur, t)
 

--- a/contract/r/gnoswap/pool/v1/getter_test.gno
+++ b/contract/r/gnoswap/pool/v1/getter_test.gno
@@ -318,7 +318,7 @@ func TestObserve(cur realm, t *testing.T) {
 
 	pool := getMockInstance().mustGetPool("token0:token1:3000")
 	slot0Before := pool.Slot0()
-	observationBefore, err := observationAt(pool.ObservationState(), slot0Before.ObservationIndex())
+	observationBefore, err := observationAt(observationsForTest(pool), slot0Before.ObservationIndex())
 	uassert.NoError(t, err)
 	observationTimestampBefore := observationBefore.BlockTimestamp()
 	observationTickCumulativeBefore := observationBefore.TickCumulative()
@@ -335,7 +335,7 @@ func TestObserve(cur realm, t *testing.T) {
 	uassert.Equal(t, secondsPerLiquidityCumulativeX128s[0], secondsPerLiquidityCumulativeX128s[1])
 
 	slot0After := pool.Slot0()
-	observationAfter, err := observationAt(pool.ObservationState(), slot0After.ObservationIndex())
+	observationAfter, err := observationAt(observationsForTest(pool), slot0After.ObservationIndex())
 	uassert.NoError(t, err)
 	uassert.Equal(t, slot0Before.ObservationIndex(), slot0After.ObservationIndex())
 	uassert.Equal(t, slot0Before.ObservationCardinality(), slot0After.ObservationCardinality())

--- a/contract/r/gnoswap/pool/v1/init.gno
+++ b/contract/r/gnoswap/pool/v1/init.gno
@@ -54,6 +54,13 @@ func initStoreData(_ int, rlm realm, poolStore pool.IPoolStore) error {
 		}
 	}
 
+	if !poolStore.HasObservations() {
+		err := poolStore.SetObservations(0, rlm, pool.NewObservationsTree())
+		if err != nil {
+			return err
+		}
+	}
+
 	if !poolStore.HasFeeAmountTickSpacing() {
 		err := poolStore.SetFeeAmountTickSpacing(0, rlm, pool.NewDefaultFeeAmountTickSpacing())
 		if err != nil {

--- a/contract/r/gnoswap/pool/v1/init.gno
+++ b/contract/r/gnoswap/pool/v1/init.gno
@@ -1,6 +1,7 @@
 package pool
 
 import (
+	ufmt "gno.land/p/nt/ufmt/v0"
 	"gno.land/r/gnoswap/access"
 	"gno.land/r/gnoswap/emission"
 	"gno.land/r/gnoswap/pool"
@@ -59,6 +60,10 @@ func initStoreData(_ int, rlm realm, poolStore pool.IPoolStore) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	if err := validatePoolObservations(poolStore); err != nil {
+		return err
 	}
 
 	if !poolStore.HasFeeAmountTickSpacing() {
@@ -133,4 +138,23 @@ func initStoreData(_ int, rlm realm, poolStore pool.IPoolStore) error {
 	}
 
 	return nil
+}
+
+// validatePoolObservations ensures every persisted pool owns an observation tree.
+// CreatePool initializes the pair in one transaction; this check catches an
+// implementation or upgrade that would otherwise leave a pool unusable later.
+func validatePoolObservations(poolStore pool.IPoolStore) error {
+	pools := poolStore.GetPools()
+	observations := poolStore.GetObservations()
+
+	var validationErr error
+	pools.Iterate("", "", func(poolPath string, _ any) bool {
+		if !observations.Has(poolPath) {
+			validationErr = ufmt.Errorf("expected observations for poolPath(%s) to exist", poolPath)
+			return true
+		}
+		return false
+	})
+
+	return validationErr
 }

--- a/contract/r/gnoswap/pool/v1/init_test.gno
+++ b/contract/r/gnoswap/pool/v1/init_test.gno
@@ -31,3 +31,14 @@ func TestInit_initStoreDataUsesFreshFeeAmountTickSpacingPerStore(cur realm, t *t
 	uassert.Equal(t, secondStoreFeeAmountTickSpacing[3000], int32(60))
 	uassert.Equal(t, secondStoreFeeAmountTickSpacing[10000], int32(200))
 }
+
+func TestInit_initStoreDataRejectsPoolWithoutObservations(cur realm, t *testing.T) {
+	poolStore := mock.NewMockPoolStore()
+	uassert.NoError(t, initStoreData(0, cur, poolStore))
+
+	pool := createTestPool()
+	poolStore.GetPools().Set(pool.PoolPath(), pool)
+
+	err := initStoreData(0, cur, poolStore)
+	uassert.ErrorContains(t, err, "expected observations for poolPath")
+}

--- a/contract/r/gnoswap/pool/v1/manager.gno
+++ b/contract/r/gnoswap/pool/v1/manager.gno
@@ -3,6 +3,7 @@ package pool
 import (
 	"chain"
 	"errors"
+	"time"
 
 	prabc "gno.land/p/gnoswap/rbac"
 	"gno.land/p/gnoswap/utils"
@@ -113,6 +114,12 @@ func (i *poolV1) CreatePool(
 		panic(err)
 	}
 
+	observations := i.store.GetObservations()
+	observations.Set(poolPath, pl.NewPoolObservationsTree(time.Now().Unix()))
+	if err := i.store.SetObservations(0, rlm, observations); err != nil {
+		panic(err)
+	}
+
 	poolCreationFee := i.store.GetPoolCreationFee()
 
 	if poolCreationFee > 0 {
@@ -209,6 +216,29 @@ func (i *poolV1) mustGetPool(poolPath string) (pool *pl.Pool) {
 func (i *poolV1) mustGetPoolBy(token0Path, token1Path string, fee uint32) *pl.Pool {
 	poolPath := GetPoolPath(token0Path, token1Path, fee)
 	return i.mustGetPool(poolPath)
+}
+
+func (i *poolV1) getObservations(poolPath string) (*pl.ObservationTree, error) {
+	observations := i.store.GetObservations()
+	value := observations.Get(poolPath)
+	if value == nil {
+		return nil, ufmt.Errorf("expected observations for poolPath(%s) to exist", poolPath)
+	}
+
+	tree, ok := value.(*pl.ObservationTree)
+	if !ok {
+		return nil, ufmt.Errorf("failed to cast observations for poolPath(%s): %T", poolPath, value)
+	}
+
+	return tree, nil
+}
+
+func (i *poolV1) mustGetObservations(poolPath string) *pl.ObservationTree {
+	tree, err := i.getObservations(poolPath)
+	if err != nil {
+		panic(makeErrorWithDetails(errDataNotFound, err.Error()))
+	}
+	return tree
 }
 
 // savePool updates a pool in the pools map and persists to storage.

--- a/contract/r/gnoswap/pool/v1/manager_test.gno
+++ b/contract/r/gnoswap/pool/v1/manager_test.gno
@@ -228,6 +228,11 @@ func TestCreatePool(cur realm, t *testing.T) {
 				// verify pool was created correctly
 				poolPath := GetPoolPath(tt.token0Path, tt.token1Path, tt.fee)
 				pool := getMockInstance().mustGetPool(poolPath)
+				observations, err := getMockInstance().getObservations(poolPath)
+				uassert.NoError(t, err)
+				initialObservation, ok := observations.Get(0)
+				uassert.True(t, ok)
+				uassert.True(t, initialObservation.Initialized())
 
 				if pool.Token0Path() != expectedPoolInfo.Token0Path() || pool.Token1Path() != expectedPoolInfo.Token1Path() {
 					t.Errorf("incorrect token paths in pool. got %s,%s want %s,%s",

--- a/contract/r/gnoswap/pool/v1/oracle.gno
+++ b/contract/r/gnoswap/pool/v1/oracle.gno
@@ -69,6 +69,7 @@ func oracleConsult(p *pl.Pool, observations *pl.ObservationTree, secondsAgo uint
 // snapshotCumulativesInside flow.
 func snapshotCumulativesInside(
 	p *pl.Pool,
+	observations *pl.ObservationTree,
 	tickLower int32,
 	tickUpper int32,
 ) (int64, *u256.Uint, uint32, error) {
@@ -97,14 +98,13 @@ func snapshotCumulativesInside(
 	}
 
 	if slot0.Tick() < tickUpper {
-		observationState := p.ObservationState()
-		if observationState == nil {
-			return 0, nil, 0, errors.New("observation state not initialized")
+		if observations == nil {
+			return 0, nil, 0, errors.New("observations not initialized")
 		}
 
 		currentTime := time.Now().Unix()
 		tickCumulative, secondsPerLiquidityCumulativeX128, err := observeSingle(
-			observationState,
+			observations,
 			currentTime,
 			0,
 			slot0.Tick(),

--- a/contract/r/gnoswap/pool/v1/oracle.gno
+++ b/contract/r/gnoswap/pool/v1/oracle.gno
@@ -187,9 +187,13 @@ func grow(observations *pl.ObservationTree, current, next uint16) (uint16, error
 		return current, errors.New("next exceeds maximum")
 	}
 
-	// ObservationTree is sparse: an absent index is an uninitialized
-	// observation. Reserve the logical capacity in Slot0 without creating
-	// placeholder tree entries; writeObservation creates entries on demand.
+	// Reserve every new slot now so the caller that increases capacity pays for
+	// its storage. This matches Uniswap's Oracle.grow behavior and prevents an
+	// unrestricted reservation from shifting allocation cost to later swappers.
+	for i := current; i < next; i++ {
+		observations.Set(i, pl.NewObservation(1, 0, "0", false))
+	}
+
 	return next, nil
 }
 

--- a/contract/r/gnoswap/pool/v1/oracle.gno
+++ b/contract/r/gnoswap/pool/v1/oracle.gno
@@ -14,14 +14,13 @@ const maxObservationCardinality uint16 = 65535
 
 // oracleConsult calculates the time-weighted average price between two points in time.
 // It returns the arithmetic mean tick and harmonic mean liquidity over the time period.
-func oracleConsult(p *pl.Pool, secondsAgo uint32) (int32, *u256.Uint, error) {
+func oracleConsult(p *pl.Pool, observations *pl.ObservationTree, secondsAgo uint32) (int32, *u256.Uint, error) {
 	if secondsAgo == 0 {
 		return 0, nil, errors.New("secondsAgo must be greater than 0")
 	}
 
-	observationState := p.ObservationState()
-	if observationState == nil {
-		return 0, nil, errors.New("observation state not initialized")
+	if observations == nil {
+		return 0, nil, errors.New("observations not initialized")
 	}
 	slot0 := p.Slot0()
 
@@ -30,7 +29,7 @@ func oracleConsult(p *pl.Pool, secondsAgo uint32) (int32, *u256.Uint, error) {
 	blockTimestamp := time.Now().Unix()
 
 	tickCumulatives, secondsPerLiquidityCumulativeX128s, err := observe(
-		observationState,
+		observations,
 		blockTimestamp,
 		secondsAgos,
 		slot0.Tick(),
@@ -171,9 +170,9 @@ func transform(last *pl.Observation, blockTimestamp int64, tick int32, liquidity
 	), nil
 }
 
-func grow(os *pl.ObservationState, current, next uint16) (uint16, error) {
-	if os == nil {
-		return current, errors.New("observation state not initialized")
+func grow(observations *pl.ObservationTree, current, next uint16) (uint16, error) {
+	if observations == nil {
+		return current, errors.New("observations not initialized")
 	}
 
 	if current <= 0 {
@@ -192,14 +191,14 @@ func grow(os *pl.ObservationState, current, next uint16) (uint16, error) {
 	for i := current; i < next; i++ {
 		observation := pl.NewDefaultObservation()
 		observation.SetBlockTimestamp(1)
-		os.SetObservation(i, observation)
+		observations.Set(i, observation)
 	}
 
 	return next, nil
 }
 
 func writeObservation(
-	os *pl.ObservationState,
+	observations *pl.ObservationTree,
 	index uint16,
 	blockTimestamp int64,
 	tick int32,
@@ -207,14 +206,14 @@ func writeObservation(
 	cardinality uint16,
 	cardinalityNext uint16,
 ) (indexUpdated uint16, cardinalityUpdated uint16, err error) {
-	if os == nil {
-		return 0, 0, errors.New("observation state not initialized")
+	if observations == nil {
+		return 0, 0, errors.New("observations not initialized")
 	}
 	if cardinality == 0 {
 		return 0, 0, errors.New("observation cardinality must be greater than 0")
 	}
 
-	last, err := observationAt(os, index)
+	last, err := observationAt(observations, index)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -231,20 +230,22 @@ func writeObservation(
 	}
 
 	indexUpdated = (index + 1) % cardinalityUpdated
-
 	observation, err := transform(last, blockTimestamp, tick, liquidity)
 	if err != nil {
 		return 0, 0, err
 	}
 
-	os.SetObservation(indexUpdated, observation)
+	observations.Set(indexUpdated, observation)
 	return indexUpdated, cardinalityUpdated, nil
 }
 
 // observationAt returns the observation at a specific index
 // Returns error if the observation doesn't exist
-func observationAt(os *pl.ObservationState, index uint16) (*pl.Observation, error) {
-	obs, ok := os.ObservationAt(index)
+func observationAt(observations *pl.ObservationTree, index uint16) (*pl.Observation, error) {
+	if observations == nil {
+		return nil, errors.New("observations not initialized")
+	}
+	obs, ok := observations.Get(index)
 	if !ok || obs == nil {
 		return nil, errors.New(errNotInitializedObservation)
 	}
@@ -254,7 +255,7 @@ func observationAt(os *pl.ObservationState, index uint16) (*pl.Observation, erro
 
 // observeSingle returns the data for a single observation at a specific time ago
 func observeSingle(
-	os *pl.ObservationState,
+	observations *pl.ObservationTree,
 	time int64,
 	secondsAgo uint32,
 	tick int32,
@@ -264,7 +265,7 @@ func observeSingle(
 ) (int64, string, error) {
 	if secondsAgo == 0 {
 		// if secondsAgo is 0, return current values
-		last, err := observationAt(os, index)
+		last, err := observationAt(observations, index)
 		if err != nil {
 			return 0, "", err
 		}
@@ -291,7 +292,7 @@ func observeSingle(
 
 	// find the observations before and after the target
 	beforeOrAt, atOrAfter, err := getSurroundingObservations(
-		os,
+		observations,
 		target,
 		tick,
 		index,
@@ -340,7 +341,7 @@ func observeSingle(
 // It uses binary search over the logical time-ordered view of the circular buffer.
 // Logical order starts at (index+1) % cardinality (oldest) and ends at index (latest).
 func getSurroundingObservations(
-	os *pl.ObservationState,
+	observations *pl.ObservationTree,
 	target int64,
 	tick int32,
 	index uint16,
@@ -348,7 +349,7 @@ func getSurroundingObservations(
 	cardinality uint16,
 ) (*pl.Observation, *pl.Observation, error) {
 	// Optimistically set before to the newest observation
-	beforeOrAt, err := observationAt(os, index)
+	beforeOrAt, err := observationAt(observations, index)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -371,9 +372,9 @@ func getSurroundingObservations(
 
 	// Now, set before to the oldest observation
 	start := (index + 1) % cardinality
-	beforeOrAt, err = observationAt(os, start)
+	beforeOrAt, err = observationAt(observations, start)
 	if err != nil || !beforeOrAt.Initialized() {
-		beforeOrAt, err = observationAt(os, 0)
+		beforeOrAt, err = observationAt(observations, 0)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -385,11 +386,11 @@ func getSurroundingObservations(
 	}
 
 	// If we've reached this point, we have to binary search
-	return binarySearch(os, target, index, cardinality)
+	return binarySearch(observations, target, index, cardinality)
 }
 
 func binarySearch(
-	os *pl.ObservationState,
+	observations *pl.ObservationTree,
 	target int64,
 	index uint16,
 	cardinality uint16,
@@ -404,7 +405,7 @@ func binarySearch(
 		i = (l + r) / 2
 
 		beforeIndex := uint16(i % uint64(cardinality))
-		beforeOrAt, err = observationAt(os, beforeIndex)
+		beforeOrAt, err = observationAt(observations, beforeIndex)
 		if err != nil || !beforeOrAt.Initialized() {
 			// we've landed on an uninitialized tick, keep searching higher (more recently)
 			l = i + 1
@@ -412,7 +413,7 @@ func binarySearch(
 		}
 
 		afterIndex := uint16((i + 1) % uint64(cardinality))
-		atOrAfter, err = observationAt(os, afterIndex)
+		atOrAfter, err = observationAt(observations, afterIndex)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -436,7 +437,7 @@ func binarySearch(
 
 // observe returns the cumulative tick and liquidity as of each timestamp secondsAgo from the current time.
 func observe(
-	os *pl.ObservationState,
+	observations *pl.ObservationTree,
 	time int64,
 	secondsAgos []uint32,
 	tick int32,
@@ -454,7 +455,7 @@ func observe(
 
 	for i, secondsAgo := range secondsAgos {
 		tickCumulative, secondsPerLiquidity, err := observeSingle(
-			os,
+			observations,
 			time,
 			secondsAgo,
 			tick,

--- a/contract/r/gnoswap/pool/v1/oracle.gno
+++ b/contract/r/gnoswap/pool/v1/oracle.gno
@@ -187,13 +187,9 @@ func grow(observations *pl.ObservationTree, current, next uint16) (uint16, error
 		return current, errors.New("next exceeds maximum")
 	}
 
-	// This is more efficient than checking all slots from 0
-	for i := current; i < next; i++ {
-		observation := pl.NewDefaultObservation()
-		observation.SetBlockTimestamp(1)
-		observations.Set(i, observation)
-	}
-
+	// ObservationTree is sparse: an absent index is an uninitialized
+	// observation. Reserve the logical capacity in Slot0 without creating
+	// placeholder tree entries; writeObservation creates entries on demand.
 	return next, nil
 }
 

--- a/contract/r/gnoswap/pool/v1/oracle_integration_test.gno
+++ b/contract/r/gnoswap/pool/v1/oracle_integration_test.gno
@@ -260,7 +260,7 @@ func TestObservationTree_BoundaryConditions(cur realm, t *testing.T) {
 	})
 }
 
-// Grow reserves logical capacity without allocating sparse tree entries.
+// Grow reserves capacity by allocating uninitialized placeholder observations.
 func TestObservationTree_GrowInvariants(cur realm, t *testing.T) {
 	currentTime := time.Now().Unix()
 	os := pl.NewPoolObservationsTree(currentTime)
@@ -276,7 +276,9 @@ func TestObservationTree_GrowInvariants(cur realm, t *testing.T) {
 	obs0 := mustObservation(os, 0)
 	uassert.True(t, obs0.Initialized(), "Slot 0 should remain initialized")
 	for i := currentCard; i < nextCard; i++ {
-		uassert.False(t, os.Has(i), "Grow must not allocate an uninitialized slot")
+		obs := mustObservation(os, i)
+		uassert.False(t, obs.Initialized(), "Grow must allocate an uninitialized slot")
+		uassert.Equal(t, int64(1), obs.BlockTimestamp())
 	}
 
 	// Test growing again
@@ -285,9 +287,10 @@ func TestObservationTree_GrowInvariants(cur realm, t *testing.T) {
 	uassert.NoError(t, err, "Should grow successfully again")
 	uassert.Equal(t, newCard2, newCardinality2, "Should return new cardinality")
 
-	// Verify the additional logical slots remain absent.
+	// Verify the additional slots are allocated but uninitialized.
 	for i := nextCard; i < newCard2; i++ {
-		uassert.False(t, os.Has(i), "Grow must not allocate an uninitialized slot")
+		obs := mustObservation(os, i)
+		uassert.False(t, obs.Initialized(), "Grow must allocate an uninitialized slot")
 	}
 }
 
@@ -417,12 +420,13 @@ func TestObservationTree_ObservationAt(cur realm, t *testing.T) {
 	})
 
 	t.Run("Uninitialized observation", func(cur realm, t *testing.T) {
-		// Grow reserves capacity but leaves uninitialized slots absent.
+		// Grow creates uninitialized placeholder slots.
 		_, err := grow(os, 1, 5)
 		uassert.NoError(t, err, "Should grow successfully")
 
-		_, err = observationAt(os, 3)
-		uassert.Error(t, err, "Should error for an absent uninitialized observation")
+		obs, err := observationAt(os, 3)
+		uassert.NoError(t, err, "Should return an uninitialized placeholder")
+		uassert.False(t, obs.Initialized())
 	})
 }
 
@@ -493,7 +497,7 @@ func createTestPoolWithLiquidity() *pl.Pool {
 			tick:         0,
 			unlocked:     true,
 		},
-		liquidity:        u256.MustFromDecimal("5000000"),
+		liquidity:    u256.MustFromDecimal("5000000"),
 		observations: pl.NewPoolObservationsTree(baseTime),
 	})
 	return mockPool

--- a/contract/r/gnoswap/pool/v1/oracle_integration_test.gno
+++ b/contract/r/gnoswap/pool/v1/oracle_integration_test.gno
@@ -260,7 +260,7 @@ func TestObservationTree_BoundaryConditions(cur realm, t *testing.T) {
 	})
 }
 
-// After grow, all slots in [currentCardinality, nextCardinality) should exist but have initialized==false
+// Grow reserves logical capacity without allocating sparse tree entries.
 func TestObservationTree_GrowInvariants(cur realm, t *testing.T) {
 	currentTime := time.Now().Unix()
 	os := pl.NewPoolObservationsTree(currentTime)
@@ -273,19 +273,10 @@ func TestObservationTree_GrowInvariants(cur realm, t *testing.T) {
 	uassert.NoError(t, err, "Should grow successfully")
 	uassert.Equal(t, nextCard, newCardinality, "Should return new cardinality")
 
-	// Verify all slots are created
-	for i := uint16(0); i < nextCard; i++ {
-		obs := mustObservation(os, i)
-		uassert.NotNil(t, obs, "Observation slot should exist")
-
-		// Check initialization status
-		if i == 0 {
-			// First slot should be initialized from newObservationTree
-			uassert.True(t, obs.Initialized(), "Slot 0 should be initialized")
-		} else if i >= currentCard && i < nextCard {
-			// New slots should NOT be initialized by grow
-			uassert.False(t, obs.Initialized(), "New slot should not be initialized")
-		}
+	obs0 := mustObservation(os, 0)
+	uassert.True(t, obs0.Initialized(), "Slot 0 should remain initialized")
+	for i := currentCard; i < nextCard; i++ {
+		uassert.False(t, os.Has(i), "Grow must not allocate an uninitialized slot")
 	}
 
 	// Test growing again
@@ -294,11 +285,9 @@ func TestObservationTree_GrowInvariants(cur realm, t *testing.T) {
 	uassert.NoError(t, err, "Should grow successfully again")
 	uassert.Equal(t, newCard2, newCardinality2, "Should return new cardinality")
 
-	// Verify new slots
+	// Verify the additional logical slots remain absent.
 	for i := nextCard; i < newCard2; i++ {
-		obs := mustObservation(os, i)
-		uassert.NotNil(t, obs, "Observation slot should exist")
-		uassert.False(t, obs.Initialized(), "New slot should not be initialized")
+		uassert.False(t, os.Has(i), "Grow must not allocate an uninitialized slot")
 	}
 }
 
@@ -428,15 +417,12 @@ func TestObservationTree_ObservationAt(cur realm, t *testing.T) {
 	})
 
 	t.Run("Uninitialized observation", func(cur realm, t *testing.T) {
-		// Grow to create slots (new slots are created with initialized=false)
+		// Grow reserves capacity but leaves uninitialized slots absent.
 		_, err := grow(os, 1, 5)
 		uassert.NoError(t, err, "Should grow successfully")
 
-		// observationAt should return uninitialized observation (without error)
-		obs, err := observationAt(os, 3)
-		uassert.NoError(t, err, "Should return observation even if uninitialized")
-		uassert.NotNil(t, obs, "Observation should not be nil")
-		uassert.False(t, obs.Initialized(), "Observation should be uninitialized")
+		_, err = observationAt(os, 3)
+		uassert.Error(t, err, "Should error for an absent uninitialized observation")
 	})
 }
 

--- a/contract/r/gnoswap/pool/v1/oracle_integration_test.gno
+++ b/contract/r/gnoswap/pool/v1/oracle_integration_test.gno
@@ -32,11 +32,11 @@ func TestOracle_SwapScenarios(cur realm, t *testing.T) {
 				// Now calculate TWAP from the beginning
 				// We can't use OracleConsult directly because it uses time.Now()
 				// Instead, we'll test the observation data directly
-				observationState := pool.ObservationState()
+				observations := observationsForTest(pool)
 				slot0 := pool.Slot0()
-				obs, err := observationAt(observationState, slot0.ObservationIndex())
+				obs, err := observationAt(observations, slot0.ObservationIndex())
 				uassert.NoError(t, err, "Last observation should succeed")
-				firstObs := observationState.Observations()[0]
+				firstObs := mustObservation(observations, 0)
 
 				// Calculate TWAP manually
 				tickDelta := obs.TickCumulative() - firstObs.TickCumulative()
@@ -58,10 +58,10 @@ func TestOracle_SwapScenarios(cur realm, t *testing.T) {
 			verifyFn: func(t *testing.T, pool *pl.Pool, scenarios []swapScenario) {
 				// Query observations to verify seconds per liquidity accumulation
 				secondsAgos := []uint32{0, 300, 600, 900}
-				observationState := pool.ObservationState()
+				observations := observationsForTest(pool)
 				slot0 := pool.Slot0()
 				_, secondsPerLiquidityCumulatives, err := observe(
-					observationState,
+					observations,
 					baseTime+900,
 					secondsAgos,
 					pool.Slot0Tick(),
@@ -86,9 +86,9 @@ func TestOracle_SwapScenarios(cur realm, t *testing.T) {
 				{time: baseTime + 300, tick: 1500, liquidity: "0", description: "tick remains same with zero liquidity"},
 			},
 			verifyFn: func(t *testing.T, pool *pl.Pool, scenarios []swapScenario) {
-				observationState := pool.ObservationState()
+				observations := observationsForTest(pool)
 				slot0 := pool.Slot0()
-				obs, err := observationAt(observationState, slot0.ObservationIndex())
+				obs, err := observationAt(observations, slot0.ObservationIndex())
 				uassert.NoError(t, err, "Last observation should succeed")
 
 				expectedTickCumulative := int64(1500 * 300) // 450000
@@ -103,12 +103,12 @@ func TestOracle_SwapScenarios(cur realm, t *testing.T) {
 			pool := createTestPoolWithLiquidity()
 
 			// Gradually increase cardinality as needed
-			observationState := pool.ObservationState()
+			observations := observationsForTest(pool)
 			slot0 := pool.Slot0()
 			currentCard := slot0.ObservationCardinality()
 			neededCard := uint16(len(tt.scenarios) + 1) // +1 for initial observation
 			if neededCard > currentCard {
-				_, err := grow(observationState, currentCard, neededCard)
+				_, err := grow(observations, currentCard, neededCard)
 				uassert.NoError(t, err, "Should grow cardinality")
 				slot0.SetObservationCardinalityNext(neededCard)
 			}
@@ -120,8 +120,8 @@ func TestOracle_SwapScenarios(cur realm, t *testing.T) {
 				}
 
 				// writeObservation will initialize observation state if needed
-				observationState := pool.ObservationState()
-				err := writeObservationWithSlot0(observationState, &slot0, scenario.time, scenario.tick, pool.Liquidity())
+				observations := observationsForTest(pool)
+				err := writeObservationWithSlot0(observations, &slot0, scenario.time, scenario.tick, pool.Liquidity())
 				uassert.NoError(t, err, ufmt.Sprintf("Observation at %s should succeed", scenario.description))
 			}
 			pool.SetSlot0(slot0)
@@ -133,11 +133,11 @@ func TestOracle_SwapScenarios(cur realm, t *testing.T) {
 }
 
 // Query with secondsAgo=0 immediately after initialization should return valid virtual observation
-func TestObservationState_InitializeAndQuerySecondsAgoZero(cur realm, t *testing.T) {
+func TestObservationTree_InitializeAndQuerySecondsAgoZero(cur realm, t *testing.T) {
 	currentTime := time.Now().Unix()
 
 	// Create new observation state
-	os := pl.NewObservationState(currentTime)
+	os := pl.NewPoolObservationsTree(currentTime)
 	slot0 := testObservationSlot0(0, 1, 1)
 
 	// Test immediate query with secondsAgo=0
@@ -176,11 +176,11 @@ func TestObservationState_InitializeAndQuerySecondsAgoZero(cur realm, t *testing
 }
 
 // Verify before/after observations are accurate when target is at boundaries (<, =, >) with cardinality 1 and N
-func TestObservationState_BoundaryConditions(cur realm, t *testing.T) {
+func TestObservationTree_BoundaryConditions(cur realm, t *testing.T) {
 	currentTime := time.Now().Unix()
 
 	t.Run("Cardinality=1", func(cur realm, t *testing.T) {
-		os := pl.NewObservationState(currentTime)
+		os := pl.NewPoolObservationsTree(currentTime)
 
 		// Test target < observation timestamp (should error with OLD)
 		_, _, err := getSurroundingObservations(
@@ -227,7 +227,7 @@ func TestObservationState_BoundaryConditions(cur realm, t *testing.T) {
 	})
 
 	t.Run("Cardinality=N", func(cur realm, t *testing.T) {
-		os := pl.NewObservationState(currentTime)
+		os := pl.NewPoolObservationsTree(currentTime)
 		slot0 := testObservationSlot0(0, 5, 5)
 
 		// Grow to cardinality 5
@@ -261,9 +261,9 @@ func TestObservationState_BoundaryConditions(cur realm, t *testing.T) {
 }
 
 // After grow, all slots in [currentCardinality, nextCardinality) should exist but have initialized==false
-func TestObservationState_GrowInvariants(cur realm, t *testing.T) {
+func TestObservationTree_GrowInvariants(cur realm, t *testing.T) {
 	currentTime := time.Now().Unix()
-	os := pl.NewObservationState(currentTime)
+	os := pl.NewPoolObservationsTree(currentTime)
 
 	// Test growing from 1 to 10
 	currentCard := uint16(1)
@@ -275,12 +275,12 @@ func TestObservationState_GrowInvariants(cur realm, t *testing.T) {
 
 	// Verify all slots are created
 	for i := uint16(0); i < nextCard; i++ {
-		obs := os.Observations()[i]
+		obs := mustObservation(os, i)
 		uassert.NotNil(t, obs, "Observation slot should exist")
 
 		// Check initialization status
 		if i == 0 {
-			// First slot should be initialized from newObservationState
+			// First slot should be initialized from newObservationTree
 			uassert.True(t, obs.Initialized(), "Slot 0 should be initialized")
 		} else if i >= currentCard && i < nextCard {
 			// New slots should NOT be initialized by grow
@@ -296,16 +296,16 @@ func TestObservationState_GrowInvariants(cur realm, t *testing.T) {
 
 	// Verify new slots
 	for i := nextCard; i < newCard2; i++ {
-		obs := os.Observations()[i]
+		obs := mustObservation(os, i)
 		uassert.NotNil(t, obs, "Observation slot should exist")
 		uassert.False(t, obs.Initialized(), "New slot should not be initialized")
 	}
 }
 
 // Binary search and interpolation should work correctly after index wrapping
-func TestObservationState_IndexWrapping(cur realm, t *testing.T) {
+func TestObservationTree_IndexWrapping(cur realm, t *testing.T) {
 	currentTime := time.Now().Unix()
-	os := pl.NewObservationState(currentTime)
+	os := pl.NewPoolObservationsTree(currentTime)
 
 	// Grow to small cardinality for easy testing
 	cardinality := uint16(5)
@@ -362,9 +362,9 @@ func TestObservationState_IndexWrapping(cur realm, t *testing.T) {
 }
 
 // Reject cardinalityNext > max, allow cardinalityNext == max
-func TestObservationState_CardinalityNexts(cur realm, t *testing.T) {
+func TestObservationTree_CardinalityNexts(cur realm, t *testing.T) {
 	currentTime := time.Now().Unix()
-	os := pl.NewObservationState(currentTime)
+	os := pl.NewPoolObservationsTree(currentTime)
 
 	t.Run("Reject cardinalityNext > max", func(cur realm, t *testing.T) {
 		// Since maxObservationCardinality is 65535 (max uint16),
@@ -411,9 +411,9 @@ func TestObservationState_CardinalityNexts(cur realm, t *testing.T) {
 }
 
 // ObservationAt with various states
-func TestObservationState_ObservationAt(cur realm, t *testing.T) {
+func TestObservationTree_ObservationAt(cur realm, t *testing.T) {
 	currentTime := time.Now().Unix()
-	os := pl.NewObservationState(currentTime)
+	os := pl.NewPoolObservationsTree(currentTime)
 
 	t.Run("Valid observation", func(cur realm, t *testing.T) {
 		obs, err := observationAt(os, 0)
@@ -441,9 +441,9 @@ func TestObservationState_ObservationAt(cur realm, t *testing.T) {
 }
 
 // Transform edge cases
-func TestObservationState_Transform(cur realm, t *testing.T) {
+func TestObservationTree_Transform(cur realm, t *testing.T) {
 	currentTime := time.Now().Unix()
-	os := pl.NewObservationState(currentTime)
+	os := pl.NewPoolObservationsTree(currentTime)
 	slot0 := testObservationSlot0(0, 1, 1)
 	lastObs, _ := observationAt(os, slot0.ObservationIndex())
 
@@ -508,7 +508,7 @@ func createTestPoolWithLiquidity() *pl.Pool {
 			unlocked:     true,
 		},
 		liquidity:        u256.MustFromDecimal("5000000"),
-		observationState: pl.NewObservationState(baseTime),
+		observations: pl.NewPoolObservationsTree(baseTime),
 	})
 	return mockPool
 }

--- a/contract/r/gnoswap/pool/v1/oracle_seed_test.gno
+++ b/contract/r/gnoswap/pool/v1/oracle_seed_test.gno
@@ -21,7 +21,7 @@ func TestTickTransitionSeedsOracleFromSwapStartTick(cur realm, t *testing.T) {
 	pool := makeMockPool(createMockPoolParams{
 		slot0:            mockSlot0{tick: swapStartTick},
 		liquidity:        u256.One(),
-		observationState: pl.NewObservationState(currentTime - timeDelta),
+		observations: pl.NewPoolObservationsTree(currentTime - timeDelta),
 	})
 	pool.SetTick(crossedTick, pl.NewTickInfo())
 
@@ -33,7 +33,7 @@ func TestTickTransitionSeedsOracleFromSwapStartTick(cur realm, t *testing.T) {
 	cache := newSwapCache(0, u256.One(), currentTime, pool.Slot0())
 	step := StepComputations{tickNext: crossedTick, initialized: true}
 
-	getMockInstance().tickTransition(step, false, state, pool, cache, nil)
+	getMockInstance().tickTransition(step, false, state, pool, observationsForTest(pool), cache, nil)
 
 	tick, err := pool.GetTick(crossedTick)
 	uassert.NoError(t, err)

--- a/contract/r/gnoswap/pool/v1/oracle_seed_test.gno
+++ b/contract/r/gnoswap/pool/v1/oracle_seed_test.gno
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	uassert "gno.land/p/nt/uassert/v0"
 	u256 "gno.land/p/gnoswap/uint256"
+	uassert "gno.land/p/nt/uassert/v0"
 	pl "gno.land/r/gnoswap/pool"
 )
 
@@ -19,8 +19,8 @@ func TestTickTransitionSeedsOracleFromSwapStartTick(cur realm, t *testing.T) {
 
 	currentTime := time.Now().Unix()
 	pool := makeMockPool(createMockPoolParams{
-		slot0:            mockSlot0{tick: swapStartTick},
-		liquidity:        u256.One(),
+		slot0:        mockSlot0{tick: swapStartTick},
+		liquidity:    u256.One(),
 		observations: pl.NewPoolObservationsTree(currentTime - timeDelta),
 	})
 	pool.SetTick(crossedTick, pl.NewTickInfo())

--- a/contract/r/gnoswap/pool/v1/oracle_spec_test.gno
+++ b/contract/r/gnoswap/pool/v1/oracle_spec_test.gno
@@ -45,8 +45,8 @@ func testInitializeCardinalityNextIsOne(t *testing.T) {
 
 func testInitializeSetsFirstSlot(t *testing.T) {
 	currentTime := time.Now().Unix()
-	os := pl.NewObservationState(currentTime)
-	obs0 := os.Observations()[0]
+	os := pl.NewPoolObservationsTree(currentTime)
+	obs0 := mustObservation(os, 0)
 	uassert.True(t, obs0.Initialized())
 	uassert.Equal(t, currentTime, obs0.BlockTimestamp())
 	uassert.Equal(t, int64(0), obs0.TickCumulative())
@@ -73,7 +73,7 @@ func TestOracleGrow(cur realm, t *testing.T) {
 
 func testGrowIncreasesCardinalityNext(t *testing.T) {
 	currentTime := time.Now().Unix()
-	os := pl.NewObservationState(currentTime)
+	os := pl.NewPoolObservationsTree(currentTime)
 	slot0 := testObservationSlot0(0, 1, 1)
 	_, err := grow(os, 1, 5)
 	uassert.NoError(t, err)
@@ -86,11 +86,11 @@ func testGrowIncreasesCardinalityNext(t *testing.T) {
 
 func testGrowDoesNotTouchFirstSlot(t *testing.T) {
 	currentTime := time.Now().Unix()
-	os := pl.NewObservationState(currentTime)
+	os := pl.NewPoolObservationsTree(currentTime)
 	_, err := grow(os, 1, 5)
 	uassert.NoError(t, err)
 
-	obs0 := os.Observations()[0]
+	obs0 := mustObservation(os, 0)
 	uassert.Equal(t, "0", obs0.SecondsPerLiquidityCumulativeX128())
 	uassert.Equal(t, int64(0), obs0.TickCumulative())
 	uassert.Equal(t, currentTime, obs0.BlockTimestamp())
@@ -99,7 +99,7 @@ func testGrowDoesNotTouchFirstSlot(t *testing.T) {
 
 func testGrowNoOpIfAlreadyLarge(t *testing.T) {
 	currentTime := time.Now().Unix()
-	os := pl.NewObservationState(currentTime)
+	os := pl.NewPoolObservationsTree(currentTime)
 	newCard, err := grow(os, 1, 5)
 	uassert.NoError(t, err)
 	uassert.Equal(t, uint16(5), newCard)
@@ -111,12 +111,12 @@ func testGrowNoOpIfAlreadyLarge(t *testing.T) {
 
 func testGrowAddsDataToSlots(t *testing.T) {
 	currentTime := time.Now().Unix()
-	os := pl.NewObservationState(currentTime)
+	os := pl.NewPoolObservationsTree(currentTime)
 	_, err := grow(os, 1, 5)
 	uassert.NoError(t, err)
 
 	for i := uint16(1); i < 5; i++ {
-		obs := os.Observations()[i]
+		obs := mustObservation(os, i)
 		uassert.Equal(t, "0", obs.SecondsPerLiquidityCumulativeX128())
 		uassert.Equal(t, int64(0), obs.TickCumulative())
 		uassert.False(t, obs.Initialized())
@@ -145,13 +145,13 @@ func TestOracleWrite(cur realm, t *testing.T) {
 
 func testSingleElementOverwrite(t *testing.T) {
 	currentTime := time.Now().Unix()
-	os := pl.NewObservationState(currentTime)
+	os := pl.NewPoolObservationsTree(currentTime)
 	slot0 := testObservationSlot0(0, 1, 1)
 	err := writeObservationWithSlot0(os, &slot0, currentTime+1, 0, u256.Zero())
 	uassert.NoError(t, err)
 	uassert.Equal(t, uint16(0), slot0.ObservationIndex())
 
-	obs0 := os.Observations()[0]
+	obs0 := mustObservation(os, 0)
 	uassert.True(t, obs0.Initialized())
 	uassert.Equal(t, "340282366920938463463374607431768211456", obs0.SecondsPerLiquidityCumulativeX128())
 	uassert.Equal(t, int64(0), obs0.TickCumulative())
@@ -161,7 +161,7 @@ func testSingleElementOverwrite(t *testing.T) {
 	uassert.NoError(t, err)
 	uassert.Equal(t, uint16(0), slot0.ObservationIndex())
 
-	obs0 = os.Observations()[0]
+	obs0 = mustObservation(os, 0)
 	uassert.Equal(t, "680564733841876926926749214863536422912", obs0.SecondsPerLiquidityCumulativeX128())
 	uassert.Equal(t, int64(10), obs0.TickCumulative())
 	uassert.Equal(t, currentTime+6, obs0.BlockTimestamp())
@@ -170,7 +170,7 @@ func testSingleElementOverwrite(t *testing.T) {
 	uassert.NoError(t, err)
 	uassert.Equal(t, uint16(0), slot0.ObservationIndex())
 
-	obs0 = os.Observations()[0]
+	obs0 = mustObservation(os, 0)
 	uassert.Equal(t, "808170621437228850725514692650449502208", obs0.SecondsPerLiquidityCumulativeX128())
 	uassert.Equal(t, int64(7), obs0.TickCumulative())
 	uassert.Equal(t, currentTime+9, obs0.BlockTimestamp())
@@ -178,7 +178,7 @@ func testSingleElementOverwrite(t *testing.T) {
 
 func testDoesNothingIfTimeUnchanged(t *testing.T) {
 	currentTime := time.Now().Unix()
-	os := pl.NewObservationState(currentTime)
+	os := pl.NewPoolObservationsTree(currentTime)
 	slot0 := testObservationSlot0(0, 1, 1)
 	_, err := grow(os, 1, 2)
 	uassert.NoError(t, err)
@@ -196,7 +196,7 @@ func testDoesNothingIfTimeUnchanged(t *testing.T) {
 
 func testWritesIndexOnTimeChange(t *testing.T) {
 	currentTime := time.Now().Unix()
-	os := pl.NewObservationState(currentTime)
+	os := pl.NewPoolObservationsTree(currentTime)
 	slot0 := testObservationSlot0(0, 1, 1)
 	_, err := grow(os, 1, 3)
 	uassert.NoError(t, err)
@@ -211,7 +211,7 @@ func testWritesIndexOnTimeChange(t *testing.T) {
 	uassert.NoError(t, err)
 	uassert.Equal(t, uint16(2), slot0.ObservationIndex())
 
-	obs1 := os.Observations()[1]
+	obs1 := mustObservation(os, 1)
 	uassert.Equal(t, int64(0), obs1.TickCumulative())
 	uassert.Equal(t, "2041694201525630780780247644590609268736", obs1.SecondsPerLiquidityCumulativeX128())
 	uassert.True(t, obs1.Initialized())
@@ -220,7 +220,7 @@ func testWritesIndexOnTimeChange(t *testing.T) {
 
 func testGrowsCardinalityWhenWritingPast(t *testing.T) {
 	currentTime := time.Now().Unix()
-	os := pl.NewObservationState(currentTime)
+	os := pl.NewPoolObservationsTree(currentTime)
 	slot0 := testObservationSlot0(0, 1, 1)
 	_, err := grow(os, 1, 2)
 	uassert.NoError(t, err)
@@ -241,7 +241,7 @@ func testGrowsCardinalityWhenWritingPast(t *testing.T) {
 	uassert.Equal(t, uint16(4), slot0.ObservationCardinality())
 	uassert.Equal(t, uint16(2), slot0.ObservationIndex())
 
-	obs2 := os.Observations()[2]
+	obs2 := mustObservation(os, 2)
 	uassert.Equal(t, "1247702012043441032699040227249816775338", obs2.SecondsPerLiquidityCumulativeX128())
 	uassert.Equal(t, int64(20), obs2.TickCumulative())
 	uassert.True(t, obs2.Initialized())
@@ -250,7 +250,7 @@ func testGrowsCardinalityWhenWritingPast(t *testing.T) {
 
 func testWrapsAround(t *testing.T) {
 	currentTime := time.Now().Unix()
-	os := pl.NewObservationState(currentTime)
+	os := pl.NewPoolObservationsTree(currentTime)
 	slot0 := testObservationSlot0(0, 1, 1)
 	_, err := grow(os, 1, 3)
 	uassert.NoError(t, err)
@@ -268,7 +268,7 @@ func testWrapsAround(t *testing.T) {
 
 	uassert.Equal(t, uint16(0), slot0.ObservationIndex())
 
-	obs0 := os.Observations()[0]
+	obs0 := mustObservation(os, 0)
 	uassert.Equal(t, "2268549112806256423089164049545121409706", obs0.SecondsPerLiquidityCumulativeX128())
 	uassert.Equal(t, int64(14), obs0.TickCumulative())
 	uassert.True(t, obs0.Initialized())
@@ -277,7 +277,7 @@ func testWrapsAround(t *testing.T) {
 
 func testAccumulatesLiquidity(t *testing.T) {
 	currentTime := time.Now().Unix()
-	os := pl.NewObservationState(currentTime)
+	os := pl.NewPoolObservationsTree(currentTime)
 	slot0 := testObservationSlot0(0, 1, 1)
 	_, err := grow(os, 1, 4)
 	uassert.NoError(t, err)
@@ -295,25 +295,25 @@ func testAccumulatesLiquidity(t *testing.T) {
 
 	uassert.Equal(t, uint16(3), slot0.ObservationIndex())
 
-	obs1 := os.Observations()[1]
+	obs1 := mustObservation(os, 1)
 	uassert.True(t, obs1.Initialized())
 	uassert.Equal(t, int64(0), obs1.TickCumulative())
 	uassert.Equal(t, "1020847100762815390390123822295304634368", obs1.SecondsPerLiquidityCumulativeX128())
 	uassert.Equal(t, currentTime+3, obs1.BlockTimestamp())
 
-	obs2 := os.Observations()[2]
+	obs2 := mustObservation(os, 2)
 	uassert.True(t, obs2.Initialized())
 	uassert.Equal(t, int64(12), obs2.TickCumulative())
 	uassert.Equal(t, "1701411834604692317316873037158841057280", obs2.SecondsPerLiquidityCumulativeX128())
 	uassert.Equal(t, currentTime+7, obs2.BlockTimestamp())
 
-	obs3 := os.Observations()[3]
+	obs3 := mustObservation(os, 3)
 	uassert.True(t, obs3.Initialized())
 	uassert.Equal(t, int64(-23), obs3.TickCumulative())
 	uassert.Equal(t, "1984980473705474370203018543351981233493", obs3.SecondsPerLiquidityCumulativeX128())
 	uassert.Equal(t, currentTime+12, obs3.BlockTimestamp())
 
-	obs4, ok := os.Observations()[4]
+	obs4, ok := os.Get(4)
 	if ok {
 		uassert.False(t, obs4.Initialized())
 	}
@@ -353,13 +353,13 @@ func TestOracleObserve(cur realm, t *testing.T) {
 
 func testObserveFailsIfOlderNotExist(t *testing.T) {
 	currentTime := time.Now().Unix()
-	os := pl.NewObservationState(currentTime + 5)
+	os := pl.NewPoolObservationsTree(currentTime + 5)
 	_, _, err := observeSingle(os, currentTime+5, 1, 2, 0, u256.NewUint(4), 1)
 	uassert.Error(t, err)
 }
 
 func testObserveFailsIfSecondsAgoExceedsCurrentTime(t *testing.T) {
-	os := pl.NewObservationState(0)
+	os := pl.NewPoolObservationsTree(0)
 	_, _, err := observeSingle(os, 10, 11, 2, 0, u256.NewUint(4), 1)
 	uassert.ErrorContains(t, err, "[GNOSWAP-POOL-026]")
 }
@@ -367,7 +367,7 @@ func testObserveFailsIfSecondsAgoExceedsCurrentTime(t *testing.T) {
 // TestOracleLookbackErrorsAreDistinct pins the two rejection reasons to separate error codes.
 func TestOracleLookbackErrorsAreDistinct(cur realm, t *testing.T) {
 	// Retention failure: oldest observation (t=100) is newer than target (t=99).
-	tooOld := pl.NewObservationState(100)
+	tooOld := pl.NewPoolObservationsTree(100)
 	_, _, errTooOld := observeSingle(tooOld, 150, 51, 12, 0, u256.NewUint(4), 1)
 	uassert.ErrorContains(t, errTooOld, "[GNOSWAP-POOL-025]")
 	if errTooOld != nil && strings.Contains(errTooOld.Error(), "[GNOSWAP-POOL-026]") {
@@ -375,7 +375,7 @@ func TestOracleLookbackErrorsAreDistinct(cur realm, t *testing.T) {
 	}
 
 	// Malformed request: secondsAgo exceeds the chain's own age.
-	beforeEpoch := pl.NewObservationState(0)
+	beforeEpoch := pl.NewPoolObservationsTree(0)
 	_, _, errEpoch := observeSingle(beforeEpoch, 10, 11, 12, 0, u256.NewUint(4), 1)
 	uassert.ErrorContains(t, errEpoch, "[GNOSWAP-POOL-026]")
 	if errEpoch != nil && strings.Contains(errEpoch.Error(), "[GNOSWAP-POOL-025]") {
@@ -388,11 +388,11 @@ func testObserveInterpolatesMaxLiquidity(t *testing.T) {
 	maxLiquidity := u256.MustFromDecimal("340282366920938463463374607431768211455")
 
 	// initialize({ liquidity: MaxUint128, tick: 0, time: 0 })
-	os := pl.NewObservationState(currentTime)
+	os := pl.NewPoolObservationsTree(currentTime)
 	slot0 := testObservationSlot0(0, 1, 1)
 	// Manually set first observation with MaxUint128 liquidity
-	firstObs := os.Observations()[0]
-	os.SetObservation(0, pl.NewObservation(
+	firstObs := mustObservation(os, 0)
+	os.Set(0, pl.NewObservation(
 		currentTime,
 		firstObs.TickCumulative(),
 		"0", // secondsPerLiquidityCumulativeX128
@@ -422,7 +422,7 @@ func testObserveInterpolatesMinLiquidity(t *testing.T) {
 	maxLiquidity := u256.MustFromDecimal("340282366920938463463374607431768211455")
 
 	// initialize({ liquidity: 0, tick: 0, time: 0 })
-	os := pl.NewObservationState(currentTime)
+	os := pl.NewPoolObservationsTree(currentTime)
 	slot0 := testObservationSlot0(0, 1, 1)
 	_, err := grow(os, 1, 2)
 	uassert.NoError(t, err)
@@ -471,7 +471,7 @@ func testObserveInterpolatesSameAs0For1(t *testing.T) {
 	maxLiquidity := u256.MustFromDecimal("340282366920938463463374607431768211455")
 
 	// initialize({ liquidity: 1, tick: 0, time: 0 })
-	os := pl.NewObservationState(currentTime)
+	os := pl.NewPoolObservationsTree(currentTime)
 	slot0 := testObservationSlot0(0, 1, 1)
 	_, err := grow(os, 1, 2)
 	uassert.NoError(t, err)
@@ -514,7 +514,7 @@ func testObserveInterpolatesSameAs0For1(t *testing.T) {
 
 func testObserveSingleAtCurrentTime(t *testing.T) {
 	currentTime := time.Now().Unix()
-	os := pl.NewObservationState(currentTime + 5)
+	os := pl.NewPoolObservationsTree(currentTime + 5)
 	tickCum, secondsPerLiq, err := observeSingle(os, currentTime+5, 0, 2, 0, u256.NewUint(4), 1)
 	uassert.NoError(t, err)
 	uassert.Equal(t, int64(0), tickCum)
@@ -524,7 +524,7 @@ func testObserveSingleAtCurrentTime(t *testing.T) {
 func testObserveSinglePastExact(t *testing.T) {
 	// initialize({ liquidity: 4, tick: 2, time: 5 })
 	currentTime := time.Now().Unix()
-	os := pl.NewObservationState(currentTime + 5)
+	os := pl.NewPoolObservationsTree(currentTime + 5)
 	// advanceTime(3) - time is now 8, but no update() called
 	// Only one observation at time=5
 
@@ -539,7 +539,7 @@ func testObserveSinglePastExact(t *testing.T) {
 func testObserveSinglePastCounterfactualPast(t *testing.T) {
 	// initialize({ liquidity: 4, tick: 2, time: 5 })
 	currentTime := time.Now().Unix()
-	os := pl.NewObservationState(currentTime + 5)
+	os := pl.NewPoolObservationsTree(currentTime + 5)
 	// advanceTime(3) - time is now 8, no update() called
 	// Only one observation at time=5
 
@@ -556,7 +556,7 @@ func testObserveSinglePastCounterfactualPast(t *testing.T) {
 func testObserveSinglePastCounterfactualNow(t *testing.T) {
 	// initialize({ liquidity: 4, tick: 2, time: 5 })
 	currentTime := time.Now().Unix()
-	os := pl.NewObservationState(currentTime + 5)
+	os := pl.NewPoolObservationsTree(currentTime + 5)
 	// advanceTime(3) - time is now 8, no update() called
 	// Only one observation at time=5
 
@@ -572,7 +572,7 @@ func testObserveSinglePastCounterfactualNow(t *testing.T) {
 
 func testObserveTwoChronological0Exact(t *testing.T) {
 	currentTime := time.Now().Unix()
-	os := pl.NewObservationState(currentTime + 5)
+	os := pl.NewPoolObservationsTree(currentTime + 5)
 	slot0 := testObservationSlot0(0, 1, 1)
 	_, err := grow(os, 1, 2)
 	uassert.NoError(t, err)
@@ -590,7 +590,7 @@ func testObserveTwoChronological0Exact(t *testing.T) {
 
 func testObserveTwoChronological0Counterfactual(t *testing.T) {
 	currentTime := time.Now().Unix()
-	os := pl.NewObservationState(currentTime + 5)
+	os := pl.NewPoolObservationsTree(currentTime + 5)
 	slot0 := testObservationSlot0(0, 1, 1)
 	_, err := grow(os, 1, 2)
 	uassert.NoError(t, err)
@@ -608,7 +608,7 @@ func testObserveTwoChronological0Counterfactual(t *testing.T) {
 
 func testObserveTwoChronologicalExactFirst(t *testing.T) {
 	currentTime := time.Now().Unix()
-	os := pl.NewObservationState(currentTime + 5)
+	os := pl.NewPoolObservationsTree(currentTime + 5)
 	slot0 := testObservationSlot0(0, 1, 1)
 	_, err := grow(os, 1, 2)
 	uassert.NoError(t, err)
@@ -626,7 +626,7 @@ func testObserveTwoChronologicalExactFirst(t *testing.T) {
 
 func testObserveTwoChronologicalBetween(t *testing.T) {
 	currentTime := time.Now().Unix()
-	os := pl.NewObservationState(currentTime + 5)
+	os := pl.NewPoolObservationsTree(currentTime + 5)
 	slot0 := testObservationSlot0(0, 1, 1)
 	_, err := grow(os, 1, 2)
 	uassert.NoError(t, err)
@@ -645,7 +645,7 @@ func testObserveTwoChronologicalBetween(t *testing.T) {
 func testObserveTwoReverse0Exact(t *testing.T) {
 	// initialize({ liquidity: 5, tick: -5, time: 5 })
 	currentTime := time.Now().Unix()
-	os := pl.NewObservationState(currentTime + 5)
+	os := pl.NewPoolObservationsTree(currentTime + 5)
 	slot0 := testObservationSlot0(0, 1, 1)
 	_, err := grow(os, 1, 2)
 	uassert.NoError(t, err)
@@ -675,7 +675,7 @@ func testObserveTwoReverse0Exact(t *testing.T) {
 func testObserveTwoReverse0Counterfactual(t *testing.T) {
 	// initialize({ liquidity: 5, tick: -5, time: 5 })
 	currentTime := time.Now().Unix()
-	os := pl.NewObservationState(currentTime + 5)
+	os := pl.NewPoolObservationsTree(currentTime + 5)
 	slot0 := testObservationSlot0(0, 1, 1)
 	_, err := grow(os, 1, 2)
 	uassert.NoError(t, err)
@@ -703,7 +703,7 @@ func testObserveTwoReverse0Counterfactual(t *testing.T) {
 func testObserveTwoReverseExactFirst(t *testing.T) {
 	// initialize({ liquidity: 5, tick: -5, time: 5 })
 	currentTime := time.Now().Unix()
-	os := pl.NewObservationState(currentTime + 5)
+	os := pl.NewPoolObservationsTree(currentTime + 5)
 	slot0 := testObservationSlot0(0, 1, 1)
 	_, err := grow(os, 1, 2)
 	uassert.NoError(t, err)
@@ -731,7 +731,7 @@ func testObserveTwoReverseExactFirst(t *testing.T) {
 func testObserveTwoReverseBetween(t *testing.T) {
 	// initialize({ liquidity: 5, tick: -5, time: 5 })
 	currentTime := time.Now().Unix()
-	os := pl.NewObservationState(currentTime + 5)
+	os := pl.NewPoolObservationsTree(currentTime + 5)
 	slot0 := testObservationSlot0(0, 1, 1)
 	_, err := grow(os, 1, 2)
 	uassert.NoError(t, err)
@@ -758,7 +758,7 @@ func testObserveTwoReverseBetween(t *testing.T) {
 
 func testObserveFetchMultiple(t *testing.T) {
 	currentTime := time.Now().Unix()
-	os := pl.NewObservationState(currentTime + 5)
+	os := pl.NewPoolObservationsTree(currentTime + 5)
 	slot0 := testObservationSlot0(0, 1, 1)
 	liquidity := u256.NewUint(1 << 15)
 
@@ -823,8 +823,8 @@ func TestOracleFiveObservations(cur realm, t *testing.T) {
 	}
 }
 
-func setupFiveObservations(startTime int64) (*pl.ObservationState, pl.Slot0) {
-	os := pl.NewObservationState(startTime)
+func setupFiveObservations(startTime int64) (*pl.ObservationTree, pl.Slot0) {
+	os := pl.NewPoolObservationsTree(startTime)
 	slot0 := testObservationSlot0(0, 1, 1)
 	grow(os, 1, 5)
 	slot0.SetObservationCardinality(1)

--- a/contract/r/gnoswap/pool/v1/oracle_spec_test.gno
+++ b/contract/r/gnoswap/pool/v1/oracle_spec_test.gno
@@ -61,7 +61,7 @@ func TestOracleGrow(cur realm, t *testing.T) {
 		{"increases the cardinality next for the first call", testGrowIncreasesCardinalityNext},
 		{"does not touch the first slot", testGrowDoesNotTouchFirstSlot},
 		{"is no op if oracle is already gte that size", testGrowNoOpIfAlreadyLarge},
-		{"does not allocate uninitialized slots", testGrowDoesNotAllocateUninitializedSlots},
+		{"adds uninitialized placeholder slots", testGrowAddsUninitializedSlots},
 	}
 
 	for _, tt := range tests {
@@ -109,14 +109,18 @@ func testGrowNoOpIfAlreadyLarge(t *testing.T) {
 	uassert.Equal(t, uint16(5), newCard)
 }
 
-func testGrowDoesNotAllocateUninitializedSlots(t *testing.T) {
+func testGrowAddsUninitializedSlots(t *testing.T) {
 	currentTime := time.Now().Unix()
 	os := pl.NewPoolObservationsTree(currentTime)
 	_, err := grow(os, 1, 5)
 	uassert.NoError(t, err)
 
 	for i := uint16(1); i < 5; i++ {
-		uassert.False(t, os.Has(i))
+		obs := mustObservation(os, i)
+		uassert.Equal(t, int64(1), obs.BlockTimestamp())
+		uassert.Equal(t, "0", obs.SecondsPerLiquidityCumulativeX128())
+		uassert.Equal(t, int64(0), obs.TickCumulative())
+		uassert.False(t, obs.Initialized())
 	}
 }
 

--- a/contract/r/gnoswap/pool/v1/oracle_spec_test.gno
+++ b/contract/r/gnoswap/pool/v1/oracle_spec_test.gno
@@ -61,7 +61,7 @@ func TestOracleGrow(cur realm, t *testing.T) {
 		{"increases the cardinality next for the first call", testGrowIncreasesCardinalityNext},
 		{"does not touch the first slot", testGrowDoesNotTouchFirstSlot},
 		{"is no op if oracle is already gte that size", testGrowNoOpIfAlreadyLarge},
-		{"adds data to all the slots", testGrowAddsDataToSlots},
+		{"does not allocate uninitialized slots", testGrowDoesNotAllocateUninitializedSlots},
 	}
 
 	for _, tt := range tests {
@@ -109,17 +109,14 @@ func testGrowNoOpIfAlreadyLarge(t *testing.T) {
 	uassert.Equal(t, uint16(5), newCard)
 }
 
-func testGrowAddsDataToSlots(t *testing.T) {
+func testGrowDoesNotAllocateUninitializedSlots(t *testing.T) {
 	currentTime := time.Now().Unix()
 	os := pl.NewPoolObservationsTree(currentTime)
 	_, err := grow(os, 1, 5)
 	uassert.NoError(t, err)
 
 	for i := uint16(1); i < 5; i++ {
-		obs := mustObservation(os, i)
-		uassert.Equal(t, "0", obs.SecondsPerLiquidityCumulativeX128())
-		uassert.Equal(t, int64(0), obs.TickCumulative())
-		uassert.False(t, obs.Initialized())
+		uassert.False(t, os.Has(i))
 	}
 }
 
@@ -313,10 +310,7 @@ func testAccumulatesLiquidity(t *testing.T) {
 	uassert.Equal(t, "1984980473705474370203018543351981233493", obs3.SecondsPerLiquidityCumulativeX128())
 	uassert.Equal(t, currentTime+12, obs3.BlockTimestamp())
 
-	obs4, ok := os.Get(4)
-	if ok {
-		uassert.False(t, obs4.Initialized())
-	}
+	uassert.False(t, os.Has(4))
 }
 
 func TestOracleObserve(cur realm, t *testing.T) {

--- a/contract/r/gnoswap/pool/v1/oracle_test.gno
+++ b/contract/r/gnoswap/pool/v1/oracle_test.gno
@@ -9,8 +9,8 @@ import (
 	pl "gno.land/r/gnoswap/pool"
 )
 
-// TestObservationState_Write tests basic write operations on ObservationState
-func TestObservationState_Write(cur realm, t *testing.T) {
+// TestObservationTree_Write tests basic write operations on ObservationTree
+func TestObservationTree_Write(cur realm, t *testing.T) {
 	currentTime := time.Now().Unix()
 
 	tests := []struct {
@@ -80,7 +80,7 @@ func TestObservationState_Write(cur realm, t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
-			os := pl.NewObservationState(tt.initialTime)
+			os := pl.NewPoolObservationsTree(tt.initialTime)
 			slot0 := testObservationSlot0(0, 1, 1)
 
 			var err error
@@ -108,8 +108,8 @@ func TestObservationState_Write(cur realm, t *testing.T) {
 	}
 }
 
-// TestObservationState_CircularBuffer tests circular buffer behavior with multiple cardinality
-func TestObservationState_CircularBuffer(cur realm, t *testing.T) {
+// TestObservationTree_CircularBuffer tests circular buffer behavior with multiple cardinality
+func TestObservationTree_CircularBuffer(cur realm, t *testing.T) {
 	currentTime := time.Now().Unix()
 
 	tests := []struct {
@@ -148,7 +148,7 @@ func TestObservationState_CircularBuffer(cur realm, t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
-			os := pl.NewObservationState(currentTime)
+			os := pl.NewPoolObservationsTree(currentTime)
 			slot0 := testObservationSlot0(0, tt.cardinality, tt.cardinalityNext)
 
 			liquidity := u256.MustFromDecimal("1000000")
@@ -223,23 +223,23 @@ func TestPool_IncreaseObservationCardinalityNext(cur realm, t *testing.T) {
 			initPoolTest(cur, t)
 			pool := createTestPool()
 			currentTime := time.Now().Unix()
-			observationState := pool.ObservationState()
+			observations := observationsForTest(pool)
 			slot0 := pool.Slot0()
 
 			if tt.initialCardinality > 0 {
 				slot0.SetObservationIndex(0)
 				slot0.SetObservationCardinality(tt.initialCardinality)
 				slot0.SetObservationCardinalityNext(tt.initialCardinalityNext)
-				writeObservationWithSlot0(observationState, &slot0, currentTime, pool.Slot0Tick(), pool.Liquidity())
+				writeObservationWithSlot0(observations, &slot0, currentTime, pool.Slot0Tick(), pool.Liquidity())
 				pool.SetSlot0(slot0)
-				pool.SetObservationState(observationState)
+				setObservationsForTest(pool, observations)
 			} else {
-				pool.SetObservationState(nil)
+				setObservationsForTest(pool, nil)
 			}
 
-			if tt.expectError {
-				err := increaseObservationCardinalityNextForTest(pool, tt.newCardinalityNext)
-				uassert.ErrorContains(t, err, tt.errorContains)
+		if tt.expectError {
+			_, err := grow(nil, tt.initialCardinalityNext, tt.newCardinalityNext)
+			uassert.ErrorContains(t, err, tt.errorContains)
 			} else {
 				increaseObservationCardinalityNextForTest(pool, tt.newCardinalityNext)
 				slot0 := pool.Slot0()
@@ -292,15 +292,15 @@ func TestOracleConsult_RoundingTable(cur realm, t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
 			pool := createTestPool()
-			observationState := newObservationStateWithDelta(tt.secondsAgo, tt.tickDelta)
-			pool.SetObservationState(observationState)
+			observations := newObservationTreeWithDelta(tt.secondsAgo, tt.tickDelta)
+			setObservationsForTest(pool, observations)
 			slot0 := pool.Slot0()
 			slot0.SetObservationIndex(1)
 			slot0.SetObservationCardinality(2)
 			slot0.SetObservationCardinalityNext(2)
 			pool.SetSlot0(slot0)
 
-			twapTick, _, err := oracleConsult(pool, tt.secondsAgo)
+			twapTick, _, err := oracleConsult(pool, observationsForTest(pool), tt.secondsAgo)
 			uassert.NoError(t, err, "oracleConsult should succeed for configured observations")
 			uassert.Equal(t, tt.expected, twapTick, "unexpected TWAP tick")
 		})
@@ -360,15 +360,15 @@ func TestOracleConsult_HarmonicMeanLiquidity(cur realm, t *testing.T) {
 			secondsPerLiq1 := u256.MustFromDecimal(tt.secondsPerLiqCumulatives[1])
 			delta := u256.Zero().Sub(secondsPerLiq1, secondsPerLiq0)
 
-			observationState := newObservationStateWithLiquidity(tt.secondsAgo, tt.tickCumulatives[1]-tt.tickCumulatives[0], delta)
-			pool.SetObservationState(observationState)
+			observations := newObservationTreeWithLiquidity(tt.secondsAgo, tt.tickCumulatives[1]-tt.tickCumulatives[0], delta)
+			setObservationsForTest(pool, observations)
 			slot0 := pool.Slot0()
 			slot0.SetObservationIndex(1)
 			slot0.SetObservationCardinality(2)
 			slot0.SetObservationCardinalityNext(2)
 			pool.SetSlot0(slot0)
 
-			arithmeticMeanTick, harmonicMeanLiquidity, err := oracleConsult(pool, tt.secondsAgo)
+			arithmeticMeanTick, harmonicMeanLiquidity, err := oracleConsult(pool, observationsForTest(pool), tt.secondsAgo)
 			uassert.NoError(t, err, "oracleConsult should succeed")
 
 			// Check arithmetic mean tick
@@ -400,7 +400,7 @@ func TestOracleConsult_ErrorCases(cur realm, t *testing.T) {
 			name: "secondsAgo is zero",
 			setupPool: func() *pl.Pool {
 				pool := createTestPool()
-				pool.SetObservationState(pl.NewObservationState(time.Now().Unix()))
+				setObservationsForTest(pool, pl.NewPoolObservationsTree(time.Now().Unix()))
 				return pool
 			},
 			secondsAgo:    0,
@@ -410,7 +410,7 @@ func TestOracleConsult_ErrorCases(cur realm, t *testing.T) {
 			name: "observation state not initialized",
 			setupPool: func() *pl.Pool {
 				pool := createTestPool()
-				pool.SetObservationState(nil)
+				setObservationsForTest(pool, nil)
 				return pool
 			},
 			secondsAgo:    3600,
@@ -421,20 +421,24 @@ func TestOracleConsult_ErrorCases(cur realm, t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
 			pool := tt.setupPool()
-			_, _, err := oracleConsult(pool, tt.secondsAgo)
+			var observations *pl.ObservationTree
+			if tt.name != "observation state not initialized" {
+				observations = observationsForTest(pool)
+			}
+			_, _, err := oracleConsult(pool, observations, tt.secondsAgo)
 			uassert.ErrorContains(t, err, tt.expectedError)
 		})
 	}
 }
 
-// newObservationStateWithDelta seeds a 2-slot observation state so that the
+// newObservationTreeWithDelta seeds a 2-slot observation state so that the
 // tick cumulative delta over secondsAgo is tickDelta.
-func newObservationStateWithDelta(secondsAgo uint32, tickDelta int64) *pl.ObservationState {
+func newObservationTreeWithDelta(secondsAgo uint32, tickDelta int64) *pl.ObservationTree {
 	now := time.Now().Unix()
 	start := now - int64(secondsAgo)
 
-	os := pl.NewObservationState(start)
-	os.SetObservation(1, pl.NewObservation(
+	os := pl.NewPoolObservationsTree(start)
+	os.Set(1, pl.NewObservation(
 		now,
 		tickDelta,
 		"0",
@@ -443,14 +447,14 @@ func newObservationStateWithDelta(secondsAgo uint32, tickDelta int64) *pl.Observ
 	return os
 }
 
-// newObservationStateWithLiquidity seeds a 2-slot observation state with
+// newObservationTreeWithLiquidity seeds a 2-slot observation state with
 // tick cumulative delta and seconds per liquidity delta.
-func newObservationStateWithLiquidity(secondsAgo uint32, tickDelta int64, secondsPerLiquidityDelta *u256.Uint) *pl.ObservationState {
+func newObservationTreeWithLiquidity(secondsAgo uint32, tickDelta int64, secondsPerLiquidityDelta *u256.Uint) *pl.ObservationTree {
 	now := time.Now().Unix()
 	start := now - int64(secondsAgo)
 
-	os := pl.NewObservationState(start)
-	os.SetObservation(1, pl.NewObservation(
+	os := pl.NewPoolObservationsTree(start)
+	os.Set(1, pl.NewObservation(
 		now,
 		tickDelta,
 		secondsPerLiquidityDelta.ToString(),

--- a/contract/r/gnoswap/pool/v1/oracle_test.gno
+++ b/contract/r/gnoswap/pool/v1/oracle_test.gno
@@ -237,9 +237,9 @@ func TestPool_IncreaseObservationCardinalityNext(cur realm, t *testing.T) {
 				setObservationsForTest(pool, nil)
 			}
 
-		if tt.expectError {
-			_, err := grow(nil, tt.initialCardinalityNext, tt.newCardinalityNext)
-			uassert.ErrorContains(t, err, tt.errorContains)
+			if tt.expectError {
+				_, err := grow(nil, tt.initialCardinalityNext, tt.newCardinalityNext)
+				uassert.ErrorContains(t, err, tt.errorContains)
 			} else {
 				increaseObservationCardinalityNextForTest(pool, tt.newCardinalityNext)
 				slot0 := pool.Slot0()
@@ -247,6 +247,23 @@ func TestPool_IncreaseObservationCardinalityNext(cur realm, t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPool_IncreaseObservationCardinalityNextFailsWithoutStoredObservations(cur realm, t *testing.T) {
+	initPoolTest(cur, t)
+	testing.SetRealm(adminRealm)
+	mockInstanceSetPoolCreationFee(0, cur, 0)
+	mockInstanceCreatePool(0, cur, barPath, bazPath, fee3000, "79228162514264337593543950336")
+
+	poolPath := GetPoolPath(barPath, bazPath, fee3000)
+	observations := getMockInstance().store.GetObservations()
+	observations.Remove(poolPath)
+	uassert.NoError(t, getMockInstance().store.SetObservations(0, cur, observations))
+
+	testing.SetRealm(rouRealm)
+	uassert.AbortsWithMessage(t, cur, "[GNOSWAP-POOL-005] requested data not found || expected observations for poolPath(gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/baz.BAZ:3000) to exist", func(cur realm) {
+		mockInstanceIncreaseObservationCardinalityNext(0, cur, barPath, bazPath, fee3000, 2)
+	})
 }
 
 // Verify TWAP rounding for a variety of tickDelta/secondsAgo combinations

--- a/contract/r/gnoswap/pool/v1/oracle_test.gno
+++ b/contract/r/gnoswap/pool/v1/oracle_test.gno
@@ -407,14 +407,14 @@ func TestOracleConsult_ErrorCases(cur realm, t *testing.T) {
 			expectedError: "secondsAgo must be greater than 0",
 		},
 		{
-			name: "observation state not initialized",
+			name: "observations not initialized",
 			setupPool: func() *pl.Pool {
 				pool := createTestPool()
 				setObservationsForTest(pool, nil)
 				return pool
 			},
 			secondsAgo:    3600,
-			expectedError: "observation state not initialized",
+			expectedError: "observations not initialized",
 		},
 	}
 
@@ -422,7 +422,7 @@ func TestOracleConsult_ErrorCases(cur realm, t *testing.T) {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
 			pool := tt.setupPool()
 			var observations *pl.ObservationTree
-			if tt.name != "observation state not initialized" {
+			if tt.name != "observations not initialized" {
 				observations = observationsForTest(pool)
 			}
 			_, _, err := oracleConsult(pool, observations, tt.secondsAgo)

--- a/contract/r/gnoswap/pool/v1/pool.gno
+++ b/contract/r/gnoswap/pool/v1/pool.gno
@@ -79,7 +79,8 @@ func (i *poolV1) Mint(
 
 	liquidityDelta := gnsmath.SafeConvertToInt128(liquidity)
 	positionParam := newModifyPositionParams(positionCaller, tickLower, tickUpper, liquidityDelta)
-	_, amount0, amount1, err := modifyPosition(pool, positionParam)
+	observations := i.mustGetObservations(pool.PoolPath())
+	_, amount0, amount1, err := modifyPosition(pool, observations, positionParam)
 	if err != nil {
 		panic(err)
 	}
@@ -151,7 +152,8 @@ func (i *poolV1) Burn(
 
 	posParams := newModifyPositionParams(positionCaller, tickLower, tickUpper, liqDelta)
 	pool := i.mustGetPoolBy(token0Path, token1Path, fee)
-	position, amount0, amount1, err := modifyPosition(pool, posParams)
+	observations := i.mustGetObservations(pool.PoolPath())
+	position, amount0, amount1, err := modifyPosition(pool, observations, posParams)
 	if err != nil {
 		panic(err)
 	}
@@ -526,15 +528,12 @@ func (i *poolV1) IncreaseObservationCardinalityNext(
 	i.lockPool(0, rlm)
 	defer i.unlockPool(0, rlm)
 
-	observationState := pool.ObservationState()
-	if observationState == nil {
-		panic("observation state not initialized")
-	}
+	observations := i.mustGetObservations(pool.PoolPath())
 	if cardinalityNext > maxObservationCardinality {
 		panic("observation cardinality next exceeds maximum")
 	}
 	observationCardinalityNextNew, err := grow(
-		observationState,
+		observations,
 		slot0Before.ObservationCardinalityNext(),
 		cardinalityNext,
 	)

--- a/contract/r/gnoswap/pool/v1/pool_test.gno
+++ b/contract/r/gnoswap/pool/v1/pool_test.gno
@@ -140,16 +140,16 @@ func verifyPriceCumulativeAccuracy(t *testing.T, pool *pl.Pool, timeElapsed int6
 	t.Helper()
 
 	slot0 := pool.Slot0()
-	lastObs, _ := observationAt(pool.ObservationState(), slot0.ObservationIndex())
+	lastObs, _ := observationAt(observationsForTest(pool), slot0.ObservationIndex())
 	beforeCumulative := lastObs.TickCumulative()
 	beforeTime := lastObs.BlockTimestamp()
 
 	// Update price cumulative
-	observationState := pool.ObservationState()
-	writeObservationWithSlot0(observationState, &slot0, beforeTime+timeElapsed, expectedTick, pool.Liquidity())
+	observations := observationsForTest(pool)
+	writeObservationWithSlot0(observations, &slot0, beforeTime+timeElapsed, expectedTick, pool.Liquidity())
 	pool.SetSlot0(slot0)
 
-	afterObservation, _ := observationAt(pool.ObservationState(), slot0.ObservationIndex())
+	afterObservation, _ := observationAt(observationsForTest(pool), slot0.ObservationIndex())
 	afterCumulative := afterObservation.TickCumulative()
 	actualIncrease := afterCumulative - beforeCumulative
 	expectedIncrease := int64(expectedTick) * timeElapsed
@@ -489,33 +489,33 @@ func TestCalculateTickCumulative_PrecisionAndEdgeCases(cur realm, t *testing.T) 
 			slot0 := pl.NewSlot0(u256.MustFromDecimal(EQUAL_PRICE_RATIO), tt.initialTick, 0, true)
 			pool.SetSlot0(slot0)
 
-			observationState := pl.NewObservationState(100)
+			observations := pl.NewPoolObservationsTree(100)
 			obs := pl.NewObservation(
 				100,
 				5000000000,
 				"0",
 				true,
 			)
-			observationState.SetObservation(0, obs)
-			pool.SetObservationState(observationState)
+			observations.Set(0, obs)
+			setObservationsForTest(pool, observations)
 			pool.SetLiquidity(u256.MustFromDecimal(tt.liquidity))
 
 			slot0 = pool.Slot0()
-			lastObs, _ := observationAt(pool.ObservationState(), slot0.ObservationIndex())
+			lastObs, _ := observationAt(observationsForTest(pool), slot0.ObservationIndex())
 			beforeTickCumulative := lastObs.TickCumulative()
 
-			observationState = pool.ObservationState()
-			lastObs, err := observationAt(observationState, slot0.ObservationIndex())
+			observations = observationsForTest(pool)
+			lastObs, err := observationAt(observations, slot0.ObservationIndex())
 
 			uassert.NoError(t, err, "Last observation should succeed")
 			currentTime := lastObs.BlockTimestamp() + tt.timeElapsed
 
 			// When: Execute accumulation calculation
-			observationState2 := pool.ObservationState()
+			observations2 := observationsForTest(pool)
 			slot0 = pool.Slot0()
-			writeObservationWithSlot0(observationState2, &slot0, currentTime, tt.initialTick, pool.Liquidity())
+			writeObservationWithSlot0(observations2, &slot0, currentTime, tt.initialTick, pool.Liquidity())
 			pool.SetSlot0(slot0)
-			lastObs, _ = observationAt(observationState2, slot0.ObservationIndex())
+			lastObs, _ = observationAt(observations2, slot0.ObservationIndex())
 			tickCumulative := lastObs.TickCumulative()
 			lastUpdateTime := lastObs.BlockTimestamp()
 

--- a/contract/r/gnoswap/pool/v1/position.gno
+++ b/contract/r/gnoswap/pool/v1/position.gno
@@ -158,7 +158,7 @@ func setPosition(p *pl.Pool, posKey string, positionInfo pl.PositionInfo) {
 //   - PositionInfo: updated position information
 //   - *u256.Uint: amount of token0 needed/returned
 //   - *u256.Uint: amount of token1 needed/returned
-func modifyPosition(p *pl.Pool, params ModifyPositionParams) (pl.PositionInfo, *u256.Uint, *u256.Uint, error) {
+func modifyPosition(p *pl.Pool, observations *pl.ObservationTree, params ModifyPositionParams) (pl.PositionInfo, *u256.Uint, *u256.Uint, error) {
 	if err := validateTicks(params.tickLower, params.tickUpper); err != nil {
 		return pl.NewDefaultPositionInfo(), zero, zero, err
 	}
@@ -166,7 +166,7 @@ func modifyPosition(p *pl.Pool, params ModifyPositionParams) (pl.PositionInfo, *
 	// get current state and price bounds
 	tick := p.Slot0Tick()
 	// update position state
-	position, err := updatePosition(p, params, tick)
+	position, err := updatePosition(p, observations, params, tick)
 	if err != nil {
 		return pl.NewDefaultPositionInfo(), zero, zero, err
 	}
@@ -198,13 +198,12 @@ func modifyPosition(p *pl.Pool, params ModifyPositionParams) (pl.PositionInfo, *
 		liquidityBefore := p.Liquidity()
 		currentTime := time.Now().Unix()
 		// Update oracle BEFORE liquidity changes
-		observationState := p.ObservationState()
-		if observationState == nil {
-			return pl.NewDefaultPositionInfo(), zero, zero, errors.New("observation state not initialized")
+		if observations == nil {
+			return pl.NewDefaultPositionInfo(), zero, zero, errors.New("observations not initialized")
 		}
 		slot0 := p.Slot0()
 		observationIndex, observationCardinality, err := writeObservation(
-			observationState,
+			observations,
 			slot0.ObservationIndex(),
 			currentTime,
 			tick,
@@ -275,7 +274,7 @@ func modifyPosition(p *pl.Pool, params ModifyPositionParams) (pl.PositionInfo, *
 //	println("Updated Position Info:", updatedPosition)
 //
 // ```
-func updatePosition(p *pl.Pool, positionParams ModifyPositionParams, tick int32) (pl.PositionInfo, error) {
+func updatePosition(p *pl.Pool, observations *pl.ObservationTree, positionParams ModifyPositionParams, tick int32) (pl.PositionInfo, error) {
 	feeGrowthGlobal0X128 := p.FeeGrowthGlobal0X128().Clone()
 	feeGrowthGlobal1X128 := p.FeeGrowthGlobal1X128().Clone()
 	liquidityDelta := positionParams.liquidityDelta
@@ -283,10 +282,12 @@ func updatePosition(p *pl.Pool, positionParams ModifyPositionParams, tick int32)
 	var flippedLower, flippedUpper bool
 	if !liquidityDelta.IsZero() {
 		blockTimestamp := time.Now().Unix()
-		observationState := p.ObservationState()
+		if observations == nil {
+			return pl.NewDefaultPositionInfo(), errors.New("observations not initialized")
+		}
 		slot0 := p.Slot0()
 		tickCumulative, secondsPerLiquidityStr, err := observeSingle(
-			observationState,
+			observations,
 			blockTimestamp,
 			0,
 			slot0.Tick(),

--- a/contract/r/gnoswap/pool/v1/position_test.gno
+++ b/contract/r/gnoswap/pool/v1/position_test.gno
@@ -118,7 +118,7 @@ func createPositionWithValidation(t *testing.T, pool *pl.Pool, scenario Position
 	}
 
 	var err error
-	_, amount0, amount1, err = modifyPosition(pool, params)
+	_, amount0, amount1, err = modifyPosition(pool, observationsForTest(pool), params)
 	if err != nil {
 		t.Fatalf("Failed to create position: %v", err)
 	}
@@ -151,7 +151,7 @@ func updatePositionLiquidity(t *testing.T, pool *pl.Pool, owner address, tickLow
 		liquidityDelta: delta,
 	}
 
-	_, amount0, amount1, err := modifyPosition(pool, params)
+	_, amount0, amount1, err := modifyPosition(pool, observationsForTest(pool), params)
 	if err != nil {
 		t.Fatalf("Failed to update position liquidity: %v", err)
 	}
@@ -318,7 +318,7 @@ func TestPositionUpdateWithKey_LPStrategies(cur realm, t *testing.T) {
 					tickUpper:      MODERATE_UPPER,
 					liquidityDelta: i256.MustFromDecimal(MEDIUM_LIQUIDITY),
 				}
-				modifyPosition(pool, params)
+				modifyPosition(pool, observationsForTest(pool), params)
 			}
 
 			// update position
@@ -587,7 +587,7 @@ func TestModifyPosition_WithDifferentPrice(cur realm, t *testing.T) {
 					liquidityDelta: i256.MustFromDecimal(test.liquidity),
 				}
 
-				_, amount0, amount1, err := modifyPosition(pool, params)
+				_, amount0, amount1, err := modifyPosition(pool, observationsForTest(pool), params)
 				uassert.NoError(t, err, "Position creation should succeed")
 
 				// Then: Validate token requirements based on price
@@ -663,7 +663,7 @@ func TestModifyPositionEdgeCases(cur realm, t *testing.T) {
 			liquidityDelta: i256.Zero(),
 		}
 
-		_, _, _, err := modifyPosition(pool, params)
+		_, _, _, err := modifyPosition(pool, observationsForTest(pool), params)
 		uassert.Equal(t, err.Error(), "[GNOSWAP-POOL-007] zero liquidity || both liquidityDelta and current position's liquidity are zero")
 	})
 
@@ -683,11 +683,11 @@ func TestModifyPositionEdgeCases(cur realm, t *testing.T) {
 			tickUpper:      -9000,
 			liquidityDelta: i256.MustFromDecimal("100000000"),
 		}
-		modifyPosition(pool, params)
+		modifyPosition(pool, observationsForTest(pool), params)
 
 		// remove liquidity
 		params.liquidityDelta = i256.MustFromDecimal("-100000000")
-		_, amount0, amount1, _ := modifyPosition(pool, params)
+		_, amount0, amount1, _ := modifyPosition(pool, observationsForTest(pool), params)
 
 		// remove amount should be same as added amount
 		uassert.Equal(t, amount0.ToString(), "8040315")
@@ -826,7 +826,7 @@ func TestPositionFeeCalculation_EdgeCases(cur realm, t *testing.T) {
 			liquidityDelta: i256.MustFromDecimal("1000000000000000000000"), // Large but safe value
 		}
 
-		modifyPosition(pool, params)
+		modifyPosition(pool, observationsForTest(pool), params)
 
 		// When: Maximum fee growth occurs
 		maxFeeGrowth := "340282366920938463463374607431768211456" // Q128
@@ -835,7 +835,7 @@ func TestPositionFeeCalculation_EdgeCases(cur realm, t *testing.T) {
 		// Update position to trigger fee calculation
 		params.liquidityDelta = i256.Zero()
 		uassert.PanicsContains(t, cur, "overflows int64 range", func() {
-			modifyPosition(pool, params)
+			modifyPosition(pool, observationsForTest(pool), params)
 		})
 
 		t.Logf("✓ Fee overflow protection: overflow is rejected at int64 boundary")
@@ -866,7 +866,7 @@ func TestPositionFeeCalculation_EdgeCases(cur realm, t *testing.T) {
 				tickUpper:      r.tickUpper,
 				liquidityDelta: i256.MustFromDecimal(MEDIUM_LIQUIDITY),
 			}
-			modifyPosition(pool, params)
+			modifyPosition(pool, observationsForTest(pool), params)
 		}
 
 		// Simulate trading activity
@@ -898,7 +898,7 @@ func TestPositionFeeCalculation_EdgeCases(cur realm, t *testing.T) {
 				tickUpper:      r.tickUpper,
 				liquidityDelta: i256.Zero(),
 			}
-			modifyPosition(pool, params)
+			modifyPosition(pool, observationsForTest(pool), params)
 
 			posKey := getPositionKey(r.tickLower, r.tickUpper)
 			positionValue := pool.Positions().Get(posKey)
@@ -945,7 +945,7 @@ func TestPositionSecurity_EdgeCases(cur realm, t *testing.T) {
 			liquidityDelta: i256.MustFromDecimal(SMALL_LIQUIDITY),
 		}
 
-		_, amt0Second, amt1Second, err := modifyPosition(pool, params)
+		_, amt0Second, amt1Second, err := modifyPosition(pool, observationsForTest(pool), params)
 		t.Logf("amt0Second: %s", amt0Second)
 		t.Logf("amt1Second: %s", amt1Second)
 		uassert.NoError(t, err, "Adding to existing position should succeed")
@@ -1007,7 +1007,7 @@ func TestPositionSecurity_EdgeCases(cur realm, t *testing.T) {
 					liquidityDelta: i256.MustFromDecimal(DUST_LIQUIDITY),
 				}
 
-				_, _, _, err := modifyPosition(pool, params)
+				_, _, _, err := modifyPosition(pool, observationsForTest(pool), params)
 
 				if test.valid {
 					uassert.NoError(t, err, "Valid range should succeed")
@@ -1036,12 +1036,12 @@ func TestPositionSecurity_EdgeCases(cur realm, t *testing.T) {
 			liquidityDelta: i256.MustFromDecimal(MEDIUM_LIQUIDITY),
 		}
 
-		modifyPosition(pool, params)
+		modifyPosition(pool, observationsForTest(pool), params)
 		posKey := getPositionKey(CONCENTRATED_LOWER, CONCENTRATED_UPPER)
 
 		// When: Remove all liquidity
 		params.liquidityDelta = i256.MustFromDecimal("-" + MEDIUM_LIQUIDITY)
-		_, removeAmt0, removeAmt1, err := modifyPosition(pool, params)
+		_, removeAmt0, removeAmt1, err := modifyPosition(pool, observationsForTest(pool), params)
 		uassert.NoError(t, err, "Removing liquidity should succeed")
 
 		// Then: Verify position state
@@ -1084,7 +1084,7 @@ func TestPositionSecurity_EdgeCases(cur realm, t *testing.T) {
 				liquidityDelta: i256.MustFromDecimal(lp.amount),
 			}
 
-			_, _, _, err := modifyPosition(pool, params)
+			_, _, _, err := modifyPosition(pool, observationsForTest(pool), params)
 			uassert.NoError(t, err, "LP position creation should succeed")
 
 			liquidityToAdd := u256.MustFromDecimal(lp.amount)
@@ -1192,7 +1192,7 @@ func TestPosition_LiquidityBoundaryEdgeCases(cur realm, t *testing.T) {
 						tickUpper:      60,
 						liquidityDelta: liqDelta,
 					}
-					modifyPosition(pool, params)
+					modifyPosition(pool, observationsForTest(pool), params)
 				})
 			} else {
 				liq := u256.MustFromDecimal(tt.liquidity)
@@ -1203,7 +1203,7 @@ func TestPosition_LiquidityBoundaryEdgeCases(cur realm, t *testing.T) {
 					tickUpper:      60,
 					liquidityDelta: liqDelta,
 				}
-				position, amount0, amount1, err := modifyPosition(pool, params)
+				position, amount0, amount1, err := modifyPosition(pool, observationsForTest(pool), params)
 
 				uassert.NoError(t, err)
 				uassert.Equal(t, tt.liquidity, position.Liquidity())
@@ -1226,18 +1226,18 @@ func TestPosition_LiquidityBoundaryExistingPositionUpdate(cur realm, t *testing.
 		liquidityDelta: gnsmath.SafeConvertToInt128(initialLiquidity),
 	}
 
-	position, _, _, err := modifyPosition(pool, params)
+	position, _, _, err := modifyPosition(pool, observationsForTest(pool), params)
 	uassert.NoError(t, err)
 	uassert.Equal(t, initialLiquidity.ToString(), position.Liquidity())
 
 	params.liquidityDelta = i256.MustFromDecimal("1")
-	position, _, _, err = modifyPosition(pool, params)
+	position, _, _, err = modifyPosition(pool, observationsForTest(pool), params)
 	uassert.NoError(t, err)
 	uassert.Equal(t, maxLiquidityPerTick.ToString(), position.Liquidity())
 
 	params.liquidityDelta = i256.MustFromDecimal("1")
 	uassert.PanicsContains(t, cur, "maxLiquidity", func() {
-		modifyPosition(pool, params)
+		modifyPosition(pool, observationsForTest(pool), params)
 	})
 }
 
@@ -1252,7 +1252,7 @@ func TestPosition_AmountOverflowEdgeCases(cur realm, t *testing.T) {
 			tickUpper:      60,
 			liquidityDelta: i256.MustFromDecimal("1000000"),
 		}
-		position, _, _, err := modifyPosition(pool, params)
+		position, _, _, err := modifyPosition(pool, observationsForTest(pool), params)
 		uassert.NoError(t, err)
 
 		// Verify initial tokensOwed
@@ -1264,7 +1264,7 @@ func TestPosition_AmountOverflowEdgeCases(cur realm, t *testing.T) {
 
 		// Remove liquidity
 		params.liquidityDelta = i256.MustFromDecimal("-1000000")
-		position2, amount0, amount1, err := modifyPosition(pool, params)
+		position2, amount0, amount1, err := modifyPosition(pool, observationsForTest(pool), params)
 		uassert.NoError(t, err)
 
 		// Verify amounts are properly calculated and bounded to uint128

--- a/contract/r/gnoswap/pool/v1/snapshot_cumulatives_inside_test.gno
+++ b/contract/r/gnoswap/pool/v1/snapshot_cumulatives_inside_test.gno
@@ -74,7 +74,7 @@ func TestSnapshotCumulativesInside_RangePosition(cur realm, t *testing.T) {
 				tt.upper,
 			)
 
-			tickCumulativeInside, secondsPerLiquidityInsideX128, secondsInside, err := snapshotCumulativesInside(pool, -10, 10)
+			tickCumulativeInside, secondsPerLiquidityInsideX128, secondsInside, err := snapshotCumulativesInside(pool, observationsForTest(pool), -10, 10)
 			uassert.NoError(t, err)
 			uassert.Equal(t, tt.wantTick, tickCumulativeInside)
 			uassert.Equal(t, tt.wantLiquidity, secondsPerLiquidityInsideX128.ToString())
@@ -99,20 +99,20 @@ func TestSnapshotCumulativesInside_UsesCounterfactualCurrentObservation(cur real
 	)
 	pool.SetLiquidity(u256.One())
 
-	observationBefore, ok := pool.ObservationState().ObservationAt(0)
+	observationBefore, ok := observationsForTest(pool).Get(0)
 	uassert.True(t, ok)
 	beforeTimestamp := observationBefore.BlockTimestamp()
 	beforeTickCumulative := observationBefore.TickCumulative()
 	beforeSecondsPerLiquidity := observationBefore.SecondsPerLiquidityCumulativeX128()
 	slot0Before := pool.Slot0()
 
-	tickCumulativeInside, secondsPerLiquidityInsideX128, secondsInside, err := snapshotCumulativesInside(pool, -10, 20)
+	tickCumulativeInside, secondsPerLiquidityInsideX128, secondsInside, err := snapshotCumulativesInside(pool, observationsForTest(pool), -10, 20)
 	uassert.NoError(t, err)
 	uassert.Equal(t, int64(700), tickCumulativeInside)
 	uassert.Equal(t, u256.Zero().Mul(u256.NewUint(10), consts.Q128()).ToString(), secondsPerLiquidityInsideX128.ToString())
 	uassert.Equal(t, uint32(70), secondsInside)
 
-	observationAfter, ok := pool.ObservationState().ObservationAt(0)
+	observationAfter, ok := observationsForTest(pool).Get(0)
 	uassert.True(t, ok)
 	uassert.Equal(t, beforeTimestamp, observationAfter.BlockTimestamp())
 	uassert.Equal(t, beforeTickCumulative, observationAfter.TickCumulative())
@@ -160,7 +160,7 @@ func TestSnapshotCumulativesInside_ValidatesRangeAndTicks(cur realm, t *testing.
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(cur realm, t *testing.T) {
-			_, _, _, err := snapshotCumulativesInside(pool, tt.tickLower, tt.tickUpper)
+			_, _, _, err := snapshotCumulativesInside(pool, observationsForTest(pool), tt.tickLower, tt.tickUpper)
 			uassert.ErrorContains(t, err, tt.wantErr)
 		})
 	}
@@ -185,14 +185,14 @@ func newSnapshotCumulativesInsidePool(
 	pool.SetSlot0(slot0)
 	pool.SetLiquidity(u256.One())
 
-	observationState := pl.NewObservationState(observationTimestamp)
-	observationState.SetObservation(0, pl.NewObservation(
+	observations := pl.NewPoolObservationsTree(observationTimestamp)
+	observations.Set(0, pl.NewObservation(
 		observationTimestamp,
 		observationTickCumulative,
 		observationSecondsPerLiquidityX128,
 		true,
 	))
-	pool.SetObservationState(observationState)
+	setObservationsForTest(pool, observations)
 
 	ticks := pl.NewPoolTicksTree()
 	ticks.Set(pl.EncodeTickKey(tickLower), lower)

--- a/contract/r/gnoswap/pool/v1/swap.gno
+++ b/contract/r/gnoswap/pool/v1/swap.gno
@@ -175,6 +175,7 @@ func (i *poolV1) Swap(
 	}
 
 	pool := i.mustGetPoolBy(token0Path, token1Path, fee)
+	observations := i.mustGetObservations(pool.PoolPath())
 
 	slot0Start := pool.Slot0()
 	i.lockPool(0, rlm)
@@ -223,19 +224,15 @@ func (i *poolV1) Swap(
 		}
 	}
 
-	result, err := i.computeSwap(pool, comp, onTickCross)
+	result, err := i.computeSwap(pool, observations, comp, onTickCross)
 	if err != nil {
 		panic(err)
 	}
 
 	// Update oracle BEFORE applying swap result (using pre-swap state)
 	if result.NewTick != slot0Start.Tick() {
-		observationState := pool.ObservationState()
-		if observationState == nil {
-			panic("observation state not initialized")
-		}
 		observationIndex, observationCardinality, err := writeObservation(
-			observationState,
+			observations,
 			slot0Start.ObservationIndex(),
 			cache.blockTimestamp,
 			slot0Start.Tick(),
@@ -282,7 +279,7 @@ func (i *poolV1) Swap(
 	}
 
 	slot0 := pool.Slot0()
-	lastObservation, err := observationAt(pool.ObservationState(), slot0.ObservationIndex())
+	lastObservation, err := observationAt(observations, slot0.ObservationIndex())
 	if err != nil {
 		panic(err)
 	}
@@ -350,7 +347,7 @@ func (i *poolV1) DrySwap(
 
 	pool := i.mustGetPoolBy(token0Path, token1Path, fee)
 	blockTimestamp := time.Now().Unix()
-	poolSnapshot := newDrySwapSnapshot(pool, blockTimestamp)
+	poolSnapshot, observationsSnapshot := newDrySwapSnapshot(pool, blockTimestamp)
 
 	slot0Start := poolSnapshot.Slot0()
 	sqrtPriceLimit := u256.MustFromDecimal(sqrtPriceLimitX96)
@@ -370,7 +367,7 @@ func (i *poolV1) DrySwap(
 		Cache:             cache,
 	}
 
-	result, err := i.computeSwap(poolSnapshot, comp, nil)
+	result, err := i.computeSwap(poolSnapshot, observationsSnapshot, comp, nil)
 	if err != nil {
 		return "0", "0", err
 	}
@@ -412,18 +409,17 @@ type tickCrossHookFn func(pool *pl.Pool, tickId int32, zeroForOne bool, timestam
 // assemble the two the loop reads: the tick tree (crossed and rewritten) and
 // the tick bitmaps (scanned for the next initialized tick). The oracle state is
 // a fresh one, because the simulation must not extend the stored observations.
-func newDrySwapSnapshot(pool *pl.Pool, blockTimestamp int64) *pl.Pool {
+func newDrySwapSnapshot(pool *pl.Pool, blockTimestamp int64) (*pl.Pool, *pl.ObservationTree) {
 	snapshot := pool.Clone()
 	snapshot.SetTicks(copyPoolTicks(pool.Ticks()))
 	snapshot.SetTickBitmaps(copyPoolTickBitmaps(pool.TickBitmaps()))
-	snapshot.SetObservationState(pl.NewObservationState(blockTimestamp))
 	slot0 := snapshot.Slot0()
 	slot0.SetObservationIndex(0)
 	slot0.SetObservationCardinality(1)
 	slot0.SetObservationCardinalityNext(1)
 	snapshot.SetSlot0(slot0)
 
-	return snapshot
+	return snapshot, pl.NewPoolObservationsTree(blockTimestamp)
 }
 
 // copyPoolTicks copies a tick tree slot by slot. TickInfo is a value type, so
@@ -451,13 +447,13 @@ func copyPoolTickBitmaps(src map[int16]string) map[int16]string {
 	return copied
 }
 
-func (i *poolV1) computeSwap(pool *pl.Pool, comp SwapComputation, onTickCross tickCrossHookFn) (*SwapResult, error) {
+func (i *poolV1) computeSwap(pool *pl.Pool, observations *pl.ObservationTree, comp SwapComputation, onTickCross tickCrossHookFn) (*SwapResult, error) {
 	state := comp.InitialState
 	var err error
 
 	// Compute swap steps until completion
 	for shouldContinueSwap(state, comp.SqrtPriceLimitX96) {
-		state, err = i.computeSwapStep(state, pool, comp.ZeroForOne, comp.SqrtPriceLimitX96, comp.ExactInput, comp.Cache, onTickCross)
+		state, err = i.computeSwapStep(state, pool, observations, comp.ZeroForOne, comp.SqrtPriceLimitX96, comp.ExactInput, comp.Cache, onTickCross)
 		if err != nil {
 			return nil, err
 		}
@@ -581,6 +577,7 @@ func shouldContinueSwap(state SwapState, sqrtPriceLimitX96 *u256.Uint) bool {
 func (i *poolV1) computeSwapStep(
 	state SwapState,
 	pool *pl.Pool,
+	observations *pl.ObservationTree,
 	zeroForOne bool,
 	sqrtPriceLimitX96 *u256.Uint,
 	exactInput bool,
@@ -622,7 +619,7 @@ func (i *poolV1) computeSwapStep(
 
 	// handling tick transitions
 	if newState.sqrtPriceX96.Eq(step.sqrtPriceNextX96) {
-		newState, err = i.tickTransition(step, zeroForOne, newState, pool, cache, onTickCross)
+		newState, err = i.tickTransition(step, zeroForOne, newState, pool, observations, cache, onTickCross)
 		if err != nil {
 			return state, err
 		}
@@ -771,20 +768,15 @@ func updateAmounts(step StepComputations, state SwapState, exactInput bool) (Swa
 }
 
 // tickTransition handles the transition between price ticks during a swap
-func (i *poolV1) tickTransition(step StepComputations, zeroForOne bool, state SwapState, pool *pl.Pool, cache *SwapCache, onTickCross tickCrossHookFn) (SwapState, error) {
+func (i *poolV1) tickTransition(step StepComputations, zeroForOne bool, state SwapState, pool *pl.Pool, observations *pl.ObservationTree, cache *SwapCache, onTickCross tickCrossHookFn) (SwapState, error) {
 	// ensure existing state to keep immutability
 	newState := state
 
 	if step.initialized {
 		// Compute oracle values on first initialized tick cross
 		if !cache.computedLatestObservation {
-			observationState := pool.ObservationState()
-			if observationState == nil {
-				return newState, errors.New("observation state not initialized")
-			}
-
 			tickCumulative, secondsPerLiquidityStr, err := observeSingle(
-				observationState,
+				observations,
 				cache.blockTimestamp,
 				0,
 				cache.slot0Start.Tick(),

--- a/contract/r/gnoswap/pool/v1/swap_test.gno
+++ b/contract/r/gnoswap/pool/v1/swap_test.gno
@@ -322,7 +322,7 @@ func TestSwapComputation_CoreEngine(cur realm, t *testing.T) {
 			}
 
 			// When: Execute swap computation
-			result, err := getMockInstance().computeSwap(mockPool, computation, nil)
+			result, err := getMockInstance().computeSwap(mockPool, observationsForTest(mockPool), computation, nil)
 			// Then: Verify computation result
 			if err != nil {
 				t.Fatalf("Unexpected error during swap computation: %v", err)
@@ -365,7 +365,7 @@ func TestSwap_TickTransitionLiquidityBoundary(cur realm, t *testing.T) {
 		})
 
 		step := StepComputations{initialized: true, tickNext: 1}
-		newState, err := getMockInstance().tickTransition(step, false, state, pool, cache, nil)
+		newState, err := getMockInstance().tickTransition(step, false, state, pool, observationsForTest(pool), cache, nil)
 		uassert.NoError(t, err)
 
 		uassert.Equal(t, maxUint128.ToString(), newState.liquidity.ToString())
@@ -392,14 +392,14 @@ func TestSwap_TickTransitionLiquidityBoundary(cur realm, t *testing.T) {
 
 		step := StepComputations{initialized: true, tickNext: 1}
 		uassert.PanicsContains(t, cur, "result exceeds uint128 range", func() {
-			_, _ = getMockInstance().tickTransition(step, false, state, pool, cache, nil)
+			_, _ = getMockInstance().tickTransition(step, false, state, pool, observationsForTest(pool), cache, nil)
 		})
 	})
 }
 
 func TestSwap_TickTransitionUsesSwapStartTickForOracle(cur realm, t *testing.T) {
 	pool := pl.NewPool("token0", "token1", FeeTier500, u256.One(), 1, 0, 0)
-	pool.SetObservationState(pl.NewObservationState(100))
+	setObservationsForTest(pool, pl.NewPoolObservationsTree(100))
 
 	tickInfo := pl.NewTickInfo()
 	tickInfo.SetInitialized(true)
@@ -416,7 +416,7 @@ func TestSwap_TickTransitionUsesSwapStartTickForOracle(cur realm, t *testing.T) 
 	cache := newSwapCache(0, u256.NewUint(100), 200, slot0)
 	step := StepComputations{initialized: true, tickNext: 20}
 
-	_, err := getMockInstance().tickTransition(step, false, state, pool, cache, nil)
+	_, err := getMockInstance().tickTransition(step, false, state, pool, observationsForTest(pool), cache, nil)
 	uassert.NoError(t, err)
 	tickInfoAfter, err := pool.GetTick(20)
 	uassert.NoError(t, err)
@@ -425,7 +425,7 @@ func TestSwap_TickTransitionUsesSwapStartTickForOracle(cur realm, t *testing.T) 
 
 func TestSwap_TickTransitionPropagatesOracleError(cur realm, t *testing.T) {
 	pool := pl.NewPool("token0", "token1", FeeTier500, u256.One(), 1, 0, 0)
-	pool.SetObservationState(nil)
+	setObservationsForTest(pool, nil)
 	tickInfo := pl.NewTickInfo()
 	tickInfo.SetInitialized(true)
 	pool.SetTick(20, tickInfo)
@@ -435,7 +435,7 @@ func TestSwap_TickTransitionPropagatesOracleError(cur realm, t *testing.T) {
 	state := newSwapState(i256.Zero(), u256.Zero(), u256.NewUint(100), slot0)
 	step := StepComputations{initialized: true, tickNext: 20}
 
-	_, err := getMockInstance().tickTransition(step, false, state, pool, cache, nil)
+	_, err := getMockInstance().tickTransition(step, false, state, pool, observationsForTest(pool), cache, nil)
 	uassert.ErrorContains(t, err, "observation state not initialized")
 }
 
@@ -1568,7 +1568,7 @@ func TestSwap_PriceLimitEdgeCase_ZeroAmount(cur realm, t *testing.T) {
 		Cache:             cache,
 	}
 
-	result, _ := getMockInstance().computeSwap(pool, comp, nil)
+	result, _ := getMockInstance().computeSwap(pool, observationsForTest(pool), comp, nil)
 	uassert.Equal(t, "0", result.Amount0.ToString(), "DrySwap should return amount0=0")
 	uassert.Equal(t, "2", result.Amount1.ToString(), "DrySwap should return amount1=2")
 

--- a/contract/r/gnoswap/pool/v1/swap_test.gno
+++ b/contract/r/gnoswap/pool/v1/swap_test.gno
@@ -435,8 +435,8 @@ func TestSwap_TickTransitionPropagatesOracleError(cur realm, t *testing.T) {
 	state := newSwapState(i256.Zero(), u256.Zero(), u256.NewUint(100), slot0)
 	step := StepComputations{initialized: true, tickNext: 20}
 
-	_, err := getMockInstance().tickTransition(step, false, state, pool, observationsForTest(pool), cache, nil)
-	uassert.ErrorContains(t, err, "observation state not initialized")
+	_, err := getMockInstance().tickTransition(step, false, state, pool, nil, cache, nil)
+	uassert.ErrorContains(t, err, "observations not initialized")
 }
 
 func TestDrySwap_ValidationAndFailures(cur realm, t *testing.T) {

--- a/contract/r/gnoswap/pool/v1/tick_test.gno
+++ b/contract/r/gnoswap/pool/v1/tick_test.gno
@@ -515,14 +515,14 @@ func TestTickUpdateSeedsOracleOutsideForActiveTick(cur realm, t *testing.T) {
 	pool := pl.NewPool("token0", "token1", STANDARD_FEE_TIER, u256.MustFromDecimal(EQUAL_PRICE_RATIO), 1, 5, 0)
 	pool.SetLiquidity(u256.NewUint(100))
 
-	observationState := pl.NewObservationState(startTime)
-	pool.SetObservationState(observationState)
+	observations := pl.NewPoolObservationsTree(startTime)
+	setObservationsForTest(pool, observations)
 	slot0 := pool.Slot0()
-	uassert.NoError(t, writeObservationWithSlot0(observationState, &slot0, initTime, 5, pool.Liquidity()))
+	uassert.NoError(t, writeObservationWithSlot0(observations, &slot0, initTime, 5, pool.Liquidity()))
 	pool.SetSlot0(slot0)
 
 	tickCumulativeAtInit, secondsPerLiquidityAtInit, err := observeSingle(
-		observationState,
+		observations,
 		initTime,
 		0,
 		pool.Slot0Tick(),
@@ -534,7 +534,7 @@ func TestTickUpdateSeedsOracleOutsideForActiveTick(cur realm, t *testing.T) {
 
 	restoreContext := setOracleTestContext(initTime)
 	defer restoreContext()
-	_, err = updatePosition(pool, newModifyPositionParams(address("g1lp"), 0, 10, i256.NewInt(10)), pool.Slot0Tick())
+	_, err = updatePosition(pool, observationsForTest(pool), newModifyPositionParams(address("g1lp"), 0, 10, i256.NewInt(10)), pool.Slot0Tick())
 	uassert.NoError(t, err)
 
 	lowerTick := getTick(pool, 0)
@@ -543,7 +543,7 @@ func TestTickUpdateSeedsOracleOutsideForActiveTick(cur realm, t *testing.T) {
 	uassert.Equal(t, uint32(initTime), lowerTick.SecondsOutside())
 
 	tickCumulativeAtCross, secondsPerLiquidityAtCross, err := observeSingle(
-		observationState,
+		observations,
 		crossTime,
 		0,
 		pool.Slot0Tick(),

--- a/contract/r/gnoswap/pool/v1/twap_consistency_test.gno
+++ b/contract/r/gnoswap/pool/v1/twap_consistency_test.gno
@@ -182,7 +182,8 @@ func TestOracle_TWAPConsistencyCases(cur realm, t *testing.T) {
 			restoreContext := setOracleTestContext(tt.currentTime)
 			defer restoreContext()
 
-			got, _, err := oracleConsult(newTwapConsistencyPool(tt), tt.secondsAgo)
+			pool := newTwapConsistencyPool(tt)
+			got, _, err := oracleConsult(pool, observationsForTest(pool), tt.secondsAgo)
 			if tt.wantErr != "" {
 				uassert.ErrorContains(t, err, tt.wantErr)
 				return
@@ -211,7 +212,7 @@ func newTwapConsistencyPool(tt twapConsistencyCase) *pl.Pool {
 	slot0.SetTick(tt.currentTick)
 	pool.SetSlot0(slot0)
 	pool.SetLiquidity(u256.MustFromDecimal("1000"))
-	pool.SetObservationState(newTwapConsistencyObservationState(tt.observations))
+	setObservationsForTest(pool, newTwapConsistencyObservationTree(tt.observations))
 	slot0.SetObservationIndex(uint16(len(tt.observations) - 1))
 	slot0.SetObservationCardinality(uint16(len(tt.observations)))
 	slot0.SetObservationCardinalityNext(uint16(len(tt.observations)))
@@ -220,8 +221,8 @@ func newTwapConsistencyPool(tt twapConsistencyCase) *pl.Pool {
 	return pool
 }
 
-func newTwapConsistencyObservationState(observations []twapConsistencyObservation) *pl.ObservationState {
-	os := pl.NewObservationState(observations[0].timestamp)
+func newTwapConsistencyObservationTree(observations []twapConsistencyObservation) *pl.ObservationTree {
+	os := pl.NewPoolObservationsTree(observations[0].timestamp)
 
 	seeded := make(map[uint16]*pl.Observation)
 	for i, observation := range observations {
@@ -232,7 +233,9 @@ func newTwapConsistencyObservationState(observations []twapConsistencyObservatio
 			true,
 		)
 	}
-	os.SetObservations(seeded)
+	for index, observation := range seeded {
+		os.Set(index, observation)
+	}
 
 	return os
 }

--- a/contract/r/gnoswap/pool/v1/twap_consistency_test.gno
+++ b/contract/r/gnoswap/pool/v1/twap_consistency_test.gno
@@ -224,17 +224,13 @@ func newTwapConsistencyPool(tt twapConsistencyCase) *pl.Pool {
 func newTwapConsistencyObservationTree(observations []twapConsistencyObservation) *pl.ObservationTree {
 	os := pl.NewPoolObservationsTree(observations[0].timestamp)
 
-	seeded := make(map[uint16]*pl.Observation)
 	for i, observation := range observations {
-		seeded[uint16(i)] = pl.NewObservation(
+		os.Set(uint16(i), pl.NewObservation(
 			observation.timestamp,
 			observation.tickCumulative,
 			"0",
 			true,
-		)
-	}
-	for index, observation := range seeded {
-		os.Set(index, observation)
+		))
 	}
 
 	return os

--- a/contract/r/gnoswap/pool/v1/type.gno
+++ b/contract/r/gnoswap/pool/v1/type.gno
@@ -66,7 +66,7 @@ type SwapCache struct {
 	tickCumulative                    int64      // current tick accumulator value
 	secondsPerLiquidityCumulativeX128 *u256.Uint // current seconds per liquidity accumulator
 	computedLatestObservation         bool       // whether we've computed the above accumulators
-	slot0Start                        pl.Slot0     // immutable Slot0 snapshot captured at swap start
+	slot0Start                        pl.Slot0   // immutable Slot0 snapshot captured at swap start
 }
 
 func newSwapCache(

--- a/contract/r/gnoswap/pool/v1/utils_test.gno
+++ b/contract/r/gnoswap/pool/v1/utils_test.gno
@@ -1003,7 +1003,7 @@ func TestIterateTicksBoundary(cur realm, t *testing.T) {
 					tickUpper:      tickUpper,
 					liquidityDelta: i256.MustFromDecimal("1000000"),
 				}
-				_, _, _, err := modifyPosition(pool, params)
+				_, _, _, err := modifyPosition(pool, observationsForTest(pool), params)
 				if err != nil {
 					t.Logf("Warning: Failed to create position for tick %d: %v", tick, err)
 				}

--- a/contract/r/gnoswap/test/fuzz/_mock_test.gno
+++ b/contract/r/gnoswap/test/fuzz/_mock_test.gno
@@ -764,8 +764,8 @@ func newMockStakerStore() *MockStakerStore {
 		poolTierGetHalvingBlocksInRange: func(start, end int64) ([]int64, []int64, error) {
 			return emission.GetStakerEmissionAmountPerSecondInRange(start, end)
 		},
-		warmupTemplate:                   sr.DefaultWarmupTemplate(),
-		currentSwapBatch:                 swapBatch,
+		warmupTemplate:   sr.DefaultWarmupTemplate(),
+		currentSwapBatch: swapBatch,
 	}
 }
 

--- a/contract/r/gnoswap/test/fuzz/_mock_test.gno
+++ b/contract/r/gnoswap/test/fuzz/_mock_test.gno
@@ -18,6 +18,7 @@ import (
 
 type mockPoolStore struct {
 	pools                *bptree.BPTree
+	observations         *bptree.BPTree
 	feeAmountTickSpacing map[uint32]int32
 	slot0FeeProtocol     uint8
 	poolCreationFee      int64
@@ -42,6 +43,19 @@ func (s *mockPoolStore) GetPools() *bptree.BPTree {
 // SetPools stores the map containing all pool data.
 func (s *mockPoolStore) SetPools(_ int, rlm realm, pools *bptree.BPTree) error {
 	s.pools = pools
+	return nil
+}
+
+func (s *mockPoolStore) HasObservations() bool {
+	return s.observations != nil
+}
+
+func (s *mockPoolStore) GetObservations() *bptree.BPTree {
+	return s.observations
+}
+
+func (s *mockPoolStore) SetObservations(_ int, rlm realm, observations *bptree.BPTree) error {
+	s.observations = observations
 	return nil
 }
 
@@ -194,6 +208,7 @@ func NewMockPoolStoreWithHook(
 
 	return &mockPoolStore{
 		pools:                pool.NewPoolsTree(),
+		observations:         pool.NewObservationsTree(),
 		feeAmountTickSpacing: feeAmountTickSpacing,
 		slot0FeeProtocol:     0,
 		poolCreationFee:      100_000_000,


### PR DESCRIPTION
## Summary

Moves the oracle observation buffer out of each `Pool` object into store-backed B+trees. This keeps ordinary pool state compact while preserving the Uniswap-style oracle model introduced by #1407 and the public oracle surface in #1408.

```text
observations[poolPath][observationIndex] -> Observation
```

## Why

`Pool` previously owned an in-memory observation map. As cardinality grows, ordinary pool reads and updates become coupled to an ever-growing oracle buffer. This PR makes the buffer independent of pool state so a pool lookup does not load or clone its full observation history.

The contract is not deployed yet, so this is a direct storage-shape change: **no state migration, legacy compatibility layer, or fallback read path is included.**

## Design

- Remove `ObservationState` and `Pool.observationState`.
- Add `StoreKeyObservations`, with an outer B+tree keyed by `poolPath`.
- Store each pool's observations in a typed `ObservationTree`, keyed by `uint16` observation index.
- Move the fixed-width `uint16` key codec into `gno.land/p/gnoswap/utils`.
- Keep `observationIndex`, `observationCardinality`, and `observationCardinalityNext` in `Slot0`.
- Create the per-pool observation tree atomically with the pool and its initial observation.
- Validate the `pools` ↔ `observations` pairing during initializer/upgrade execution.
- Preserve Uniswap `Oracle.grow` economics: increasing `observationCardinalityNext` writes uninitialized placeholder observations immediately. The permissionless caller that reserves capacity pays the storage cost; later swappers do not inherit it.

The singleton-realm mapping is:

```text
GnoSwap: observations[poolPath][index]
Uniswap: observations[index]
```

## Correctness hardening

- Remove redundant pre-transform writes in `writeObservation`.
- Guard uninitialized `ObservationTree` access and update stale clone documentation.
- Abort public mutations that encounter a missing pool observation tree, and cover that boundary with regression tests.

## Scope

Updates every oracle read/write path: swap, position updates, dry-swap snapshots, getters, upgrade fixtures, scenarios, and fuzz mocks. The whole-buffer getter remains absent; consumers use PR2 `GetObservationAt` and `Observe` APIs.

## Dependency

Depends on #1408.

## Validation

- `make test PKG=gno.land/r/gnoswap/pool/v1`
- `make test PKG=gno.land/r/gnoswap/scenario/pool`
- `make test PKG=gno.land/r/gnoswap/test/fuzz`