### PR TITLE
fix(staker): decouple unstaking from reward payout

### DIFF
--- a/contract/r/gnoswap/staker/README.md
+++ b/contract/r/gnoswap/staker/README.md
@@ -48,11 +48,24 @@ Stakes LP position NFT to earn rewards.
 
 ### `UnStakeToken`
 
-Unstakes position and collects all rewards.
+Unstakes a position and settles its rewards into the claimable ledger. The rewards are not
+transferred here: withdrawing a position must never depend on a reward transfer succeeding,
+so payout is left to `ClaimRewards`.
 
 ### `CollectReward`
 
-Collects accumulated rewards without unstaking.
+Collects accumulated rewards without unstaking: settles them, then pays out the ledger.
+
+### `ClaimRewards`
+
+Pays out the caller's settled-but-unpaid rewards. Each token is paid independently, and a
+token the staker reserve cannot currently cover stays claimable instead of aborting.
+
+### `ClaimRewardsFor`
+
+Same payout for another receiver. Permissionless, since the funds only ever reach the
+ledger owner; it exists so the community pool's share can be flushed after unstake-only
+flows.
 
 ### `CreateExternalIncentive`
 
@@ -185,8 +198,11 @@ CreateExternalIncentive(
 // Collect rewards without unstaking
 CollectReward(123)
 
-// Unstake and collect all rewards
+// Unstake; rewards are settled, not paid
 UnStakeToken(123)
+
+// Withdraw everything settled so far
+ClaimRewards()
 ```
 
 ## Security

--- a/contract/r/gnoswap/staker/_mock_test.gno
+++ b/contract/r/gnoswap/staker/_mock_test.gno
@@ -132,6 +132,42 @@ func (m *MockStaker) SetUnStakingFee(_ int, rlm realm, fee uint64) {
 	m.Response.Get("SetUnStakingFee")
 }
 
+func (m *MockStaker) ClaimRewards(_ int, rlm realm) map[string]int64 {
+	res, ok := m.Response.Get("ClaimRewards")
+	if !ok {
+		return make(map[string]int64)
+	}
+
+	return res[0].(map[string]int64)
+}
+
+func (m *MockStaker) ClaimRewardsFor(_ int, rlm realm, receiver address) map[string]int64 {
+	res, ok := m.Response.Get("ClaimRewardsFor")
+	if !ok {
+		return make(map[string]int64)
+	}
+
+	return res[0].(map[string]int64)
+}
+
+func (m *MockStaker) GetClaimableRewardsOf(receiver address) map[string]int64 {
+	res, ok := m.Response.Get("GetClaimableRewardsOf")
+	if !ok {
+		return make(map[string]int64)
+	}
+
+	return res[0].(map[string]int64)
+}
+
+func (m *MockStaker) GetClaimableReward(receiver address, tokenPath string) int64 {
+	res, ok := m.Response.Get("GetClaimableReward")
+	if !ok {
+		return 0
+	}
+
+	return res[0].(int64)
+}
+
 func (m *MockStaker) GetPendingProtocolFees() map[string]int64 {
 	res, ok := m.Response.Get("GetPendingProtocolFees")
 	if !ok {

--- a/contract/r/gnoswap/staker/getter.gno
+++ b/contract/r/gnoswap/staker/getter.gno
@@ -300,3 +300,14 @@ func GetPoolHistoricalTicks(poolPath string) *rotree.ReadOnlyTree {
 func GetPendingProtocolFees() map[string]int64 {
 	return cloneStringInt64Map(getImplementation().GetPendingProtocolFees())
 }
+
+// GetClaimableRewardsOf returns receiver's settled-but-unpaid reward amounts, keyed by
+// token path.
+func GetClaimableRewardsOf(receiver address) map[string]int64 {
+	return cloneStringInt64Map(getImplementation().GetClaimableRewardsOf(receiver))
+}
+
+// GetClaimableReward returns receiver's settled-but-unpaid amount for a single token.
+func GetClaimableReward(receiver address, tokenPath string) int64 {
+	return getImplementation().GetClaimableReward(receiver, tokenPath)
+}

--- a/contract/r/gnoswap/staker/proxy.gno
+++ b/contract/r/gnoswap/staker/proxy.gno
@@ -12,13 +12,17 @@ func StakeToken(cur realm, positionId uint64, referrer string) string {
 	return getImplementation().StakeToken(0, cur, positionId, referrer)
 }
 
-// UnStakeToken unstakes a position NFT and collects rewards.
+// UnStakeToken unstakes a position NFT and settles its rewards into the claimable ledger.
+//
+// The settled rewards are NOT transferred here; withdraw them with ClaimRewards. Keeping
+// payout out of this path is what guarantees a position can always be withdrawn, even when
+// a reward transfer would fail.
 //
 // Parameters:
 //   - positionId: ID of the position to unstake
 //
 // Returns:
-//   - string: collected reward details
+//   - string: pool path the position was staked in
 func UnStakeToken(cur realm, positionId uint64) string {
 	return getImplementation().UnStakeToken(0, cur, positionId)
 }
@@ -36,6 +40,28 @@ func UnStakeToken(cur realm, positionId uint64) string {
 func CollectReward(cur realm, positionId uint64) (string, string, map[string]int64, map[string]int64) {
 	poolPath, stakingDetails, internalRewards, externalRewards := getImplementation().CollectReward(0, cur, positionId)
 	return poolPath, stakingDetails, cloneStringInt64Map(internalRewards), cloneStringInt64Map(externalRewards)
+}
+
+// ClaimRewards pays out every reward that has already been settled for the caller.
+//
+// Rewards are settled into the claimable ledger by CollectReward and by UnStakeToken. This
+// is the withdrawal half, and it needs no staked position: a position can be unstaked
+// first and its rewards claimed afterwards.
+//
+// Returns the amount paid per token path.
+func ClaimRewards(cur realm) map[string]int64 {
+	return cloneStringInt64Map(getImplementation().ClaimRewards(0, cur))
+}
+
+// ClaimRewardsFor pays out receiver's settled rewards to receiver.
+//
+// Permissionless: the funds only ever reach the ledger owner. It exists so anyone can flush
+// the community pool's share (internal penalties and unclaimable rewards) after positions
+// are unstaked without collecting.
+//
+// Returns the amount paid per token path.
+func ClaimRewardsFor(cur realm, receiver address) map[string]int64 {
+	return cloneStringInt64Map(getImplementation().ClaimRewardsFor(0, cur, receiver))
 }
 
 // SetPoolTier sets the reward tier for a pool.

--- a/contract/r/gnoswap/staker/store.gno
+++ b/contract/r/gnoswap/staker/store.gno
@@ -24,6 +24,7 @@ const (
 	StoreKeyTokenSpecificMinimumRewards      StoreKey = "tokenSpecificMinimumRewards"
 	StoreKeyUnstakingFee                     StoreKey = "unstakingFee"
 	StoreKeyPendingProtocolFees              StoreKey = "pendingProtocolFees"
+	StoreKeyClaimableRewards                 StoreKey = "claimableRewards"
 	StoreKeyPools                            StoreKey = "pools"
 	StoreKeyPoolTierMemberships              StoreKey = "poolTierMemberships"
 	StoreKeyPoolTierRatio                    StoreKey = "poolTierRatio"
@@ -383,6 +384,33 @@ func (s *stakerStore) SetPendingProtocolFees(_ int, rlm realm, fees map[string]i
 	}
 
 	return s.kvStore.Set(0, rlm, StoreKeyPendingProtocolFees.String(), fees)
+}
+
+// ClaimableRewards
+func (s *stakerStore) HasClaimableRewardsStoreKey() bool {
+	return s.kvStore.Has(StoreKeyClaimableRewards.String())
+}
+
+func (s *stakerStore) GetClaimableRewards() *bptree.BPTree {
+	result, err := s.kvStore.Get(StoreKeyClaimableRewards.String())
+	if err != nil {
+		panic(err)
+	}
+
+	rewards, ok := result.(*bptree.BPTree)
+	if !ok {
+		panic(ufmt.Sprintf("failed to cast result to *bptree.BPTree: %T", result))
+	}
+
+	return rewards
+}
+
+func (s *stakerStore) SetClaimableRewards(_ int, rlm realm, rewards *bptree.BPTree) error {
+	if !rlm.IsCurrent() {
+		return errors.New(ErrSpoofedRealm)
+	}
+
+	return s.kvStore.Set(0, rlm, StoreKeyClaimableRewards.String(), rewards)
 }
 
 // Pools

--- a/contract/r/gnoswap/staker/types.gno
+++ b/contract/r/gnoswap/staker/types.gno
@@ -15,6 +15,8 @@ type IStakerManager interface {
 	StakeToken(_ int, rlm realm, positionId uint64, referrer string) string
 	UnStakeToken(_ int, rlm realm, positionId uint64) string
 	CollectReward(_ int, rlm realm, positionId uint64) (string, string, map[string]int64, map[string]int64)
+	ClaimRewards(_ int, rlm realm) map[string]int64
+	ClaimRewardsFor(_ int, rlm realm, receiver address) map[string]int64
 
 	SetPoolTier(_ int, rlm realm, poolPath string, tier uint64)
 	ChangePoolTier(_ int, rlm realm, poolPath string, tier uint64)
@@ -94,6 +96,8 @@ type IStakerGetter interface {
 	GetTargetPoolPathByIncentiveId(poolPath string, incentiveId string) string
 	GetUnstakingFee() uint64
 	GetPendingProtocolFees() map[string]int64
+	GetClaimableRewardsOf(receiver address) map[string]int64
+	GetClaimableReward(receiver address, tokenPath string) int64
 	IsStaked(positionId uint64) bool
 	GetTotalEmissionSent() int64
 	GetAllowedTokens() []string
@@ -154,6 +158,11 @@ type IStakerStore interface {
 	HasPendingProtocolFeesStoreKey() bool
 	GetPendingProtocolFees() map[string]int64
 	SetPendingProtocolFees(_ int, rlm realm, fees map[string]int64) error
+
+	// ClaimableRewards
+	HasClaimableRewardsStoreKey() bool
+	GetClaimableRewards() *bptree.BPTree
+	SetClaimableRewards(_ int, rlm realm, rewards *bptree.BPTree) error
 
 	// Pools
 	HasPoolsStoreKey() bool

--- a/contract/r/gnoswap/staker/v1/README.md
+++ b/contract/r/gnoswap/staker/v1/README.md
@@ -170,8 +170,11 @@ CreateExternalIncentive(
 // Collect rewards without unstaking
 CollectReward(123)
 
-// Unstake and collect all rewards
+// Unstake; rewards are settled, not paid
 UnStakeToken(123)
+
+// Withdraw everything settled so far
+ClaimRewards()
 ```
 
 ## Security

--- a/contract/r/gnoswap/staker/v1/_mock_test.gno
+++ b/contract/r/gnoswap/staker/v1/_mock_test.gno
@@ -24,6 +24,7 @@ type MockStakerStore struct {
 	tokenSpecificMinimumRewards      map[string]int64
 	unstakingFee                     uint64
 	pendingProtocolFees              map[string]int64
+	claimableRewards                 *bptree.BPTree
 	pools                            *bptree.BPTree
 	poolTierMemberships              *bptree.BPTree
 	poolTierRatio                    sr.TierRatio
@@ -213,6 +214,20 @@ func (s *MockStakerStore) SetPendingProtocolFees(_ int, rlm realm, fees map[stri
 	return nil
 }
 
+// ClaimableRewards
+func (s *MockStakerStore) HasClaimableRewardsStoreKey() bool {
+	return s.claimableRewards != nil
+}
+
+func (s *MockStakerStore) GetClaimableRewards() *bptree.BPTree {
+	return s.claimableRewards
+}
+
+func (s *MockStakerStore) SetClaimableRewards(_ int, rlm realm, rewards *bptree.BPTree) error {
+	s.claimableRewards = rewards
+	return nil
+}
+
 // Pools
 func (s *MockStakerStore) HasPoolsStoreKey() bool {
 	return s.pools != nil
@@ -367,6 +382,7 @@ func newMockStakerStore() *MockStakerStore {
 		tokenSpecificMinimumRewards:      make(map[string]int64),
 		unstakingFee:                     0,
 		pendingProtocolFees:              make(map[string]int64),
+		claimableRewards:                 sr.NewBPTreeN(16),
 		pools:                            sr.NewBPTreeN(16),
 		poolTierMemberships:              sr.NewBPTreeN(16),
 		poolTierRatio:                    sr.NewTierRatio(0, 0, 0),

--- a/contract/r/gnoswap/staker/v1/claimable_reward.gno
+++ b/contract/r/gnoswap/staker/v1/claimable_reward.gno
@@ -1,0 +1,252 @@
+package staker
+
+import (
+	"chain"
+	"chain/runtime"
+	"time"
+
+	bptree "gno.land/p/nt/bptree/v0"
+	ufmt "gno.land/p/nt/ufmt/v0"
+
+	"gno.land/p/gnoswap/gnsmath"
+	prbac "gno.land/p/gnoswap/rbac"
+	"gno.land/p/gnoswap/utils"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/common"
+	en "gno.land/r/gnoswap/emission"
+	"gno.land/r/gnoswap/halt"
+	sr "gno.land/r/gnoswap/staker"
+)
+
+// claimableRewardKeySeparator separates the receiver address from the token path in a
+// ledger key. Neither an address nor a token path can contain it, so a key round-trips
+// unambiguously and a receiver's entries form a contiguous key range.
+const claimableRewardKeySeparator = "\x00"
+
+// claimableRewardRangeEnd terminates a receiver's key range. Iterate treats end as
+// exclusive, and "\x01" is the smallest string that sorts after every key prefixed with
+// the receiver plus the separator.
+const claimableRewardRangeEnd = "\x01"
+
+// ClaimableRewards is the ledger of settled-but-not-yet-paid reward amounts, keyed by
+// (receiver, token path).
+//
+// Reward settlement credits this ledger instead of transferring tokens, so the accounting
+// half of a collect can never be blocked by the payout half. Payout drains the ledger in a
+// separate step (CollectReward's tail, or ClaimRewards), and anything that cannot be paid
+// right now stays here until it can.
+type ClaimableRewards struct {
+	tree *bptree.BPTree
+}
+
+// NewClaimableRewards creates an empty claimable reward ledger.
+func NewClaimableRewards() *ClaimableRewards {
+	return &ClaimableRewards{
+		tree: sr.NewBPTreeN(16), // receiver|tokenPath -> int64
+	}
+}
+
+// claimableRewardEntry is one ledger row.
+type claimableRewardEntry struct {
+	tokenPath string
+	amount    int64
+}
+
+// claimableRewardKey builds the ledger key for a (receiver, token path) pair.
+func claimableRewardKey(receiver address, tokenPath string) string {
+	return receiver.String() + claimableRewardKeySeparator + tokenPath
+}
+
+// get returns the amount currently claimable by receiver for tokenPath.
+func (self *ClaimableRewards) get(receiver address, tokenPath string) int64 {
+	value := self.tree.Get(claimableRewardKey(receiver, tokenPath))
+	if value == nil {
+		return 0
+	}
+
+	amount, ok := value.(int64)
+	if !ok {
+		panic(ufmt.Sprintf("failed to cast claimable reward to int64: %T", value))
+	}
+
+	return amount
+}
+
+// add credits amount to the receiver's balance for tokenPath. Non-positive amounts are
+// ignored so the ledger only ever holds payable rows.
+func (self *ClaimableRewards) add(receiver address, tokenPath string, amount int64) {
+	if amount <= 0 {
+		return
+	}
+
+	self.tree.Set(
+		claimableRewardKey(receiver, tokenPath),
+		gnsmath.SafeAddInt64(self.get(receiver, tokenPath), amount),
+	)
+}
+
+// remove clears the receiver's balance for tokenPath.
+func (self *ClaimableRewards) remove(receiver address, tokenPath string) {
+	self.tree.Remove(claimableRewardKey(receiver, tokenPath))
+}
+
+// entriesOf returns every ledger row belonging to receiver.
+//
+// The rows are materialized before they are returned because callers remove them while
+// paying out, and mutating the tree mid-iteration is not safe.
+func (self *ClaimableRewards) entriesOf(receiver address) []claimableRewardEntry {
+	entries := make([]claimableRewardEntry, 0)
+
+	prefix := receiver.String() + claimableRewardKeySeparator
+	self.tree.Iterate(prefix, receiver.String()+claimableRewardRangeEnd, func(key string, value any) bool {
+		amount, ok := value.(int64)
+		if !ok {
+			panic(ufmt.Sprintf("failed to cast claimable reward to int64: %T", value))
+		}
+
+		entries = append(entries, claimableRewardEntry{
+			tokenPath: key[len(prefix):],
+			amount:    amount,
+		})
+
+		return false
+	})
+
+	return entries
+}
+
+// getClaimableRewards returns the claimable reward ledger backed by the store.
+func (s *stakerV1) getClaimableRewards() *ClaimableRewards {
+	return &ClaimableRewards{
+		tree: s.store.GetClaimableRewards(),
+	}
+}
+
+// creditClaimableReward records amount as owed to receiver in tokenPath, without moving
+// any tokens.
+func (s *stakerV1) creditClaimableReward(receiver address, tokenPath string, amount int64) {
+	s.getClaimableRewards().add(receiver, tokenPath, amount)
+}
+
+// payoutClaimableRewards drains the receiver's ledger rows and transfers them out.
+//
+// Every token is handled independently and best-effort: a token the staker realm cannot
+// currently cover is left in the ledger (and reported through an event) rather than
+// aborting the whole payout, so one short or misbehaving reward token cannot strand the
+// rest. Pending protocol fees for the token are forwarded first, but only when the
+// balance covers both, so fee forwarding can never eat into what the receiver is owed.
+//
+// Returns the amount actually paid per token path.
+func (s *stakerV1) payoutClaimableRewards(_ int, rlm realm, receiver address) map[string]int64 {
+	paid := make(map[string]int64)
+
+	claimable := s.getClaimableRewards()
+	entries := claimable.entriesOf(receiver)
+	if len(entries) == 0 {
+		return paid
+	}
+
+	stakerAddr := access.MustGetAddress(prbac.ROLE_STAKER.String())
+	previousRealm := rlm.Previous()
+
+	for _, entry := range entries {
+		if entry.amount <= 0 {
+			claimable.remove(receiver, entry.tokenPath)
+			continue
+		}
+
+		balance := common.BalanceOf(entry.tokenPath, stakerAddr)
+		if balance < entry.amount {
+			chain.Emit(
+				"InsufficientClaimableReward",
+				"prevAddr", previousRealm.Address().String(),
+				"prevRealm", previousRealm.PkgPath(),
+				"receiver", receiver.String(),
+				"tokenPath", entry.tokenPath,
+				"claimableAmount", utils.FormatInt(entry.amount),
+				"availableAmount", utils.FormatInt(balance),
+				"currentTime", utils.FormatInt(time.Now().Unix()),
+				"currentHeight", utils.FormatInt(runtime.ChainHeight()),
+			)
+
+			continue
+		}
+
+		// Effects before interactions: the row is cleared before anything leaves this
+		// realm, so a re-entrant claim cannot see it twice.
+		claimable.remove(receiver, entry.tokenPath)
+
+		pendingProtocolFee := s.store.GetPendingProtocolFees()[entry.tokenPath]
+		if pendingProtocolFee > 0 && balance >= gnsmath.SafeAddInt64(pendingProtocolFee, entry.amount) {
+			s.settleProtocolFee(0, rlm, entry.tokenPath, 0)
+		}
+
+		common.SafeGRC20Transfer(0, rlm, entry.tokenPath, receiver, entry.amount)
+
+		paid[entry.tokenPath] = entry.amount
+
+		chain.Emit(
+			"ClaimReward",
+			"prevAddr", previousRealm.Address().String(),
+			"prevRealm", previousRealm.PkgPath(),
+			"receiver", receiver.String(),
+			"tokenPath", entry.tokenPath,
+			"amount", utils.FormatInt(entry.amount),
+			"currentTime", utils.FormatInt(time.Now().Unix()),
+			"currentHeight", utils.FormatInt(runtime.ChainHeight()),
+		)
+	}
+
+	return paid
+}
+
+// ClaimRewards pays out every reward the caller has already had settled.
+//
+// Rewards are settled into the claimable ledger by CollectReward and by UnStakeToken; this
+// is the withdrawal half. It carries no dependency on a staked position, so a position can
+// be unstaked first and its rewards claimed later.
+//
+// Returns the amount paid per token path.
+func (s *stakerV1) ClaimRewards(_ int, rlm realm) map[string]int64 {
+	access.AssertIsRlmCurrent(0, rlm)
+
+	halt.AssertIsNotHaltedWithdraw()
+
+	en.MintAndDistributeGns(cross(rlm))
+
+	return s.payoutClaimableRewards(0, rlm, rlm.Previous().Address())
+}
+
+// ClaimRewardsFor pays out receiver's settled rewards to receiver.
+//
+// Permissionless by design: the funds can only ever reach the ledger owner, and an open
+// entry point is what lets the community pool's share (internal penalties and unclaimable
+// rewards) be flushed after an unstake-only flow.
+//
+// Returns the amount paid per token path.
+func (s *stakerV1) ClaimRewardsFor(_ int, rlm realm, receiver address) map[string]int64 {
+	access.AssertIsRlmCurrent(0, rlm)
+
+	halt.AssertIsNotHaltedWithdraw()
+
+	en.MintAndDistributeGns(cross(rlm))
+
+	return s.payoutClaimableRewards(0, rlm, receiver)
+}
+
+// GetClaimableRewardsOf returns every settled-but-unpaid reward amount of receiver, keyed
+// by token path.
+func (s *stakerV1) GetClaimableRewardsOf(receiver address) map[string]int64 {
+	rewards := make(map[string]int64)
+	for _, entry := range s.getClaimableRewards().entriesOf(receiver) {
+		rewards[entry.tokenPath] = entry.amount
+	}
+
+	return rewards
+}
+
+// GetClaimableReward returns receiver's settled-but-unpaid amount for a single token.
+func (s *stakerV1) GetClaimableReward(receiver address, tokenPath string) int64 {
+	return s.getClaimableRewards().get(receiver, tokenPath)
+}

--- a/contract/r/gnoswap/staker/v1/claimable_reward_test.gno
+++ b/contract/r/gnoswap/staker/v1/claimable_reward_test.gno
@@ -1,0 +1,88 @@
+package staker
+
+import (
+	"testing"
+
+	uassert "gno.land/p/nt/uassert/v0"
+
+	"gno.land/r/gnoswap/gns"
+)
+
+func TestClaimableRewardsLedger(cur realm, t *testing.T) {
+	ledger := NewClaimableRewards()
+
+	uassert.Equal(t, int64(0), ledger.get(addr01, gnsPath))
+
+	ledger.add(addr01, gnsPath, 100)
+	ledger.add(addr01, gnsPath, 50)
+	ledger.add(addr01, barPath, 7)
+	ledger.add(addr02, gnsPath, 3)
+
+	// Non-positive credits are dropped so the ledger only holds payable rows.
+	ledger.add(addr01, bazPath, 0)
+	ledger.add(addr01, bazPath, -5)
+
+	uassert.Equal(t, int64(150), ledger.get(addr01, gnsPath))
+	uassert.Equal(t, int64(7), ledger.get(addr01, barPath))
+	uassert.Equal(t, int64(3), ledger.get(addr02, gnsPath))
+	uassert.Equal(t, int64(0), ledger.get(addr01, bazPath))
+
+	// A receiver only ever sees its own rows.
+	entries := ledger.entriesOf(addr01)
+	uassert.Equal(t, 2, len(entries))
+
+	amountByToken := make(map[string]int64)
+	for _, entry := range entries {
+		amountByToken[entry.tokenPath] = entry.amount
+	}
+	uassert.Equal(t, int64(150), amountByToken[gnsPath])
+	uassert.Equal(t, int64(7), amountByToken[barPath])
+
+	ledger.remove(addr01, gnsPath)
+	uassert.Equal(t, int64(0), ledger.get(addr01, gnsPath))
+	uassert.Equal(t, 1, len(ledger.entriesOf(addr01)))
+	uassert.Equal(t, int64(3), ledger.get(addr02, gnsPath))
+}
+
+func TestPayoutClaimableRewardsPaysAndClearsLedger(cur realm, t *testing.T) {
+	initStakerTest(cur, t)
+	instance := getMockInstance()
+
+	claimable := int64(12_345)
+	instance.creditClaimableReward(addr01, GNS_TOKEN_KEY, claimable)
+
+	// The payout checks the ROLE_STAKER reserve, while the local mock instance transfers
+	// as staker/v1 (see stakerV1Addr), so both need to hold the reward.
+	testing.SetRealm(adminRealm)
+	gns.Transfer(cross(cur), stakerAddr, claimable)
+	gns.Transfer(cross(cur), stakerV1Addr, claimable)
+
+	balanceBefore := gns.BalanceOf(addr01)
+
+	testing.SetRealm(stakerRealm)
+	paid := instance.payoutClaimableRewards(0, cur, addr01)
+
+	uassert.Equal(t, claimable, paid[GNS_TOKEN_KEY])
+	uassert.Equal(t, balanceBefore+claimable, gns.BalanceOf(addr01))
+	uassert.Equal(t, int64(0), instance.GetClaimableReward(addr01, GNS_TOKEN_KEY))
+}
+
+// A token the reserve cannot cover is left claimable rather than aborting the payout, so a
+// short reserve can never strand a receiver's other rewards - and, more importantly, can
+// never propagate back into unstaking.
+func TestPayoutClaimableRewardsSkipsUnaffordableToken(cur realm, t *testing.T) {
+	initStakerTest(cur, t)
+	instance := getMockInstance()
+
+	unaffordable := int64(1_000_000_000_000_000_000)
+	instance.creditClaimableReward(addr01, GNS_TOKEN_KEY, unaffordable)
+
+	balanceBefore := gns.BalanceOf(addr01)
+
+	testing.SetRealm(stakerRealm)
+	paid := instance.payoutClaimableRewards(0, cur, addr01)
+
+	uassert.Equal(t, 0, len(paid))
+	uassert.Equal(t, balanceBefore, gns.BalanceOf(addr01))
+	uassert.Equal(t, unaffordable, instance.GetClaimableReward(addr01, GNS_TOKEN_KEY))
+}

--- a/contract/r/gnoswap/staker/v1/init.gno
+++ b/contract/r/gnoswap/staker/v1/init.gno
@@ -115,6 +115,13 @@ func initStoreData(_ int, rlm realm, stakerStore sr.IStakerStore, emissionAccess
 		}
 	}
 
+	if !stakerStore.HasClaimableRewardsStoreKey() {
+		err := stakerStore.SetClaimableRewards(0, rlm, sr.NewBPTreeN(16))
+		if err != nil {
+			return err
+		}
+	}
+
 	if !stakerStore.HasWarmupTemplateStoreKey() {
 		err := stakerStore.SetWarmupTemplate(0, rlm, sr.DefaultWarmupTemplate())
 		if err != nil {

--- a/contract/r/gnoswap/staker/v1/protocol_fee_unstaking.gno
+++ b/contract/r/gnoswap/staker/v1/protocol_fee_unstaking.gno
@@ -17,8 +17,14 @@ import (
 // GetUnstakingFee returns the current unstaking fee rate in basis points.
 func (s *stakerV1) GetUnstakingFee() uint64 { return s.store.GetUnstakingFee() }
 
-// handleStakingRewardFee calculates and applies the unstaking fee.
-func (s *stakerV1) handleStakingRewardFee(
+// accrueStakingRewardFee splits amount into the receiver portion and the protocol fee
+// portion, recording the fee as pending instead of forwarding it.
+//
+// It performs no cross-realm call at all, so reward settlement (and therefore unstaking)
+// cannot be blocked by a halted protocol fee realm or by a reward token whose
+// approve/transfer reverts. The recorded fee is forwarded by settleProtocolFee on the next
+// payout for the same token.
+func (s *stakerV1) accrueStakingRewardFee(
 	_ int,
 	rlm realm,
 	tokenPath string,
@@ -31,7 +37,6 @@ func (s *stakerV1) handleStakingRewardFee(
 
 	unstakingFee := s.GetUnstakingFee()
 	if unstakingFee == 0 {
-		s.settleProtocolFee(0, rlm, tokenPath, 0)
 		return amount, 0, nil
 	}
 
@@ -42,11 +47,10 @@ func (s *stakerV1) handleStakingRewardFee(
 	}
 
 	if feeAmount == 0 {
-		s.settleProtocolFee(0, rlm, tokenPath, 0)
 		return amount, 0, nil
 	}
 
-	s.settleProtocolFee(0, rlm, tokenPath, feeAmount)
+	s.addPendingProtocolFee(0, rlm, tokenPath, feeAmount)
 
 	return gnsmath.SafeSubInt64(amount, feeAmount), feeAmount, nil
 }

--- a/contract/r/gnoswap/staker/v1/protocol_fee_unstaking_test.gno
+++ b/contract/r/gnoswap/staker/v1/protocol_fee_unstaking_test.gno
@@ -7,7 +7,6 @@ import (
 	uassert "gno.land/p/nt/uassert/v0"
 	ufmt "gno.land/p/nt/ufmt/v0"
 	"gno.land/r/gnoswap/gns"
-	"gno.land/r/onbloc/foo"
 
 	_ "gno.land/r/gnoswap/rbac"
 
@@ -15,82 +14,53 @@ import (
 	_ "gno.land/r/gnoswap/protocol_fee/v1"
 )
 
-func TestHandleStakingRewardFee(cur realm, t *testing.T) {
+func TestAccrueStakingRewardFee(cur realm, t *testing.T) {
 	tests := []struct {
-		name             string
-		tokenPath        string
-		amount           int64
-		stakerBalance    int64
-		internal         bool
-		expectedFee      int64
-		expectedNet      int64
-		expectedHasPanic bool
-		expectedPanicMsg string
+		name        string
+		tokenPath   string
+		amount      int64
+		internal    bool
+		expectedFee int64
+		expectedNet int64
 	}{
 		{
-			name:          "No fee configured",
-			tokenPath:     gnsPath,
-			amount:        10000,
-			stakerBalance: 0,
-			internal:      true,
-			expectedFee:   0,
-			expectedNet:   10000,
+			name:        "No fee configured",
+			tokenPath:   gnsPath,
+			amount:      10000,
+			internal:    true,
+			expectedFee: 0,
+			expectedNet: 10000,
 		},
 		{
-			name:          "Standard fee",
-			tokenPath:     fooPath,
-			amount:        10000,
-			stakerBalance: 100,
-			internal:      false,
-			expectedFee:   100,
-			expectedNet:   9900,
+			name:        "Standard fee",
+			tokenPath:   fooPath,
+			amount:      10000,
+			internal:    false,
+			expectedFee: 100,
+			expectedNet: 9900,
 		},
 		{
-			name:             "Standard fee but staker balance is insufficient",
-			tokenPath:        fooPath,
-			amount:           10000,
-			stakerBalance:    0,
-			internal:         false,
-			expectedFee:      100,
-			expectedNet:      9900,
-			expectedHasPanic: true,
-			expectedPanicMsg: "insufficient balance",
+			// Accrual never transfers, so an empty staker reserve changes nothing:
+			// the fee is only recorded as pending here.
+			name:        "Standard fee without any staker balance",
+			tokenPath:   fooPath,
+			amount:      10000,
+			internal:    false,
+			expectedFee: 100,
+			expectedNet: 9900,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(cur realm, t *testing.T) {
 			initStakerTest(cur, t)
+			instance := getMockInstance()
 
-			getMockInstance().store.SetUnstakingFee(0, cur, uint64(tc.expectedFee)) // Set the fee globally for the test
+			instance.store.SetUnstakingFee(0, cur, uint64(tc.expectedFee)) // Set the fee globally for the test
 
-			if tc.stakerBalance > 0 {
-				testing.SetRealm(adminRealm)
-				foo.Transfer(cross(cur), stakerAddr, tc.stakerBalance)
-				// The local mock instance pays the protocol fee from the
-				// staker/v1 realm (the cross(rlm) transfer actor), so fund it too.
-				foo.Transfer(cross(cur), stakerV1Addr, tc.stakerBalance)
-			}
-
-			// Set the caller identity on the test frame's own cur so the
-			// protocol_fee crossing inside handleStakingRewardFee sees the staker
-			// role as cur.Previous(). Setting it inside a nested closure would
-			// only mutate that closure's frame, not the cur passed below.
 			testing.SetRealm(stakerRealm)
 
-			handleStakingRewardFeeFn := func() (int64, int64, error) {
-				return getMockInstance().handleStakingRewardFee(0, cur, tc.tokenPath, tc.amount, tc.internal)
-			}
-
-			if tc.expectedHasPanic {
-				uassert.AbortsWithMessage(t, cur, tc.expectedPanicMsg, func() {
-					handleStakingRewardFeeFn()
-				})
-
-				return
-			}
-
-			netAmount, _, err := handleStakingRewardFeeFn()
+			netAmount, feeAmount, err := instance.accrueStakingRewardFee(0, cur, tc.tokenPath, tc.amount, tc.internal)
 			if err != nil {
 				t.Errorf("Expected no error, got %v", err)
 			}
@@ -98,8 +68,34 @@ func TestHandleStakingRewardFee(cur realm, t *testing.T) {
 			if netAmount != tc.expectedNet {
 				t.Errorf("Expected netAmount %d, got %d", tc.expectedNet, netAmount)
 			}
+
+			expectedFeeTokenPath := tc.tokenPath
+			if tc.internal {
+				expectedFeeTokenPath = GNS_TOKEN_KEY
+			}
+
+			uassert.Equal(t, tc.expectedFee, feeAmount)
+			uassert.Equal(t, feeAmount, instance.store.GetPendingProtocolFees()[expectedFeeTokenPath])
 		})
 	}
+}
+
+// Forwarding an accrued fee still needs the reserve to cover it. The failure is confined
+// to the payout path, which is why accrual records the fee instead of forwarding it.
+func TestSettleProtocolFeeWithInsufficientBalance(cur realm, t *testing.T) {
+	initStakerTest(cur, t)
+	instance := getMockInstance()
+
+	instance.store.SetUnstakingFee(0, cur, 100)
+
+	testing.SetRealm(stakerRealm)
+	_, feeAmount, err := instance.accrueStakingRewardFee(0, cur, fooPath, 10000, false)
+	uassert.NoError(t, err)
+	uassert.Equal(t, int64(100), feeAmount)
+
+	uassert.AbortsWithMessage(t, cur, "insufficient balance", func() {
+		instance.settleProtocolFee(0, cur, fooPath, 0)
+	})
 }
 
 func TestAddPendingProtocolFee(cur realm, t *testing.T) {
@@ -308,8 +304,8 @@ func TestSetUnStakingFeeInternal(cur realm, t *testing.T) {
 	}
 }
 
-// Test handleStakingRewardFee with various scenarios
-func TestHandleStakingRewardFeeEdgeCases(cur realm, t *testing.T) {
+// Test accrueStakingRewardFee with various scenarios
+func TestAccrueStakingRewardFeeEdgeCases(cur realm, t *testing.T) {
 	tests := []struct {
 		name         string
 		tokenPath    string
@@ -394,7 +390,7 @@ func TestHandleStakingRewardFeeEdgeCases(cur realm, t *testing.T) {
 			}
 
 			testing.SetRealm(stakerRealm)
-			netAmount, feeAmount, err := instance.handleStakingRewardFee(0, cur, tt.tokenPath, tt.amount, tt.internal)
+			netAmount, feeAmount, err := instance.accrueStakingRewardFee(0, cur, tt.tokenPath, tt.amount, tt.internal)
 
 			if tt.expectError {
 				uassert.Error(t, err)
@@ -407,8 +403,8 @@ func TestHandleStakingRewardFeeEdgeCases(cur realm, t *testing.T) {
 	}
 }
 
-// Test handleStakingRewardFee calculation precision
-func TestHandleStakingRewardFeeCalculationPrecision(cur realm, t *testing.T) {
+// Test accrueStakingRewardFee calculation precision
+func TestAccrueStakingRewardFeeCalculationPrecision(cur realm, t *testing.T) {
 	tests := []struct {
 		name        string
 		amount      int64

--- a/contract/r/gnoswap/staker/v1/staker.gno
+++ b/contract/r/gnoswap/staker/v1/staker.gno
@@ -15,11 +15,8 @@ import (
 	"gno.land/r/gnoswap/access"
 	_ "gno.land/r/gnoswap/rbac"
 
-	"gno.land/r/gnoswap/common"
 	"gno.land/r/gnoswap/halt"
 	sr "gno.land/r/gnoswap/staker"
-
-	"gno.land/r/gnoswap/gns"
 
 	en "gno.land/r/gnoswap/emission"
 	pn "gno.land/r/gnoswap/position"
@@ -416,14 +413,29 @@ func (s *stakerV1) transferDeposit(_ int, rlm realm, positionId uint64, owner, c
 	return s.nftAccessor.TransferFrom(0, rlm, owner, to, positionIdFrom(positionId))
 }
 
+// rewardSettlement is the outcome of settling one position's rewards.
+//
+// It records what settlement credited to the claimable reward ledger so the caller can
+// report the amounts without re-deriving them.
+type rewardSettlement struct {
+	owner                 address
+	internalRewardToUser  int64
+	internalRewardPenalty int64
+	externalRewards       map[string]int64 // reward token -> gross amount collected for the owner
+	externalPenalties     map[string]int64 // reward token -> warmup penalty retained by the incentive
+}
+
 // CollectReward harvests accumulated rewards for a staked position. This includes both
 // internal GNS emission and external incentive rewards.
 //
 // State Transition:
-//  1. Warm-up amounts are clears for both internal and external rewards
-//  2. Reward tokens are transferred to the owner
-//  3. Penalty fees are transferred to protocol/community addresses
-//  4. GNS balance is recalculated
+//  1. Warm-up amounts are cleared for both internal and external rewards
+//  2. Reward amounts are settled into the claimable reward ledger
+//  3. The ledger is paid out to the owner and to the community pool
+//
+// Settlement and payout are separate steps on purpose: settlement never moves a token, and
+// payout treats each token independently, so a reward that cannot be paid right now stays
+// claimable instead of aborting the collect. UnStakeToken performs settlement only.
 //
 // Requirements:
 //   - Contract must not be halted
@@ -431,12 +443,10 @@ func (s *stakerV1) transferDeposit(_ int, rlm realm, positionId uint64, owner, c
 //   - Position must be staked (have a deposit record)
 //
 // Parameters:
-// CollectReward claims accumulated rewards without unstaking.
-//
-// Parameters:
 //   - positionId: LP position NFT token ID
 //
-// Returns poolPath, gnsAmount, externalRewards map, externalPenalties map.
+// Returns internal reward paid to the user, internal penalty, external rewards map and
+// external penalties map.
 func (s *stakerV1) CollectReward(_ int, rlm realm, positionId uint64) (string, string, map[string]int64, map[string]int64) {
 	access.AssertIsRlmCurrent(0, rlm)
 
@@ -445,10 +455,34 @@ func (s *stakerV1) CollectReward(_ int, rlm realm, positionId uint64) (string, s
 	caller := rlm.Previous().Address()
 	assertIsDepositor(s, caller, positionId)
 
+	en.MintAndDistributeGns(cross(rlm))
+
+	settlement := s.settlePositionReward(0, rlm, positionId)
+
+	communityPoolAddr := access.MustGetAddress(prbac.ROLE_COMMUNITY_POOL.String())
+	s.payoutClaimableRewards(0, rlm, settlement.owner)
+	s.payoutClaimableRewards(0, rlm, communityPoolAddr)
+
+	return utils.FormatInt(settlement.internalRewardToUser),
+		utils.FormatInt(settlement.internalRewardPenalty),
+		settlement.externalRewards,
+		settlement.externalPenalties
+}
+
+// settlePositionReward performs the reward accounting for a staked position: it stops
+// accrual at the current time, advances every last-collect cursor, draws the amounts down
+// from the incentives, and credits what is owed to the claimable reward ledger.
+//
+// It deliberately performs no token transfer and no reward-token cross-call, so nothing a
+// token realm (or a short staker reserve) does can make settlement revert. That is what
+// lets UnStakeToken settle a position and hand the NFT back without depending on the
+// payout succeeding.
+//
+// The caller is responsible for the access checks, for bringing emission up to date when
+// that matters, and for paying the ledger out.
+func (s *stakerV1) settlePositionReward(_ int, rlm realm, positionId uint64) *rewardSettlement {
 	deposit := s.getDeposits().get(positionId)
 	depositResolver := NewDepositResolver(deposit)
-
-	en.MintAndDistributeGns(cross(rlm))
 
 	currentTime := time.Now().Unix()
 	blockHeight := runtime.ChainHeight()
@@ -484,7 +518,7 @@ func (s *stakerV1) CollectReward(_ int, rlm realm, positionId uint64) (string, s
 	lowerOutsideAccX128 := lowerTickResolver.CurrentOutsideAccumulation(currentTime)
 	upperOutsideAccX128 := upperTickResolver.CurrentOutsideAccumulation(currentTime)
 
-	// transfer external rewards to user
+	// credit external rewards to the owner
 	communityPoolAddr := access.MustGetAddress(prbac.ROLE_COMMUNITY_POOL.String())
 	toUserExternalReward := make(map[string]int64)
 	toUserExternalPenalty := make(map[string]int64)
@@ -537,7 +571,7 @@ func (s *stakerV1) CollectReward(_ int, rlm realm, positionId uint64) (string, s
 		depositResolver.addCollectedExternalReward(incentiveId, totalRewardAmount)
 
 		// Update the last collect time ONLY for this specific incentive
-		// This happens only if the reward was successfully transferred.
+		// This happens only if the reward was successfully settled.
 		err := depositResolver.updateExternalRewardLastCollectTime(incentiveId, currentTime)
 		if err != nil {
 			panic(err)
@@ -552,14 +586,12 @@ func (s *stakerV1) CollectReward(_ int, rlm realm, positionId uint64) (string, s
 		// update
 		s.getExternalIncentives().set(incentiveId, incentive)
 
-		toUser, feeAmount, err := s.handleStakingRewardFee(0, rlm, rewardToken, rewardAmount, false)
+		toUser, feeAmount, err := s.accrueStakingRewardFee(0, rlm, rewardToken, rewardAmount, false)
 		if err != nil {
 			panic(err.Error())
 		}
 
-		if toUser > 0 {
-			common.SafeGRC20Transfer(0, rlm, rewardToken, deposit.Owner(), toUser)
-		}
+		s.creditClaimableReward(deposit.Owner(), rewardToken, toUser)
 
 		chain.Emit(
 			"ProtocolFeeExternalReward",
@@ -607,7 +639,7 @@ func (s *stakerV1) CollectReward(_ int, rlm realm, positionId uint64) (string, s
 
 	// internal reward to user
 	if !skipInternalUpdate {
-		toUser, feeAmount, err := s.handleStakingRewardFee(0, rlm, GNS_TOKEN_KEY, reward.Internal, true)
+		toUser, feeAmount, err := s.accrueStakingRewardFee(0, rlm, GNS_TOKEN_KEY, reward.Internal, true)
 		if err != nil {
 			panic(err.Error())
 		}
@@ -667,20 +699,9 @@ func (s *stakerV1) CollectReward(_ int, rlm realm, positionId uint64) (string, s
 	deposits := s.getDeposits()
 	deposits.set(positionId, deposit)
 
-	if internalRewardToUser > 0 {
-		gns.Transfer(cross(rlm), deposit.Owner(), internalRewardToUser)
-	}
-
-	if internalRewardPenalty > 0 {
-		gns.Transfer(cross(rlm), communityPoolAddr, internalRewardPenalty)
-	}
-
-	if unClaimableInternal > 0 {
-		gns.Transfer(cross(rlm), communityPoolAddr, unClaimableInternal)
-	}
-
-	rewardToUser := utils.FormatInt(internalRewardToUser)
-	rewardPenalty := utils.FormatInt(internalRewardPenalty)
+	s.creditClaimableReward(deposit.Owner(), GNS_TOKEN_KEY, internalRewardToUser)
+	s.creditClaimableReward(communityPoolAddr, GNS_TOKEN_KEY, internalRewardPenalty)
+	s.creditClaimableReward(communityPoolAddr, GNS_TOKEN_KEY, unClaimableInternal)
 
 	if !skipInternalUpdate {
 		chain.Emit(
@@ -692,9 +713,9 @@ func (s *stakerV1) CollectReward(_ int, rlm realm, positionId uint64) (string, s
 			"recipient", depositResolver.Owner().String(),
 			"rewardToken", GNS_TOKEN_KEY,
 			"rewardAmount", utils.FormatInt(internalReward),
-			"rewardToUser", rewardToUser,
+			"rewardToUser", utils.FormatInt(internalRewardToUser),
 			"rewardToFee", utils.FormatInt(internalRewardToFee),
-			"rewardPenalty", rewardPenalty,
+			"rewardPenalty", utils.FormatInt(internalRewardPenalty),
 			"rewardUnClaimableAmount", utils.FormatInt(unClaimableInternal),
 			"currentTime", utils.FormatInt(currentTime),
 			"currentHeight", utils.FormatInt(blockHeight),
@@ -705,22 +726,33 @@ func (s *stakerV1) CollectReward(_ int, rlm realm, positionId uint64) (string, s
 		)
 	}
 
-	return rewardToUser, rewardPenalty, toUserExternalReward, toUserExternalPenalty
+	return &rewardSettlement{
+		owner:                 deposit.Owner(),
+		internalRewardToUser:  internalRewardToUser,
+		internalRewardPenalty: internalRewardPenalty,
+		externalRewards:       toUserExternalReward,
+		externalPenalties:     toUserExternalPenalty,
+	}
 }
 
-// UnStakeToken withdraws an LP token from staking, collecting all pending rewards
-// and returning the token to its original owner.
+// UnStakeToken withdraws an LP token from staking and returns it to its original owner.
 //
 // Parameters:
 //   - positionId: LP position NFT token ID to unstake
-//   - unwrapResult: Convert WUGNOT to GNOT if true
 //
 // Process:
-//  1. Collects all pending rewards (GNS + external)
+//  1. Settles all pending rewards (GNS + external) into the claimable reward ledger
 //  2. Transfers NFT ownership back to original owner
 //  3. Clears position operator rights
 //  4. Removes from reward tracking systems
 //  5. Cleans up all staking metadata
+//
+// Rewards are settled but NOT paid out here. Paying them out would make withdrawing a
+// position depend on a reward transfer succeeding, so a drained staker reserve or a single
+// misbehaving reward token could lock the NFT in the staker forever. The settled amounts
+// are withdrawn separately with ClaimRewards, which can fail and be retried without ever
+// putting the position at risk. Emission is deliberately not touched either, for the same
+// reason.
 //
 // Returns:
 //   - poolPath: Pool identifier where position was staked
@@ -740,8 +772,8 @@ func (s *stakerV1) UnStakeToken(_ int, rlm realm, positionId uint64) string { //
 	// unStaked status
 	poolPath := deposit.TargetPoolPath()
 
-	// claim All Rewards
-	s.CollectReward(0, rlm, positionId)
+	// settle all rewards into the claimable ledger; payout is left to ClaimRewards
+	s.settlePositionReward(0, rlm, positionId)
 
 	if err := s.applyUnStake(positionId); err != nil {
 		panic(err)

--- a/contract/r/gnoswap/test/fuzz/_mock_test.gno
+++ b/contract/r/gnoswap/test/fuzz/_mock_test.gno
@@ -370,6 +370,7 @@ type MockStakerStore struct {
 	tokenSpecificMinimumRewards      map[string]int64
 	unstakingFee                     uint64
 	pendingProtocolFees              map[string]int64
+	claimableRewards                 *bptree.BPTree
 	pools                            *bptree.BPTree
 	poolTierMemberships              *bptree.BPTree
 	poolTierRatio                    sr.TierRatio
@@ -565,6 +566,20 @@ func (s *MockStakerStore) SetPendingProtocolFees(_ int, rlm realm, fees map[stri
 	return nil
 }
 
+// ClaimableRewards
+func (s *MockStakerStore) HasClaimableRewardsStoreKey() bool {
+	return s.claimableRewards != nil
+}
+
+func (s *MockStakerStore) GetClaimableRewards() *bptree.BPTree {
+	return s.claimableRewards
+}
+
+func (s *MockStakerStore) SetClaimableRewards(_ int, rlm realm, rewards *bptree.BPTree) error {
+	s.claimableRewards = rewards
+	return nil
+}
+
 // Pools
 func (s *MockStakerStore) HasPoolsStoreKey() bool {
 	return s.pools != nil
@@ -733,6 +748,7 @@ func newMockStakerStore() *MockStakerStore {
 		tokenSpecificMinimumRewards:      make(map[string]int64),
 		unstakingFee:                     0,
 		pendingProtocolFees:              make(map[string]int64),
+		claimableRewards:                 sr.NewBPTreeN(16),
 		pools:                            sr.NewBPTreeN(16),
 		poolTierMemberships:              sr.NewBPTreeN(16),
 		poolTierRatio:                    sr.NewTierRatio(0, 0, 0),
@@ -744,8 +760,8 @@ func newMockStakerStore() *MockStakerStore {
 		poolTierGetHalvingBlocksInRange: func(start, end int64) ([]int64, []int64) {
 			return emission.GetStakerEmissionAmountPerSecondInRange(start, end)
 		},
-		warmupTemplate:                   sr.DefaultWarmupTemplate(),
-		currentSwapBatch:                 swapBatch,
+		warmupTemplate:   sr.DefaultWarmupTemplate(),
+		currentSwapBatch: swapBatch,
 	}
 }
 

--- a/contract/r/scenario/staker/external_incentive_refund_with_multiple_unclaimable_periods_filetest.gno
+++ b/contract/r/scenario/staker/external_incentive_refund_with_multiple_unclaimable_periods_filetest.gno
@@ -351,6 +351,10 @@ func verifyRefundTransfer(cur realm, creatorGnsBefore int64) {
 func collectExternalIncentive(cur realm) {
 	testing.SetRealm(userRealm)
 
+	// The unstakes above settled their rewards into the claimable ledger without paying
+	// them out. Flush that first so the delta below measures only this collection.
+	sr.ClaimRewards(cross(cur))
+
 	gnsBefore := gns.BalanceOf(userUser)
 	sr.CollectReward(cross(cur), 1)
 	gnsAfter := gns.BalanceOf(userUser)

--- a/contract/r/scenario/staker/full_internal_external_filetest.gno
+++ b/contract/r/scenario/staker/full_internal_external_filetest.gno
@@ -445,6 +445,8 @@ func unstakeToken01(cur realm) {
 	println("[INFO] unstake token 01")
 	beforeGns := gns.BalanceOf(adminUser)
 	sr.UnStakeToken(cross(cur), 1)
+	// Unstaking only settles the reward; ClaimRewards is what pays it out.
+	sr.ClaimRewards(cross(cur))
 	afterGns := gns.BalanceOf(adminUser)
 
 	rewardFromUnstake := afterGns - beforeGns

--- a/contract/r/scenario/staker/staker_native_create_collect_unstake_filetest.gno
+++ b/contract/r/scenario/staker/staker_native_create_collect_unstake_filetest.gno
@@ -414,6 +414,8 @@ func unstakeToken02(cur realm) {
 
 	println("[INFO] unstake token 02 (no unwrap)")
 	sr.UnStakeToken(cross(cur), 2)
+	// Unstaking only settles the reward; ClaimRewards is what pays it out.
+	sr.ClaimRewards(cross(cur))
 	testing.SkipHeights(1)
 
 	owner := gnft.MustOwnerOf(positionIdFrom(cur, 2))
@@ -482,6 +484,8 @@ func unstakeToken01(cur realm) {
 
 	println("[INFO] unstake token 01 (no unwrap)")
 	sr.UnStakeToken(cross(cur), 1)
+	// Unstaking only settles the reward; ClaimRewards is what pays it out.
+	sr.ClaimRewards(cross(cur))
 	testing.SkipHeights(1)
 
 	owner := gnft.MustOwnerOf(positionIdFrom(cur, 1))

--- a/contract/r/scenario/staker/staker_native_create_collect_unstake_with_finish_filetest.gno
+++ b/contract/r/scenario/staker/staker_native_create_collect_unstake_with_finish_filetest.gno
@@ -413,6 +413,8 @@ func unstakeToken(cur realm, tokenId uint64) {
 
 	println("[INFO] unstake token (no unwrap)")
 	sr.UnStakeToken(cross(cur), tokenId)
+	// Unstaking only settles the reward; ClaimRewards is what pays it out.
+	sr.ClaimRewards(cross(cur))
 	testing.SkipHeights(1)
 
 	owner := gnft.MustOwnerOf(positionIdFrom(cur, tokenId))

--- a/contract/r/scenario/staker/tracking_unclaimed_period_validation_filetest.gno
+++ b/contract/r/scenario/staker/tracking_unclaimed_period_validation_filetest.gno
@@ -197,6 +197,11 @@ func testUnclaimablePeriodRewardDistribution(cur realm) {
 	gnft.Approve(cross(cur), stakerAddr, grc721.TokenID(strconv.Itoa(int(positionId))))
 	sr.StakeToken(cross(cur), positionId, "")
 
+	// Unstaking settles the community pool's share into the claimable ledger instead of
+	// transferring it. Flush it first so the balance delta below measures only what this
+	// collection produces.
+	sr.ClaimRewardsFor(cross(cur), communityPoolAddr)
+
 	communityBalanceBefore1 := gns.BalanceOf(communityPoolAddr)
 	sr.CollectReward(cross(cur), positionId)
 	communityBalanceAfter1 := gns.BalanceOf(communityPoolAddr)
@@ -212,6 +217,8 @@ func testUnclaimablePeriodRewardDistribution(cur realm) {
 	gnft.Approve(cross(cur), stakerAddr, grc721.TokenID(strconv.Itoa(int(positionId))))
 	sr.StakeToken(cross(cur), positionId, "")
 	endTime := time.Now().Unix()
+
+	sr.ClaimRewardsFor(cross(cur), communityPoolAddr)
 
 	communityBalanceBefore2 := gns.BalanceOf(communityPoolAddr)
 	sr.CollectReward(cross(cur), positionId)

--- a/contract/r/scenario/staker/tracking_unclaimed_period_validation_with_multi_position_filetest.gno
+++ b/contract/r/scenario/staker/tracking_unclaimed_period_validation_with_multi_position_filetest.gno
@@ -222,6 +222,11 @@ func testUnclaimablePeriodRewardDistribution(cur realm) {
 	gnft.Approve(cross(cur), stakerAddr, grc721.TokenID(strconv.Itoa(int(positionId))))
 	sr.StakeToken(cross(cur), positionId, "")
 
+	// Unstaking settles the community pool's share into the claimable ledger instead of
+	// transferring it. Flush it first so the balance delta below measures only what this
+	// collection produces.
+	sr.ClaimRewardsFor(cross(cur), communityPoolAddr)
+
 	communityBalanceBefore1 := gns.BalanceOf(communityPoolAddr)
 	sr.CollectReward(cross(cur), positionId)
 	communityBalanceAfter1 := gns.BalanceOf(communityPoolAddr)
@@ -237,6 +242,8 @@ func testUnclaimablePeriodRewardDistribution(cur realm) {
 	gnft.Approve(cross(cur), stakerAddr, grc721.TokenID(strconv.Itoa(int(positionId))))
 	sr.StakeToken(cross(cur), positionId, "")
 	endTime := time.Now().Unix()
+
+	sr.ClaimRewardsFor(cross(cur), communityPoolAddr)
 
 	communityBalanceBefore2 := gns.BalanceOf(communityPoolAddr)
 	sr.CollectReward(cross(cur), positionId)

--- a/contract/r/scenario/staker/unstake_with_drained_reward_reserve_filetest.gno
+++ b/contract/r/scenario/staker/unstake_with_drained_reward_reserve_filetest.gno
@@ -1,0 +1,185 @@
+// PKGPATH: gno.land/r/gnoswap/v1/main
+
+// Withdrawing a staked position must never depend on the reward payout succeeding.
+//
+// This drains the staker realm's GNS reserve so that paying the position's internal reward
+// would abort, then unstakes. The NFT comes back, the reward stays owed through the
+// claimable ledger, and it is paid once the reserve can cover it.
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"gno.land/r/gnoswap/scenarioutils"
+
+	"gno.land/p/demo/tokens/grc721"
+	ufmt "gno.land/p/nt/ufmt/v0"
+
+	"gno.land/r/gnoswap/access"
+	en "gno.land/r/gnoswap/emission"
+
+	"gno.land/r/gnoswap/gnft"
+	"gno.land/r/gnoswap/gns"
+
+	pl "gno.land/r/gnoswap/pool"
+	pn "gno.land/r/gnoswap/position"
+	sr "gno.land/r/gnoswap/staker"
+
+	prabc "gno.land/p/gnoswap/rbac"
+	_ "gno.land/r/gnoswap/rbac"
+
+	_ "gno.land/r/gnoswap/pool/v1"
+	_ "gno.land/r/gnoswap/position/v1"
+	_ "gno.land/r/gnoswap/staker/v1"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/baz"
+)
+
+var (
+	adminAddr, _ = access.GetAddress(prabc.ROLE_ADMIN.String())
+	adminUser    = adminAddr
+	adminRealm   = testing.NewUserRealm(adminAddr)
+
+	stakerAddr, _ = access.GetAddress(prabc.ROLE_STAKER.String())
+	stakerRealm   = testing.NewCodeRealm("gno.land/r/gnoswap/staker")
+
+	poolAddr, _ = access.GetAddress(prabc.ROLE_POOL.String())
+
+	// sink receives the drained reserve so it can be sent back later.
+	sink address = "g1v9kxjcm9ta047h6lta047h6lta047h6lzd40gh"
+
+	barPath = "gno.land/r/onbloc/bar.BAR"
+	bazPath = "gno.land/r/onbloc/baz.BAZ"
+
+	poolPath = "gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/baz.BAZ:3000"
+
+	fee3000 uint32 = 3000
+
+	maxTimeout int64 = 9999999999
+	maxInt64   int64 = 9223372036854775807
+)
+
+func main(cur realm) {
+	println("[SCENARIO] 1. Stake a position in a tier 1 pool")
+	positionId := setup(cur)
+
+	println()
+	println("[SCENARIO] 2. Drain the staker reward reserve")
+	drained := drainStakerReserve(cur)
+
+	println()
+	println("[SCENARIO] 3. Unstake with an empty reserve")
+	unstakeWithEmptyReserve(cur, positionId)
+
+	println()
+	println("[SCENARIO] 4. Claim once the reserve is restored")
+	claimAfterRefund(cur, drained)
+}
+
+func setup(cur realm) uint64 {
+	testing.SetRealm(adminRealm)
+
+	scenarioutils.EnsureCanonicalDefaultPool(cross(cur))
+	en.SetDistributionStartTime(cross(cur), time.Now().Unix()+1)
+	sr.SetUnStakingFee(cross(cur), 0)
+	pl.SetPoolCreationFee(cross(cur), 0)
+
+	pl.CreatePool(cross(cur), barPath, bazPath, fee3000, "79228162514264337593543950337")
+	sr.SetPoolTier(cross(cur), poolPath, 1)
+
+	bar.Approve(cross(cur), poolAddr, maxInt64)
+	baz.Approve(cross(cur), poolAddr, maxInt64)
+
+	positionId, _, _, _ := pn.Mint(
+		cross(cur),
+		barPath,
+		bazPath,
+		fee3000,
+		int32(-1020),
+		int32(1020),
+		"100000",
+		"100000",
+		"1",
+		"1",
+		maxTimeout,
+		adminUser,
+		"",
+	)
+
+	gnft.Approve(cross(cur), stakerAddr, positionIdFrom(cur, positionId))
+	sr.StakeToken(cross(cur), positionId, "")
+
+	println("[INFO] position staked, accumulating rewards")
+	testing.SkipHeights(100)
+
+	return positionId
+}
+
+func drainStakerReserve(cur realm) int64 {
+	// Bring emission up to date first so the reserve holds what the position earned, then
+	// empty it: any reward transfer from here on would abort.
+	testing.SetRealm(adminRealm)
+	en.MintAndDistributeGns(cross(cur))
+
+	testing.SetRealm(stakerRealm)
+	drained := gns.BalanceOf(stakerAddr)
+	gns.Transfer(cross(cur), sink, drained)
+
+	ufmt.Printf("[EXPECTED] staker GNS reserve after draining: %d\n", gns.BalanceOf(stakerAddr))
+
+	return drained
+}
+
+func unstakeWithEmptyReserve(cur realm, positionId uint64) {
+	testing.SetRealm(adminRealm)
+
+	balanceBefore := gns.BalanceOf(adminUser)
+
+	// Before the split this call collected rewards inline, so an empty reserve aborted it
+	// and left the position locked in the staker.
+	sr.UnStakeToken(cross(cur), positionId)
+
+	ufmt.Printf("[EXPECTED] position still staked: %t\n", sr.IsStaked(positionId))
+	ufmt.Printf("[EXPECTED] NFT returned to owner: %t\n", gnft.MustOwnerOf(positionIdFrom(cur, positionId)) == adminUser)
+	ufmt.Printf("[EXPECTED] owner GNS paid during unstake: %d\n", gns.BalanceOf(adminUser)-balanceBefore)
+	ufmt.Printf("[EXPECTED] reward settled as claimable: %t\n", sr.GetClaimableReward(adminUser, "gno.land/r/gnoswap/gns.GNS") > 0)
+}
+
+func claimAfterRefund(cur realm, drained int64) {
+	// Return the drained reserve so the settled reward becomes payable.
+	testing.SetRealm(testing.NewUserRealm(sink))
+	gns.Transfer(cross(cur), stakerAddr, drained)
+
+	claimable := sr.GetClaimableReward(adminUser, "gno.land/r/gnoswap/gns.GNS")
+
+	testing.SetRealm(adminRealm)
+	balanceBefore := gns.BalanceOf(adminUser)
+	sr.ClaimRewards(cross(cur))
+
+	ufmt.Printf("[EXPECTED] claimed the settled reward: %t\n", gns.BalanceOf(adminUser)-balanceBefore >= claimable)
+	ufmt.Printf("[EXPECTED] claimable left after claiming: %d\n", sr.GetClaimableReward(adminUser, "gno.land/r/gnoswap/gns.GNS"))
+}
+
+func positionIdFrom(cur realm, positionId uint64) grc721.TokenID {
+	return grc721.TokenID(ufmt.Sprintf("%d", positionId))
+}
+
+// Output:
+// [SCENARIO] 1. Stake a position in a tier 1 pool
+// [INFO] position staked, accumulating rewards
+//
+// [SCENARIO] 2. Drain the staker reward reserve
+// [EXPECTED] staker GNS reserve after draining: 0
+//
+// [SCENARIO] 3. Unstake with an empty reserve
+// [EXPECTED] position still staked: false
+// [EXPECTED] NFT returned to owner: true
+// [EXPECTED] owner GNS paid during unstake: 0
+// [EXPECTED] reward settled as claimable: true
+//
+// [SCENARIO] 4. Claim once the reserve is restored
+// [EXPECTED] claimed the settled reward: true
+// [EXPECTED] claimable left after claiming: 0

--- a/contract/r/scenario/upgrade/implements/mock/staker/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/mock/staker/test_impl.gno
@@ -65,6 +65,21 @@ func (t *TestStaker) CollectReward(_ int, rlm realm, positionId uint64) (string,
 	return result[0].(string), result[1].(string), result[2].(map[string]int64), result[3].(map[string]int64)
 }
 
+func (t *TestStaker) ClaimRewards(_ int, rlm realm) map[string]int64 {
+	return t.ExecuteFn(
+		"ClaimRewards",
+		func(args ...any) any { return t.instance.ClaimRewards(0, rlm) },
+	).(map[string]int64)
+}
+
+func (t *TestStaker) ClaimRewardsFor(_ int, rlm realm, receiver address) map[string]int64 {
+	return t.ExecuteFn(
+		"ClaimRewardsFor",
+		func(args ...any) any { return t.instance.ClaimRewardsFor(0, rlm, args[0].(address)) },
+		receiver,
+	).(map[string]int64)
+}
+
 func (t *TestStaker) SetPoolTier(_ int, rlm realm, poolPath string, tier uint64) {
 	t.ExecuteFn(
 		"SetPoolTier",
@@ -662,6 +677,22 @@ func (t *TestStaker) GetPoolHistoricalTicks(poolPath string) *rotree.ReadOnlyTre
 		},
 		poolPath,
 	).(*rotree.ReadOnlyTree)
+}
+
+func (t *TestStaker) GetClaimableRewardsOf(receiver address) map[string]int64 {
+	return t.ExecuteFn(
+		"GetClaimableRewardsOf",
+		func(args ...any) any { return t.instance.GetClaimableRewardsOf(args[0].(address)) },
+		receiver,
+	).(map[string]int64)
+}
+
+func (t *TestStaker) GetClaimableReward(receiver address, tokenPath string) int64 {
+	return t.ExecuteFn(
+		"GetClaimableReward",
+		func(args ...any) any { return t.instance.GetClaimableReward(args[0].(address), args[1].(string)) },
+		receiver, tokenPath,
+	).(int64)
 }
 
 func (t *TestStaker) GetPendingProtocolFees() map[string]int64 {

--- a/contract/r/scenario/upgrade/implements/security/insecure_staker_callback/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/security/insecure_staker_callback/test_impl.gno
@@ -65,6 +65,20 @@ func (t *TestStaker) CollectReward(_ int, rlm realm, positionId uint64) (string,
 	return t.instance.CollectReward(0, rlm, positionId)
 }
 
+func (t *TestStaker) ClaimRewards(_ int, rlm realm) map[string]int64 {
+	if !t.isActive("ClaimRewards") {
+		panic("test implementation: ClaimRewards not supported")
+	}
+	return t.instance.ClaimRewards(0, rlm)
+}
+
+func (t *TestStaker) ClaimRewardsFor(_ int, rlm realm, receiver address) map[string]int64 {
+	if !t.isActive("ClaimRewardsFor") {
+		panic("test implementation: ClaimRewardsFor not supported")
+	}
+	return t.instance.ClaimRewardsFor(0, rlm, receiver)
+}
+
 func (t *TestStaker) SetPoolTier(_ int, rlm realm, poolPath string, tier uint64) {
 	if !t.isActive("SetPoolTier") {
 		panic("test implementation: SetPoolTier not supported")
@@ -540,6 +554,20 @@ func (t *TestStaker) GetPoolHistoricalTicks(poolPath string) *rotree.ReadOnlyTre
 		panic("test implementation: GetPoolHistoricalTicks not supported")
 	}
 	return t.instance.GetPoolHistoricalTicks(poolPath)
+}
+
+func (t *TestStaker) GetClaimableRewardsOf(receiver address) map[string]int64 {
+	if !t.isActive("GetClaimableRewardsOf") {
+		panic("test implementation: GetClaimableRewardsOf not supported")
+	}
+	return t.instance.GetClaimableRewardsOf(receiver)
+}
+
+func (t *TestStaker) GetClaimableReward(receiver address, tokenPath string) int64 {
+	if !t.isActive("GetClaimableReward") {
+		panic("test implementation: GetClaimableReward not supported")
+	}
+	return t.instance.GetClaimableReward(receiver, tokenPath)
 }
 
 func (t *TestStaker) GetPendingProtocolFees() map[string]int64 {

--- a/contract/r/scenario/upgrade/implements/v2_invalid/staker/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v2_invalid/staker/test_impl.gno
@@ -60,6 +60,20 @@ func (t *TestStaker) CollectReward(_ int, rlm realm, positionId uint64) (string,
 	return t.instance.CollectReward(0, rlm, positionId)
 }
 
+func (t *TestStaker) ClaimRewards(_ int, rlm realm) map[string]int64 {
+	if !t.isActive("ClaimRewards") {
+		panic("test implementation: ClaimRewards not supported")
+	}
+	return t.instance.ClaimRewards(0, rlm)
+}
+
+func (t *TestStaker) ClaimRewardsFor(_ int, rlm realm, receiver address) map[string]int64 {
+	if !t.isActive("ClaimRewardsFor") {
+		panic("test implementation: ClaimRewardsFor not supported")
+	}
+	return t.instance.ClaimRewardsFor(0, rlm, receiver)
+}
+
 func (t *TestStaker) SetPoolTier(_ int, rlm realm, poolPath string, tier uint64) {
 	if !t.isActive("SetPoolTier") {
 		panic("test implementation: SetPoolTier not supported")
@@ -535,6 +549,20 @@ func (t *TestStaker) GetPoolHistoricalTicks(poolPath string) *rotree.ReadOnlyTre
 		panic("test implementation: GetPoolHistoricalTicks not supported")
 	}
 	return t.instance.GetPoolHistoricalTicks(poolPath)
+}
+
+func (t *TestStaker) GetClaimableRewardsOf(receiver address) map[string]int64 {
+	if !t.isActive("GetClaimableRewardsOf") {
+		panic("test implementation: GetClaimableRewardsOf not supported")
+	}
+	return t.instance.GetClaimableRewardsOf(receiver)
+}
+
+func (t *TestStaker) GetClaimableReward(receiver address, tokenPath string) int64 {
+	if !t.isActive("GetClaimableReward") {
+		panic("test implementation: GetClaimableReward not supported")
+	}
+	return t.instance.GetClaimableReward(receiver, tokenPath)
 }
 
 func (t *TestStaker) GetPendingProtocolFees() map[string]int64 {

--- a/contract/r/scenario/upgrade/implements/v2_valid/staker/claimable_reward.gno
+++ b/contract/r/scenario/upgrade/implements/v2_valid/staker/claimable_reward.gno
@@ -1,0 +1,1 @@
+../../../../../gnoswap/staker/v1/claimable_reward.gno

--- a/contract/r/scenario/upgrade/implements/v3_valid/staker/test_impl.gno
+++ b/contract/r/scenario/upgrade/implements/v3_valid/staker/test_impl.gno
@@ -38,6 +38,14 @@ func (t *TestStaker) CollectReward(_ int, rlm realm, positionId uint64) (string,
 	return t.instance.CollectReward(0, rlm, positionId)
 }
 
+func (t *TestStaker) ClaimRewards(_ int, rlm realm) map[string]int64 {
+	return t.instance.ClaimRewards(0, rlm)
+}
+
+func (t *TestStaker) ClaimRewardsFor(_ int, rlm realm, receiver address) map[string]int64 {
+	return t.instance.ClaimRewardsFor(0, rlm, receiver)
+}
+
 func (t *TestStaker) SetPoolTier(_ int, rlm realm, poolPath string, tier uint64) {
 	t.instance.SetPoolTier(0, rlm, poolPath, tier)
 }
@@ -309,6 +317,14 @@ func (t *TestStaker) GetPoolGlobalRewardRatioAccumulations(poolPath string) *rot
 
 func (t *TestStaker) GetPoolHistoricalTicks(poolPath string) *rotree.ReadOnlyTree {
 	return t.instance.GetPoolHistoricalTicks(poolPath)
+}
+
+func (t *TestStaker) GetClaimableRewardsOf(receiver address) map[string]int64 {
+	return t.instance.GetClaimableRewardsOf(receiver)
+}
+
+func (t *TestStaker) GetClaimableReward(receiver address, tokenPath string) int64 {
+	return t.instance.GetClaimableReward(receiver, tokenPath)
 }
 
 func (t *TestStaker) GetPendingProtocolFees() map[string]int64 {

--- a/docs/staker.md
+++ b/docs/staker.md
@@ -7,6 +7,7 @@ Stakes LP NFTs, distributes GNS emissions and external incentives.
 | File | Purpose |
 |------|---------|
 | `staker.gno` | Core staking logic |
+| `claimable_reward.gno` | Claimable reward ledger and payout |
 | `external_incentive.gno` | External incentive management |
 | `reward_calculation*.gno` | Reward computation |
 | `calculate_pool_position_reward.gno` | Per-position reward calculation |
@@ -29,8 +30,14 @@ Stakes LP NFTs, distributes GNS emissions and external incentives.
 - Active window: `startTimestamp <= now < endTimestamp`. Both bounds required.
 - `refunded` flag prevents double-claim on `EndExternalIncentive`. Set atomically.
 - `EndExternalIncentive` needs `now >= endTimestamp` and keeps the record; `CancelExternalIncentive` needs `now < startTimestamp`, removes it from the incentive tree, the per-pool start-time index and the global tree, and refunds the reward tokens plus the GNS deposit to the **creator** (never a caller-supplied address). Callable by admin, governance, or the creator. Removal is only safe before the start: discovery is bounded by the current time, so no deposit can reference a pending incentive.
-- `lastCollectTime` tracked **per incentive** (not shared). Updated only after successful transfer.
+- `lastCollectTime` tracked **per incentive** (not shared). Updated only after the reward is successfully settled.
 - `rewardPerSecond = totalReward / duration` — integer truncation leaves dust. Verify dust does not accumulate into locked balance.
+
+### Reward settlement vs payout
+- `settlePositionReward` does the accounting (cursors, incentive draw-down, ledger credit) and performs **no** token transfer and no reward-token cross-call. Keep it that way: it is what makes withdrawal independent of payout.
+- `UnStakeToken` settles only. It must never transfer a reward or call `MintAndDistributeGns`, or a drained reserve / misbehaving reward token would lock the NFT in the staker.
+- `payoutClaimableRewards` is best-effort per token: a token the ROLE_STAKER reserve cannot cover stays in the ledger (`InsufficientClaimableReward` event) instead of aborting.
+- Protocol fees are recorded as pending at settlement (`accrueStakingRewardFee`) and forwarded during payout, and only when the reserve covers the fee **and** the receiver's amount.
 
 ### Warmup
 - Final warmup tier must be `math.MaxInt64`. Finite value → panic when block time passes it.
@@ -40,6 +47,7 @@ Stakes LP NFTs, distributes GNS emissions and external incentives.
 
 - Finite final warmup tier → panic at runtime.
 - Pool tier removal blocks unstake → NFTs permanently locked.
+- Reward transfer reintroduced into the unstake path → drained reserve locks NFTs.
 - `lastCollectTime` shared across incentives → wrong reward amounts.
 - `referrer` not forwarded → lost referral attribution.
 - `rewardPerSecond` dust not handled → small balance permanently locked.


### PR DESCRIPTION
## Problem

`UnStakeToken` called `CollectReward` inline, so every failure mode of the payout half also
blocked withdrawal:

- a drained staker GNS reserve made `gns.Transfer` abort ([staker.gno#L671](https://github.com/gnoswap-labs/gnoswap/blob/main/contract/r/gnoswap/staker/v1/staker.gno#L671))
- a reward token whose transfer reverts did the same for external rewards ([staker.gno#L561](https://github.com/gnoswap-labs/gnoswap/blob/main/contract/r/gnoswap/staker/v1/staker.gno#L561))

Either case left the position NFT locked in the staker. A panic crossing a realm boundary
cannot be recovered from in Gno, so the payout cannot simply be wrapped — the accounting and
the transfer have to be separated.

## Change

Reward handling is split into settlement and payout:

- **`settlePositionReward`** does the accounting only — stops accrual, advances the
  last-collect cursors, draws the amounts down from the incentives, and credits what is owed
  to a new claimable reward ledger. It performs no token transfer and no reward-token
  cross-call, so it cannot revert on anything a token realm or a short reserve does.
- **`payoutClaimableRewards`** drains the ledger one token at a time. A token the reserve
  cannot cover stays claimable and is reported through an `InsufficientClaimableReward`
  event instead of aborting the payout.
- **`CollectReward`** = settle + payout, so the collect path is unchanged for users.
- **`UnStakeToken`** settles only, and no longer calls `MintAndDistributeGns`. The NFT always
  comes back; rewards are withdrawn separately.

New entry points:

| Function | Purpose |
|---|---|
| `ClaimRewards(cur)` | Pays out the caller's settled-but-unpaid rewards |
| `ClaimRewardsFor(cur, receiver)` | Same payout for another receiver. Permissionless — funds only ever reach the ledger owner — so the community pool's share (internal penalties, unclaimable rewards) can be flushed after unstake-only flows |
| `GetClaimableRewardsOf(receiver)` / `GetClaimableReward(receiver, tokenPath)` | Views over the ledger |

Protocol fees follow the existing pending-fee idiom: `accrueStakingRewardFee` records the fee
at settlement, and `settleProtocolFee` forwards it during payout — only when the reserve
covers both the fee and the receiver's amount.

## Behaviour change

`UnStakeToken` no longer transfers rewards. It is a 1-tx → 2-tx change for anyone who relied
on unstaking to also pay out. Everything else about the amounts is identical.

## Verification

- `contract/r/gnoswap/staker`, `staker/v1`, `pool/v1`, `position/v1`, `router/v1`,
  `gov/staker/v1`, `gov/governance/v1`, `protocol_fee/v1`, `gnft` — all pass
- All `contract/r/scenario/*` suites pass
- The six scenario filetests that measured balance deltas across `UnStakeToken` now claim
  explicitly at the same point. **Their golden outputs are unchanged**, which shows the split
  preserves the amounts and only moves when they are paid.
- New coverage: `claimable_reward_test.gno` (ledger, payout, short-reserve skip) and
  `unstake_with_drained_reward_reserve_filetest.gno` — drains the staker's GNS reserve, then
  unstakes and gets the NFT back, with the reward settled as claimable and paid once the
  reserve is restored.
