### PR TITLE
perf(uint256): reuse quotient and remainder in DivRoundingUp

### DIFF
--- a/contract/p/gnoswap/uint256/fullmath.gno
+++ b/contract/p/gnoswap/uint256/fullmath.gno
@@ -84,15 +84,9 @@ func MulDivRoundingUp(a, b, denominator *Uint) *Uint {
 // DivRoundingUp calculates ceil(x / y) and returns the result.
 // Panics if y is zero.
 func DivRoundingUp(x, y *Uint) *Uint {
-	div := new(Uint).Div(x, y)
-	mod := new(Uint).Mod(x, y)
-	return new(Uint).Add(div, gt(mod, &Uint{0, 0, 0, 0}))
-}
-
-// gt returns One() if x > y, otherwise returns Zero().
-func gt(x, y *Uint) *Uint {
-	if x.Gt(y) {
-		return &Uint{1, 0, 0, 0}
+	div, mod := new(Uint).DivMod(x, y, new(Uint))
+	if !mod.IsZero() {
+		div.Add(div, &Uint{1, 0, 0, 0})
 	}
-	return &Uint{0, 0, 0, 0}
+	return div
 }

--- a/contract/p/gnoswap/uint256/fullmath_test.gno
+++ b/contract/p/gnoswap/uint256/fullmath_test.gno
@@ -463,6 +463,12 @@ func TestDivRoundingUp(t *testing.T) {
 			y:         "0",
 			wantPanic: true,
 		},
+		{
+			name:      "panic_zero_divided_by_zero",
+			x:         "0",
+			y:         "0",
+			wantPanic: true,
+		},
 
 		// Boundary: max values
 		{
@@ -482,6 +488,30 @@ func TestDivRoundingUp(t *testing.T) {
 			x:    "1000000000000000000000000000000000000001",
 			y:    "1000000000000000000",
 			want: "1000000000000000000001", // 1000000000000000000 + 1
+		},
+		{
+			name: "max_divided_by_one",
+			x:    MAX_UINT256,
+			y:    "1",
+			want: MAX_UINT256,
+		},
+		{
+			name: "rounding_carries_into_next_limb",
+			x:    MAX_UINT256,
+			y:    "6277101735386680763835789423207666416102355444464034512896", // 2^192
+			want: "18446744073709551616",                                       // 2^64
+		},
+		{
+			name: "multi_limb_exact_division",
+			x:    MAX_UINT256,
+			y:    "340282366920938463463374607431768211457", // 2^128 + 1
+			want: "340282366920938463463374607431768211455", // 2^128 - 1
+		},
+		{
+			name: "remainder_only_in_high_limb",
+			x:    "6277101735386680763835789423207666416120802188537744064512", // 2^192 + 2^64
+			y:    "6277101735386680763835789423207666416102355444464034512896", // 2^192
+			want: "2",
 		},
 	}
 
@@ -505,6 +535,13 @@ func TestDivRoundingUp(t *testing.T) {
 
 			if !got.Eq(want) {
 				t.Errorf("DivRoundingUp(%s, %s) = %s, want %s", tc.x, tc.y, got.ToString(), tc.want)
+			}
+			if x.ToString() != tc.x || y.ToString() != tc.y {
+				t.Fatal("DivRoundingUp modified its inputs")
+			}
+			got.Clear()
+			if x.ToString() != tc.x || y.ToString() != tc.y {
+				t.Fatal("mutating the result modified an input")
 			}
 		})
 	}
@@ -559,37 +596,18 @@ func TestMulDivFloorVsCeil(t *testing.T) {
 	}
 }
 
-// ceil == floor || ceil == floor+1
-func TestDivRoundingUpProperty(t *testing.T) {
-	testCases := []struct {
-		x, y uint64
-	}{
-		{100, 3},   // 33.33... -> floor=33, ceil=34
-		{100, 10},  // 10.0 -> floor=10, ceil=10 (exact)
-		{1000, 7},  // 142.857... -> floor=142, ceil=143
-		{999, 333}, // 3.0 -> floor=3, ceil=3 (exact)
-		{1, 2},     // 0.5 -> floor=0, ceil=1
-		{0, 999},   // 0.0 -> floor=0, ceil=0 (exact)
+func TestDivRoundingUpSharedInput(t *testing.T) {
+	x := MaxUint256()
+	got := DivRoundingUp(x, x)
+	if !got.Eq(One()) {
+		t.Fatalf("DivRoundingUp(x, x) = %s, want 1", got.ToString())
 	}
-
-	for i, tc := range testCases {
-		t.Run(ufmt.Sprintf("property_test_%d", i), func(t *testing.T) {
-			if tc.y == 0 {
-				return // Skip division by zero
-			}
-
-			xUint := MustFromDecimal(ufmt.Sprintf("%d", tc.x))
-			yUint := MustFromDecimal(ufmt.Sprintf("%d", tc.y))
-
-			ceil := DivRoundingUp(xUint, yUint)
-			floor := new(Uint).Div(xUint, yUint)
-			floorPlusOne := new(Uint).Add(floor, One())
-
-			if !ceil.Eq(floor) && !ceil.Eq(floorPlusOne) {
-				t.Errorf("Property failed: ceil(%s) != floor(%s) && ceil != floor+1(%s)",
-					ceil.ToString(), floor.ToString(), floorPlusOne.ToString())
-			}
-		})
+	if x.ToString() != MAX_UINT256 {
+		t.Fatal("DivRoundingUp modified the shared input")
+	}
+	got.Clear()
+	if x.ToString() != MAX_UINT256 {
+		t.Fatal("mutating the result modified the shared input")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Reuse the existing `DivMod` in `DivRoundingUp` instead of computing quotient and remainder separately.
- Increment the fresh quotient only when the remainder is nonzero and remove the unused `gt` helper.
- Open as a draft for review; this is not a deployment or a merge-readiness claim.

## Context
The previous implementation calls both `Div` and `Mod`, repeating division work for large operands. Both quantities are already available from `DivMod`.

This PR is limited to `DivRoundingUp`. It does not optimize `MulDivRoundingUp` or change other math primitives.

## Behavior / Safety
- Preserve `ceil(x / y)`, including zero dividends, exact division, and nonzero remainders.
- Preserve the zero-divisor panic (`division by zero`).
- Keep inputs unchanged and return a fresh result object.
- Rounding cannot overflow: the maximum quotient requires maximum uint256 divided by one, which has no remainder.
- No public signature, event, storage schema, access-control, or lock changes.

## Measured Impact
Measured baseline: `b12f0f8760a3e88e9539b0c8cfd32b38a5297c68`.
Measured candidate: `0a7729ab02b845de8a06451fd6bbddff6fabf07b`.
Metric-enabled Gno: `bac78a97b20e12ba471bdd73a41af31bd94bdc12`.

| Workload | Baseline gas | Candidate gas | Gas delta | Net storage delta | CPU-cycle delta |
| --- | ---: | ---: | ---: | ---: | ---: |
| DivRoundingUp (Q128 remainder) | 487,336 | 252,676 | -234,660 (-48.15%) | 0 B | -229,935 |
| GetAmount0Delta | 3,631,434 | 3,274,179 | -357,255 (-9.84%) | 0 B | -350,776 |
| MultiHop ExactIn (2 hops) | 52,553,428 | 51,964,831 | -588,597 (-1.12%) | 0 B | -577,627 |
| MultiHop ExactOut (2 hops) | 72,989,313 | 72,048,913 | -940,400 (-1.29%) | 0 B | -922,018 |
| MultiHop ExactOut (3 hops) | 110,644,705 | 109,702,397 | -942,308 (-0.85%) | 0 B | -923,926 |
| Direct pool swap (fee:500) | 47,027,189 | 47,027,189 | 0 (0.00%) | 0 B | 0 |
| Swap (halving, 50 staked tick-crosses) | 445,312,170 | 445,312,170 | 0 (0.00%) | 0 B | 0 |

Across 123 matched metric rows, 18 have lower gas and 105 have unchanged gas. No gas or CPU-cycle increase was measured; all net storage diffs are unchanged. Existing single-hop and staked tick-cross swap fixtures are unchanged. Function-level savings are not whole-swap savings, and execution gas is distinct from submitted gas fees. Full reports and measurement caveats are in the tracker PR.

## Verification
Passed on the measured candidate in its contract worktree:
```sh
make test PKG=gno.land/p/gnoswap/uint256
make test PKG=gno.land/p/gnoswap/gnsmath
```
Passed in the tracker worktree with identical fixtures and runtime for both commits:
```sh
make compare-metric-force 0a7729ab02b845de8a06451fd6bbddff6fabf07b b12f0f8760a3e88e9539b0c8cfd32b38a5297c68
```
The direct fixture asserts expected ceiling results and unchanged inputs against both revisions. All 369 comparison values were checked against the two source reports. These are focused package tests and standard metrics, not a claim that the full contract suite or PR CI has passed. Review and PR CI remain pending; if the candidate changes, refresh validation and the paired reports.

## Additional Test Coverage
Test-only follow-up commit: `1529fe9b611993249e605c598743b6381121cbd4`.
- Check `0 / 0` still panics, including against an incorrect zero-dividend fast path.
- Check maximum uint256 divided by one does not spuriously increment/overflow.
- Check rounding carry across the 64-bit limb boundary and exact division with a multi-limb denominator.
- Check a remainder whose low limb is zero still triggers rounding up.
- Verify ordinary and shared numerator/denominator inputs remain unchanged, including after mutating the returned result.
- Replace the weak `ceil == floor || floor + 1` property test, which also accepted an incorrect floor result, with direct shared-input/ownership coverage; ceiling cases assert exact expected values.

Re-ran `make test PKG=gno.land/p/gnoswap/uint256` successfully after the additions (14 table cases plus the shared-input test). Expected boundary values were independently calculated with arbitrary-precision integer arithmetic.

The follow-up changes only `fullmath_test.gno`; production code and tracker fixtures remain unchanged. Performance reports still identify measured commit `0a7729ab02b845de8a06451fd6bbddff6fabf07b`, not the new test-only head. Benchmarks were not rerun for this test-only commit; the tracker excludes contract tests from its measured runtime.

## Related PRs
- Performance evidence: https://github.com/gnoswap-labs/gnoswap-performance-tracker/pull/46

## Compatibility / Deployment Notes
- No companion backend, indexer, frontend, or data migration change is required.
- The tracker PR is benchmark evidence, not a runtime dependency. The two PRs do not require an atomic merge or a deployment order.
- No deployment is performed by this PR. Any contract rollout requires the normal separate release process.
