### PR TITLE
perf(staker): skip unchanged outside checkpoints

### DIFF
--- a/contract/r/gnoswap/staker/v1/reward_calculation_tick.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_tick.gno
@@ -52,10 +52,16 @@ func (self *TickResolver) modifyDepositUpper(currentTime int64, liquidity *i256.
 }
 
 // updateCurrentOutsideAccumulation updates the tick's outside accumulation
-// It "flips" the accumulation's inside/outside by subtracting the current outside accumulation from the global accumulation
+// It "flips" the accumulation's inside/outside by subtracting the current outside accumulation from the global accumulation.
+// An unchanged result does not require a checkpoint because predecessor queries
+// return the same value for this and all subsequent timestamps.
 func (self *TickResolver) updateCurrentOutsideAccumulation(timestamp int64, acc *u256.Uint) {
 	currentOutsideAccumulation := self.CurrentOutsideAccumulation(timestamp)
 	newOutsideAccumulation := u256.Zero().Sub(acc, currentOutsideAccumulation)
+	if newOutsideAccumulation.Eq(currentOutsideAccumulation) {
+		return
+	}
+
 	self.SetOutsideAccumulationAt(timestamp, newOutsideAccumulation)
 }
 

--- a/contract/r/gnoswap/staker/v1/reward_calculation_tick_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_tick_test.gno
@@ -287,6 +287,18 @@ func TestUpdateCurrentOutsideAccumulation(t *testing.T) {
 	}
 }
 
+func TestUpdateCurrentOutsideAccumulation_SkipsUnchangedCheckpoint(t *testing.T) {
+	tick := sr.NewTick(100)
+	tick.SetOutsideAccumulationAt(400, u256.NewUint(500))
+
+	tickResolver := NewTickResolver(tick)
+	tickResolver.updateCurrentOutsideAccumulation(500, u256.NewUint(1000))
+
+	uassert.Equal(t, 1, tick.OutsideAccumulation().Size())
+	uassert.Equal(t, "500", tickResolver.CurrentOutsideAccumulation(500).ToString())
+	uassert.Equal(t, "500", tickResolver.CurrentOutsideAccumulation(600).ToString())
+}
+
 func TestTickCrossHook_BatchesNetZeroDeltaInitializedTick(cur realm, t *testing.T) {
 	initStakerTest(cur, t)
 


### PR DESCRIPTION
## Summary
- Skip writing a new outside-accumulation checkpoint when the flipped value is unchanged from the current one.

## Context
- `updateCurrentOutsideAccumulation` always wrote a new checkpoint on tick cross, even when the flipped outside accumulation equals the value already stored. Predecessor lookups for this and all later timestamps would resolve to the same value regardless, so the extra checkpoint was pure overhead.

## Changes
- `reward_calculation_tick.gno`: return early from `updateCurrentOutsideAccumulation` when the new outside accumulation equals the current one, avoiding a redundant `SetOutsideAccumulationAt` write.
- Added a unit test covering the unchanged-value skip path.

## Verification
- `make test PKG=gno.land/r/gnoswap/staker/v1` — all tests pass.
- Ran the performance tracker's metric suite comparing this branch against `main` (same base commit otherwise): tick-cross swap scenarios show up to ~98% less storage diff and ~1.5% less gas at higher tick-cross counts, with no regressions elsewhere.