### PR TITLE
chore: align Gno tooling with Pearl

### DIFF
--- a/.github/workflows/run_integration_test.yml
+++ b/.github/workflows/run_integration_test.yml
@@ -15,8 +15,8 @@ jobs:
       - name: Check out gno
         uses: actions/checkout@v4
         with:
-          repository: gnoswap-labs/gno
-          ref: master
+          repository: gnolang/gno
+          ref: chain/pearl
           path: ./gno
 
       - name: Set up Go

--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -33,9 +33,9 @@ jobs:
   setup-gno:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out gno (master)
+      - name: Check out Gno (Pearl)
         run: |
-          git clone --depth 1 https://github.com/gnoswap-labs/gno.git gno -b master
+          git clone --branch chain/pearl --single-branch --depth 1 https://github.com/gnolang/gno.git gno
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -66,9 +66,9 @@ jobs:
       - name: Check out gnoswap repo
         uses: actions/checkout@v4
 
-      - name: Check out gno (master)
+      - name: Check out Gno (Pearl)
         run: |
-          git clone --depth 1 https://github.com/gnoswap-labs/gno.git gno -b master
+          git clone --branch chain/pearl --single-branch --depth 1 https://github.com/gnolang/gno.git gno
 
       - name: Link contracts into gno/examples/gno.land (setup.py, same as Makefile)
         run: python3 setup.py -w .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ make integration-test-build
 - For direct `gno test`, run `python3 setup.py -w <workdir>` first, then test from `<workdir>/gno/examples`.
 - `RUN=` maps to `gno test -run`; use regexes for subtests.
 - Filetests and integration txtar cases are coarse-grained. Do not update golden/bless outputs without reviewing diffs.
-- CI clones `gnoswap-labs/gno`, runs `setup.py`, updates fuzz seeds, and executes package tests via `.github/scripts/run_tests.rb`.
+- CI clones `gnolang/gno` at `chain/pearl`, runs `setup.py`, updates fuzz seeds, and executes package tests via `.github/scripts/run_tests.rb`.
 
 ## Conventions & Rules
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ RUN apk add --no-cache \
 
 WORKDIR /app
 
-# Clone gno repository (master branch from gnoswap-labs)
-RUN git clone --branch master --single-branch --depth 1 \
-    https://github.com/gnoswap-labs/gno.git /app/gno
+# Clone the toolchain that backs the current Pearl testnet.
+RUN git clone --branch chain/pearl --single-branch --depth 1 \
+    https://github.com/gnolang/gno.git /app/gno
 
 # Build gno tools
 WORKDIR /app/gno

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ PROJECT_ROOT := $(shell pwd)
 TMP_PATH := $(PROJECT_ROOT)/tmp
 GNO_PATH := $(TMP_PATH)/gno
 GNOSWAP_PATH := $(TMP_PATH)/gnoswap
+GNO_REPOSITORY ?= https://github.com/gnolang/gno.git
+GNO_REF ?= chain/pearl
+
 SCRIPT := $(PROJECT_ROOT)/scripts/test.sh
 
 include $(PROJECT_ROOT)/scripts/test_values.mk
@@ -63,7 +66,7 @@ test:
 	fi
 	@if [ ! -d "$(WORKDIR)/gno" ]; then \
 		echo "📦 gno repository not found. Cloning..."; \
-		git clone git@github.com:gnoswap-labs/gno.git $(WORKDIR)/gno; \
+		git clone --branch $(GNO_REF) --single-branch --depth 1 $(GNO_REPOSITORY) $(WORKDIR)/gno; \
 	fi
 	@python3 $(PROJECT_ROOT)/setup.py -w $(WORKDIR)
 	@cd $(WORKDIR)/gno/examples && \

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -26,9 +26,9 @@ clone_repos() {
   echo "✅ Cloning gnoswap repository into tmp/gnoswap..."
   git clone https://github.com/gnoswap-labs/gnoswap.git "$GNOSWAP_PATH"
 
-  # Clone gno repository into $TMP_PATH
-  echo "✅ Cloning gno repository into tmp/gno..."
-  git clone --depth 1 --branch master https://github.com/gnolang/gno.git "$GNO_PATH"
+  # Clone the Gno source that backs the current Pearl testnet.
+  echo "✅ Cloning Pearl Gno repository into tmp/gno..."
+  git clone --depth 1 --branch chain/pearl https://github.com/gnolang/gno.git "$GNO_PATH"
 }
 
 # ✅ env setup(Go, Python install)


### PR DESCRIPTION
## Summary
- align local, Docker, CI, and script-based Gno checkouts with `gnolang/gno@chain/pearl`
- centralize the quick test runner repository and ref in the Makefile
- keep the agent guidance aligned with the CI toolchain

## Verification
- `make test WORKDIR=tmp-pearl PKG=gno.land/r/gnoswap/gov/governance`
- `make test WORKDIR=tmp-pearl PKG=gno.land/r/gnoswap/gov/staker`
- `make test WORKDIR=tmp-pearl PKG=gno.land/r/gnoswap/launchpad`
- `bash -n scripts/test.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and test workflows to use the official Gno repository and the `chain/pearl` branch.
  * Added configurable Gno repository and branch settings for test setup.
  * Switched repository checkouts to shallow, single-branch clones where applicable.

* **Documentation**
  * Updated CI documentation and test output to reflect the Pearl testnet source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->