### PR TITLE
fix(router): return positive output amounts

### DIFF
--- a/contract/r/gnoswap/router/v1/exact_in.gno
+++ b/contract/r/gnoswap/router/v1/exact_in.gno
@@ -161,7 +161,7 @@ func (r *routerV1) ExactInSingleSwapRoute(
 //
 // Returns:
 //   - inputAmount: Actual input amount consumed as string
-//   - outputAmount: Actual output amount received as string (negative value)
+//   - outputAmount: Actual output amount received as string
 //
 // Panics if swap execution fails or token transfer fails.
 func (r *routerV1) exactInSwapRoute(
@@ -183,8 +183,6 @@ func (r *routerV1) exactInSwapRoute(
 	// handle referral registration
 	actualReferrer := referral.TryRegister(cross(rlm), caller, referrer)
 
-	resultInputAmount := inputAmount
-	resultOutputAmount := -outputAmount
 
 	eventAttrs := append([]string{
 		"prevAddr", caller.String(),
@@ -193,8 +191,8 @@ func (r *routerV1) exactInSwapRoute(
 		"output", params.outputToken,
 		"exactAmount", utils.FormatInt(params.exactAmount),
 		"quote", params.quoteArr,
-		"resultInputAmount", utils.FormatInt(resultInputAmount),
-		"resultOutputAmount", utils.FormatInt(resultOutputAmount),
+		"resultInputAmount", utils.FormatInt(inputAmount),
+		"resultOutputAmount", utils.FormatInt(outputAmount),
 		"referrer", actualReferrer,
 	}, buildRouteEventAttrs(params.routeArr)...)
 
@@ -203,7 +201,7 @@ func (r *routerV1) exactInSwapRoute(
 		eventAttrs...,
 	)
 
-	return resultInputAmount, resultOutputAmount
+	return inputAmount, outputAmount
 }
 
 type ExactInSwapOperation struct {

--- a/contract/r/gnoswap/router/v1/exact_in_test.gno
+++ b/contract/r/gnoswap/router/v1/exact_in_test.gno
@@ -251,7 +251,7 @@ func TestExactInZeroForOneFalse(cur realm, t *testing.T) {
 			quoteArr:         "100",
 			amountOutMin:     "85",
 			expectedAmount0:  "100",
-			expectedAmount1:  "-98",
+			expectedAmount1:  "98",
 			expectPanic:      false,
 		},
 	}

--- a/contract/r/gnoswap/router/v1/exact_out.gno
+++ b/contract/r/gnoswap/router/v1/exact_out.gno
@@ -161,7 +161,7 @@ func (r *routerV1) ExactOutSingleSwapRoute(
 //
 // Returns:
 //   - inputAmount: Actual input amount consumed as string
-//   - outputAmount: Actual output amount received as string (negative value)
+//   - outputAmount: Actual output amount received as string
 //
 // Panics if swap execution fails or token transfer fails.
 func (r *routerV1) exactOutSwapRoute(
@@ -183,8 +183,6 @@ func (r *routerV1) exactOutSwapRoute(
 	// handle referral registration
 	actualReferrer := referral.TryRegister(cross(rlm), caller, referrer)
 
-	resultInputAmount := inputAmount
-	resultOutputAmount := -outputAmount
 
 	eventAttrs := append([]string{
 		"prevAddr", caller.String(),
@@ -193,8 +191,8 @@ func (r *routerV1) exactOutSwapRoute(
 		"output", params.outputToken,
 		"exactAmount", utils.FormatInt(params.exactAmount),
 		"quote", params.quoteArr,
-		"resultInputAmount", utils.FormatInt(resultInputAmount),
-		"resultOutputAmount", utils.FormatInt(resultOutputAmount),
+		"resultInputAmount", utils.FormatInt(inputAmount),
+		"resultOutputAmount", utils.FormatInt(outputAmount),
 		"referrer", actualReferrer,
 	}, buildRouteEventAttrs(params.routeArr)...)
 
@@ -203,7 +201,7 @@ func (r *routerV1) exactOutSwapRoute(
 		eventAttrs...,
 	)
 
-	return resultInputAmount, resultOutputAmount
+	return inputAmount, outputAmount
 }
 
 // ExactOutSwapOperation handles swaps where the output amount is specified.

--- a/contract/r/gnoswap/router/v1/exact_out_test.gno
+++ b/contract/r/gnoswap/router/v1/exact_out_test.gno
@@ -204,7 +204,7 @@ func TestExactOutSwapBoundary(cur realm, t *testing.T) {
 
 		uassert.NotEqual(t, amountIn, "0")
 		uassert.NotEqual(t, amountOut, "0")
-		uassert.Equal(t, false, strings.HasPrefix(amountOut, "-"))
+		uassert.False(t, strings.HasPrefix(amountOut, "-"))
 	})
 
 	t.Run("failed exact out swap at boundary", func(cur realm, t *testing.T) {

--- a/contract/r/gnoswap/router/v1/exact_out_test.gno
+++ b/contract/r/gnoswap/router/v1/exact_out_test.gno
@@ -204,6 +204,7 @@ func TestExactOutSwapBoundary(cur realm, t *testing.T) {
 
 		uassert.NotEqual(t, amountIn, "0")
 		uassert.NotEqual(t, amountOut, "0")
+		uassert.Equal(t, false, strings.HasPrefix(amountOut, "-"))
 	})
 
 	t.Run("failed exact out swap at boundary", func(cur realm, t *testing.T) {

--- a/contract/r/gnoswap/router/v1/router_test.gno
+++ b/contract/r/gnoswap/router/v1/router_test.gno
@@ -230,7 +230,7 @@ func TestCompareExactInAndDrySwapWithNoLiquidityChanged(cur realm, t *testing.T)
 			quoteArr:         "100",
 			amountOutMin:     "85000000",
 			expectedAmount0:  "100000000",
-			expectedAmount1:  "-98817367",
+			expectedAmount1:  "98817367",
 			expectPanic:      true,
 		},
 	}
@@ -429,7 +429,7 @@ func TestCompareExactInAndDrySwapWithWhenLiquidityAdded(cur realm, t *testing.T)
 			quoteArr:         "100",
 			amountOutMin:     "20000000",
 			expectedAmount0:  "50000000",
-			expectedAmount1:  "-49776285",
+			expectedAmount1:  "49776285",
 			expectPanic:      true,
 		},
 	}
@@ -626,7 +626,7 @@ func TestCompareExactInAndDrySwapWithWhenZeroForOneIsFalse(cur realm, t *testing
 			quoteArr:         "100",
 			amountOutMin:     "850000",
 			expectedAmount0:  "10000000",
-			expectedAmount1:  "-9875422",
+			expectedAmount1:  "9875422",
 			expectPanic:      true,
 		},
 	}

--- a/contract/r/scenario/getter/pool_getter_filetest.gno
+++ b/contract/r/scenario/getter/pool_getter_filetest.gno
@@ -870,7 +870,7 @@ func getObservationState(cur realm) {
 // [SCENARIO] 1.4 ExactIn Swap Route for tick changes
 // [INFO] Executing ExactIn swap
 // [EXPECTED] amountIn: 1000000
-// [EXPECTED] amountOut: -985678
+// [EXPECTED] amountOut: 985678
 // [EXPECTED] admin bar balance change: 985678
 // [EXPECTED] admin foo balance change: -1000000
 // [EXPECTED] pool bar balance change: -987158

--- a/contract/r/scenario/getter/position_getter_filetest.gno
+++ b/contract/r/scenario/getter/position_getter_filetest.gno
@@ -507,7 +507,7 @@ func getPositionOwner(cur realm) {
 // [SCENARIO] 1.4 ExactIn Swap Route for fee accumulation
 // [INFO] Executing ExactIn swap for fee accumulation
 // [EXPECTED] amountIn: 1000000
-// [EXPECTED] amountOut: -985678
+// [EXPECTED] amountOut: 985678
 // [EXPECTED] admin bar balance change: 985678
 // [EXPECTED] admin foo balance change: -1000000
 // [EXPECTED] pool bar balance change: -987158

--- a/contract/r/scenario/gov/staker/collect_reward_delegation_multi_swap_fee_filetest.gno
+++ b/contract/r/scenario/gov/staker/collect_reward_delegation_multi_swap_fee_filetest.gno
@@ -200,7 +200,7 @@ func checkBalanceFn(cur realm, tokenPath string, addr address, fn func()) {
 // [SCENARIO] 3. First swap (before alice delegation)
 // [EXPECTED] pool current tick: -1
 // [EXPECTED] inputTokenAmount(gno.land/r/onbloc/bar.BAR): 10000
-// [EXPECTED] outputTokenAmount(gno.land/r/onbloc/qux.QUX): -9955
+// [EXPECTED] outputTokenAmount(gno.land/r/onbloc/qux.QUX): 9955
 //
 // [SCENARIO] 4. Alice delegates in the middle
 // [INFO] delegated 1000000 GNS from g1v9kxjcm9ta047h6lta047h6lta047h6lzd40gh to g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5
@@ -208,7 +208,7 @@ func checkBalanceFn(cur realm, tokenPath string, addr address, fn func()) {
 // [SCENARIO] 5. Second swap (after alice delegation)
 // [EXPECTED] pool current tick: -2
 // [EXPECTED] inputTokenAmount(gno.land/r/onbloc/bar.BAR): 10000
-// [EXPECTED] outputTokenAmount(gno.land/r/onbloc/qux.QUX): -9954
+// [EXPECTED] outputTokenAmount(gno.land/r/onbloc/qux.QUX): 9954
 //
 // [SCENARIO] 6. Check and collect protocol fee reward for admin
 // [INFO] collected protocol fee reward for g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5

--- a/contract/r/scenario/gov/staker/collect_reward_delegation_multi_withdrawal_fee_filetest.gno
+++ b/contract/r/scenario/gov/staker/collect_reward_delegation_multi_withdrawal_fee_filetest.gno
@@ -216,7 +216,7 @@ func checkBalanceFn(cur realm, tokenPath string, addr address, fn func()) {
 // [SCENARIO] 3. Swap to generate fees
 // [EXPECTED] pool current tick: -914
 // [EXPECTED] inputTokenAmount(gno.land/r/onbloc/bar.BAR): 1000000000
-// [EXPECTED] outputTokenAmount(gno.land/r/onbloc/qux.QUX): -951067458
+// [EXPECTED] outputTokenAmount(gno.land/r/onbloc/qux.QUX): 951067458
 //
 // [SCENARIO] 4. First withdrawal fee collection (before alice delegation)
 // [INFO] collected position fee for position 1
@@ -227,7 +227,7 @@ func checkBalanceFn(cur realm, tokenPath string, addr address, fn func()) {
 // [SCENARIO] 6. Second swap to generate more fees
 // [EXPECTED] pool current tick: -1000
 // [EXPECTED] inputTokenAmount(gno.land/r/onbloc/bar.BAR): 52325114
-// [EXPECTED] outputTokenAmount(gno.land/r/onbloc/qux.QUX): -47432542
+// [EXPECTED] outputTokenAmount(gno.land/r/onbloc/qux.QUX): 47432542
 //
 // [SCENARIO] 7. Second withdrawal fee collection (after alice delegation)
 // [INFO] collected position fee for position 1

--- a/contract/r/scenario/gov/staker/collect_reward_swap_route_fee_filetest.gno
+++ b/contract/r/scenario/gov/staker/collect_reward_swap_route_fee_filetest.gno
@@ -186,7 +186,7 @@ func checkBalanceFn(cur realm, tokenPath string, addr address, fn func()) {
 // [SCENARIO] 3. Swap route by swap route fee
 // [EXPECTED] pool current tick: -1
 // [EXPECTED] inputTokenAmount(gno.land/r/onbloc/bar.BAR): 10000
-// [EXPECTED] outputTokenAmount(gno.land/r/onbloc/qux.QUX): -9955
+// [EXPECTED] outputTokenAmount(gno.land/r/onbloc/qux.QUX): 9955
 //
 // [SCENARIO] 4. Check and collect protocol fee reward for alice
 // [INFO] collected protocol fee reward for g1v9kxjcm9ta047h6lta047h6lta047h6lzd40gh

--- a/contract/r/scenario/gov/staker/collect_reward_withdrawal_fee_filetest.gno
+++ b/contract/r/scenario/gov/staker/collect_reward_withdrawal_fee_filetest.gno
@@ -203,7 +203,7 @@ func checkBalanceFn(cur realm, tokenPath string, addr address, fn func()) {
 // [SCENARIO] 3. Swap route by swap route fee
 // [EXPECTED] pool current tick: -914
 // [EXPECTED] inputTokenAmount(gno.land/r/onbloc/bar.BAR): 1000000000
-// [EXPECTED] outputTokenAmount(gno.land/r/onbloc/qux.QUX): -951067458
+// [EXPECTED] outputTokenAmount(gno.land/r/onbloc/qux.QUX): 951067458
 //
 // [SCENARIO] 4. Check and collect protocol fee reward for alice
 // [INFO] collected protocol fee reward for g1v9kxjcm9ta047h6lta047h6lta047h6lzd40gh

--- a/contract/r/scenario/halt/safe_mode_blocks_withdraw_filetest.gno
+++ b/contract/r/scenario/halt/safe_mode_blocks_withdraw_filetest.gno
@@ -317,7 +317,7 @@ func disableSafeModeAndVerify(cur realm) {
 //
 // [STEP 7] Test: Router swap works in Safe Mode
 // [INFO] Attempting router swap in Safe Mode...
-// [SUCCESS] Router swap works in Safe Mode! AmountIn: 100000, AmountOut: -99513
+// [SUCCESS] Router swap works in Safe Mode! AmountIn: 100000, AmountOut: 99513
 //
 // [STEP 8] Disable Safe Mode and verify withdraw works
 // [INFO] Safe Mode disabled. Withdraw halted: false (should be false)

--- a/contract/r/scenario/router/dryswap_cross_into_inactive_liquidity_filetest.gno
+++ b/contract/r/scenario/router/dryswap_cross_into_inactive_liquidity_filetest.gno
@@ -77,7 +77,7 @@ func main(cur realm) {
 		cross(cur), bazPath, barPath, amountIn, route, "100", "1",
 		time.Now().Add(time.Hour).Unix(), "",
 	)
-	if actualIn != dryIn || actualOut != "-"+dryOut {
+	if actualIn != dryIn || actualOut != dryOut {
 		panic("expected router DrySwapRoute and ExactInSwapRoute amounts to match")
 	}
 
@@ -94,6 +94,6 @@ func main(cur realm) {
 // [SCENARIO] Router DrySwap crosses into an initially inactive liquidity range
 // [INFO] Active liquidity before quote: 0
 // [INFO] Router DrySwap amounts: 6000000 5893260
-// [INFO] Router Swap amounts: 6000000 -5893260
+// [INFO] Router Swap amounts: 6000000 5893260
 // [INFO] Tick after router swap: 218
 // [RESULT] Router quote and swap crossed into inactive liquidity

--- a/contract/r/scenario/router/dryswap_swap_consistency_filetest.gno
+++ b/contract/r/scenario/router/dryswap_swap_consistency_filetest.gno
@@ -604,7 +604,8 @@ func printExactOutTolerance(cur realm, requested string, dryOut string, toleranc
 func assertExactOutOutputMatches(cur realm, dryOut, actualOut string) {
 	actualOutAmount, okActualOut := parseInt64(cur, actualOut)
 	uassert.Equal(t, true, okActualOut)
-	uassert.Equal(t, dryOut, strconv.FormatInt(absInt64(cur, actualOutAmount), 10))
+	uassert.Equal(t, true, actualOutAmount > 0)
+	uassert.Equal(t, dryOut, actualOut)
 }
 
 func drySwapExactOutForAmount(cur realm, inputToken, outputToken string, amount int64, route, quote, amountLimit string) (string, bool, int64, bool) {
@@ -1051,25 +1052,25 @@ func testMultiHop_TwoRoute_ThreeHop_ExactOut_Fail(cur realm) {
 // [EXPECTED] DrySwap amountIn should be 100000
 // [EXPECTED] DrySwap amountOut should be 99800
 // [EXPECTED] Actual amountIn should be 100000
-// [EXPECTED] Actual amountOut should be -99800
+// [EXPECTED] Actual amountOut should be 99800
 //
 // [INFO] Testing Exact In - Medium amount
 // [EXPECTED] DrySwap amountIn should be 10000000
 // [EXPECTED] DrySwap amountOut should be 9977346
 // [EXPECTED] Actual amountIn should be 10000000
-// [EXPECTED] Actual amountOut should be -9977346
+// [EXPECTED] Actual amountOut should be 9977346
 //
 // [INFO] Testing Exact In - Large amount
 // [EXPECTED] DrySwap amountIn should be 1000000000
 // [EXPECTED] DrySwap amountOut should be 972055147
 // [EXPECTED] Actual amountIn should be 1000000000
-// [EXPECTED] Actual amountOut should be -972055147
+// [EXPECTED] Actual amountOut should be 972055147
 //
 // [INFO] Testing Exact In - Almost all liquidity
 // [EXPECTED] DrySwap amountIn should be 100000000000
 // [EXPECTED] DrySwap amountOut should be 10643831036
 // [EXPECTED] Actual amountIn should be 100000000000
-// [EXPECTED] Actual amountOut should be -10643831036
+// [EXPECTED] Actual amountOut should be 10643831036
 //
 // [SCENARIO] 3. Test Exact Out Swaps - DrySwap vs Actual Swap
 // [INFO] Testing Exact Out - Small amount
@@ -1077,21 +1078,21 @@ func testMultiHop_TwoRoute_ThreeHop_ExactOut_Fail(cur realm) {
 // [EXPECTED] DrySwap amountOut should be 100000
 // [EXPECTED] DrySwap success should be true
 // [EXPECTED] Actual amountIn should be 38005732
-// [EXPECTED] Actual amountOut should be -100000
+// [EXPECTED] Actual amountOut should be 100000
 //
 // [INFO] Testing Exact Out - Medium amount
 // [EXPECTED] DrySwap amountIn should be 3956433712
 // [EXPECTED] DrySwap amountOut should be 10000000
 // [EXPECTED] DrySwap success should be true
 // [EXPECTED] Actual amountIn should be 3956433712
-// [EXPECTED] Actual amountOut should be -10000000
+// [EXPECTED] Actual amountOut should be 10000000
 //
 // [INFO] Testing Exact Out - Large amount
 // [EXPECTED] DrySwap amountIn should be 679799534408
 // [EXPECTED] DrySwap amountOut should be 1000000000
 // [EXPECTED] DrySwap success should be true
 // [EXPECTED] Actual amountIn should be 679799534408
-// [EXPECTED] Actual amountOut should be -1000000000
+// [EXPECTED] Actual amountOut should be 1000000000
 //
 // [INFO] Testing Bug Scenario - Large exact out
 // [EXPECTED] DrySwap amountIn should be 0
@@ -1115,71 +1116,71 @@ func testMultiHop_TwoRoute_ThreeHop_ExactOut_Fail(cur realm) {
 // [EXPECTED] Zero exact out - Returned expected error
 //
 // [INFO] Testing reverse direction swap consistency
-// [EXPECTED] Forward swap - Dry: in=1000000 out(with fee)=931857046 | Actual: in=1000000 out=-931857046
-// [EXPECTED] Reverse swap - Dry: in=1000000 out(with fee)=1069 | Actual: in=1000000 out=-1069
+// [EXPECTED] Forward swap - Dry: in=1000000 out(with fee)=931857046 | Actual: in=1000000 out=931857046
+// [EXPECTED] Reverse swap - Dry: in=1000000 out(with fee)=1069 | Actual: in=1000000 out=1069
 //
 // [INFO] Testing with maximum slippage protection
 // [EXPECTED] Tight slippage - DrySwap returns in=1000000 out=931161307 success=true
-// [EXPECTED] Swap - Dry: in=1000000 out(with fee)=931161307 | Actual: in=1000000 out(with fee)=-931161307
+// [EXPECTED] Swap - Dry: in=1000000 out(with fee)=931161307 | Actual: in=1000000 out(with fee)=931161307
 //
 // [SCENARIO] 6. Test Multi-Hop Routes
 // [INFO] 2-hop single-route matrix
 // [INFO] Testing Multi-Hop (2-hop) Exact In
 // [EXPECTED] DrySwap 2-hop - in=100000 out=271134 success=true
-// [EXPECTED] Actual swap 2-hop - in=100000 out=-271134
-// [EXPECTED] Results should match: DryIn=100000 ActualIn=100000, DryOut=271134 ActualOut=-271134
+// [EXPECTED] Actual swap 2-hop - in=100000 out=271134
+// [EXPECTED] Results should match: DryIn=100000 ActualIn=100000, DryOut=271134 ActualOut=271134
 //
 // [INFO] Testing Multi-Hop (2-hop) Exact Out - Success
 // [EXPECTED] DrySwap 2-hop ExactOut success - in=246 out=663 success=true
 // [EXPECTED] ExactOut tolerance check: requested=663 dryOut=663 diff=0 tolerance=2 withinTolerance=true
-// [EXPECTED] Actual swap 2-hop ExactOut success - in=246 out=-663
+// [EXPECTED] Actual swap 2-hop ExactOut success - in=246 out=663
 //
 // [INFO] Testing Multi-Hop (2-hop) Exact Out - Success
 // [EXPECTED] DrySwap 2-hop ExactOut success - in=368826450 out=1000000000 success=true
 // [EXPECTED] ExactOut tolerance check: requested=1000000000 dryOut=1000000000 diff=0 tolerance=2 withinTolerance=true
-// [EXPECTED] Actual swap 2-hop ExactOut success - in=368826450 out=-1000000000
+// [EXPECTED] Actual swap 2-hop ExactOut success - in=368826450 out=1000000000
 //
 // [INFO] 2-hop two-route matrix
 // [INFO] Testing Multi-Hop (2-hop, two-route) Exact In
 // [EXPECTED] DrySwap 2-hop two-route ExactIn - in=100000 out=271123 success=true
-// [EXPECTED] Actual swap 2-hop two-route ExactIn - in=100000 out=-271123
+// [EXPECTED] Actual swap 2-hop two-route ExactIn - in=100000 out=271123
 //
 // [INFO] Testing Multi-Hop (2-hop, two-route) Exact Out - Success
 // [EXPECTED] DrySwap 2-hop two-route ExactOut success - in=372 out=1000 success=true
 // [EXPECTED] ExactOut tolerance check: requested=1000 dryOut=1000 diff=0 tolerance=4 withinTolerance=true
-// [EXPECTED] Actual swap 2-hop two-route ExactOut success - in=372 out=-1000
+// [EXPECTED] Actual swap 2-hop two-route ExactOut success - in=372 out=1000
 //
 // [INFO] Testing Multi-Hop (2-hop, two-route) Exact Out - Success
 // [EXPECTED] DrySwap 2-hop two-route ExactOut success - in=368837267 out=1000000000 success=true
 // [EXPECTED] ExactOut tolerance check: requested=1000000000 dryOut=1000000000 diff=0 tolerance=4 withinTolerance=true
-// [EXPECTED] Actual swap 2-hop two-route ExactOut success - in=368840871 out=-1000000000
+// [EXPECTED] Actual swap 2-hop two-route ExactOut success - in=368840871 out=1000000000
 //
 // [INFO] 3-hop single-route matrix
 // [INFO] Testing Multi-Hop (3-hop round trip) - swapCount=3
 // [EXPECTED] DrySwap 3-hop - in=10000 out=9297855 success=true
-// [EXPECTED] Actual swap 3-hop - in=10000 out=-9298785
+// [EXPECTED] Actual swap 3-hop - in=10000 out=9298785
 //
 // [INFO] Testing Multi-Hop (3-hop) Exact Out - Success
 // [EXPECTED] DrySwap 3-hop ExactOut success - in=247 out=663 success=true
 // [EXPECTED] ExactOut tolerance check: requested=663 dryOut=663 diff=0 tolerance=3 withinTolerance=true
-// [EXPECTED] Actual swap 3-hop ExactOut success - in=247 out=-663
+// [EXPECTED] Actual swap 3-hop ExactOut success - in=247 out=663
 //
 // [INFO] Testing Multi-Hop (3-hop) Exact Out - Success
 // [EXPECTED] DrySwap 3-hop ExactOut success - in=7 out=10 success=true
 // [EXPECTED] ExactOut tolerance check: requested=10 dryOut=10 diff=0 tolerance=3 withinTolerance=true
-// [EXPECTED] Actual swap 3-hop ExactOut success - in=7 out=-10
+// [EXPECTED] Actual swap 3-hop ExactOut success - in=7 out=10
 //
 // [INFO] 3-hop two-route matrix
 // [INFO] Testing Multi-Hop (3-hop, two-route) Exact In
 // [EXPECTED] DrySwap 3-hop two-route ExactIn - in=10000 out=25380 success=true
-// [EXPECTED] Actual swap 3-hop two-route ExactIn - in=10000 out=-25380
+// [EXPECTED] Actual swap 3-hop two-route ExactIn - in=10000 out=25380
 //
 // [INFO] Testing Multi-Hop (3-hop, two-route) Exact Out - Success
 // [EXPECTED] DrySwap 3-hop two-route ExactOut success - in=6 out=2 success=true
 // [EXPECTED] ExactOut tolerance check: requested=2 dryOut=2 diff=0 tolerance=4 withinTolerance=true
-// [EXPECTED] Actual swap 3-hop two-route ExactOut success - in=6 out=-2
+// [EXPECTED] Actual swap 3-hop two-route ExactOut success - in=6 out=2
 //
 // [INFO] Testing Multi-Hop (3-hop, two-route) Exact Out - Success
 // [EXPECTED] DrySwap 3-hop two-route ExactOut success - in=432334 out=1000000 success=true
 // [EXPECTED] ExactOut tolerance check: requested=1000000 dryOut=1000000 diff=0 tolerance=4 withinTolerance=true
-// [EXPECTED] Actual swap 3-hop two-route ExactOut success - in=432334 out=-1000000
+// [EXPECTED] Actual swap 3-hop two-route ExactOut success - in=432334 out=1000000

--- a/contract/r/scenario/router/exact_in_multi_swap_route_with_cycle_path_filetest.gno
+++ b/contract/r/scenario/router/exact_in_multi_swap_route_with_cycle_path_filetest.gno
@@ -208,6 +208,6 @@ func exactInSwapRoute(cur realm,
 // [INFO] queryRatios: 100
 // [INFO] minAmountOut: 1
 // [EXPECTED] inputTokenAmount(WUGNOT): 10000000
-// [EXPECTED] outputTokenAmount(BAR): -9421648
+// [EXPECTED] outputTokenAmount(BAR): 9421648
 // [EXPECTED] WUGNOT balance changed: -10000000
 // [EXPECTED] BAR balance changed: 9421648

--- a/contract/r/scenario/router/exact_in_single_swap_route_filetest.gno
+++ b/contract/r/scenario/router/exact_in_single_swap_route_filetest.gno
@@ -194,6 +194,6 @@ func exactInSingleSwapRouteBy(cur realm,
 // [INFO] queryRatios: 100
 // [INFO] minAmountOut: 1
 // [EXPECTED] inputTokenAmount(GNS): 10000000
-// [EXPECTED] outputTokenAmount(GNOT): -9695218
+// [EXPECTED] outputTokenAmount(GNOT): 9695218
 // [EXPECTED] GNS balance changed: 9695218
 // [EXPECTED] WUGNOT balance changed: -10000000

--- a/contract/r/scenario/router/exact_in_single_swap_route_partial_filetest.gno
+++ b/contract/r/scenario/router/exact_in_single_swap_route_partial_filetest.gno
@@ -196,6 +196,6 @@ func exactInSingleSwapRouteBy(cur realm,
 // [INFO] minAmountOut: 1
 // [EXPECTED] pool current tick: -10
 // [EXPECTED] inputTokenAmount(GNS): 170253
-// [EXPECTED] outputTokenAmount(GNOT): -169826
+// [EXPECTED] outputTokenAmount(GNOT): 169826
 // [EXPECTED] GNS balance changed: 169826
 // [EXPECTED] WUGNOT balance changed: -170253

--- a/contract/r/scenario/router/exact_in_swap_return_from_terminal_tick_filetest.gno
+++ b/contract/r/scenario/router/exact_in_swap_return_from_terminal_tick_filetest.gno
@@ -125,23 +125,23 @@ func assertTickInRange(path string, lower, upper int32, terminal string) {
 // [SUCCESS] Minted the only position in range [-50, 50]
 // [STEP 2] Move the pool to the lower terminal tick
 // [ACTION] Execute bar -> baz ExactIn swap with input=100000
-// [RESULT] Forward swap: in=10028 out=-9985
+// [RESULT] Forward swap: in=10028 out=9985
 // [EXPECTED] Tick after lower terminal swap: -887271
 //
 // [STEP 3] Recover from the lower terminal tick
 // [ACTION] Execute baz -> bar ExactIn swap with input=1000
-// [RESULT] Recovery swap: in=1000 out=-1002
+// [RESULT] Recovery swap: in=1000 out=1002
 // [EXPECTED] Tick after lower recovery swap: -45
 // [SUCCESS] Returned to the active [-50, 50] range
 //
 // [STEP 4] Move the pool to the upper terminal tick
 // [ACTION] Execute baz -> bar ExactIn swap with input=100000
-// [RESULT] Forward swap: in=19030 out=-18993
+// [RESULT] Forward swap: in=19030 out=18993
 // [EXPECTED] Tick after upper terminal swap: 887270
 //
 // [STEP 5] Recover from the upper terminal tick
 // [ACTION] Execute bar -> baz ExactIn swap with input=1000
-// [RESULT] Recovery swap: in=1000 out=-1002
+// [RESULT] Recovery swap: in=1000 out=1002
 // [EXPECTED] Tick after upper recovery swap: 44
 // [SUCCESS] Returned to the active [-50, 50] range
 // [RESULT] Router returned from both terminal ticks to active liquidity

--- a/contract/r/scenario/router/exact_in_swap_route_with_input_native_token_filetest.gno
+++ b/contract/r/scenario/router/exact_in_swap_route_with_input_native_token_filetest.gno
@@ -192,6 +192,6 @@ func exactInSwapRouteBy(cur realm,
 // [INFO] queryRatios: 100
 // [INFO] minAmountOut: 1
 // [EXPECTED] inputTokenAmount(GNS): 1000
-// [EXPECTED] outputTokenAmount(GNOT): -997
+// [EXPECTED] outputTokenAmount(GNOT): 997
 // [EXPECTED] GNS balance changed: 997
 // [EXPECTED] WUGNOT balance changed: -1000

--- a/contract/r/scenario/router/exact_in_swap_route_with_native_token_filetest.gno
+++ b/contract/r/scenario/router/exact_in_swap_route_with_native_token_filetest.gno
@@ -192,6 +192,6 @@ func exactInSwapRouteBy(cur realm,
 // [INFO] queryRatios: 100
 // [INFO] minAmountOut: 1
 // [EXPECTED] inputTokenAmount(GNS): 1000
-// [EXPECTED] outputTokenAmount(GNOT): -2000
+// [EXPECTED] outputTokenAmount(GNOT): 2000
 // [EXPECTED] GNS balance changed: -1000
 // [EXPECTED] GNOT balance changed: 0

--- a/contract/r/scenario/router/exact_in_swap_route_with_protocol_fee_filetest.gno
+++ b/contract/r/scenario/router/exact_in_swap_route_with_protocol_fee_filetest.gno
@@ -170,7 +170,7 @@ func swapRouteWithBalanceCheck(cur realm) {
 // [INFO] protocol fee foo balance: 0
 // [INFO] Executing ExactIn swap
 // [EXPECTED] amountIn: 1000000
-// [EXPECTED] amountOut: -985678
+// [EXPECTED] amountOut: 985678
 // [EXPECTED] admin bar balance change: 985678
 // [EXPECTED] admin foo balance change: -1000000
 // [EXPECTED] pool bar balance change: -987158

--- a/contract/r/scenario/router/exact_in_swap_route_with_wrapped_native_output_token_filetest.gno
+++ b/contract/r/scenario/router/exact_in_swap_route_with_wrapped_native_output_token_filetest.gno
@@ -270,7 +270,7 @@ func exactInSwapRouteBy(cur realm,
 // [INFO] queryRatios: 100
 // [INFO] minAmountOut: 1
 // [EXPECTED] inputTokenAmount: 1000000
-// [EXPECTED] outputTokenAmount: -986743
+// [EXPECTED] outputTokenAmount: 986743
 // [EXPECTED] WUGNOT balance changed: 986743
 // [EXPECTED] GNOT balance changed: 0
 // [EXPECTED] GNS balance changed: 0
@@ -285,7 +285,7 @@ func exactInSwapRouteBy(cur realm,
 // [INFO] queryRatios: 100
 // [INFO] minAmountOut: 1
 // [EXPECTED] inputTokenAmount: 1000000
-// [EXPECTED] outputTokenAmount: -975329
+// [EXPECTED] outputTokenAmount: 975329
 // [EXPECTED] WUGNOT balance changed: 975329
 // [EXPECTED] GNOT balance changed: 0
 // [EXPECTED] GNS balance changed: 0
@@ -300,7 +300,7 @@ func exactInSwapRouteBy(cur realm,
 // [INFO] queryRatios: 100
 // [INFO] minAmountOut: 1
 // [EXPECTED] inputTokenAmount: 1000000
-// [EXPECTED] outputTokenAmount: -998223
+// [EXPECTED] outputTokenAmount: 998223
 // [EXPECTED] WUGNOT balance changed: 0
 // [EXPECTED] GNOT balance changed: 0
 // [EXPECTED] GNS balance changed: 998223
@@ -315,7 +315,7 @@ func exactInSwapRouteBy(cur realm,
 // [INFO] queryRatios: 100
 // [INFO] minAmountOut: 1
 // [EXPECTED] inputTokenAmount: 1000000
-// [EXPECTED] outputTokenAmount: -1004036
+// [EXPECTED] outputTokenAmount: 1004036
 // [EXPECTED] WUGNOT balance changed: -1000000
 // [EXPECTED] GNOT balance changed: 0
 // [EXPECTED] GNS balance changed: 0

--- a/contract/r/scenario/router/exact_out_amount_verification_filetest.gno
+++ b/contract/r/scenario/router/exact_out_amount_verification_filetest.gno
@@ -299,37 +299,37 @@ func singleHopLowFeePool(cur realm) {
 // [INFO] all pools at 1:1 price with 20T liquidity each
 //
 // [SCENARIO] 2. 1-route 1-hop: ExactOut 1,000,000 bar (baz→bar:3000)
-// [INFO] amountIn=1004517 amountOut=-1000000
+// [INFO] amountIn=1004517 amountOut=1000000
 // [EXPECTED] user received: 1000000 (want: 1000000)
 // [EXPECTED] protocol fee: 1502 = pool(1001502) - user(1000000)
 //
 // [SCENARIO] 3. 1-route 2-hop: ExactOut 1,000,000 foo (bar→baz→foo)
-// [INFO] amountIn=1007543 amountOut=-1000000
+// [INFO] amountIn=1007543 amountOut=1000000
 // [EXPECTED] user received: 1000000 (want: 1000000)
 // [EXPECTED] protocol fee (foo): 1502
 //
 // [SCENARIO] 4. 1-route 3-hop: ExactOut 100,000 qux (bar→baz→foo→qux)
-// [INFO] amountIn=101062 amountOut=-100000
+// [INFO] amountIn=101062 amountOut=100000
 // [EXPECTED] user received: 100000 (want: 100000)
 // [EXPECTED] protocol fee (qux): 150
 //
 // [SCENARIO] 5. 2-route split (50/50): ExactOut 1,000,000 bar (baz→bar:3000, baz→bar:500)
-// [INFO] amountIn=1003262 amountOut=-1000000
+// [INFO] amountIn=1003262 amountOut=1000000
 // [EXPECTED] user received: 1000000 (want: 1000000)
 // [EXPECTED] protocol fee (bar): 1502
 //
 // [SCENARIO] 6. 1-route 1-hop minimum: ExactOut 1 bar
-// [INFO] amountIn=3 amountOut=-1
+// [INFO] amountIn=3 amountOut=1
 // [EXPECTED] user received: 1 (want: 1)
 // [EXPECTED] protocol fee: 0 (want: 0, truncated)
 //
 // [SCENARIO] 7. 1-route 1-hop large: ExactOut 9,000,000,000,000 bar
-// [INFO] amountIn=16457760709370 amountOut=-9000000000000
+// [INFO] amountIn=16457760709370 amountOut=9000000000000
 // [EXPECTED] user received: 9000000000000 (want: 9000000000000)
 // [EXPECTED] protocol fee: 13520280420 = pool(9013520280420) - user(9000000000000)
 //
 // [SCENARIO] 8. 1-route 1-hop low-fee pool (500): ExactOut 1,000,000 bar
-// [INFO] amountIn=1002005 amountOut=-1000000
+// [INFO] amountIn=1002005 amountOut=1000000
 // [EXPECTED] user received: 1000000 (want: 1000000)
 // [EXPECTED] protocol fee (bar): 1502
 

--- a/contract/r/scenario/router/exact_out_gnot_swap_route_with_single_route_filetest.gno
+++ b/contract/r/scenario/router/exact_out_gnot_swap_route_with_single_route_filetest.gno
@@ -213,4 +213,4 @@ func exactOutSwapRouteBy(cur realm,
 // [INFO] queryRatios: 100
 // [INFO] amountInMax: 10000000
 // [EXPECTED] wugnot balance of admin: 1001502
-// [EXPECTED] outputTokenAmount: -1001502
+// [EXPECTED] outputTokenAmount: 1001502

--- a/contract/r/scenario/router/exact_out_router_fee_edge_cases_filetest.gno
+++ b/contract/r/scenario/router/exact_out_router_fee_edge_cases_filetest.gno
@@ -168,14 +168,14 @@ func exactOutLargeAmount(cur realm) {
 // [INFO] created bar:baz:3000 pool with 50T liquidity
 //
 // [SCENARIO] 2. ExactOut very small amount (1 token)
-// [INFO] amountIn: 3, amountOut: -1
+// [INFO] amountIn: 3, amountOut: 1
 // [INFO] user bar received: 1
 // [INFO] protocol fee (bar): 0
 // [EXPECTED] user receives exactly 1 bar: 1
 // [EXPECTED] protocol fee is 0 (truncated): 0
 //
 // [SCENARIO] 3. ExactOut large amount (9,000,000,000,000 tokens)
-// [INFO] amountIn: 11028810316105, amountOut: -9000000000000
+// [INFO] amountIn: 11028810316105, amountOut: 9000000000000
 // [INFO] user bar received: 9000000000000
 // [INFO] pool bar output: 9013520280420
 // [INFO] protocol fee (bar): 13520280420

--- a/contract/r/scenario/router/exact_out_router_fee_verification_filetest.gno
+++ b/contract/r/scenario/router/exact_out_router_fee_verification_filetest.gno
@@ -283,7 +283,7 @@ func multiHop1PercentFee(cur realm) {
 // [INFO] created bar:baz:3000 and baz:foo:3000 pools with 100M liquidity each
 //
 // [SCENARIO] 2. Single-hop ExactOut (0.15% fee, 1,000,000 bar)
-// [INFO] amountIn: 1014679, amountOut: -1000000
+// [INFO] amountIn: 1014679, amountOut: 1000000
 // [INFO] user bar received: 1000000
 // [INFO] user baz consumed: 1014679
 // [INFO] pool bar output: 1001502
@@ -292,7 +292,7 @@ func multiHop1PercentFee(cur realm) {
 // [EXPECTED] protocol fee = pool output - user received: 1502 = 1001502 - 1000000
 //
 // [SCENARIO] 3. Single-hop ExactOut (1% fee, 1,000,000 bar)
-// [INFO] amountIn: 1044400, amountOut: -1000000
+// [INFO] amountIn: 1044400, amountOut: 1000000
 // [INFO] user bar received: 1000000
 // [INFO] pool bar output: 1010101
 // [INFO] protocol fee (bar): 10101
@@ -300,14 +300,14 @@ func multiHop1PercentFee(cur realm) {
 // [EXPECTED] protocol fee = pool output - user received: 10101 = 1010101 - 1000000
 //
 // [SCENARIO] 4. Multi-hop ExactOut (0.15% fee, 1,000 foo via bar→baz→foo)
-// [INFO] amountIn: 969, amountOut: -1000
+// [INFO] amountIn: 969, amountOut: 1000
 // [INFO] user foo received: 1000
 // [INFO] user bar consumed: 969
 // [INFO] protocol fee (foo): 1
 // [EXPECTED] user receives exactly 1,000 foo: 1000
 //
 // [SCENARIO] 5. Multi-hop ExactOut (1% fee, 1,000 foo via bar→baz→foo)
-// [INFO] amountIn: 978, amountOut: -1000
+// [INFO] amountIn: 978, amountOut: 1000
 // [INFO] user foo received: 1000
 // [INFO] user bar consumed: 978
 // [INFO] protocol fee (foo): 10

--- a/contract/r/scenario/router/exact_out_single_swap_route_filetest.gno
+++ b/contract/r/scenario/router/exact_out_single_swap_route_filetest.gno
@@ -193,6 +193,6 @@ func exactOutSingleSwapRouteBy(cur realm,
 // [INFO] queryRatios: 100
 // [INFO] maxAmountOut: 10000
 // [EXPECTED] inputTokenAmount(GNS): 1003
-// [EXPECTED] outputTokenAmount(GNOT): -1000
+// [EXPECTED] outputTokenAmount(GNOT): 1000
 // [EXPECTED] GNS balance changed: 1000
 // [EXPECTED] WUGNOT balance changed: -1003

--- a/contract/r/scenario/router/exact_out_single_swap_route_native_partial_filetest.gno
+++ b/contract/r/scenario/router/exact_out_single_swap_route_native_partial_filetest.gno
@@ -196,6 +196,6 @@ func exactOutSingleSwapRouteBy(cur realm,
 // [INFO] maxAmountOut: 100000000
 // [EXPECTED] pool current tick: -10
 // [EXPECTED] inputTokenAmount(GNS): 170253
-// [EXPECTED] outputTokenAmount(GNOT): -169826
+// [EXPECTED] outputTokenAmount(GNOT): 169826
 // [EXPECTED] GNS balance changed: 169826
 // [EXPECTED] WUGNOT balance changed: -170253

--- a/contract/r/scenario/router/exact_out_swap_return_from_terminal_tick_filetest.gno
+++ b/contract/r/scenario/router/exact_out_swap_return_from_terminal_tick_filetest.gno
@@ -123,23 +123,23 @@ func assertInRange(label string) {
 // [SUCCESS] Minted the only position in range [-50, 50]
 // [STEP 2] Move the pool to the lower terminal tick
 // [ACTION] Execute bar -> baz ExactIn swap with input=100000
-// [RESULT] Forward swap: in=10028 out=-9985
+// [RESULT] Forward swap: in=10028 out=9985
 // [EXPECTED] Tick after lower terminal: -887271
 //
 // [STEP 3] Recover from the lower terminal tick with ExactOut
 // [ACTION] Request 1000 bar with bounded max input=10000
-// [RESULT] Recovery swap: in=998 out=-1000
+// [RESULT] Recovery swap: in=998 out=1000
 // [EXPECTED] Tick after lower ExactOut reverse: -46
 // [SUCCESS] Returned to the active [-50, 50] range
 //
 // [STEP 4] Move the pool to the upper terminal tick
 // [ACTION] Execute baz -> bar ExactIn swap with input=100000
-// [RESULT] Forward swap: in=19033 out=-18995
+// [RESULT] Forward swap: in=19033 out=18995
 // [EXPECTED] Tick after upper terminal: 887270
 //
 // [STEP 5] Recover from the upper terminal tick with ExactOut
 // [ACTION] Request 1000 baz with bounded max input=10000
-// [RESULT] Recovery swap: in=998 out=-1000
+// [RESULT] Recovery swap: in=998 out=1000
 // [EXPECTED] Tick after upper ExactOut reverse: 45
 // [SUCCESS] Returned to the active [-50, 50] range
 // [RESULT] Router ExactOut returned from both terminal ticks

--- a/contract/r/scenario/router/exact_out_swap_route_with_multi_route_filetest.gno
+++ b/contract/r/scenario/router/exact_out_swap_route_with_multi_route_filetest.gno
@@ -204,4 +204,4 @@ func exactOutSwapRouteBy(cur realm,
 // [INFO] queryRatios: 40,40,20
 // [INFO] amountInMax: 10000000
 // [EXPECTED] inputTokenAmount: 1005548
-// [EXPECTED] outputTokenAmount: -1001502
+// [EXPECTED] outputTokenAmount: 1001502

--- a/contract/r/scenario/router/exact_out_swap_route_with_protocol_fee_filetest.gno
+++ b/contract/r/scenario/router/exact_out_swap_route_with_protocol_fee_filetest.gno
@@ -170,7 +170,7 @@ func swapRouteWithBalanceCheck(cur realm) {
 // [INFO] protocol fee foo balance: 0
 // [INFO] Executing ExactOut swap
 // [EXPECTED] amountIn: 1014679
-// [EXPECTED] amountOut: -1000000
+// [EXPECTED] amountOut: 1000000
 // [EXPECTED] admin bar balance change: 1000000
 // [EXPECTED] admin foo balance change: -1014679
 // [EXPECTED] pool bar balance change: -1001502

--- a/contract/r/scenario/router/exact_out_swap_route_with_single_route_filetest.gno
+++ b/contract/r/scenario/router/exact_out_swap_route_with_single_route_filetest.gno
@@ -204,4 +204,4 @@ func exactOutSwapRouteBy(cur realm,
 // [INFO] queryRatios: 100
 // [INFO] amountInMax: 10000000
 // [EXPECTED] inputTokenAmount: 1004496
-// [EXPECTED] outputTokenAmount: -1001502
+// [EXPECTED] outputTokenAmount: 1001502

--- a/contract/r/scenario/router/exact_out_swap_route_with_wrapped_native_output_token_filetest.gno
+++ b/contract/r/scenario/router/exact_out_swap_route_with_wrapped_native_output_token_filetest.gno
@@ -266,7 +266,7 @@ func exactOutSwapRouteBy(cur realm,
 // [INFO] queryRatios: 100
 // [INFO] maxAmountIn: 100000000000
 // [EXPECTED] inputTokenAmount: 1013515
-// [EXPECTED] outputTokenAmount: -1000000
+// [EXPECTED] outputTokenAmount: 1000000
 // [EXPECTED] WUGNOT balance changed: 1000000
 // [EXPECTED] GNS balance changed: 0
 // [EXPECTED] BAR balance changed: -1013515
@@ -280,7 +280,7 @@ func exactOutSwapRouteBy(cur realm,
 // [INFO] queryRatios: 100
 // [INFO] maxAmountIn: 100000000000
 // [EXPECTED] inputTokenAmount: 1025608
-// [EXPECTED] outputTokenAmount: -1000000
+// [EXPECTED] outputTokenAmount: 1000000
 // [EXPECTED] WUGNOT balance changed: 1000000
 // [EXPECTED] GNS balance changed: 0
 // [EXPECTED] BAR balance changed: -1025608
@@ -294,7 +294,7 @@ func exactOutSwapRouteBy(cur realm,
 // [INFO] queryRatios: 100
 // [INFO] maxAmountIn: 100000000000
 // [EXPECTED] inputTokenAmount: 1001565
-// [EXPECTED] outputTokenAmount: -1000000
+// [EXPECTED] outputTokenAmount: 1000000
 // [EXPECTED] WUGNOT balance changed: 0
 // [EXPECTED] GNS balance changed: 1000000
 // [EXPECTED] BAR balance changed: -1001565
@@ -308,7 +308,7 @@ func exactOutSwapRouteBy(cur realm,
 // [INFO] queryRatios: 100
 // [INFO] maxAmountIn: 100000000000
 // [EXPECTED] inputTokenAmount: 995511
-// [EXPECTED] outputTokenAmount: -1000000
+// [EXPECTED] outputTokenAmount: 1000000
 // [EXPECTED] WUGNOT balance changed: -995511
 // [EXPECTED] GNS balance changed: 0
 // [EXPECTED] BAR balance changed: 1000000

--- a/contract/r/scenario/router/fee_calculation_accuracy_filetest.gno
+++ b/contract/r/scenario/router/fee_calculation_accuracy_filetest.gno
@@ -271,36 +271,36 @@ func testExactOutFeeCalculation(cur realm) {
 // [SCENARIO] 1. Fee Calculation for Different Tiers
 // [INFO] Testing 0.01% fee tier
 // [EXPECTED] Input: 1000000000
-// [EXPECTED] Output: -994487688
+// [EXPECTED] Output: 994487688
 // [EXPECTED] Fee should be ~100,000 units (0.01% of input)
 // [INFO] Testing 0.05% fee tier
 // [EXPECTED] Input: 1000000000
-// [EXPECTED] Output: -994091411
+// [EXPECTED] Output: 994091411
 // [EXPECTED] Fee should be ~500,000 units (0.05% of input)
 // [INFO] Testing 0.30% fee tier
 // [EXPECTED] Input: 1000000000
-// [EXPECTED] Output: -991626613
+// [EXPECTED] Output: 991626613
 // [EXPECTED] Fee should be ~3,000,000 units (0.30% of input)
 // [INFO] Testing 1.00% fee tier
 // [EXPECTED] Input: 1000000000
-// [EXPECTED] Output: -984679480
+// [EXPECTED] Output: 984679480
 // [EXPECTED] Fee should be ~10,000,000 units (1.00% of input)
 //
 // [SCENARIO] 2. Fee Accumulation Over Multiple Swaps
 // [INFO] Testing fee accumulation over multiple swaps
-// [INFO] SWAP 1 - In: 100000000, Out: -98980966
-// [INFO] SWAP 2 - In: 100000000, Out: -98903481
-// [INFO] SWAP 3 - In: 100000000, Out: -98826089
+// [INFO] SWAP 1 - In: 100000000, Out: 98980966
+// [INFO] SWAP 2 - In: 100000000, Out: 98903481
+// [INFO] SWAP 3 - In: 100000000, Out: 98826089
 // [EXPECTED] Each swap should deduct 0.05% fee consistently
 //
 // [SCENARIO] 3. Fee Precision for Small Amounts
 // [INFO] Testing fee precision for small amounts
 // [EXPECTED] Small amount in: 1337
-// [EXPECTED] Small amount out: -1321
+// [EXPECTED] Small amount out: 1321
 // [EXPECTED] Fee calculation should handle rounding correctly
 //
 // [SCENARIO] 4. Fee Calculation in Exact Out Swaps
 // [INFO] Testing fee calculation in exact out swaps
 // [EXPECTED] Input required: 995739810
-// [EXPECTED] Output received: -1000000000
+// [EXPECTED] Output received: 1000000000
 // [EXPECTED] Input should be ~1,000,500,250 (accounting for 0.05% fee)

--- a/contract/r/scenario/router/inactive_liquidity_callback_and_recovery_filetest.gno
+++ b/contract/r/scenario/router/inactive_liquidity_callback_and_recovery_filetest.gno
@@ -194,12 +194,12 @@ func assertActiveLiquidity(wantZero bool, label string) {
 //
 // [STEP 5] Cross remaining [100, 200] liquidity and reach the upper terminal
 // [ACTION] Execute baz -> bar ExactIn swap with input=100000
-// [RESULT] Forward swap: in=10154 out=-9985
+// [RESULT] Forward swap: in=10154 out=9985
 // [EXPECTED] tick after crossing out-of-range liquidity: 887270
 //
 // [STEP 6] Recover from the upper terminal
 // [ACTION] Execute bar -> baz ExactIn swap with input=1000
-// [RESULT] Recovery swap: in=1000 out=-1017
+// [RESULT] Recovery swap: in=1000 out=1017
 // [EXPECTED] tick after recovery swap: 189
 // [EXPECTED] Active liquidity is zero after re-entering the out-of-range position: false
 // [SUCCESS] Re-entered and reactivated the [100, 200] position

--- a/contract/r/scenario/router/position_lifecycle_with_native_token_filetest.gno
+++ b/contract/r/scenario/router/position_lifecycle_with_native_token_filetest.gno
@@ -264,7 +264,7 @@ func testBurnPositionWithUnwrap(cur realm, removedLiquidity string) {
 //
 // [SCENARIO] 3. Execute Swaps (Generate Fees)
 // [INFO] Executing swaps to generate fees
-// [INFO] Swap 1 - GNS in: 10000000 WUGNOT out: -9695218
+// [INFO] Swap 1 - GNS in: 10000000 WUGNOT out: 9695218
 // [INFO] Protocol fee balance WUGNOT: 115880
 // [INFO] Protocol fee balance GNS: 0
 // [EXPECTED] Pool fee (0.5%) accumulated correctly

--- a/contract/r/scenario/router/position_router_swaps_multi_position_filetest.gno
+++ b/contract/r/scenario/router/position_router_swaps_multi_position_filetest.gno
@@ -250,7 +250,7 @@ func executeExactOutRouterSwaps(cur realm) {
 // [INFO] Pool balance of BAR: 10907007633
 // [INFO] Pool balance of FOO: 11000000000
 // [EXPECTED] Swap amountIn should be 1000000000000
-// [EXPECTED] Swap amountOut should be -10804908355
+// [EXPECTED] Swap amountOut should be 10804908355
 // [SCENARIO] 4. Execute exact out swap with almost all
 // [INFO] Executing first swap FOO -> BAR
 // [EXPECTED] Dry swap amountIn should be 0

--- a/contract/r/scenario/router/price_impact_analysis_filetest.gno
+++ b/contract/r/scenario/router/price_impact_analysis_filetest.gno
@@ -361,38 +361,38 @@ func calculatePriceImpact(cur realm, initialPriceStr, finalPriceStr string) stri
 // [INFO] Testing small trade (0.01% of liquidity)
 // [INFO] Initial sqrt price: 79228162514264337593543950336
 // [INFO] Final sqrt price: 79227921418862449018200183058
-// [EXPECTED] Small trade amountOut: -9979977
+// [EXPECTED] Small trade amountOut: 9979977
 // [EXPECTED] Price impact should be < 0.01%, actual: 0.00%
 //
 // [INFO] Testing medium trade (1% of liquidity)
 // [INFO] Initial sqrt price: 79227921418862449018200183058
 // [INFO] Final sqrt price: 79203819286443894850535749976
-// [EXPECTED] Medium trade amountOut: -997691074
+// [EXPECTED] Medium trade amountOut: 997691074
 // [EXPECTED] Price impact should be 0.01~0.1%, actual: 0.03%
 //
 // [INFO] Testing large trade (10% of liquidity)
 // [INFO] Initial sqrt price: 79203819286443894850535749976
 // [INFO] Final sqrt price: 78963602055082262766367635762
-// [EXPECTED] Large trade amountOut: -9943625870
+// [EXPECTED] Large trade amountOut: 9943625870
 // [EXPECTED] Price impact should be > 0.1%, actual: 0.30%
 //
 // [SCENARIO] 2. Price Impact Across Different Fee Tiers
 // [INFO] Comparing price impact across fee tiers
-// [EXPECTED] 0.05% fee pool output: -991046211
-// [EXPECTED] 0.3% fee pool output: -990386319
-// [EXPECTED] 0.05% fee pool output: -991046211
-// [EXPECTED] 0.3% fee pool output: -990386319
+// [EXPECTED] 0.05% fee pool output: 991046211
+// [EXPECTED] 0.3% fee pool output: 990386319
+// [EXPECTED] 0.05% fee pool output: 991046211
+// [EXPECTED] 0.3% fee pool output: 990386319
 // [EXPECTED] Lower fee tier should give better output (less price impact)
 // [EXPECTED] Price impact actual: 0.03%
 // [EXPECTED] Price impact actual: 0.51%
 //
 // [SCENARIO] 3. Multi-hop Price Impact Analysis
 // [INFO] Testing multi-hop price impact
-// [EXPECTED] Single hop output: -990445427
+// [EXPECTED] Single hop output: 990445427
 // [INFO] Multi-hop swaps aggregate price impact from each hop
 //
 // [SCENARIO] 4. Price Impact at Tick Boundaries
 // [INFO] Testing price impact at tick boundaries
-// [EXPECTED] Within tick output: -990145
-// [EXPECTED] Cross-tick output: -47801658638
+// [EXPECTED] Within tick output: 990145
+// [EXPECTED] Cross-tick output: 47801658638
 // [INFO] Crossing tick boundaries increases price impact non-linearly

--- a/contract/r/scenario/router/router_all_2_route_2_hop_filetest.gno
+++ b/contract/r/scenario/router/router_all_2_route_2_hop_filetest.gno
@@ -128,7 +128,7 @@ func testSwapRouteBarQuxExactIn(cur realm) {
 	)
 
 	println("[EXPECTED] amountIn:", amountIn, "expected: 1000")
-	println("[EXPECTED] amountOut:", amountOut, "expected: -7318")
+	println("[EXPECTED] amountOut:", amountOut, "expected: 7318")
 	println()
 }
 
@@ -174,7 +174,7 @@ func testSwapRouteBarQuxExactOut(cur realm) {
 	)
 
 	println("[EXPECTED] amountIn:", amountIn, "expected: 141")
-	println("[EXPECTED] amountOut:", amountOut, "expected: -1001")
+	println("[EXPECTED] amountOut:", amountOut, "expected: 1001")
 	println()
 }
 
@@ -220,7 +220,7 @@ func TestSwapRouteQuxBarExactIn(cur realm) {
 	)
 
 	println("[EXPECTED] amountIn:", amountIn, "expected: 1000")
-	println("[EXPECTED] amountOut:", amountOut, "expected: -135")
+	println("[EXPECTED] amountOut:", amountOut, "expected: 135")
 	println()
 }
 
@@ -266,7 +266,7 @@ func TestSwapRouteQuxBarExactOut(cur realm) {
 	)
 
 	println("[EXPECTED] amountIn:", amountIn, "expected: 7365")
-	println("[EXPECTED] amountOut:", amountOut, "expected: -999")
+	println("[EXPECTED] amountOut:", amountOut, "expected: 999")
 	println()
 }
 
@@ -289,7 +289,7 @@ func TestSwapRouteQuxBarExactOut(cur realm) {
 // [INFO] Approving tokens for swap
 // [INFO] Executing swap route (bar → baz → qux)
 // [EXPECTED] amountIn: 1000 expected: 1000
-// [EXPECTED] amountOut: -7318 expected: -7318
+// [EXPECTED] amountOut: 7318 expected: 7318
 //
 // [SCENARIO] Given: Dry swap route bar to qux exact out preparation
 // [INFO] Executing dry swap route exact out (bar → baz → qux)
@@ -299,7 +299,7 @@ func TestSwapRouteQuxBarExactOut(cur realm) {
 // [INFO] Approving tokens for swap
 // [INFO] Executing swap route exact out (bar → baz → qux)
 // [EXPECTED] amountIn: 141 expected: 141
-// [EXPECTED] amountOut: -1001 expected: -1001
+// [EXPECTED] amountOut: 1001 expected: 1001
 //
 // [SCENARIO] Given: Dry swap route qux to bar exact in preparation
 // [INFO] Executing dry swap route (qux → baz → bar)
@@ -309,7 +309,7 @@ func TestSwapRouteQuxBarExactOut(cur realm) {
 // [INFO] Approving tokens for swap
 // [INFO] Executing swap route (qux → baz → bar)
 // [EXPECTED] amountIn: 1000 expected: 1000
-// [EXPECTED] amountOut: -135 expected: -135
+// [EXPECTED] amountOut: 135 expected: 135
 //
 // [SCENARIO] Given: Dry swap route qux to bar exact out preparation
 // [INFO] Executing dry swap route exact out (qux → baz → bar)
@@ -319,6 +319,6 @@ func TestSwapRouteQuxBarExactOut(cur realm) {
 // [INFO] Approving tokens for swap
 // [INFO] Executing swap route exact out (qux → baz → bar)
 // [EXPECTED] amountIn: 7373 expected: 7365
-// [EXPECTED] amountOut: -1000 expected: -999
+// [EXPECTED] amountOut: 1000 expected: 999
 //
 // [INFO] Scenario completed

--- a/contract/r/scenario/router/router_spec_1_exact_in_filetest.gno
+++ b/contract/r/scenario/router/router_spec_1_exact_in_filetest.gno
@@ -147,7 +147,7 @@ func testExactInputSinglePool(cur realm) {
 	)
 
 	println("[EXPECTED] amountIn:", amountIn, "expected: 3")
-	println("[EXPECTED] amountOut:", amountOut, "expected: -1")
+	println("[EXPECTED] amountOut:", amountOut, "expected: 1")
 
 	println("[INFO] Checking balances after swap")
 	poolToken0After := bar.BalanceOf(poolAddr)
@@ -194,7 +194,7 @@ func testExactInputSinglePool(cur realm) {
 // [INFO] user1 baz balance: 0
 // [INFO] Executing ExactIn swap (3 bar → baz)
 // [EXPECTED] amountIn: 3 expected: 3
-// [EXPECTED] amountOut: -1 expected: -1
+// [EXPECTED] amountOut: 1 expected: 1
 // [INFO] Checking balances after swap
 // [EXPECTED] user1 bar balance change: 9997 expected: 9997
 // [EXPECTED] user1 baz balance change: 1 expected: 1

--- a/contract/r/scenario/router/router_spec_2_exact_in_filetest.gno
+++ b/contract/r/scenario/router/router_spec_2_exact_in_filetest.gno
@@ -100,7 +100,7 @@ func main(cur realm) {
 	)
 
 	println("[EXPECTED] amountIn:", amountIn, "expected: 3")
-	println("[EXPECTED] amountOut:", amountOut, "expected: -1")
+	println("[EXPECTED] amountOut:", amountOut, "expected: 1")
 
 	println("[INFO] Checking balances after swap")
 	poolToken0After := bar.BalanceOf(poolAddr)
@@ -132,7 +132,7 @@ func main(cur realm) {
 // [INFO] admin foo balance: 99999999000000
 // [INFO] Executing ExactIn swap (3 bar → foo)
 // [EXPECTED] amountIn: 3 expected: 3
-// [EXPECTED] amountOut: -1 expected: -1
+// [EXPECTED] amountOut: 1 expected: 1
 // [INFO] Checking balances after swap
 // [EXPECTED] admin bar balance change: 99999999000001 expected: 99999999000001
 // [EXPECTED] admin foo balance change: 99999998999997 expected: 99999998999997

--- a/contract/r/scenario/router/router_spec_3_exact_in_filetest.gno
+++ b/contract/r/scenario/router/router_spec_3_exact_in_filetest.gno
@@ -102,7 +102,7 @@ func main(cur realm) {
 	token2After := foo.BalanceOf(adminAddr)
 
 	println("[EXPECTED] amountIn:", amountIn, "expected: 5")
-	println("[EXPECTED] amountOut:", amountOut, "expected: -1")
+	println("[EXPECTED] amountOut:", amountOut, "expected: 1")
 
 	println("[EXPECTED] admin bar balance change:", token0After, "expected:", token0Before+1)
 	println("[EXPECTED] admin foo balance change:", token2After, "expected:", token2Before-5)
@@ -128,7 +128,7 @@ func main(cur realm) {
 // [INFO] Executing ExactIn swap (5 foo → baz → bar)
 // [INFO] Checking balances after swap
 // [EXPECTED] amountIn: 5 expected: 5
-// [EXPECTED] amountOut: -1 expected: -1
+// [EXPECTED] amountOut: 1 expected: 1
 // [EXPECTED] admin bar balance change: 99999999000001 expected: 99999999000001
 // [EXPECTED] admin foo balance change: 99999998999995 expected: 99999998999995
 // [INFO] Scenario completed

--- a/contract/r/scenario/router/router_spec_4_exact_in_filetest.gno
+++ b/contract/r/scenario/router/router_spec_4_exact_in_filetest.gno
@@ -103,7 +103,7 @@ func main(cur realm) {
 	token2After := foo.BalanceOf(adminAddr)
 
 	println("[EXPECTED] amountIn:", amountIn, "expected: 5")
-	println("[EXPECTED] amountOut:", amountOut, "expected: -1")
+	println("[EXPECTED] amountOut:", amountOut, "expected: 1")
 
 	println("[EXPECTED] admin bar balance change:", token0After, "expected:", token0Before-5)
 	println("[EXPECTED] admin foo balance change:", token2After, "expected:", token2Before+1)
@@ -128,7 +128,7 @@ func main(cur realm) {
 // [INFO] Executing ExactIn swap (5 bar → baz → foo)
 // [INFO] Checking balances after swap
 // [EXPECTED] amountIn: 5 expected: 5
-// [EXPECTED] amountOut: -1 expected: -1
+// [EXPECTED] amountOut: 1 expected: 1
 // [EXPECTED] admin bar balance change: 99999998999995 expected: 99999998999995
 // [EXPECTED] admin foo balance change: 99999999000001 expected: 99999999000001
 // [INFO] Scenario completed

--- a/contract/r/scenario/router/router_spec_5_exact_out_filetest.gno
+++ b/contract/r/scenario/router/router_spec_5_exact_out_filetest.gno
@@ -96,7 +96,7 @@ func main(cur realm) {
 	token1After := baz.BalanceOf(adminAddr)
 
 	println("[EXPECTED] amountIn:", amountIn, "expected: 3")
-	println("[EXPECTED] amountOut:", amountOut, "expected: -1")
+	println("[EXPECTED] amountOut:", amountOut, "expected: 1")
 
 	println("[EXPECTED] admin bar balance change:", token0After, "expected:", token0Before-3)
 	println("[EXPECTED] admin baz balance change:", token1After, "expected:", token1Before+1)
@@ -119,7 +119,7 @@ func main(cur realm) {
 // [INFO] Executing ExactOut swap (bar → 1 baz)
 // [INFO] Checking balances after swap
 // [EXPECTED] amountIn: 3 expected: 3
-// [EXPECTED] amountOut: -1 expected: -1
+// [EXPECTED] amountOut: 1 expected: 1
 // [EXPECTED] admin bar balance change: 99999998999997 expected: 99999998999997
 // [EXPECTED] admin baz balance change: 99999999000001 expected: 99999999000001
 // [INFO] Scenario completed

--- a/contract/r/scenario/router/router_spec_6_exact_out_filetest.gno
+++ b/contract/r/scenario/router/router_spec_6_exact_out_filetest.gno
@@ -92,7 +92,7 @@ func main(cur realm) {
 	token1After := baz.BalanceOf(adminAddr)
 
 	println("[EXPECTED] amountIn:", amountIn, "expected: 3")
-	println("[EXPECTED] amountOut:", amountOut, "expected: -1")
+	println("[EXPECTED] amountOut:", amountOut, "expected: 1")
 
 	println("[EXPECTED] admin bar balance change:", token0After, "expected:", token0Before+1)
 	println("[EXPECTED] admin baz balance change:", token1After, "expected:", token1Before-3)
@@ -115,7 +115,7 @@ func main(cur realm) {
 // [INFO] Executing ExactOut swap (baz → 1 bar)
 // [INFO] Checking balances after swap
 // [EXPECTED] amountIn: 3 expected: 3
-// [EXPECTED] amountOut: -1 expected: -1
+// [EXPECTED] amountOut: 1 expected: 1
 // [EXPECTED] admin bar balance change: 99999999000001 expected: 99999999000001
 // [EXPECTED] admin baz balance change: 99999998999997 expected: 99999998999997
 // [INFO] Scenario completed

--- a/contract/r/scenario/router/router_spec_7_exact_out_filetest.gno
+++ b/contract/r/scenario/router/router_spec_7_exact_out_filetest.gno
@@ -89,7 +89,7 @@ func main(cur realm) {
 	token2After := foo.BalanceOf(adminAddr)
 
 	println("[EXPECTED] amountIn:", amountIn, "expected: 5")
-	println("[EXPECTED] amountOut:", amountOut, "expected: -1")
+	println("[EXPECTED] amountOut:", amountOut, "expected: 1")
 
 	println("[EXPECTED] admin bar balance change:", token0After, "expected:", token0Before-5)
 	println("[EXPECTED] admin foo balance change:", token2After, "expected:", token2Before+1)
@@ -108,7 +108,7 @@ func main(cur realm) {
 // [INFO] Minting position in bar-baz pool
 // [INFO] Minting position in baz-foo pool
 // [EXPECTED] amountIn: 5 expected: 5
-// [EXPECTED] amountOut: -1 expected: -1
+// [EXPECTED] amountOut: 1 expected: 1
 // [EXPECTED] admin bar balance change: 99999998999995 expected: 99999998999995
 // [EXPECTED] admin foo balance change: 99999999000001 expected: 99999999000001
 // [INFO] Scenario completed

--- a/contract/r/scenario/router/router_spec_8_exact_out_filetest.gno
+++ b/contract/r/scenario/router/router_spec_8_exact_out_filetest.gno
@@ -90,7 +90,7 @@ func main(cur realm) {
 	token2After := foo.BalanceOf(adminAddr)
 
 	println("[EXPECTED] amountIn:", amountIn, "expected: 5")
-	println("[EXPECTED] amountOut:", amountOut, "expected: -1")
+	println("[EXPECTED] amountOut:", amountOut, "expected: 1")
 
 	println("[EXPECTED] admin bar balance change:", token0After, "expected:", token0Before+1)
 	println("[EXPECTED] admin foo balance change:", token2After, "expected:", token2Before-5)
@@ -111,7 +111,7 @@ func main(cur realm) {
 // [INFO] Approving tokens for swap
 // [INFO] Checking balances before swap
 // [EXPECTED] amountIn: 5 expected: 5
-// [EXPECTED] amountOut: -1 expected: -1
+// [EXPECTED] amountOut: 1 expected: 1
 // [EXPECTED] admin bar balance change: 99999999000001 expected: 99999999000001
 // [EXPECTED] admin foo balance change: 99999998999995 expected: 99999998999995
 // [INFO] Scenario completed

--- a/contract/r/scenario/router/router_swap_native_token_integration_filetest.gno
+++ b/contract/r/scenario/router/router_swap_native_token_integration_filetest.gno
@@ -354,9 +354,9 @@ func testMultiHopUsdcToGnot(cur realm) {
 // [INFO] WUGNOT deducted: 1000000
 // [INFO] GNS received: 995078
 // [INFO] Pool fee (0.05%): 500
-// [INFO] Router fee (0.15%): 1492
+// [INFO] Router fee (0.15%): -1492
 // [INFO] AmountIn reported: 1000000
-// [INFO] AmountOut reported: -995078
+// [INFO] AmountOut reported: 995078
 // [EXPECTED] WUGNOT deducted = 1000000
 // [EXPECTED] Wrap happens internally
 // [EXPECTED] Pool fee accumulated correctly
@@ -370,7 +370,7 @@ func testMultiHopUsdcToGnot(cur realm) {
 // [INFO] Pool fee (0.05%): 499
 // [INFO] Router fee (0.15%): 1500
 // [INFO] AmountIn reported: 999077
-// [INFO] AmountOut reported: -1000000
+// [INFO] AmountOut reported: 1000000
 // [EXPECTED] User receives 1,000,000 WUGNOT
 // [EXPECTED] Router fee charged on output side
 // [EXPECTED] Unwrap happens internally
@@ -381,7 +381,7 @@ func testMultiHopUsdcToGnot(cur realm) {
 // [INFO] WUGNOT spent: 1000000
 // [INFO] USDC received: 991686
 // [INFO] AmountIn reported: 1000000
-// [INFO] AmountOut reported: -991686
+// [INFO] AmountOut reported: 991686
 // [EXPECTED] Only first hop wraps GNOT
 // [EXPECTED] Correct fee accumulation across hops
 // [EXPECTED] Router fee applied on final output
@@ -391,7 +391,7 @@ func testMultiHopUsdcToGnot(cur realm) {
 // [INFO] USDC spent: 996682
 // [INFO] WUGNOT received: 1000000
 // [INFO] AmountIn reported: 996682
-// [INFO] AmountOut reported: -1000000
+// [INFO] AmountOut reported: 1000000
 // [EXPECTED] Only last hop unwraps to WUGNOT
 // [EXPECTED] User receives exactly 1,000,000 WUGNOT
 // [EXPECTED] Correct fee distribution across hops

--- a/contract/r/scenario/router/router_swap_route_1route_1hop_all_liquidity_exact_in_filetest.gno
+++ b/contract/r/scenario/router/router_swap_route_1route_1hop_all_liquidity_exact_in_filetest.gno
@@ -114,7 +114,7 @@ func main(cur realm) {
 	)
 
 	println("[EXPECTED] amountIn:", amountIn, "expected: 140000")
-	println("[EXPECTED] amountOut:", amountOut, "expected: -105765")
+	println("[EXPECTED] amountOut:", amountOut, "expected: 105765")
 
 	println("[INFO] Checking pool state after swap")
 	pool, _ = pl.GetPools().Get(pl.GetPoolPath(barPath, bazPath, fee500)).(*pl.Pool)
@@ -215,7 +215,7 @@ func bazApprove(cur realm, t *testing.T, owner, spender address, amount int64) {
 // [INFO] Approving tokens for swap
 // [INFO] Executing ExactIn swap (140000 bar → baz)
 // [EXPECTED] amountIn: 140000 expected: 140000
-// [EXPECTED] amountOut: -105765 expected: -105765
+// [EXPECTED] amountOut: 105765 expected: 105765
 // [INFO] Checking pool state after swap
 // [EXPECTED] pool liquidity after swap: 435768 expected: 435768
 // [EXPECTED] pool tick after swap: -5569 expected: -5569

--- a/contract/r/scenario/router/router_swap_route_1route_1hop_filetest.gno
+++ b/contract/r/scenario/router/router_swap_route_1route_1hop_filetest.gno
@@ -117,7 +117,7 @@ func main(cur realm) {
 	)
 
 	println("[EXPECTED] amountIn:", amountIn, "expected: 1000")
-	println("[EXPECTED] amountOut:", amountOut, "expected: -2707")
+	println("[EXPECTED] amountOut:", amountOut, "expected: 2707")
 
 	println("[INFO] Test 2: ExactOut swap (bar → baz)")
 	println("[INFO] Approving tokens for swap")
@@ -137,7 +137,7 @@ func main(cur realm) {
 	)
 
 	println("[EXPECTED] amountIn:", amountIn, "expected: 371")
-	println("[EXPECTED] amountOut:", amountOut, "expected: -999")
+	println("[EXPECTED] amountOut:", amountOut, "expected: 999")
 
 	println("[INFO] Test 3: ExactIn swap (baz → bar)")
 	println("[INFO] Approving tokens for swap")
@@ -157,7 +157,7 @@ func main(cur realm) {
 	)
 
 	println("[EXPECTED] amountIn:", amountIn, "expected: 1000")
-	println("[EXPECTED] amountOut:", amountOut, "expected: -368")
+	println("[EXPECTED] amountOut:", amountOut, "expected: 368")
 
 	println("[INFO] Test 4: ExactOut swap (baz → bar)")
 	println("[INFO] Approving tokens for swap")
@@ -177,7 +177,7 @@ func main(cur realm) {
 	)
 
 	println("[EXPECTED] amountIn:", amountIn, "expected: 8171")
-	println("[EXPECTED] amountOut:", amountOut, "expected: -2996")
+	println("[EXPECTED] amountOut:", amountOut, "expected: 2996")
 
 	println("[INFO] Scenario completed")
 }
@@ -202,17 +202,17 @@ func main(cur realm) {
 // [INFO] Test 1: ExactIn swap (bar → baz)
 // [INFO] Approving tokens for swap
 // [EXPECTED] amountIn: 1000 expected: 1000
-// [EXPECTED] amountOut: -2707 expected: -2707
+// [EXPECTED] amountOut: 2707 expected: 2707
 // [INFO] Test 2: ExactOut swap (bar → baz)
 // [INFO] Approving tokens for swap
 // [EXPECTED] amountIn: 371 expected: 371
-// [EXPECTED] amountOut: -1000 expected: -999
+// [EXPECTED] amountOut: 1000 expected: 999
 // [INFO] Test 3: ExactIn swap (baz → bar)
 // [INFO] Approving tokens for swap
 // [EXPECTED] amountIn: 1000 expected: 1000
-// [EXPECTED] amountOut: -368 expected: -368
+// [EXPECTED] amountOut: 368 expected: 368
 // [INFO] Test 4: ExactOut swap (baz → bar)
 // [INFO] Approving tokens for swap
 // [EXPECTED] amountIn: 8182 expected: 8171
-// [EXPECTED] amountOut: -3000 expected: -2996
+// [EXPECTED] amountOut: 3000 expected: 2996
 // [INFO] Scenario completed

--- a/contract/r/scenario/router/router_swap_route_1route_3hop_wrapped_native_middle_filetest.gno
+++ b/contract/r/scenario/router/router_swap_route_1route_3hop_wrapped_native_middle_filetest.gno
@@ -179,7 +179,7 @@ func testSwapRouteGnsBarExactIn(cur realm) {
 	println("[INFO] amountOut:", amountOut)
 
 	println("[EXPECTED] amountIn:", amountIn, "expected: 1000")
-	println("[EXPECTED] amountOut:", amountOut, "expected: -7317")
+	println("[EXPECTED] amountOut:", amountOut, "expected: 7317")
 	println()
 }
 
@@ -225,8 +225,8 @@ func testSwapRouteGnsBarExactIn(cur realm) {
 // [INFO] Approving tokens for swap
 // [INFO] Executing ExactIn swap (1000 gns → wugnot → bar)
 // [INFO] amountIn: 1000
-// [INFO] amountOut: -7317
+// [INFO] amountOut: 7317
 // [EXPECTED] amountIn: 1000 expected: 1000
-// [EXPECTED] amountOut: -7317 expected: -7317
+// [EXPECTED] amountOut: 7317 expected: 7317
 //
 // [INFO] Scenario completed

--- a/contract/r/scenario/router/router_swap_route_2route_2hop_filetest.gno
+++ b/contract/r/scenario/router/router_swap_route_2route_2hop_filetest.gno
@@ -136,7 +136,7 @@ func testSwapRouteBarQuxExactIn(cur realm) {
 	)
 
 	println("[EXPECTED] amountIn:", amountIn, "expected: 1000")
-	println("[EXPECTED] amountOut:", amountOut, "expected: -7318")
+	println("[EXPECTED] amountOut:", amountOut, "expected: 7318")
 	println()
 }
 
@@ -158,7 +158,7 @@ func testSwapRouteBarQuxExactOut(cur realm) {
 	)
 
 	println("[EXPECTED] amountIn:", amountIn, "expected: 140")
-	println("[EXPECTED] amountOut:", amountOut, "expected: -1001")
+	println("[EXPECTED] amountOut:", amountOut, "expected: 1001")
 	println()
 }
 
@@ -180,7 +180,7 @@ func testSwapRouteQuxBarExactIn(cur realm) {
 	)
 
 	println("[EXPECTED] amountIn:", amountIn, "expected: 1000")
-	println("[EXPECTED] amountOut:", amountOut, "expected: -135")
+	println("[EXPECTED] amountOut:", amountOut, "expected: 135")
 	println()
 }
 
@@ -206,7 +206,7 @@ func testwapRouteQuxBarExactOut(cur realm) {
 	)
 
 	println("[EXPECTED] amountIn:", amountIn, "expected: 7373")
-	println("[EXPECTED] amountOut:", amountOut, "expected: -1000")
+	println("[EXPECTED] amountOut:", amountOut, "expected: 1000")
 	println()
 }
 
@@ -231,22 +231,22 @@ func testwapRouteQuxBarExactOut(cur realm) {
 // [INFO] Approving tokens for swap
 // [INFO] Executing ExactIn swap with 2 routes (1000 bar → baz → qux)
 // [EXPECTED] amountIn: 1000 expected: 1000
-// [EXPECTED] amountOut: -7318 expected: -7318
+// [EXPECTED] amountOut: 7318 expected: 7318
 //
 // [SCENARIO] Given: Swap route bar to qux exact out preparation
 // [INFO] Executing ExactOut swap with 2 routes (bar → baz → 1000 qux)
 // [EXPECTED] amountIn: 140 expected: 140
-// [EXPECTED] amountOut: -1001 expected: -1001
+// [EXPECTED] amountOut: 1001 expected: 1001
 //
 // [SCENARIO] Given: Swap route qux to bar exact in preparation
 // [INFO] Executing ExactIn swap with 2 routes (1000 qux → baz → bar)
 // [EXPECTED] amountIn: 1000 expected: 1000
-// [EXPECTED] amountOut: -135 expected: -135
+// [EXPECTED] amountOut: 135 expected: 135
 //
 // [SCENARIO] Given: Swap route qux to bar exact out preparation
 // [INFO] Approving tokens for swap
 // [INFO] Executing ExactOut swap with 2 routes (qux → baz → 1000 bar)
 // [EXPECTED] amountIn: 7373 expected: 7373
-// [EXPECTED] amountOut: -1000 expected: -1000
+// [EXPECTED] amountOut: 1000 expected: 1000
 //
 // [INFO] Scenario completed

--- a/contract/r/scenario/router/router_swap_validate_balance_filetest.gno
+++ b/contract/r/scenario/router/router_swap_validate_balance_filetest.gno
@@ -437,9 +437,9 @@ func validateFinalReconciliation(cur realm, initial, final BalanceSnapshot) {
 //
 // [SCENARIO] 4. Perform Swaps (Both Directions)
 // [INFO] Swap 1: 10,000,000 GNOT → GNS
-// [INFO] Swap 1 - In: 10000000 Out: -9426232
+// [INFO] Swap 1 - In: 10000000 Out: 9426232
 // [INFO] Swap 2: GNS → 5,000,000 GNOT
-// [INFO] Swap 2 - In: 4597249 Out: -5000000
+// [INFO] Swap 2 - In: 4597249 Out: 5000000
 // [BALANCE] After Swaps
 //   User - WGNOT: 945000000 GNS: 954828983
 //   Position - WUGNOT: 0 GNS: 0

--- a/contract/r/scenario/router/swap_balance_extreme_cases_filetest.gno
+++ b/contract/r/scenario/router/swap_balance_extreme_cases_filetest.gno
@@ -394,7 +394,7 @@ func validateSystemBalance(cur realm, initial, final BalanceSnapshot) {
 //
 // [SCENARIO] 3. Extreme Case 1: Very Large Swap (90% of liquidity)
 // [INFO] Extreme Swap: Swapping 450000000000 FOO -> BAR (90% of liquidity)
-// [INFO] Large Swap - In: 450000000000 Out: -245987862163
+// [INFO] Large Swap - In: 450000000000 Out: 245987862163
 // [INFO] Expected: Massive price impact and slippage
 // [INFO] After Large Swap
 // [EXPECTED] User BAR balance: 745987862163
@@ -416,7 +416,7 @@ func validateSystemBalance(cur realm, initial, final BalanceSnapshot) {
 //
 // [SCENARIO] 4. Extreme Case 2: Swap Back with High Slippage
 // [INFO] Reverse Swap: Getting 200000000000 FOO back
-// [INFO] Reverse Swap - In: 75286230276 Out: -200000000000
+// [INFO] Reverse Swap - In: 75286230276 Out: 200000000000
 // [INFO] After Reverse Swap
 // [EXPECTED] User BAR balance: 670701631887
 // [EXPECTED] User FOO balance: 250000000000
@@ -437,7 +437,7 @@ func validateSystemBalance(cur realm, initial, final BalanceSnapshot) {
 //
 // [SCENARIO] 5. Extreme Case 3: Small Swap After Large Price Movement
 // [INFO] Small Swap: Swapping 1000000 FOO -> BAR (after extreme movement)
-// [INFO] Small Swap - In: 1000000 Out: -469486
+// [INFO] Small Swap - In: 1000000 Out: 469486
 // [INFO] After Small Swap
 // [EXPECTED] User BAR balance: 670702101373
 // [EXPECTED] User FOO balance: 249999000000

--- a/contract/r/scenario/router/swap_balance_in_range_position_filetest.gno
+++ b/contract/r/scenario/router/swap_balance_in_range_position_filetest.gno
@@ -360,7 +360,7 @@ func validateSystemBalance(cur realm, initial, final BalanceSnapshot) {
 //
 // [SCENARIO] 4. Exact In Swap (FOO -> BAR)
 // [INFO] Swapping 10000000000 FOO -> BAR
-// [INFO] Exact In - In: 10000000000 Out: -9252300294
+// [INFO] Exact In - In: 10000000000 Out: 9252300294
 // [INFO] After Exact In Swap
 // [EXPECTED] User BAR balance: 59252300294
 // [EXPECTED] User FOO balance: 40000000000
@@ -381,7 +381,7 @@ func validateSystemBalance(cur realm, initial, final BalanceSnapshot) {
 //
 // [SCENARIO] 5. Exact Out Swap (BAR -> FOO)
 // [INFO] Swapping BAR -> 5000000000 FOO
-// [INFO] Exact Out - In: 4469297080 Out: -5000000000
+// [INFO] Exact Out - In: 4469297080 Out: 5000000000
 // [INFO] After Exact Out Swap
 // [EXPECTED] User BAR balance: 54783003214
 // [EXPECTED] User FOO balance: 45000000000

--- a/contract/r/scenario/router/swap_balance_mixed_range_positions_filetest.gno
+++ b/contract/r/scenario/router/swap_balance_mixed_range_positions_filetest.gno
@@ -421,7 +421,7 @@ func validateSystemBalance(cur realm, initial, final BalanceSnapshot) {
 //
 // [SCENARIO] 5. Exact In Swap (FOO -> BAR) - Uses only in-range liquidity
 // [INFO] Swapping 10000000000 FOO -> BAR
-// [INFO] Exact In - In: 10000000000 Out: -9557418797
+// [INFO] Exact In - In: 10000000000 Out: 9557418797
 // [INFO] After Exact In Swap
 // [EXPECTED] User BAR balance: 129557418797
 // [EXPECTED] User FOO balance: 140000000000
@@ -442,7 +442,7 @@ func validateSystemBalance(cur realm, initial, final BalanceSnapshot) {
 //
 // [SCENARIO] 6. Exact Out Swap (BAR -> FOO) - Uses only in-range liquidity
 // [INFO] Swapping BAR -> 5000000000 FOO
-// [INFO] Exact Out - In: 4694301331 Out: -5000000000
+// [INFO] Exact Out - In: 4694301331 Out: 5000000000
 // [INFO] After Exact Out Swap
 // [EXPECTED] User BAR balance: 124863117466
 // [EXPECTED] User FOO balance: 145000000000

--- a/contract/r/scenario/router/swap_balance_multi_hop_filetest.gno
+++ b/contract/r/scenario/router/swap_balance_multi_hop_filetest.gno
@@ -477,7 +477,7 @@ func validateSystemBalance(cur realm, initial, final BalanceSnapshot) {
 //
 // [SCENARIO] 3. Single Hop Swap (BAR -> FOO)
 // [INFO] Single Hop: Swapping 10000000000 BAR -> FOO
-// [INFO] Single Hop - In: 10000000000 Out: -9602386497
+// [INFO] Single Hop - In: 10000000000 Out: 9602386497
 // [BALANCE] After Single Hop
 //   User - BAR: 390000000000 FOO: 309602386497 BAZ: 300000000000 QUX: 400000000000
 //   Pools - BAR: 110000000000 FOO: 190383188286 BAZ: 200000000000 QUX: 100000000000
@@ -495,7 +495,7 @@ func validateSystemBalance(cur realm, initial, final BalanceSnapshot) {
 //
 // [SCENARIO] 4. Two Hop Swap (BAR -> FOO -> BAZ)
 // [INFO] Two Hop: Swapping 5000000000 BAR -> FOO -> BAZ
-// [INFO] Two Hop - In: 5000000000 Out: -4451991291
+// [INFO] Two Hop - In: 5000000000 Out: 4451991291
 // [INFO] Route: BAR -> FOO (pool 1) -> BAZ (pool 2)
 // [BALANCE] After Two Hop
 //   User - BAR: 385000000000 FOO: 309602386497 BAZ: 304451991291 QUX: 400000000000
@@ -516,7 +516,7 @@ func validateSystemBalance(cur realm, initial, final BalanceSnapshot) {
 //
 // [SCENARIO] 5. Three Hop Swap (BAR -> FOO -> BAZ -> QUX)
 // [INFO] Three Hop: Swapping 3000000000 BAR -> FOO -> BAZ -> QUX
-// [INFO] Three Hop - In: 3000000000 Out: -2495426539
+// [INFO] Three Hop - In: 3000000000 Out: 2495426539
 // [INFO] Route: BAR -> FOO (pool 1) -> BAZ (pool 2) -> QUX (pool 3)
 // [BALANCE] After Three Hop
 //   User - BAR: 382000000000 FOO: 309602386497 BAZ: 304451991291 QUX: 402495426539
@@ -537,7 +537,7 @@ func validateSystemBalance(cur realm, initial, final BalanceSnapshot) {
 //
 // [SCENARIO] 6. Reverse Three Hop Swap (QUX -> BAZ -> FOO -> BAR)
 // [INFO] Reverse Three Hop: Swapping 2000000000 QUX -> BAZ -> FOO -> BAR
-// [INFO] Reverse Three Hop - In: 2000000000 Out: -2404819407
+// [INFO] Reverse Three Hop - In: 2000000000 Out: 2404819407
 // [INFO] Route: QUX -> BAZ (pool 3) -> FOO (pool 2) -> BAR (pool 1)
 // [BALANCE] After Reverse Three Hop
 //   User - BAR: 384404819407 FOO: 309602386497 BAZ: 304451991291 QUX: 400495426539

--- a/contract/r/scenario/router/swap_route_with_gnot_wugnot_filetest.gno
+++ b/contract/r/scenario/router/swap_route_with_gnot_wugnot_filetest.gno
@@ -303,7 +303,7 @@ func exactOutSwapRouteBy(cur realm,
 // [INFO] queryRatios: 100
 // [INFO] minAmountOut: 1
 // [EXPECTED] inputTokenAmount: 10000 (gno.land/r/gnoland/wugnot.wugnot)
-// [EXPECTED] outputTokenAmount: -9975 (gno.land/r/gnoland/wugnot.wugnot)
+// [EXPECTED] outputTokenAmount: 9975 (gno.land/r/gnoland/wugnot.wugnot)
 // [EXPECTED] GNS balance changed: 0
 // [EXPECTED] GNOT balance changed: 0
 // [EXPECTED] WUGNOT balance changed: -25
@@ -317,7 +317,7 @@ func exactOutSwapRouteBy(cur realm,
 // [INFO] queryRatios: 100
 // [INFO] maxAmountIn: 100000
 // [EXPECTED] inputTokenAmount: 10029 (gno.land/r/gnoland/wugnot.wugnot)
-// [EXPECTED] outputTokenAmount: -10001 (gno.land/r/gnoland/wugnot.wugnot)
+// [EXPECTED] outputTokenAmount: 10001 (gno.land/r/gnoland/wugnot.wugnot)
 // [EXPECTED] GNS balance changed: 0
 // [EXPECTED] GNOT balance changed: 0
 // [EXPECTED] WUGNOT balance changed: -28
@@ -331,7 +331,7 @@ func exactOutSwapRouteBy(cur realm,
 // [INFO] queryRatios: 100
 // [INFO] minAmountOut: 1
 // [EXPECTED] inputTokenAmount: 10000 (gno.land/r/gnoland/wugnot.wugnot)
-// [EXPECTED] outputTokenAmount: -9975 (gno.land/r/gnoland/wugnot.wugnot)
+// [EXPECTED] outputTokenAmount: 9975 (gno.land/r/gnoland/wugnot.wugnot)
 // [EXPECTED] GNS balance changed: 0
 // [EXPECTED] GNOT balance changed: 0
 // [EXPECTED] WUGNOT balance changed: -25
@@ -345,7 +345,7 @@ func exactOutSwapRouteBy(cur realm,
 // [INFO] queryRatios: 100
 // [INFO] maxAmountIn: 100000
 // [EXPECTED] inputTokenAmount: 10029 (gno.land/r/gnoland/wugnot.wugnot)
-// [EXPECTED] outputTokenAmount: -10001 (gno.land/r/gnoland/wugnot.wugnot)
+// [EXPECTED] outputTokenAmount: 10001 (gno.land/r/gnoland/wugnot.wugnot)
 // [EXPECTED] GNS balance changed: 0
 // [EXPECTED] GNOT balance changed: 0
 // [EXPECTED] WUGNOT balance changed: -28
@@ -359,7 +359,7 @@ func exactOutSwapRouteBy(cur realm,
 // [INFO] queryRatios: 100
 // [INFO] minAmountOut: 1
 // [EXPECTED] inputTokenAmount: 10000 (gno.land/r/gnoland/wugnot.wugnot)
-// [EXPECTED] outputTokenAmount: -9975 (gno.land/r/gnoland/wugnot.wugnot)
+// [EXPECTED] outputTokenAmount: 9975 (gno.land/r/gnoland/wugnot.wugnot)
 // [EXPECTED] GNS balance changed: 0
 // [EXPECTED] GNOT balance changed: 0
 // [EXPECTED] WUGNOT balance changed: -25
@@ -373,7 +373,7 @@ func exactOutSwapRouteBy(cur realm,
 // [INFO] queryRatios: 100
 // [INFO] maxAmountIn: 100000
 // [EXPECTED] inputTokenAmount: 10029 (gno.land/r/gnoland/wugnot.wugnot)
-// [EXPECTED] outputTokenAmount: -10001 (gno.land/r/gnoland/wugnot.wugnot)
+// [EXPECTED] outputTokenAmount: 10001 (gno.land/r/gnoland/wugnot.wugnot)
 // [EXPECTED] GNS balance changed: 0
 // [EXPECTED] GNOT balance changed: 0
 // [EXPECTED] WUGNOT balance changed: -28

--- a/contract/r/scenario/router/swap_with_referral_system_filetest.gno
+++ b/contract/r/scenario/router/swap_with_referral_system_filetest.gno
@@ -274,7 +274,7 @@ func swapWithReferrer(cur realm, userAddr address, referrer string) {
 // [INFO] User1 referral before swap: ''
 // [INFO] Swapping with referrer: 'g1wfjkvetjwfjhyv2lta047h6lta047h6lf0xcls'
 // [EXPECTED] inputAmount: 1000000
-// [EXPECTED] outputAmount: -995078
+// [EXPECTED] outputAmount: 995078
 // [EXPECTED] WUGNOT balance changed: -1000000
 // [EXPECTED] GNS balance changed: 995078
 // [EXPECTED] User1 referral after first swap: 'g1wfjkvetjwfjhyv2lta047h6lta047h6lf0xcls'
@@ -282,7 +282,7 @@ func swapWithReferrer(cur realm, userAddr address, referrer string) {
 // [SCENARIO] 4. Same User Swap with referral contract address (should delete existing referrer)
 // [INFO] Swapping with referrer: 'g1u0p5ld4aq6sk5l26ys27wk8nftj080l3era4wn'
 // [EXPECTED] inputAmount: 1000000
-// [EXPECTED] outputAmount: -989266
+// [EXPECTED] outputAmount: 989266
 // [EXPECTED] WUGNOT balance changed: -1000000
 // [EXPECTED] GNS balance changed: 989266
 // [EXPECTED] User1 referral after swap with empty referrer: ''
@@ -290,13 +290,13 @@ func swapWithReferrer(cur realm, userAddr address, referrer string) {
 // [SCENARIO] 5. Register Referrer Again and Swap with Different Referrer
 // [INFO] Swapping with referrer: 'g1wfjkvetjwfjhyv2lta047h6lta047h6lf0xcls'
 // [EXPECTED] inputAmount: 1000000
-// [EXPECTED] outputAmount: -983505
+// [EXPECTED] outputAmount: 983505
 // [EXPECTED] WUGNOT balance changed: -1000000
 // [EXPECTED] GNS balance changed: 983505
 // [INFO] User1 referral after re-registration: ''
 // [INFO] Swapping with referrer: 'g1wfjkvetjwfjhyvjlta047h6lta047h6l2tdl74'
 // [EXPECTED] inputAmount: 1000000
-// [EXPECTED] outputAmount: -977795
+// [EXPECTED] outputAmount: 977795
 // [EXPECTED] WUGNOT balance changed: -1000000
 // [EXPECTED] GNS balance changed: 977795
 // [EXPECTED] User1 referral after swap with different referrer: ''
@@ -306,7 +306,7 @@ func swapWithReferrer(cur realm, userAddr address, referrer string) {
 // [INFO] User2 referral before swap: ''
 // [INFO] Swapping with referrer: 'g1wfjkvetjwfjhyv6lta047h6lta047h6ltsn9xk'
 // [EXPECTED] inputAmount: 1000000
-// [EXPECTED] outputAmount: -972133
+// [EXPECTED] outputAmount: 972133
 // [EXPECTED] WUGNOT balance changed: -1000000
 // [EXPECTED] GNS balance changed: 972133
 // [EXPECTED] User2 referral after swap: 'g1wfjkvetjwfjhyv6lta047h6lta047h6ltsn9xk'
@@ -316,7 +316,7 @@ func swapWithReferrer(cur realm, userAddr address, referrer string) {
 // [INFO] User1 referral before re-registration: ''
 // [INFO] Swapping with referrer: 'g1wfjkvetjwfjhydzlta047h6lta047h6lk48j6m'
 // [EXPECTED] inputAmount: 1000000
-// [EXPECTED] outputAmount: -966521
+// [EXPECTED] outputAmount: 966521
 // [EXPECTED] WUGNOT balance changed: -1000000
 // [EXPECTED] GNS balance changed: 966521
 // [EXPECTED] User1 referral after 24h and re-registration: 'g1wfjkvetjwfjhydzlta047h6lta047h6lk48j6m'

--- a/contract/r/scenario/staker/full_internal_external_filetest.gno
+++ b/contract/r/scenario/staker/full_internal_external_filetest.gno
@@ -545,7 +545,7 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 //
 // [SCENARIO] 9. Perform swaps
 // [INFO] perform exact-in swaps
-// [EXPECTED] swap result - tokenIn: 500, tokenOut: -497
+// [EXPECTED] swap result - tokenIn: 500, tokenOut: 497
 // [INFO] check reward for position 01 after swap
 // [EXPECTED] position 01 reward after swap: 18729875
 //

--- a/contract/r/scenario/staker/multi_tier_pool_with_position_rewards_filetest.gno
+++ b/contract/r/scenario/staker/multi_tier_pool_with_position_rewards_filetest.gno
@@ -471,7 +471,7 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 // [INFO] queryRatios: 100
 // [INFO] minAmountOut: 1
 // [EXPECTED] inputTokenAmount: 2000
-// [EXPECTED] outputTokenAmount: -1980
+// [EXPECTED] outputTokenAmount: 1980
 // [EXPECTED] BAR balance changed: -2000
 // [EXPECTED] BAZ balance changed: 1980
 // [EXPECTED] pool tick changed: 0 to -197
@@ -489,7 +489,7 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 // [INFO] queryRatios: 100
 // [INFO] minAmountOut: 1
 // [EXPECTED] inputTokenAmount: 2000
-// [EXPECTED] outputTokenAmount: -2006
+// [EXPECTED] outputTokenAmount: 2006
 // [EXPECTED] BAR balance changed: 2006
 // [EXPECTED] BAZ balance changed: -2000
 // [EXPECTED] pool tick changed: -197 to 0

--- a/contract/r/scenario/staker/position_inrange_change_by_swap_external_filetest.gno
+++ b/contract/r/scenario/staker/position_inrange_change_by_swap_external_filetest.gno
@@ -456,7 +456,7 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 // [INFO] tick before swap: 0
 // [INFO] perform large swap to move price out of range
 // [INFO] swap bar for baz to move tick up
-// [INFO] swapped 100000 bar for -9985 baz
+// [INFO] swapped 100000 bar for 9985 baz
 // [EXPECTED] tick after swap: -887271
 //
 // [SCENARIO] 8. Collect external reward while out-of-range
@@ -469,7 +469,7 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 // [INFO] tick before reverse swap: -887271
 // [INFO] perform reverse swap to move price back into range
 // [INFO] swap baz for bar to move tick down
-// [INFO] swapped 1000 baz for -1002 bar
+// [INFO] swapped 1000 baz for 1002 bar
 // [EXPECTED] tick after reverse swap: -45
 // [INFO] position is back in-range
 //

--- a/contract/r/scenario/staker/position_inrange_change_by_swap_internal_filetest.gno
+++ b/contract/r/scenario/staker/position_inrange_change_by_swap_internal_filetest.gno
@@ -422,7 +422,7 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 // [INFO] tick before swap: 0
 // [INFO] perform large swap to move price out of range
 // [INFO] swap bar for baz to move tick up
-// [INFO] swapped 100000 bar for -9985 baz
+// [INFO] swapped 100000 bar for 9985 baz
 // [EXPECTED] tick after swap: -887271
 //
 // [SCENARIO] 7. Collect reward while out-of-range
@@ -435,7 +435,7 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 // [INFO] tick before reverse swap: -887271
 // [INFO] perform reverse swap to move price back into range
 // [INFO] swap baz for bar to move tick down
-// [INFO] swapped 1000 baz for -1002 bar
+// [INFO] swapped 1000 baz for 1002 bar
 // [EXPECTED] tick after reverse swap: -45
 // [INFO] position is back in-range
 //

--- a/contract/r/scenario/staker/staker_short_warmup_period_external_14_position_in_out_range_changed_by_swap_filetest.gno
+++ b/contract/r/scenario/staker/staker_short_warmup_period_external_14_position_in_out_range_changed_by_swap_filetest.gno
@@ -300,7 +300,7 @@ func makePosition1OutRange(cur realm) {
 		"",
 	)
 
-	if tokenIn != "100000" || tokenOut != "-98873" {
+	if tokenIn != "100000" || tokenOut != "98873" {
 		panic("unexpected swap result")
 	}
 

--- a/contract/r/scenario/staker/staker_short_warmup_period_internal_05_position_in_out_range_changed_by_swap_filetest.gno
+++ b/contract/r/scenario/staker/staker_short_warmup_period_internal_05_position_in_out_range_changed_by_swap_filetest.gno
@@ -261,7 +261,7 @@ func makePosition1OutRange(cur realm) {
 		"", // referrer
 	)
 
-	if tokenIn != "10000" || tokenOut != "-9884" {
+	if tokenIn != "10000" || tokenOut != "9884" {
 		panic("unexpected swap result")
 	}
 
@@ -336,7 +336,7 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 // [EXPECTED] position 02 (in-range) reward: 3886800 GNS
 //
 // [SCENARIO] 6. Make position 01 out of range via swap
-// [EXPECTED] swap executed: 10000 BAR -> -9884 QUX
+// [EXPECTED] swap executed: 10000 BAR -> 9884 QUX
 //
 // [SCENARIO] 7. Check rewards after position goes out of range
 // [INFO] checking reward for position 01 (now out-range)

--- a/contract/r/scenario/staker/zero_net_tick_cross_internal_filetest.gno
+++ b/contract/r/scenario/staker/zero_net_tick_cross_internal_filetest.gno
@@ -328,7 +328,7 @@ func positionIdFrom(cur realm, positionId any) grc721.TokenID {
 // [EXPECTED] positions staked and rewards cleared
 //
 // [SCENARIO] 5. Cross the shared boundary tick
-// [INFO] swapped 100000 BAR for -99962 BAZ
+// [INFO] swapped 100000 BAR for 99962 BAZ
 // [INFO] tick moved 15 -> 9
 // [INFO] cleared transition rewards after boundary cross
 //

--- a/contract/r/scenario/upgrade/full_lifecycle_v2_valid_upgrade_filetest.gno
+++ b/contract/r/scenario/upgrade/full_lifecycle_v2_valid_upgrade_filetest.gno
@@ -1874,8 +1874,8 @@ func finalInvariants(cur realm) {
 // [EXPECTED] minted position: 2 liquidity: 327755575
 // [EXPECTED] increased liquidity: 213383746 amount0: 10000000 amount1: 10000000
 // [EXPECTED] position liquidity now: 1280302477
-// [EXPECTED] fee-accrual swap bar->foo in/out: 2000000 -1976553
-// [EXPECTED] fee-accrual swap foo->bar in/out: 2000000 -1981465
+// [EXPECTED] fee-accrual swap bar->foo in/out: 2000000 1976553
+// [EXPECTED] fee-accrual swap foo->bar in/out: 2000000 1981465
 // [EXPECTED] pool tick after the fee-accrual swaps: 0
 // [EXPECTED] fees accrued before decrease (gross): 597 597
 // [EXPECTED] removed liquidity: 640151238 from pool: gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:500
@@ -1887,10 +1887,10 @@ func finalInvariants(cur realm) {
 // [EXPECTED] withdrawal fee expected from the gross fee: 5 5
 //
 // [SCENARIO] 6. Router: exact-in / exact-out, single and multi-hop
-// [EXPECTED] exact-in-single in/out: 1000000 -988486
-// [EXPECTED] exact-in in/out: 1000000 -990520
-// [EXPECTED] exact-out-single in/out: 505567 -500000
-// [EXPECTED] exact-out in/out: 505045 -500000
+// [EXPECTED] exact-in-single in/out: 1000000 988486
+// [EXPECTED] exact-in in/out: 1000000 990520
+// [EXPECTED] exact-out-single in/out: 505567 500000
+// [EXPECTED] exact-out in/out: 505045 500000
 // [EXPECTED] pool tick after swaps: 0
 // [EXPECTED] pool liquidity: 967906814
 // [EXPECTED] fee growth global: 358045537627336065200174822438606 358257148375155596322091915147789
@@ -2041,7 +2041,7 @@ func finalInvariants(cur realm) {
 // [SCENARIO] 18. Re-run the same operations through v2_valid
 // [EXPECTED] v2_valid minted position: 3 liquidity: 1066865580
 // [EXPECTED] v2_valid mint amounts: 49995019 50000000
-// [EXPECTED] v2_valid swap in/out: 1000000 -989093
+// [EXPECTED] v2_valid swap in/out: 1000000 989093
 // [EXPECTED] v2_valid staking reward to user/penalty: 42692363335 101132501977
 // [EXPECTED] v2_valid distributed FOO to gov staker: 27001
 // [EXPECTED] v2_valid delegated amount: 1000000000

--- a/contract/r/scenario/upgrade/pool_v2_valid_upgrade_filetest.gno
+++ b/contract/r/scenario/upgrade/pool_v2_valid_upgrade_filetest.gno
@@ -291,7 +291,7 @@ func printPoolData(cur realm) {
 // [SCENARIO] 2. Create v1 data: pool + position + swap
 // [EXPECTED] Created pool: gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:500
 // [EXPECTED] v1 minted position id=1 liquidity=1066918731
-// [EXPECTED] v1 swap in=1000000 out=-997067
+// [EXPECTED] v1 swap in=1000000 out=997067
 //
 // [SCENARIO] 3. Read v1-created data via getters
 // [EXPECTED] pool=gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:500 tick=18 liquidity=1066918731 positions=1
@@ -301,7 +301,7 @@ func printPoolData(cur realm) {
 //
 // [SCENARIO] 5. Mutate v1 data through v2_valid (taint-prone RMW)
 // [EXPECTED] v2_valid minted position id=2 liquidity=627605406
-// [EXPECTED] v2_valid swap in=1000000 out=-995547
+// [EXPECTED] v2_valid swap in=1000000 out=995547
 // [EXPECTED] v2_valid increased observation cardinality
 //
 // [SCENARIO] 6. CreatePool through v2_valid (pools BPTree RMW)
@@ -312,7 +312,7 @@ func printPoolData(cur realm) {
 //
 // [SCENARIO] 8. SetFeeProtocol + CollectProtocol through v2_valid
 // [EXPECTED] v2_valid set fee protocol, slot0FeeProtocol=102
-// [EXPECTED] v2_valid swap in=1000000 out=-994338
+// [EXPECTED] v2_valid swap in=1000000 out=994338
 // [EXPECTED] v2_valid collected protocol fees collected0=0 collected1=83 feesBefore=(0,83) feesAfter=(0,0)
 //
 // [SCENARIO] 9. Scalar fee setters through v2_valid

--- a/contract/r/scenario/upgrade/position_collectfee_upgrade_with_validate_data_filetest.gno
+++ b/contract/r/scenario/upgrade/position_collectfee_upgrade_with_validate_data_filetest.gno
@@ -452,7 +452,7 @@ func withAbortsWithMessage(cur realm, callback func(), logMessage string) {
 // [SCENARIO] 4. Perform swap to generate fees
 // [INFO] Exact-In Swap Route
 // [EXPECTED] Input token amount: 1000000
-// [EXPECTED] Output token amount: -997067
+// [EXPECTED] Output token amount: 997067
 //
 // [SCENARIO] 5. Collect fee from position before upgrade
 // [EXPECTED] Position ID: 1
@@ -493,7 +493,7 @@ func withAbortsWithMessage(cur realm, callback func(), logMessage string) {
 // [SCENARIO] 10. Perform swap to generate fees (should panic)
 // [INFO] Exact-In Swap Route
 // [EXPECTED] Input token amount: 1000000
-// [EXPECTED] Output token amount: -995202
+// [EXPECTED] Output token amount: 995202
 //
 // [SCENARIO] 11. Collect fee from position: 1
 // [EXPECTED] Position ID: 1

--- a/contract/r/scenario/upgrade/position_v2_valid_upgrade_filetest.gno
+++ b/contract/r/scenario/upgrade/position_v2_valid_upgrade_filetest.gno
@@ -293,7 +293,7 @@ func printNewPositionData(cur realm) {
 // [SCENARIO] 2. Create v1 data: pool + position + swap
 // [EXPECTED] Created pool: gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:500
 // [EXPECTED] v1 minted position id=1 liquidity=1066918731
-// [EXPECTED] v1 swap in=1000000 out=-997067
+// [EXPECTED] v1 swap in=1000000 out=997067
 //
 // [SCENARIO] 3. Read v1-created position data via getters
 // [EXPECTED] position id=1 liquidity=1066918731 tickLower=-960 tickUpper=960 pool=gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/foo.FOO:500

--- a/contract/r/scenario/upgrade/router_swap_upgrade_with_validate_data_filetest.gno
+++ b/contract/r/scenario/upgrade/router_swap_upgrade_with_validate_data_filetest.gno
@@ -409,7 +409,7 @@ func upgradeRouterContractToV2Mock(cur realm) {
 // [SCENARIO] 4. Perform swap to generate fees
 // [INFO] Exact-In Swap Route
 // [EXPECTED] Input token amount: 1000000
-// [EXPECTED] Output token amount: -997067
+// [EXPECTED] Output token amount: 997067
 //
 // [SCENARIO] 5. Check pool data by v1 version
 // [INFO] Check pool data
@@ -445,7 +445,7 @@ func upgradeRouterContractToV2Mock(cur realm) {
 // [INFO] Exact-In Swap Route
 // [INFO] ExactInSwapRoute called by v2_mock contract
 // [EXPECTED] Input token amount: 1000000
-// [EXPECTED] Output token amount: -995202
+// [EXPECTED] Output token amount: 995202
 //
 // [SCENARIO] 8. Check pool data by v2_mock version
 // [INFO] Check pool data

--- a/contract/r/scenario/upgrade/router_v2_valid_upgrade_filetest.gno
+++ b/contract/r/scenario/upgrade/router_v2_valid_upgrade_filetest.gno
@@ -250,7 +250,7 @@ func setSwapFeeV2Valid(cur realm) {
 //
 // [SCENARIO] 3. v1: set swap fee and perform swap (RMW pending protocol fees)
 // [EXPECTED] v1 swap fee set to: 20
-// [EXPECTED] v1 swap in=1000000 out=-996959
+// [EXPECTED] v1 swap in=1000000 out=996959
 //
 // [SCENARIO] 4. Read v1-created router data via getters
 // [EXPECTED] router impl=gno.land/r/gnoswap/router/v1 swapFee=20
@@ -262,16 +262,16 @@ func setSwapFeeV2Valid(cur realm) {
 // [EXPECTED] router impl=gno.land/r/gnoswap/router/v2_valid swapFee=20
 //
 // [SCENARIO] 7. ExactInSwapRoute through v2_valid (RMW pendingProtocolFees + pool)
-// [EXPECTED] v2_valid ExactInSwapRoute in=1000000 out=-995877
+// [EXPECTED] v2_valid ExactInSwapRoute in=1000000 out=995877
 //
 // [SCENARIO] 8. ExactInSingleSwapRoute through v2_valid
-// [EXPECTED] v2_valid ExactInSingleSwapRoute in=1000000 out=-994795
+// [EXPECTED] v2_valid ExactInSingleSwapRoute in=1000000 out=994795
 //
 // [SCENARIO] 9. ExactOutSwapRoute through v2_valid
-// [EXPECTED] v2_valid ExactOutSwapRoute in=1006328 out=-1000000
+// [EXPECTED] v2_valid ExactOutSwapRoute in=1006328 out=1000000
 //
 // [SCENARIO] 10. ExactOutSingleSwapRoute through v2_valid
-// [EXPECTED] v2_valid ExactOutSingleSwapRoute in=1007428 out=-1000000
+// [EXPECTED] v2_valid ExactOutSingleSwapRoute in=1007428 out=1000000
 //
 // [SCENARIO] 11. Mutate v1 data through v2_valid (SetSwapFee scalar RMW)
 // [EXPECTED] v2_valid swap fee set to: 35

--- a/contract/r/scenario/upgrade/upgrade_with_withdraw_and_halt_filetest.txt
+++ b/contract/r/scenario/upgrade/upgrade_with_withdraw_and_halt_filetest.txt
@@ -594,7 +594,7 @@ func collectLaunchpadDeposit() {
 //
 // [SCENARIO] 5. Swap for fee distribution
 // [EXPECTED] AmountIn should be 10000000
-// [EXPECTED] AmountOut should be -9862880
+// [EXPECTED] AmountOut should be 9862880
 //
 // [SCENARIO] 6. Create launchpad project
 // [EXPECTED] Project created: gno.land/r/onbloc/bar.BAR:124

--- a/contract/r/scenario/upgrade/upgrade_with_withdraw_filetest.txt
+++ b/contract/r/scenario/upgrade/upgrade_with_withdraw_filetest.txt
@@ -531,7 +531,7 @@ func collectLaunchpadDeposit() {
 //
 // [SCENARIO] 5. Swap for fee distribution
 // [EXPECTED] AmountIn should be 10000000
-// [EXPECTED] AmountOut should be -9862880
+// [EXPECTED] AmountOut should be 9862880
 //
 // [SCENARIO] 6. Create launchpad project
 // [EXPECTED] Project created: gno.land/r/onbloc/bar.BAR:124


### PR DESCRIPTION
## Summary
- Return positive `amountOut` values from the public exact-in and exact-out router APIs.
- Align execution results, emitted route-result attributes, and router scenario expectations with `DrySwapRoute`.

## Context
- The router normalized pool deltas to positive input/output amounts, transferred the positive output to the recipient, then negated only the public return value and event attribute.
- This made execution results disagree with `DrySwapRoute` and with Uniswap V3 periphery semantics.

## Changes
- Remove the execution-wrapper negation of `outputAmount`.
- Update router unit assertions and DrySwap-versus-execution scenarios to compare positive values directly.
- Update affected router filetest golden outputs.

## Behavior Changes
- `ExactIn*` and `ExactOut*` now return positive `amountOut`, matching `DrySwapRoute`.
- This is an API compatibility change for consumers that interpreted the previous negative output convention.

## References
- [Uniswap V3 pool swap interface](https://github.com/Uniswap/v3-core/blob/main/contracts/interfaces/pool/IUniswapV3PoolActions.sol#L88-L104): pool deltas are signed and negative `amountSpecified` selects exact output.
- [Uniswap V3 SwapRouter interface](https://github.com/Uniswap/v3-periphery/blob/main/contracts/interfaces/ISwapRouter.sol): router exact-input/output results are unsigned user amounts.
- [Gnoswap DrySwapRoute](https://github.com/gnoswap-labs/gnoswap/blob/main/contract/r/gnoswap/router/v1/router_dry.gno): dry quotes already return positive `amountIn` and `amountOut`.

## Verification
- `make test WORKDIR=tmp PKG=gno.land/r/gnoswap/router/v1`

## Notes
- The legacy scenario filetest runner is not executable in this worktree with the installed Gno CLI; router filetest golden expectations were updated from the established execution results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected exact-input and exact-output swaps to return and report positive output amounts.
  - Updated swap events to reflect the actual output amount without sign inversion.
  - Corrected router swap results across multiple trading scenarios.

- **Tests**
  - Added and updated coverage to verify non-negative swap outputs and the corrected expected amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->