### PR TITLE
feat(router): refund route-token leftovers to the caller in-swap

### DIFF
--- a/contract/r/gnoswap/router/v1/exact_in.gno
+++ b/contract/r/gnoswap/router/v1/exact_in.gno
@@ -170,6 +170,8 @@ func (r *routerV1) exactInSwapRoute(
 	params SwapRouteParams,
 	referrer string,
 ) (int64, int64) {
+	fundsSnapshot := r.captureFundsSnapshot(params.routeArr)
+
 	inputAmount, outputAmount, err := r.commonSwapRoute(0, rlm, params)
 	if err != nil {
 		panic(err)
@@ -180,9 +182,12 @@ func (r *routerV1) exactInSwapRoute(
 
 	common.SafeGRC20Transfer(0, rlm, params.outputToken, caller, outputAmount)
 
+	// refund any route-token surplus (e.g. a partially filled intermediate hop)
+	// within the same transaction
+	r.refundLeftovers(0, rlm, fundsSnapshot, caller)
+
 	// handle referral registration
 	actualReferrer := referral.TryRegister(cross(rlm), caller, referrer)
-
 
 	eventAttrs := append([]string{
 		"prevAddr", caller.String(),

--- a/contract/r/gnoswap/router/v1/exact_out.gno
+++ b/contract/r/gnoswap/router/v1/exact_out.gno
@@ -170,6 +170,8 @@ func (r *routerV1) exactOutSwapRoute(
 	params SwapRouteParams,
 	referrer string,
 ) (int64, int64) {
+	fundsSnapshot := r.captureFundsSnapshot(params.routeArr)
+
 	inputAmount, outputAmount, err := r.commonSwapRoute(0, rlm, params)
 	if err != nil {
 		panic(err)
@@ -180,9 +182,12 @@ func (r *routerV1) exactOutSwapRoute(
 
 	common.SafeGRC20Transfer(0, rlm, params.outputToken, caller, outputAmount)
 
+	// refund any route-token surplus (e.g. a partially filled intermediate hop)
+	// within the same transaction
+	r.refundLeftovers(0, rlm, fundsSnapshot, caller)
+
 	// handle referral registration
 	actualReferrer := referral.TryRegister(cross(rlm), caller, referrer)
-
 
 	eventAttrs := append([]string{
 		"prevAddr", caller.String(),

--- a/contract/r/gnoswap/router/v1/refund.gno
+++ b/contract/r/gnoswap/router/v1/refund.gno
@@ -1,0 +1,101 @@
+package router
+
+import (
+	"chain"
+	"strings"
+
+	gnsmath "gno.land/p/gnoswap/gnsmath"
+	prbac "gno.land/p/gnoswap/rbac"
+	"gno.land/p/gnoswap/utils"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/common"
+)
+
+// routerFundsSnapshot captures the router's balance and pending protocol fee per
+// route token before a swap, so only surpluses accrued during the swap are
+// refunded — never funds the router held beforehand.
+type routerFundsSnapshot struct {
+	tokens      []string
+	balances    map[string]int64
+	pendingFees map[string]int64
+}
+
+// collectRouteTokens returns the distinct token paths in routeArr in order of
+// first appearance. routeArr must already be validated by the entry points.
+func collectRouteTokens(routeArr string) []string {
+	seen := make(map[string]bool)
+	tokens := make([]string, 0)
+
+	appendToken := func(token string) {
+		if !seen[token] {
+			seen[token] = true
+			tokens = append(tokens, token)
+		}
+	}
+
+	for _, route := range strings.Split(routeArr, ",") {
+		for _, poolPath := range strings.Split(route, POOL_SEPARATOR) {
+			tokenIn, tokenOut, _, err := getDataForSinglePathWithError(poolPath)
+			if err != nil {
+				panic(err)
+			}
+
+			appendToken(tokenIn)
+			appendToken(tokenOut)
+		}
+	}
+
+	return tokens
+}
+
+// captureFundsSnapshot must run before the swap moves any funds.
+func (r *routerV1) captureFundsSnapshot(routeArr string) *routerFundsSnapshot {
+	routerAddr := access.MustGetAddress(prbac.ROLE_ROUTER.String())
+	pendingProtocolFees := r.store.GetPendingProtocolFees()
+
+	snapshot := &routerFundsSnapshot{
+		tokens:      collectRouteTokens(routeArr),
+		balances:    make(map[string]int64),
+		pendingFees: make(map[string]int64),
+	}
+
+	for _, token := range snapshot.tokens {
+		snapshot.balances[token] = common.BalanceOf(token, routerAddr)
+		snapshot.pendingFees[token] = pendingProtocolFees[token]
+	}
+
+	return snapshot
+}
+
+// refundLeftovers sends the caller every route-token surplus accrued in the
+// router beyond the snapshot, excluding amounts that became pending protocol
+// fees during the same swap. It must run after all state updates and payouts
+// of the swap, as the final interaction of the call.
+func (r *routerV1) refundLeftovers(_ int, rlm realm, snapshot *routerFundsSnapshot, caller address) {
+	routerAddr := access.MustGetAddress(prbac.ROLE_ROUTER.String())
+	pendingProtocolFees := r.store.GetPendingProtocolFees()
+
+	previousRealm := rlm.Previous()
+
+	for _, token := range snapshot.tokens {
+		balanceDelta := gnsmath.SafeSubInt64(common.BalanceOf(token, routerAddr), snapshot.balances[token])
+		pendingFeeDelta := gnsmath.SafeSubInt64(pendingProtocolFees[token], snapshot.pendingFees[token])
+
+		leftover := gnsmath.SafeSubInt64(balanceDelta, pendingFeeDelta)
+		if leftover <= 0 {
+			continue
+		}
+
+		common.SafeGRC20Transfer(0, rlm, token, caller, leftover)
+
+		chain.Emit(
+			"SwapRouteRefund",
+			"prevAddr", previousRealm.Address().String(),
+			"prevRealm", previousRealm.PkgPath(),
+			"tokenPath", token,
+			"amount", utils.FormatInt(leftover),
+			"recipient", caller.String(),
+		)
+	}
+}

--- a/contract/r/gnoswap/router/v1/refund_test.gno
+++ b/contract/r/gnoswap/router/v1/refund_test.gno
@@ -1,0 +1,197 @@
+package router
+
+import (
+	"chain"
+	"testing"
+
+	"gno.land/p/gnoswap/gnsmath"
+	testutils "gno.land/p/nt/testutils/v0"
+	uassert "gno.land/p/nt/uassert/v0"
+
+	pl "gno.land/r/gnoswap/pool"
+	pn "gno.land/r/gnoswap/position"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/baz"
+	"gno.land/r/onbloc/obl"
+)
+
+func TestCollectRouteTokens(cur realm, t *testing.T) {
+	tests := []struct {
+		name     string
+		routeArr string
+		want     []string
+	}{
+		{
+			name:     "single hop",
+			routeArr: "tokenA:tokenB:3000",
+			want:     []string{"tokenA", "tokenB"},
+		},
+		{
+			name:     "multi hop deduplicates shared tokens",
+			routeArr: "tokenA:tokenB:3000*POOL*tokenB:tokenC:500",
+			want:     []string{"tokenA", "tokenB", "tokenC"},
+		},
+		{
+			name:     "multi route keeps first-appearance order",
+			routeArr: "tokenA:tokenC:3000,tokenA:tokenB:500*POOL*tokenB:tokenC:3000",
+			want:     []string{"tokenA", "tokenC", "tokenB"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(cur realm, t *testing.T) {
+			got := collectRouteTokens(tt.routeArr)
+
+			uassert.Equal(t, len(got), len(tt.want))
+			for i := range tt.want {
+				uassert.Equal(t, got[i], tt.want[i])
+			}
+		})
+	}
+}
+
+func TestRefundLeftovers(cur realm, t *testing.T) {
+	router := mockRouter()
+	recipient := testutils.TestAddress("refundRecipient1")
+
+	// funds the router held before the snapshot must never be refunded
+	testing.SetRealm(adminRealm)
+	bar.Transfer(cross(cur), routerAddr, 5000)
+
+	snapshot := router.captureFundsSnapshot(singlePoolPath)
+
+	// leftover accrued after the snapshot, i.e. during a swap
+	testing.SetRealm(adminRealm)
+	bar.Transfer(cross(cur), routerAddr, 1234)
+
+	routerBarBefore := bar.BalanceOf(routerAddr)
+
+	func(cur realm) {
+		testing.SetRealm(routerRealm)
+		router.refundLeftovers(0, cur, snapshot, recipient)
+	}(cross(cur))
+
+	uassert.Equal(t, bar.BalanceOf(recipient), int64(1234))
+	uassert.Equal(t, bar.BalanceOf(routerAddr), routerBarBefore-1234)
+	// baz is on the route but accrued nothing, so nothing is sent
+	uassert.Equal(t, baz.BalanceOf(recipient), int64(0))
+}
+
+func TestRefundLeftoversExcludesPendingProtocolFee(cur realm, t *testing.T) {
+	router := mockRouter()
+	recipient := testutils.TestAddress("refundRecipient2")
+
+	snapshot := router.captureFundsSnapshot(singlePoolPath)
+
+	// 1000 accrued during the swap, of which 400 was recorded as a pending
+	// protocol fee (protocol fee realm halted mid-swap)
+	testing.SetRealm(adminRealm)
+	bar.Transfer(cross(cur), routerAddr, 1000)
+	router.addPendingProtocolFee(0, cur, barPath, 400)
+
+	func(cur realm) {
+		testing.SetRealm(routerRealm)
+		router.refundLeftovers(0, cur, snapshot, recipient)
+	}(cross(cur))
+
+	uassert.Equal(t, bar.BalanceOf(recipient), int64(600))
+}
+
+func TestRefundLeftoversNoLeftover(cur realm, t *testing.T) {
+	router := mockRouter()
+	recipient := testutils.TestAddress("refundRecipient3")
+
+	snapshot := router.captureFundsSnapshot(singlePoolPath)
+
+	func(cur realm) {
+		testing.SetRealm(routerRealm)
+		router.refundLeftovers(0, cur, snapshot, recipient)
+	}(cross(cur))
+
+	uassert.Equal(t, bar.BalanceOf(recipient), int64(0))
+	uassert.Equal(t, baz.BalanceOf(recipient), int64(0))
+}
+
+// TestExactInSwapRouteRefundsPartialFillLeftover drives a real multi-hop swap
+// whose second hop only partially fills, and verifies the intermediate-token
+// leftover is refunded to the swap caller in the same call while pre-existing
+// router funds stay untouched.
+//
+// NOTE: in this test harness the caller/payer the router derives via
+// rlm.Previous() resolves to the router v1 package address (the same reason
+// other tests in this package pre-fund routerV1Addr), so the v1 address plays
+// the swap-user role here.
+func TestExactInSwapRouteRefundsPartialFillLeftover(cur realm, t *testing.T) {
+	initRouterTest(cur, t)
+
+	callerAddr := chain.PackageAddress(routerV1Path)
+
+	testing.SetRealm(adminRealm)
+	pl.SetPoolCreationFee(cross(cur), 0)
+
+	// fresh pool pairs unused by other tests, so shared test state (pool
+	// prices, oracle observations) cannot interfere:
+	// deep first-hop pool bar-obl@3000, thin second-hop pool baz-obl@500
+	// holding only a narrow in-range position
+	CreatePool(cur, t, barPath, oblPath, fee3000, gnsmath.TickMathGetSqrtRatioAtTick(0).ToString(), admin)
+	CreatePool(cur, t, bazPath, oblPath, fee500, gnsmath.TickMathGetSqrtRatioAtTick(0).ToString(), admin)
+
+	testing.SetRealm(adminRealm)
+	TokenApprove(cur, t, barPath, admin, poolAddr, maxApprove)
+	TokenApprove(cur, t, bazPath, admin, poolAddr, maxApprove)
+	TokenApprove(cur, t, oblPath, admin, poolAddr, maxApprove)
+
+	// advance time so the pool oracle accepts a new observation
+	testing.SkipHeights(1)
+
+	testing.SetRealm(adminRealm)
+	pn.Mint(cross(cur), barPath, oblPath, fee3000, minTick, maxTick,
+		"1000000", "1000000", "0", "0", max_timeout, admin, "")
+	pn.Mint(cross(cur), bazPath, oblPath, fee500, int32(-10), int32(10),
+		"10000", "10000", "0", "0", max_timeout, admin, "")
+
+	// fund the swap caller with the input token and approve the router
+	testing.SetRealm(adminRealm)
+	bar.Transfer(cross(cur), callerAddr, 5_000_000_000)
+
+	testing.SetRealm(testing.NewCodeRealm(routerV1Path))
+	bar.Approve(cross(cur), routerAddr, maxApprove)
+
+	// pre-existing router funds must survive the refund untouched
+	testing.SetRealm(adminRealm)
+	obl.Transfer(cross(cur), routerAddr, 7777)
+
+	routerOblBefore := obl.BalanceOf(routerAddr)
+	callerOblBefore := obl.BalanceOf(callerAddr)
+	callerBazBefore := baz.BalanceOf(callerAddr)
+
+	testing.SkipHeights(100)
+
+	routeArr := barPath + ":" + oblPath + ":3000*POOL*" + oblPath + ":" + bazPath + ":500"
+
+	router := mockRouter()
+
+	testing.SetRealm(testing.NewUserRealm(callerAddr))
+	func(cur realm) {
+		testing.SetRealm(routerRealm)
+		router.ExactInSwapRoute(
+			0, cur,
+			barPath,
+			bazPath,
+			"200000",
+			routeArr,
+			"100",
+			"1",
+			max_timeout,
+			"",
+		)
+	}(cross(cur))
+
+	// the swap produced output
+	uassert.True(t, baz.BalanceOf(callerAddr) > callerBazBefore)
+	// the partially consumed intermediate token was refunded to the caller
+	uassert.True(t, obl.BalanceOf(callerAddr) > callerOblBefore)
+	// the router kept nothing from the swap and lost none of its prior funds
+	uassert.Equal(t, obl.BalanceOf(routerAddr), routerOblBefore)
+}

--- a/contract/r/scenario/router/exact_in_multi_swap_route_partial_fill_refund_filetest.gno
+++ b/contract/r/scenario/router/exact_in_multi_swap_route_partial_fill_refund_filetest.gno
@@ -1,0 +1,217 @@
+// exact in multi swap route where the second hop partially fills and the
+// intermediate-token leftover is refunded to the swapper in the same call
+
+// PKGPATH: gno.land/r/gnoswap/v1/main
+
+package main
+
+import (
+	"testing"
+
+	"gno.land/p/gnoswap/gnsmath"
+
+	uassert "gno.land/p/nt/uassert/v0"
+	ufmt "gno.land/p/nt/ufmt/v0"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/pool"
+	pn "gno.land/r/gnoswap/position"
+	"gno.land/r/gnoswap/router"
+
+	prabc "gno.land/p/gnoswap/rbac"
+	_ "gno.land/r/gnoswap/rbac"
+
+	_ "gno.land/r/gnoswap/pool/v1"
+	_ "gno.land/r/gnoswap/position/v1"
+	_ "gno.land/r/gnoswap/protocol_fee/v1"
+	_ "gno.land/r/gnoswap/router/v1"
+	_ "gno.land/r/gnoswap/staker/v1"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/baz"
+	"gno.land/r/onbloc/qux"
+)
+
+var (
+	t *testing.T
+
+	adminAddr, _ = access.GetAddress(prabc.ROLE_ADMIN.String())
+	adminRealm   = testing.NewUserRealm(adminAddr)
+
+	poolAddr, _   = access.GetAddress(prabc.ROLE_POOL.String())
+	routerAddr, _ = access.GetAddress(prabc.ROLE_ROUTER.String())
+
+	barPath = "gno.land/r/onbloc/bar.BAR"
+	bazPath = "gno.land/r/onbloc/baz.BAZ"
+	quxPath = "gno.land/r/onbloc/qux.QUX"
+
+	maxInt64 int64 = 9223372036854775807
+)
+
+func main(cur realm) {
+	println("[SCENARIO] 1. Initialize Setup")
+	initializeSetup(cur)
+	println()
+
+	println("[SCENARIO] 2. Create Deep Pool And Mint Position (bar:baz:500)")
+	createPool(cur, barPath, bazPath, 500, 0)
+	mintPosition(cur, barPath, bazPath, 500, -6960, 6960, "100000000", "100000000")
+	println()
+
+	println("[SCENARIO] 3. Create Thin Pool And Mint Narrow Position (baz:qux:500)")
+	createPool(cur, bazPath, quxPath, 500, 0)
+	mintPosition(cur, bazPath, quxPath, 500, -10, 10, "100000", "100000")
+	println()
+
+	println("[SCENARIO] 4. ExactInSwapRoute bar -> baz -> qux with partial fill on second hop")
+	exactInSwapRouteWithRefundCheck(cur,
+		barPath,
+		quxPath,
+		"10000000",
+		"gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/baz.BAZ:500*POOL*gno.land/r/onbloc/baz.BAZ:gno.land/r/onbloc/qux.QUX:500",
+		"100",
+		"1",
+	)
+	println()
+}
+
+func initializeSetup(cur realm) {
+	testing.SetRealm(adminRealm)
+	pool.SetPoolCreationFee(cross(cur), 0)
+	router.SetSwapFee(cross(cur), 0)
+
+	bar.Approve(cross(cur), poolAddr, maxInt64)
+	baz.Approve(cross(cur), poolAddr, maxInt64)
+	qux.Approve(cross(cur), poolAddr, maxInt64)
+
+	bar.Approve(cross(cur), routerAddr, maxInt64)
+
+	println("[INFO] BAR Balance of admin:", bar.BalanceOf(adminAddr))
+	println("[INFO] BAZ Balance of admin:", baz.BalanceOf(adminAddr))
+	println("[INFO] QUX Balance of admin:", qux.BalanceOf(adminAddr))
+}
+
+func createPool(cur realm, token0Path string, token1Path string, fee uint32, startTick int32) {
+	testing.SetRealm(adminRealm)
+	pool.CreatePool(
+		cross(cur),
+		token0Path,
+		token1Path,
+		fee,
+		gnsmath.TickMathGetSqrtRatioAtTick(startTick).ToString(),
+	)
+
+	ufmt.Printf("[EXPECTED] created %s:%s:%d pool at tick %d\n", token0Path, token1Path, fee, startTick)
+}
+
+func mintPosition(cur realm, token0Path string, token1Path string, fee uint32, minTick, maxTick int32, amount0 string, amount1 string) {
+	testing.SetRealm(adminRealm)
+
+	positionId, liquidity, amount0, amount1 := pn.Mint(
+		cross(cur),
+		token0Path,
+		token1Path,
+		fee,
+		minTick,
+		maxTick,
+		amount0,
+		amount1,
+		"0",
+		"0",
+		9999999999,
+		adminAddr,
+		"",
+	)
+
+	ufmt.Printf("[EXPECTED] positionId: %d\n", positionId)
+	ufmt.Printf("[EXPECTED] liquidity: %s\n", liquidity)
+	ufmt.Printf("[EXPECTED] amount0: %s\n", amount0)
+	ufmt.Printf("[EXPECTED] amount1: %s\n", amount1)
+}
+
+func exactInSwapRouteWithRefundCheck(cur realm,
+	inputToken string,
+	outputToken string,
+	specifiedAmount string,
+	routeQueryString string,
+	queryRatios string,
+	minAmountOut string,
+) {
+	testing.SetRealm(adminRealm)
+
+	beforeSwapperBar := bar.BalanceOf(adminAddr)
+	beforeSwapperBaz := baz.BalanceOf(adminAddr)
+	beforeSwapperQux := qux.BalanceOf(adminAddr)
+
+	beforeRouterBar := bar.BalanceOf(routerAddr)
+	beforeRouterBaz := baz.BalanceOf(routerAddr)
+	beforeRouterQux := qux.BalanceOf(routerAddr)
+
+	inputTokenAmount, outputTokenAmount := router.ExactInSwapRoute(
+		cross(cur),
+		inputToken,
+		outputToken,
+		specifiedAmount,
+		routeQueryString,
+		queryRatios,
+		minAmountOut,
+		int64(9999999999),
+		"",
+	)
+
+	swapperBarDelta := bar.BalanceOf(adminAddr) - beforeSwapperBar
+	swapperBazDelta := baz.BalanceOf(adminAddr) - beforeSwapperBaz
+	swapperQuxDelta := qux.BalanceOf(adminAddr) - beforeSwapperQux
+
+	ufmt.Printf("[EXPECTED] inputTokenAmount(BAR): %s\n", inputTokenAmount)
+	ufmt.Printf("[EXPECTED] outputTokenAmount(QUX): %s\n", outputTokenAmount)
+	ufmt.Printf("[EXPECTED] swapper BAR balance changed: %d\n", swapperBarDelta)
+	ufmt.Printf("[EXPECTED] swapper BAZ balance changed (refunded leftover): %d\n", swapperBazDelta)
+	ufmt.Printf("[EXPECTED] swapper QUX balance changed: %d\n", swapperQuxDelta)
+
+	// the full input was consumed and the swap produced output
+	uassert.Equal(t, ufmt.Sprintf("%d", -swapperBarDelta), inputTokenAmount)
+	uassert.Equal(t, ufmt.Sprintf("%d", swapperQuxDelta), outputTokenAmount)
+
+	// the second hop only partially filled, so part of the intermediate baz
+	// came back to the swapper as a refund
+	uassert.True(t, swapperBazDelta > 0)
+
+	// the router keeps nothing from the swap
+	uassert.Equal(t, bar.BalanceOf(routerAddr), beforeRouterBar)
+	uassert.Equal(t, baz.BalanceOf(routerAddr), beforeRouterBaz)
+	uassert.Equal(t, qux.BalanceOf(routerAddr), beforeRouterQux)
+	ufmt.Printf("[EXPECTED] router BAR/BAZ/QUX balance changed: %d/%d/%d\n",
+		bar.BalanceOf(routerAddr)-beforeRouterBar,
+		baz.BalanceOf(routerAddr)-beforeRouterBaz,
+		qux.BalanceOf(routerAddr)-beforeRouterQux,
+	)
+}
+
+// Output:
+// [SCENARIO] 1. Initialize Setup
+// [INFO] BAR Balance of admin: 100000000000000
+// [INFO] BAZ Balance of admin: 100000000000000
+// [INFO] QUX Balance of admin: 100000000000000
+//
+// [SCENARIO] 2. Create Deep Pool And Mint Position (bar:baz:500)
+// [EXPECTED] created gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/baz.BAZ:500 pool at tick 0
+// [EXPECTED] positionId: 1
+// [EXPECTED] liquidity: 340264708
+// [EXPECTED] amount0: 100000000
+// [EXPECTED] amount1: 100000000
+//
+// [SCENARIO] 3. Create Thin Pool And Mint Narrow Position (baz:qux:500)
+// [EXPECTED] created gno.land/r/onbloc/baz.BAZ:gno.land/r/onbloc/qux.QUX:500 pool at tick 0
+// [EXPECTED] positionId: 2
+// [EXPECTED] liquidity: 200060003
+// [EXPECTED] amount0: 100000
+// [EXPECTED] amount1: 100000
+//
+// [SCENARIO] 4. ExactInSwapRoute bar -> baz -> qux with partial fill on second hop
+// [EXPECTED] inputTokenAmount(BAR): 10000000
+// [EXPECTED] outputTokenAmount(QUX): 99999
+// [EXPECTED] swapper BAR balance changed: -10000000
+// [EXPECTED] swapper BAZ balance changed (refunded leftover): 9609680
+// [EXPECTED] swapper QUX balance changed: 99999
+// [EXPECTED] router BAR/BAZ/QUX balance changed: 0/0/0

--- a/contract/r/scenario/router/exact_in_multi_swap_route_partial_fill_refund_with_pending_protocol_fee_filetest.gno
+++ b/contract/r/scenario/router/exact_in_multi_swap_route_partial_fill_refund_with_pending_protocol_fee_filetest.gno
@@ -1,0 +1,244 @@
+// exact in multi swap route where the second hop partially fills while the
+// protocol fee realm is halted: the intermediate-token leftover is refunded to
+// the swapper, but the swap fee kept as a pending protocol fee stays in the
+// router and is excluded from the refund
+
+// PKGPATH: gno.land/r/gnoswap/v1/main
+
+package main
+
+import (
+	"testing"
+
+	"gno.land/p/gnoswap/gnsmath"
+
+	uassert "gno.land/p/nt/uassert/v0"
+	ufmt "gno.land/p/nt/ufmt/v0"
+
+	"gno.land/r/gnoswap/access"
+	"gno.land/r/gnoswap/halt"
+	"gno.land/r/gnoswap/pool"
+	pn "gno.land/r/gnoswap/position"
+	"gno.land/r/gnoswap/router"
+
+	prabc "gno.land/p/gnoswap/rbac"
+	_ "gno.land/r/gnoswap/rbac"
+
+	_ "gno.land/r/gnoswap/pool/v1"
+	_ "gno.land/r/gnoswap/position/v1"
+	_ "gno.land/r/gnoswap/protocol_fee/v1"
+	_ "gno.land/r/gnoswap/router/v1"
+	_ "gno.land/r/gnoswap/staker/v1"
+
+	"gno.land/r/onbloc/bar"
+	"gno.land/r/onbloc/baz"
+	"gno.land/r/onbloc/qux"
+)
+
+var (
+	t *testing.T
+
+	adminAddr, _ = access.GetAddress(prabc.ROLE_ADMIN.String())
+	adminRealm   = testing.NewUserRealm(adminAddr)
+
+	poolAddr, _   = access.GetAddress(prabc.ROLE_POOL.String())
+	routerAddr, _ = access.GetAddress(prabc.ROLE_ROUTER.String())
+
+	barPath = "gno.land/r/onbloc/bar.BAR"
+	bazPath = "gno.land/r/onbloc/baz.BAZ"
+	quxPath = "gno.land/r/onbloc/qux.QUX"
+
+	maxInt64 int64 = 9223372036854775807
+
+	swapFeeBps int64 = 100 // 1%
+)
+
+func main(cur realm) {
+	println("[SCENARIO] 1. Initialize Setup with 1% swap fee")
+	initializeSetup(cur)
+	println()
+
+	println("[SCENARIO] 2. Create Deep Pool And Mint Position (bar:baz:500)")
+	createPool(cur, barPath, bazPath, 500, 0)
+	mintPosition(cur, barPath, bazPath, 500, -6960, 6960, "100000000", "100000000")
+	println()
+
+	println("[SCENARIO] 3. Create Thin Pool And Mint Narrow Position (baz:qux:500)")
+	createPool(cur, bazPath, quxPath, 500, 0)
+	mintPosition(cur, bazPath, quxPath, 500, -10, 10, "100000", "100000")
+	println()
+
+	println("[SCENARIO] 4. Halt Protocol Fee Only")
+	haltProtocolFee(cur)
+	println()
+
+	println("[SCENARIO] 5. ExactInSwapRoute bar -> baz -> qux with partial fill and pending protocol fee")
+	exactInSwapRouteWithPendingFeeCheck(cur,
+		barPath,
+		quxPath,
+		"10000000",
+		"gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/baz.BAZ:500*POOL*gno.land/r/onbloc/baz.BAZ:gno.land/r/onbloc/qux.QUX:500",
+		"100",
+		"1",
+	)
+	println()
+}
+
+func initializeSetup(cur realm) {
+	testing.SetRealm(adminRealm)
+	pool.SetPoolCreationFee(cross(cur), 0)
+	router.SetSwapFee(cross(cur), uint64(swapFeeBps))
+
+	bar.Approve(cross(cur), poolAddr, maxInt64)
+	baz.Approve(cross(cur), poolAddr, maxInt64)
+	qux.Approve(cross(cur), poolAddr, maxInt64)
+
+	bar.Approve(cross(cur), routerAddr, maxInt64)
+
+	println("[INFO] swap fee (bps):", router.GetSwapFee())
+}
+
+func createPool(cur realm, token0Path string, token1Path string, fee uint32, startTick int32) {
+	testing.SetRealm(adminRealm)
+	pool.CreatePool(
+		cross(cur),
+		token0Path,
+		token1Path,
+		fee,
+		gnsmath.TickMathGetSqrtRatioAtTick(startTick).ToString(),
+	)
+
+	ufmt.Printf("[EXPECTED] created %s:%s:%d pool at tick %d\n", token0Path, token1Path, fee, startTick)
+}
+
+func mintPosition(cur realm, token0Path string, token1Path string, fee uint32, minTick, maxTick int32, amount0 string, amount1 string) {
+	testing.SetRealm(adminRealm)
+
+	positionId, liquidity, amount0, amount1 := pn.Mint(
+		cross(cur),
+		token0Path,
+		token1Path,
+		fee,
+		minTick,
+		maxTick,
+		amount0,
+		amount1,
+		"0",
+		"0",
+		9999999999,
+		adminAddr,
+		"",
+	)
+
+	ufmt.Printf("[EXPECTED] positionId: %d\n", positionId)
+	ufmt.Printf("[EXPECTED] liquidity: %s\n", liquidity)
+	ufmt.Printf("[EXPECTED] amount0: %s\n", amount0)
+	ufmt.Printf("[EXPECTED] amount1: %s\n", amount1)
+}
+
+func haltProtocolFee(cur realm) {
+	testing.SetRealm(adminRealm)
+	halt.SetOperationStatus(cross(cur), halt.OpTypeProtocolFee, true)
+
+	ufmt.Printf("[EXPECTED] IsHaltedProtocolFee: %t\n", halt.IsHaltedProtocolFee())
+	ufmt.Printf("[EXPECTED] IsHaltedRouter: %t\n", halt.IsHaltedRouter())
+}
+
+func exactInSwapRouteWithPendingFeeCheck(cur realm,
+	inputToken string,
+	outputToken string,
+	specifiedAmount string,
+	routeQueryString string,
+	queryRatios string,
+	minAmountOut string,
+) {
+	testing.SetRealm(adminRealm)
+
+	beforeSwapperBar := bar.BalanceOf(adminAddr)
+	beforeSwapperBaz := baz.BalanceOf(adminAddr)
+	beforeSwapperQux := qux.BalanceOf(adminAddr)
+
+	beforeRouterBar := bar.BalanceOf(routerAddr)
+	beforeRouterBaz := baz.BalanceOf(routerAddr)
+	beforeRouterQux := qux.BalanceOf(routerAddr)
+
+	inputTokenAmount, outputTokenAmount := router.ExactInSwapRoute(
+		cross(cur),
+		inputToken,
+		outputToken,
+		specifiedAmount,
+		routeQueryString,
+		queryRatios,
+		minAmountOut,
+		int64(9999999999),
+		"",
+	)
+
+	swapperBarDelta := bar.BalanceOf(adminAddr) - beforeSwapperBar
+	swapperBazDelta := baz.BalanceOf(adminAddr) - beforeSwapperBaz
+	swapperQuxDelta := qux.BalanceOf(adminAddr) - beforeSwapperQux
+	routerQuxDelta := qux.BalanceOf(routerAddr) - beforeRouterQux
+
+	pendingQuxFee := router.GetPendingProtocolFees()[quxPath]
+	grossOutput := swapperQuxDelta + pendingQuxFee
+
+	ufmt.Printf("[EXPECTED] inputTokenAmount(BAR): %s\n", inputTokenAmount)
+	ufmt.Printf("[EXPECTED] outputTokenAmount(QUX): %s\n", outputTokenAmount)
+	ufmt.Printf("[EXPECTED] swapper BAR balance changed: %d\n", swapperBarDelta)
+	ufmt.Printf("[EXPECTED] swapper BAZ balance changed (refunded leftover): %d\n", swapperBazDelta)
+	ufmt.Printf("[EXPECTED] swapper QUX balance changed: %d\n", swapperQuxDelta)
+	ufmt.Printf("[EXPECTED] pending protocol fee (QUX): %d\n", pendingQuxFee)
+	ufmt.Printf("[EXPECTED] router QUX balance changed: %d\n", routerQuxDelta)
+	ufmt.Printf("[EXPECTED] gross output before swap fee: %d\n", grossOutput)
+
+	// the full input was consumed and the swap produced output
+	uassert.Equal(t, ufmt.Sprintf("%d", -swapperBarDelta), inputTokenAmount)
+	uassert.Equal(t, ufmt.Sprintf("%d", swapperQuxDelta), outputTokenAmount)
+
+	// the second hop only partially filled, so part of the intermediate baz
+	// came back to the swapper as a refund
+	uassert.True(t, swapperBazDelta > 0)
+
+	// the swap fee could not be forwarded to the halted protocol fee realm:
+	// it stays in the router, matches the recorded pending amount exactly,
+	// and is excluded from the refund
+	uassert.True(t, pendingQuxFee > 0)
+	uassert.Equal(t, routerQuxDelta, pendingQuxFee)
+	uassert.Equal(t, pendingQuxFee, grossOutput*swapFeeBps/10000)
+
+	// no other route token is left behind in the router
+	uassert.Equal(t, bar.BalanceOf(routerAddr), beforeRouterBar)
+	uassert.Equal(t, baz.BalanceOf(routerAddr), beforeRouterBaz)
+}
+
+// Output:
+// [SCENARIO] 1. Initialize Setup with 1% swap fee
+// [INFO] swap fee (bps): 100
+//
+// [SCENARIO] 2. Create Deep Pool And Mint Position (bar:baz:500)
+// [EXPECTED] created gno.land/r/onbloc/bar.BAR:gno.land/r/onbloc/baz.BAZ:500 pool at tick 0
+// [EXPECTED] positionId: 1
+// [EXPECTED] liquidity: 340264708
+// [EXPECTED] amount0: 100000000
+// [EXPECTED] amount1: 100000000
+//
+// [SCENARIO] 3. Create Thin Pool And Mint Narrow Position (baz:qux:500)
+// [EXPECTED] created gno.land/r/onbloc/baz.BAZ:gno.land/r/onbloc/qux.QUX:500 pool at tick 0
+// [EXPECTED] positionId: 2
+// [EXPECTED] liquidity: 200060003
+// [EXPECTED] amount0: 100000
+// [EXPECTED] amount1: 100000
+//
+// [SCENARIO] 4. Halt Protocol Fee Only
+// [EXPECTED] IsHaltedProtocolFee: true
+// [EXPECTED] IsHaltedRouter: false
+//
+// [SCENARIO] 5. ExactInSwapRoute bar -> baz -> qux with partial fill and pending protocol fee
+// [EXPECTED] inputTokenAmount(BAR): 10000000
+// [EXPECTED] outputTokenAmount(QUX): 99000
+// [EXPECTED] swapper BAR balance changed: -10000000
+// [EXPECTED] swapper BAZ balance changed (refunded leftover): 9609680
+// [EXPECTED] swapper QUX balance changed: 99000
+// [EXPECTED] pending protocol fee (QUX): 999
+// [EXPECTED] router QUX balance changed: 999
+// [EXPECTED] gross output before swap fee: 99999

--- a/docs/router.md
+++ b/docs/router.md
@@ -32,3 +32,10 @@ GnoSwap charges router fee on output tokens. In exact-out swaps, user receives `
 - `SwapCallback` missing `AssertIsPool` → anyone forges callback params, drains approvals.
 - `DrySwapRoute` / live swap divergence → users see wrong expected amounts.
 - Multi-hop route where intermediate token equals input or output token → unexpected behavior.
+
+## Leftover Refund
+
+Every swap entry point snapshots the router's balance and pending protocol fee for each route token before executing (`refund.gno`). After the output payout, any surplus a route token accrued in the router during the swap — e.g. an intermediate hop that only partially filled against thin liquidity — is transferred back to the swap caller in the same transaction (`SwapRouteRefund` event per token).
+
+- Only the delta against the pre-swap snapshot is refunded. Balances the router held before the swap, and protocol fees recorded as pending during the swap (protocol fee realm halted), are never touched.
+- The refund runs after all state updates and payouts, as the final interaction of the call (CEI). There is no permissionless sweep: Uniswap's `refundETH`/`sweepToken` model relies on multicall atomicity, which does not exist here, so router balances must never be claimable by later callers.


### PR DESCRIPTION
## What changed

The router now refunds any route-token surplus it accrues during a swap back to the swap caller **within the same transaction**.

- **`contract/r/gnoswap/router/v1/refund.gno` (new)**
  - `captureFundsSnapshot` records, per route token, the router's balance and pending protocol fee before the swap moves any funds.
  - `refundLeftovers` runs after the output payout and transfers each token's surplus over the snapshot to the caller, emitting a `SwapRouteRefund` event per refunded token.
- **`exact_in.gno` / `exact_out.gno`**: both swap paths (covering all four entry points) take the snapshot before `commonSwapRoute` and refund after the output transfer.
- **`docs/router.md`**: documents the leftover-refund behavior.

## Why

In a multi-hop swap, each hop's output is delivered to the router and fed into the next hop. When an intermediate hop only partially fills (thin liquidity: the pool price reaches its limit before consuming the full amount), the unconsumed intermediate tokens were left stranded in the router with no way back to the user. This mirrors the intent of Uniswap's `refundETH`/`sweepToken`, adapted to GnoVM constraints (see security notes below).

## Security considerations

- **Delta-only refunds**: only the surplus accrued during the current call is refunded. Funds the router held before the swap are never touched, so pre-existing balances cannot be drained by a later caller.
- **Pending protocol fee exclusion**: when the protocol fee realm is halted mid-swap, the swap fee stays in the router as a pending fee. The refund computation subtracts the signed pending-fee delta, so those fees are excluded exactly (and a settlement of old pending fees during the swap nets out correctly).
- **CEI**: the refund runs after all state updates and payouts, as the final interaction of the call.
- **No permissionless sweep**: Uniswap's claim-anyone model relies on multicall atomicity, which does not exist on GnoVM. Refunds go only to the swap caller, in-swap.
- **Fail-closed arithmetic**: all delta math uses `gnsmath.SafeSubInt64`, so any overflow aborts the transaction.

## Tests

- **Unit** (`refund_test.gno`): route-token collection/dedup; delta-only refund with pre-existing balance preserved; pending-protocol-fee exclusion (1000 accrued, 400 pending → 600 refunded); no-op when nothing accrued; an end-to-end multi-hop swap against a thin narrow-range pool asserting the leftover comes back to the caller and the router balance is unchanged.
- **Scenario filetests** (`contract/r/scenario/router/`), amount-focused:
  - `exact_in_multi_swap_route_partial_fill_refund_filetest.gno`: 10,000,000 BAR in → 9,609,680 BAZ leftover refunded, 99,999 QUX out, router deltas 0/0/0.
  - `..._with_pending_protocol_fee_filetest.gno`: same route with a 1% swap fee and the protocol fee realm halted → gross output 99,999 splits into 99,000 to the swapper + 999 kept in the router matching the recorded pending fee exactly; the 9,609,680 BAZ refund is unaffected.
- Full `router/v1` package suite and the full `scenario/router` filetest suite pass; existing golden outputs are unchanged.
