### PR TITLE
perf(staker): reduce tick accumulator fanout

### DIFF
--- a/contract/r/gnoswap/staker/pool.gno
+++ b/contract/r/gnoswap/staker/pool.gno
@@ -836,7 +836,7 @@ func NewTick(tickId int32) *Tick {
 		id:                   tickId,
 		stakedLiquidityGross: u256.Zero(),
 		stakedLiquidityDelta: i256.Zero(),
-		outsideAccumulation:  NewUintTreeN(64),
+		outsideAccumulation:  NewUintTreeN(4),
 	}
 }
 


### PR DESCRIPTION
## Summary
- Reduce the initial B+ tree fanout for each staked tick's outside-accumulation checkpoint from 64 to 4.

## Context
- Each initialized staked tick allocates an outside-accumulation tree. A smaller initial fanout lowers per-tick storage allocation and tick-cross execution cost.

## Changes
- Set `NewTick()` to initialize `outsideAccumulation` with fanout 4 instead of 64.

## Behavior Changes
- No public API changes. The staker checkpoint accumulator uses a smaller internal tree fanout.

## Verification
- `make test PKG=gno.land/r/gnoswap/staker`
- [Performance tracker PR #44](https://github.com/gnoswap-labs/gnoswap-performance-tracker/pull/44) compares the same one-line 64-to-4 change at baseline `548c484` and reports savings of 17,894 gas and 5,642 B per crossed tick, with no CPU-cycle change in the measured workloads.

## Notes
- The tracker measurement candidate is `b562b62`; this PR reapplies only that same change on the current `main` base.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced the initial memory allocation for newly created tick accumulation data, improving resource efficiency without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->