### PR TITLE
perf(gnsmath): use limb operations for bit searches

### DIFF
--- a/contract/p/gnoswap/gnsmath/bit_math.gno
+++ b/contract/p/gnoswap/gnsmath/bit_math.gno
@@ -1,47 +1,10 @@
 package gnsmath
 
 import (
+	"math/bits"
+
 	u256 "gno.land/p/gnoswap/uint256"
 )
-
-// bitShift represents a bit pattern and corresponding shift amount for bit manipulation.
-type bitShift struct {
-	bitPattern *u256.Uint
-	shift      uint
-}
-
-// newMsbShifts returns the descending power-of-two thresholds used by
-// BitMathMostSignificantBit. It is a constructor (not a package-level var) so
-// each call yields freshly allocated bit patterns that callers never share.
-// Values are built from little-endian [4]uint64 literals to avoid runtime
-// shift computations.
-func newMsbShifts() []bitShift {
-	return []bitShift{
-		{&u256.Uint{0, 0, 1, 0}, 128},         // 2^128
-		{&u256.Uint{0, 1, 0, 0}, 64},          // 2^64
-		{&u256.Uint{4294967296, 0, 0, 0}, 32}, // 2^32
-		{&u256.Uint{65536, 0, 0, 0}, 16},      // 2^16
-		{&u256.Uint{256, 0, 0, 0}, 8},         // 2^8
-		{&u256.Uint{16, 0, 0, 0}, 4},          // 2^4
-		{&u256.Uint{4, 0, 0, 0}, 2},           // 2^2
-		{&u256.Uint{2, 0, 0, 0}, 1},           // 2^1
-	}
-}
-
-// newLsbShifts returns the descending (2^n - 1) masks used by
-// BitMathLeastSignificantBit. See newMsbShifts for rationale.
-func newLsbShifts() []bitShift {
-	return []bitShift{
-		{&u256.Uint{18446744073709551615, 18446744073709551615, 0, 0}, 128}, // 2^128 - 1
-		{&u256.Uint{18446744073709551615, 0, 0, 0}, 64},                     // 2^64 - 1
-		{&u256.Uint{4294967295, 0, 0, 0}, 32},                               // 2^32 - 1
-		{&u256.Uint{65535, 0, 0, 0}, 16},                                    // 2^16 - 1
-		{&u256.Uint{255, 0, 0, 0}, 8},                                       // 2^8 - 1
-		{&u256.Uint{0xf, 0, 0, 0}, 4},                                       // 2^4 - 1 = 15
-		{&u256.Uint{0x3, 0, 0, 0}, 2},                                       // 2^2 - 1 = 3
-		{&u256.Uint{0x1, 0, 0, 0}, 1},                                       // 2^1 - 1 = 1
-	}
-}
 
 // BitMathMostSignificantBit returns the 0-based position of the most significant bit in x.
 // This function is essential for AMM calculations involving price ranges and tick boundaries.
@@ -57,17 +20,7 @@ func BitMathMostSignificantBit(x *u256.Uint) uint8 {
 		panic(errMSBZeroInput)
 	}
 
-	temp := x.Clone()
-	r := uint8(0)
-
-	for _, s := range newMsbShifts() {
-		if temp.Gte(s.bitPattern) {
-			temp = temp.Rsh(temp, s.shift)
-			r += uint8(s.shift)
-		}
-	}
-
-	return r
+	return uint8(x.BitLen() - 1)
 }
 
 // BitMathLeastSignificantBit returns the 0-based position of the least significant bit in x.
@@ -84,18 +37,14 @@ func BitMathLeastSignificantBit(x *u256.Uint) uint8 {
 		panic(errLSBZeroInput)
 	}
 
-	temp := x.Clone()
-	hasSetBits := u256.Zero()
-	r := uint8(255)
-
-	for _, s := range newLsbShifts() {
-		hasSetBits = hasSetBits.And(temp, s.bitPattern)
-		if !hasSetBits.IsZero() {
-			r -= uint8(s.shift)
-		} else {
-			temp = temp.Rsh(temp, s.shift)
-		}
+	if x[0] != 0 {
+		return uint8(bits.TrailingZeros64(x[0]))
 	}
-
-	return r
+	if x[1] != 0 {
+		return uint8(64 + bits.TrailingZeros64(x[1]))
+	}
+	if x[2] != 0 {
+		return uint8(128 + bits.TrailingZeros64(x[2]))
+	}
+	return uint8(192 + bits.TrailingZeros64(x[3]))
 }

--- a/contract/p/gnoswap/gnsmath/bit_math_test.gno
+++ b/contract/p/gnoswap/gnsmath/bit_math_test.gno
@@ -560,58 +560,6 @@ func TestBitMath_VerifyCalculations(t *testing.T) {
 	}
 }
 
-func TestBitMath_ShiftTableCompleteness(t *testing.T) {
-	// Verify newMsbShifts() covers all necessary ranges
-	t.Run("msb_shifts_coverage", func(t *testing.T) {
-		expectedShifts := []uint{128, 64, 32, 16, 8, 4, 2, 1}
-
-		if len(newMsbShifts()) != len(expectedShifts) {
-			t.Errorf("newMsbShifts() has %d entries, expected %d", len(newMsbShifts()), len(expectedShifts))
-		}
-
-		for i, expected := range expectedShifts {
-			if i < len(newMsbShifts()) && newMsbShifts()[i].shift != expected {
-				t.Errorf("newMsbShifts()[%d].shift = %d, expected %d", i, newMsbShifts()[i].shift, expected)
-			}
-		}
-
-		// Verify bit patterns are correct powers of 2
-		for i, s := range newMsbShifts() {
-			// Calculate expected value: 2^shift
-			expected := new(u256.Uint).Lsh(u256.One(), s.shift)
-			if !s.bitPattern.Eq(expected) {
-				t.Errorf("newMsbShifts()[%d].bitPattern incorrect for shift %d", i, s.shift)
-			}
-		}
-	})
-
-	// Verify newLsbShifts() covers all necessary ranges
-	t.Run("lsb_shifts_coverage", func(t *testing.T) {
-		expectedShifts := []uint{128, 64, 32, 16, 8, 4, 2, 1}
-
-		if len(newLsbShifts()) != len(expectedShifts) {
-			t.Errorf("newLsbShifts() has %d entries, expected %d", len(newLsbShifts()), len(expectedShifts))
-		}
-
-		for i, expected := range expectedShifts {
-			if i < len(newLsbShifts()) && newLsbShifts()[i].shift != expected {
-				t.Errorf("newLsbShifts()[%d].shift = %d, expected %d", i, newLsbShifts()[i].shift, expected)
-			}
-		}
-
-		// Verify bit patterns are correct (2^shift - 1)
-		for i, s := range newLsbShifts() {
-			// Calculate expected value: 2^shift - 1
-			powerOfTwo := new(u256.Uint).Lsh(u256.One(), s.shift)
-			expected := new(u256.Uint).Sub(powerOfTwo, u256.One())
-
-			if !s.bitPattern.Eq(expected) {
-				t.Errorf("newLsbShifts()[%d].bitPattern incorrect for shift %d", i, s.shift)
-			}
-		}
-	})
-}
-
 // TestBitMathInputPreservation verifies that bit math functions do not mutate their input.
 func TestBitMath_InputPreservation(t *testing.T) {
 	cases := []struct {
@@ -691,62 +639,6 @@ func TestBitMath_Idempotency(t *testing.T) {
 			t.Errorf("Value mutated after multiple calls: %s", v)
 		}
 	}
-}
-
-// TestBitMathMemoryReuse specifically tests temp.Clone() is used instead of mutating the input parameter.
-func TestBitMath_MemoryReuse(t *testing.T) {
-	// Test with 2^128 - a value that triggers multiple shift operations
-	v := "340282366920938463463374607431768211456"
-
-	t.Run("MSB_no_reallocation", func(t *testing.T) {
-		x := u256.MustFromDecimal(v)
-
-		// Store the original pointer value (*Uint itself, not address of x)
-		originalPtr := x
-
-		// Execute the function that previously had mutation issues
-		msb := BitMathMostSignificantBit(x)
-
-		// Verify the pointer hasn't changed (no reallocation)
-		if x != originalPtr {
-			t.Error("Pointer value changed - unexpected reallocation occurred")
-		}
-
-		// Verify the value hasn't been mutated
-		if !x.Eq(u256.MustFromDecimal(v)) {
-			t.Error("Value was mutated")
-		}
-
-		// Verify the result is correct
-		if msb != 128 {
-			t.Errorf("Incorrect MSB: got %d, expected 128", msb)
-		}
-	})
-
-	t.Run("LSB_no_reallocation", func(t *testing.T) {
-		x := u256.MustFromDecimal(v)
-
-		// Store the original pointer value (*Uint itself, not address of x)
-		originalPtr := x
-
-		// Execute the function
-		lsb := BitMathLeastSignificantBit(x)
-
-		// Verify the pointer hasn't changed (no reallocation)
-		if x != originalPtr {
-			t.Error("Pointer value changed - unexpected reallocation occurred")
-		}
-
-		// Verify the value hasn't been mutated
-		if !x.Eq(u256.MustFromDecimal(v)) {
-			t.Error("Value was mutated")
-		}
-
-		// Verify the result is correct (2^128 has LSB at position 128)
-		if lsb != 128 {
-			t.Errorf("Incorrect LSB: got %d, expected 128", lsb)
-		}
-	})
 }
 
 func TestBitMath_SpecialPatterns(t *testing.T) {

--- a/contract/p/gnoswap/gnsmath/bit_math_test.gno
+++ b/contract/p/gnoswap/gnsmath/bit_math_test.gno
@@ -328,9 +328,21 @@ func TestBitMath_BitMathLeastSignificantBit(cur realm, t *testing.T) {
 			expected: 10,
 		},
 		{
-			name:     "2^200+2^20",
+			name:     "mixed_high_and_low_bits",
 			input:    "1606938044258990275541962092341162602522202993782792835302425600",
 			expected: 10,
+		},
+
+		// Multiple nonzero limbs: the lowest nonzero limb determines the LSB.
+		{
+			name:     "limb1_wins_over_limbs2_and_3",
+			input:    "6277101735386680764176071790128604917344661914852964433920", // 2^192 + 2^128 + 2^75
+			expected: 75,
+		},
+		{
+			name:     "limb2_wins_over_limb3",
+			input:    "6277101735386682157632364331371612762084747484986628636672", // 2^192 + 2^140
+			expected: 140,
 		},
 		{
 			name:     "max_uint256_minus_one",
@@ -361,32 +373,6 @@ func TestBitMath_BitMathLeastSignificantBit_PowersOfTwo(t *testing.T) {
 		num := new(u256.Uint).Lsh(u256.One(), uint(i))
 		result := BitMathLeastSignificantBit(num)
 		uassert.Equal(t, result, uint8(i))
-	}
-}
-
-func TestBitMath_Consistency(t *testing.T) {
-	tests := []struct {
-		name  string
-		input string
-	}{
-		{"small_number", "42"},
-		{"medium_number", "1234567890"},
-		{"large_number", "123456789012345678901234567890123456789"},
-		{"half_max", "57896044618658097711785492504343953926634992332820282019728792003956564819967"},
-		{"near_max", "115792089237316195423570985008687907853269984665640564039457584007913129639934"},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			x := u256.MustFromDecimal(tc.input)
-			msb := BitMathMostSignificantBit(x)
-			lsb := BitMathLeastSignificantBit(x)
-
-			// MSB must be >= LSB
-			if msb < lsb {
-				t.Errorf("Invalid result: MSB(%d) < LSB(%d) for %s", msb, lsb, tc.input)
-			}
-		})
 	}
 }
 
@@ -483,7 +469,7 @@ func TestBitMath_ActualValues(t *testing.T) {
 		name  string
 		input string
 	}{
-		{"2^200+2^20", "1606938044258990275541962092341162602522202993782792835302425600"},
+		{"mixed_high_and_low_bits", "1606938044258990275541962092341162602522202993782792835302425600"},
 		{"large1", "98765432109876543210987654321098765432109876543210987654321098765432"},
 		{"large2", "11111111111111111111111111111111111111111111111111111111111111111111"},
 		{"large3", "99999999999999999999999999999999999999999999999999999999999999999999"},

--- a/contract/p/gnoswap/gnsmath/tick_math.gno
+++ b/contract/p/gnoswap/gnsmath/tick_math.gno
@@ -31,39 +31,27 @@ func initialRatio(odd bool) *u256.Uint {
 // ratioConstants returns the bit-mask ratio constants in order (bit 1 to bit 19).
 func ratioConstants() []*u256.Uint {
 	return []*u256.Uint{
-		&u256.Uint{6459403834229662010, 18444899583751176498, 0, 0},  // 0xfff97272373d413259a46990580e213a (bit 1)
-		&u256.Uint{17226890335427755468, 18443055278223354162, 0, 0}, // 0xfff2e50f5f656932ef12357cf3c7fdcc (bit 2)
-		&u256.Uint{2032852871939366096, 18439367220385604838, 0, 0},  // 0xffe5caca7e10e4e61c3624eaa0941cd0 (bit 3)
-		&u256.Uint{14545316742740207172, 18431993317065449817, 0, 0}, // 0xffcb9843d60f6159c9db58835c926644 (bit 4)
-		&u256.Uint{5129152022828963008, 18417254355718160513, 0, 0},  // 0xff973b41fa98c081472e6896dfb254c0 (bit 5)
-		&u256.Uint{4894419605888772193, 18387811781193591352, 0, 0},  // 0xff2ea16466c96a3843ec78b326b52861 (bit 6)
-		&u256.Uint{1280255884321894483, 18329067761203520168, 0, 0},  // 0xfe5dee046a99a2a811c461f1969c3053 (bit 7)
-		&u256.Uint{15924666964335305636, 18212142134806087854, 0, 0}, // 0xfcbe86c7900a88aedcffc83b479aa3a4 (bit 8)
-		&u256.Uint{8010504389359918676, 17980523815641551639, 0, 0},  // 0xf987a7253ac413176f2b074cf7815e54 (bit 9)
-		&u256.Uint{10668036004952895731, 17526086738831147013, 0, 0}, // 0xf3392b0822b70005940c7a398e4b70f3 (bit 10)
-		&u256.Uint{4878133418470705625, 16651378430235024244, 0, 0},  // 0xe7159475a2c29b7443b29c7fa6e889d9 (bit 11)
-		&u256.Uint{9537173718739605541, 15030750278693429944, 0, 0},  // 0xd097f3bdfd2022b8845ad8f792aa5825 (bit 12)
-		&u256.Uint{9972618978014552549, 12247334978882834399, 0, 0},  // 0xa9f746462d870fdf8a65dc1f90e061e5 (bit 13)
-		&u256.Uint{10428997489610666743, 8131365268884726200, 0, 0},  // 0x70d869a156d2a1b890bb3df62baf32f7 (bit 14)
-		&u256.Uint{9305304367709015974, 3584323654723342297, 0, 0},   // 0x31be135f97d08fd981231505542fcfa6 (bit 15)
-		&u256.Uint{14301143598189091785, 696457651847595233, 0, 0},   // 0x9aa508b5b7a84e1c677de54f3e99bc9 (bit 16)
-		&u256.Uint{7393154844743099908, 26294789957452057, 0, 0},     // 0x5d6af8dedb81196699c329225ee604 (bit 17)
-		&u256.Uint{2209338891292245656, 37481735321082, 0, 0},        // 0x2216e584f5fa1ea926041bedfe98 (bit 18)
-		&u256.Uint{10518117631919034274, 76158723, 0, 0},             // 0x48a170391f7dc42444e8fa2 (bit 19)
+		{6459403834229662010, 18444899583751176498, 0, 0},  // 0xfff97272373d413259a46990580e213a (bit 1)
+		{17226890335427755468, 18443055278223354162, 0, 0}, // 0xfff2e50f5f656932ef12357cf3c7fdcc (bit 2)
+		{2032852871939366096, 18439367220385604838, 0, 0},  // 0xffe5caca7e10e4e61c3624eaa0941cd0 (bit 3)
+		{14545316742740207172, 18431993317065449817, 0, 0}, // 0xffcb9843d60f6159c9db58835c926644 (bit 4)
+		{5129152022828963008, 18417254355718160513, 0, 0},  // 0xff973b41fa98c081472e6896dfb254c0 (bit 5)
+		{4894419605888772193, 18387811781193591352, 0, 0},  // 0xff2ea16466c96a3843ec78b326b52861 (bit 6)
+		{1280255884321894483, 18329067761203520168, 0, 0},  // 0xfe5dee046a99a2a811c461f1969c3053 (bit 7)
+		{15924666964335305636, 18212142134806087854, 0, 0}, // 0xfcbe86c7900a88aedcffc83b479aa3a4 (bit 8)
+		{8010504389359918676, 17980523815641551639, 0, 0},  // 0xf987a7253ac413176f2b074cf7815e54 (bit 9)
+		{10668036004952895731, 17526086738831147013, 0, 0}, // 0xf3392b0822b70005940c7a398e4b70f3 (bit 10)
+		{4878133418470705625, 16651378430235024244, 0, 0},  // 0xe7159475a2c29b7443b29c7fa6e889d9 (bit 11)
+		{9537173718739605541, 15030750278693429944, 0, 0},  // 0xd097f3bdfd2022b8845ad8f792aa5825 (bit 12)
+		{9972618978014552549, 12247334978882834399, 0, 0},  // 0xa9f746462d870fdf8a65dc1f90e061e5 (bit 13)
+		{10428997489610666743, 8131365268884726200, 0, 0},  // 0x70d869a156d2a1b890bb3df62baf32f7 (bit 14)
+		{9305304367709015974, 3584323654723342297, 0, 0},   // 0x31be135f97d08fd981231505542fcfa6 (bit 15)
+		{14301143598189091785, 696457651847595233, 0, 0},   // 0x9aa508b5b7a84e1c677de54f3e99bc9 (bit 16)
+		{7393154844743099908, 26294789957452057, 0, 0},     // 0x5d6af8dedb81196699c329225ee604 (bit 17)
+		{2209338891292245656, 37481735321082, 0, 0},        // 0x2216e584f5fa1ea926041bedfe98 (bit 18)
+		{10518117631919034274, 76158723, 0, 0},             // 0x48a170391f7dc42444e8fa2 (bit 19)
 	}
 }
-
-// MSB calculation thresholds - returned as fresh instances per call.
-func msb128Threshold() *u256.Uint {
-	return &u256.Uint{18446744073709551615, 18446744073709551615, 0, 0}
-}                                // 2^128 - 1
-func msb64Threshold() *u256.Uint { return &u256.Uint{18446744073709551615, 0, 0, 0} } // 2^64 - 1
-func msb32Threshold() *u256.Uint { return &u256.Uint{4294967295, 0, 0, 0} }           // 2^32 - 1
-func msb16Threshold() *u256.Uint { return &u256.Uint{65535, 0, 0, 0} }                // 2^16 - 1
-func msb8Threshold() *u256.Uint  { return &u256.Uint{255, 0, 0, 0} }                  // 2^8 - 1
-func msb4Threshold() *u256.Uint  { return &u256.Uint{15, 0, 0, 0} }                   // 2^4 - 1
-func msb2Threshold() *u256.Uint  { return &u256.Uint{3, 0, 0, 0} }                    // 2^2 - 1
-func msb1Threshold() *u256.Uint  { return &u256.Uint{1, 0, 0, 0} }                    // 1
 
 // Pre-computed constants for tick calculation - returned as fresh instances per call.
 func log2Multiplier() *i256.Int { return &i256.Int{11745905768312294533, 13863, 0, 0} }               // 255738958999603826347141
@@ -133,62 +121,6 @@ func TickMathGetSqrtRatioAtTick(tick int32) *u256.Uint {
 	return upper
 }
 
-// getMostSignificantBit returns the position of the most significant bit (MSB) in a uint256 value.
-// Uses binary search with pre-computed thresholds for efficient calculation.
-//
-// Parameters:
-//   - r: uint256 value to find MSB for
-//
-// Returns:
-//   - msb: position of the most significant bit (0-255)
-//
-// Used internally for logarithm calculations in tick math.
-func getMostSignificantBit(r *u256.Uint) (msb uint64) {
-	temp := r.Clone()
-
-	// Optimized MSB calculation using pre-computed thresholds
-	if temp.Gt(msb128Threshold()) {
-		msb |= 128
-		temp = temp.Rsh(temp, 128)
-	}
-
-	if temp.Gt(msb64Threshold()) {
-		msb |= 64
-		temp = temp.Rsh(temp, 64)
-	}
-
-	if temp.Gt(msb32Threshold()) {
-		msb |= 32
-		temp = temp.Rsh(temp, 32)
-	}
-
-	if temp.Gt(msb16Threshold()) {
-		msb |= 16
-		temp = temp.Rsh(temp, 16)
-	}
-
-	if temp.Gt(msb8Threshold()) {
-		msb |= 8
-		temp = temp.Rsh(temp, 8)
-	}
-
-	if temp.Gt(msb4Threshold()) {
-		msb |= 4
-		temp = temp.Rsh(temp, 4)
-	}
-
-	if temp.Gt(msb2Threshold()) {
-		msb |= 2
-		temp = temp.Rsh(temp, 2)
-	}
-
-	if temp.Gt(msb1Threshold()) {
-		msb |= 1
-	}
-
-	return
-}
-
 // TickMathGetTickAtSqrtRatio calculates the tick index for a given square root price ratio.
 //
 // Converts a square root price ratio in Q64.96 format back to its tick index,
@@ -228,8 +160,8 @@ func TickMathGetTickAtSqrtRatio(sqrtPriceX96 *u256.Uint) int32 {
 	// Scale ratio by 32 bits to convert from Q64.96 to Q96.128
 	ratio := u256.Zero().Lsh(sqrtPriceX96, 32)
 
-	// Find MSB using optimized calculation
-	msb := getMostSignificantBit(ratio)
+	// The validated ratio is nonzero; its bit length gives the MSB directly.
+	msb := uint64(ratio.BitLen() - 1)
 
 	// Adjust ratio based on MSB
 	var r *u256.Uint

--- a/contract/p/gnoswap/gnsmath/tick_math_test.gno
+++ b/contract/p/gnoswap/gnsmath/tick_math_test.gno
@@ -281,8 +281,22 @@ func TestTickMath_GetTickAtSqrtRatio(cur realm, t *testing.T) {
 			expectedPanicMessage: "",
 		},
 		{
+			name:                 "just below ratio at tick 0",
+			sqrtPriceX96:         "79228162514264337593543950335",
+			expectedTick:         -1,
+			expectedHasPanic:     false,
+			expectedPanicMessage: "",
+		},
+		{
 			name:                 "sqrt ratio at tick 0",
 			sqrtPriceX96:         "79228162514264337593543950336",
+			expectedTick:         0,
+			expectedHasPanic:     false,
+			expectedPanicMessage: "",
+		},
+		{
+			name:                 "just above ratio at tick 0",
+			sqrtPriceX96:         "79228162514264337593543950337",
 			expectedTick:         0,
 			expectedHasPanic:     false,
 			expectedPanicMessage: "",


### PR DESCRIPTION
## Summary
- Replace allocation-heavy 256-bit MSB/LSB searches with direct limb operations.
- Use `Uint.BitLen() - 1` for MSB and `bits.TrailingZeros64` on the first nonzero little-endian limb for LSB.
- Replace TickMath's duplicate MSB shift search with `BitLen()` after input validation.
- Open as a draft for review; this is not a deployment or merge-readiness claim.

## Context
The prior implementations construct threshold/mask objects, clone operands, and run shift loops on every invocation. These functions are hot paths for tick lookup and swaps.

## Behavior / Safety
- Preserve public signatures, zero-input panic behavior, input immutability, TickMath rounding, storage schema, and emitted events.
- `BitLen()` scans high limbs to low limbs; LSB scans low limbs to high limbs and calls `TrailingZeros64` only for a nonzero limb.
- `TickMathGetTickAtSqrtRatio` validates its input before deriving the MSB, so the shifted ratio is nonzero.

## Measured Impact
Measured baseline: `b12f0f8760a3e88e9539b0c8cfd32b38a5297c68`.
Measured candidate: `cfa78c3528bf08dafa4d746bfb66e55446355ba1`.
Metric-enabled Gno: `bac78a97b20e12ba471bdd73a41af31bd94bdc12`.

| Workload | Baseline gas | Candidate gas | Gas delta | Net storage delta | CPU-cycle delta |
| --- | ---: | ---: | ---: | ---: | ---: |
| BitMathMSB (max uint256) | 408,995 | 32,214 | -376,781 (-92.12%) | 0 B | -364,165 |
| BitMathLSB (limb 3) | 206,651 | 29,467 | -177,184 (-85.74%) | 0 B | -167,113 |
| TickMathGetTickAtSqrtRatio (Q96) | 3,424,247 | 3,182,671 | -241,576 (-7.05%) | 0 B | -223,389 |
| Direct pool swap (fee:500) | 47,027,189 | 46,797,131 | -230,058 (-0.49%) | 0 B | -223,706 |
| ExactIn single-hop route (grc20, fee:500) | 26,840,687 | 26,610,946 | -229,741 (-0.86%) | 0 B | -223,389 |
| MultiHop ExactIn (2 hops) | 52,553,428 | 51,996,328 | -557,100 (-1.06%) | 0 B | -541,861 |
| MultiHop ExactOut (3 hops) | 110,644,705 | 109,071,023 | -1,573,682 (-1.42%) | 0 B | -1,530,500 |
| Swap (no halving, 50 staked tick-crosses) | 406,562,968 | 395,418,391 | -11,144,577 (-2.74%) | 0 B | -10,596,165 |

Across 130 matched metric rows, gas decreases in 51 and is unchanged in 79; no gas increase was measured. All net storage diffs are unchanged. Storage delta is candidate net storage diff minus baseline net storage diff; it is not a storage-footprint claim. Execution gas is distinct from submitted gas fees.

## Verification
Passed on this candidate:
```sh
make test WORKDIR=tmp/bit-search-validation PKG=gno.land/p/gnoswap/gnsmath
make test WORKDIR=tmp/bit-search-validation PKG=gno.land/p/gnoswap/gnsmath RUN='TestTickMath'
make test WORKDIR=tmp/bit-search-validation PKG=gno.land/r/gnoswap/pool/v1 RUN="'Test.*(Tick|Swap)'"
```

Performance comparison command:
```sh
make metric-force b12f0f8760a3e88e9539b0c8cfd32b38a5297c68
make metric-force cfa78c3528bf08dafa4d746bfb66e55446355ba1
make compare-metric cfa78c3528bf08dafa4d746bfb66e55446355ba1 b12f0f8760a3e88e9539b0c8cfd32b38a5297c68
```

## Additional Test Coverage
Existing coverage already exercises all 256 single-bit positions for both searches, zero-input rejection, mixed patterns, input preservation, TickMath bounds/roundtrips, and pool tick/swap paths. No redundant test-only follow-up was added.

## Related PRs
- Performance evidence: https://github.com/gnoswap-labs/gnoswap-performance-tracker/pull/47

## Compatibility / Deployment Notes
- No companion backend, indexer, frontend, or data migration change is required.
- The tracker PR is benchmark evidence, not a runtime dependency. The two PRs do not require an atomic merge or a deployment order.
- No deployment is performed by this PR. Any contract rollout requires the normal separate release process.