### PR TITLE
perf(staker): reuse crossed tick accumulation

### DIFF
--- a/contract/r/gnoswap/staker/v1/reward_calculation_tick.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_tick.gno
@@ -55,14 +55,15 @@ func (self *TickResolver) modifyDepositUpper(currentTime int64, liquidity *i256.
 // It "flips" the accumulation's inside/outside by subtracting the current outside accumulation from the global accumulation.
 // An unchanged result does not require a checkpoint because predecessor queries
 // return the same value for this and all subsequent timestamps.
-func (self *TickResolver) updateCurrentOutsideAccumulation(timestamp int64, acc *u256.Uint) {
+func (self *TickResolver) updateCurrentOutsideAccumulation(timestamp int64, acc *u256.Uint) *u256.Uint {
 	currentOutsideAccumulation := self.CurrentOutsideAccumulation(timestamp)
 	newOutsideAccumulation := u256.Zero().Sub(acc, currentOutsideAccumulation)
 	if newOutsideAccumulation.Eq(currentOutsideAccumulation) {
-		return
+		return currentOutsideAccumulation
 	}
 
 	self.SetOutsideAccumulationAt(timestamp, newOutsideAccumulation)
+	return newOutsideAccumulation
 }
 
 func NewTickResolver(tick *sr.Tick) *TickResolver {
@@ -256,13 +257,13 @@ func (s *stakerV1) processBatchedTickCrosses(_ int, rlm realm) error {
 		}
 
 		tickResolver := NewTickResolver(tick)
-		tickResolver.updateCurrentOutsideAccumulation(timestamp, newAcc)
+		outsideAccumulation := tickResolver.updateCurrentOutsideAccumulation(timestamp, newAcc)
 
 		tickCrossEventInfo := NewTickCrossEventInfo(
 			tickCross.TickID(),
 			tick.StakedLiquidityGross(),
 			tick.StakedLiquidityDelta(),
-			tickResolver.CurrentOutsideAccumulation(timestamp),
+			outsideAccumulation,
 		)
 
 		chain.Emit(

--- a/contract/r/gnoswap/staker/v1/reward_calculation_tick_test.gno
+++ b/contract/r/gnoswap/staker/v1/reward_calculation_tick_test.gno
@@ -278,11 +278,12 @@ func TestUpdateCurrentOutsideAccumulation(t *testing.T) {
 			}
 
 			tickResolver := NewTickResolver(tick)
-			tickResolver.updateCurrentOutsideAccumulation(tt.timestamp, tt.globalAcc)
+			gotAcc := tickResolver.updateCurrentOutsideAccumulation(tt.timestamp, tt.globalAcc)
 
 			// Verify the update
 			newAcc := tickResolver.CurrentOutsideAccumulation(tt.timestamp)
 			uassert.Equal(t, tt.expectedDiff, newAcc.ToString())
+			uassert.Equal(t, newAcc.ToString(), gotAcc.ToString())
 		})
 	}
 }
@@ -292,11 +293,12 @@ func TestUpdateCurrentOutsideAccumulation_SkipsUnchangedCheckpoint(t *testing.T)
 	tick.SetOutsideAccumulationAt(400, u256.NewUint(500))
 
 	tickResolver := NewTickResolver(tick)
-	tickResolver.updateCurrentOutsideAccumulation(500, u256.NewUint(1000))
+	gotAcc := tickResolver.updateCurrentOutsideAccumulation(500, u256.NewUint(1000))
 
 	uassert.Equal(t, 1, tick.OutsideAccumulation().Size())
 	uassert.Equal(t, "500", tickResolver.CurrentOutsideAccumulation(500).ToString())
 	uassert.Equal(t, "500", tickResolver.CurrentOutsideAccumulation(600).ToString())
+	uassert.Equal(t, "500", gotAcc.ToString())
 }
 
 func TestTickCrossHook_BatchesNetZeroDeltaInitializedTick(cur realm, t *testing.T) {


### PR DESCRIPTION
## Summary
- Reuse the outside accumulation computed while processing each batched staker tick cross when constructing its event payload.
- Remove the event-only predecessor lookup after the tick update.
- Open as a draft for review; this is not a deployment or merge-readiness claim.

## Context
Each crossed staker tick already computes its outside accumulation by flipping the current value against the batch-global accumulation. The previous implementation immediately queried the same timestamp again solely to populate `StakerTickCross`.

This change is limited to the batched staker tick-cross path. Immediate tick-cross processing and reward-accounting semantics are unchanged.

## Behavior / Safety
- The event receives exactly the accumulation returned by the update: the newly persisted value when changed, or the existing predecessor value when unchanged.
- Unchanged values do not create a checkpoint; timestamp lookups continue to return the same predecessor value.
- Preserve uint256 subtraction/underflow behavior, tick liquidity fields, event schema, access control, and storage layout.
- No public signature, ABI, event-field, storage-schema, or lock change.

## Measured Impact
Measured baseline: `b12f0f8760a3e88e9539b0c8cfd32b38a5297c68`.
Measured candidate: `af3f1817eea7ea884595bc584e2472f25a02f9c5`.
Metric-enabled Gno: `bac78a97b20e12ba471bdd73a41af31bd94bdc12`.

| Workload | Baseline gas | Candidate gas | Gas delta | Net storage delta | CPU-cycle delta |
| --- | ---: | ---: | ---: | ---: | ---: |
| Direct pool swap (fee:500) | 47,027,189 | 47,027,687 | +498 (+0.00%) | 0 B | 0 |
| Exact-in two-hop route | 52,553,428 | 52,553,926 | +498 (+0.00%) | 0 B | 0 |
| Staker swap (halving, 1 tick-cross) | 32,166,135 | 32,121,765 | -44,370 (-0.14%) | 0 B | -42,231 |
| Staker swap (halving, 10 tick-crosses) | 106,371,747 | 105,928,047 | -443,700 (-0.42%) | 0 B | -422,310 |
| Staker swap (halving, 50 tick-crosses) | 445,312,170 | 443,093,670 | -2,218,500 (-0.50%) | 0 B | -2,111,550 |
| Staker swap (no halving, 50 tick-crosses) | 406,562,968 | 404,344,468 | -2,218,500 (-0.55%) | 0 B | -2,111,550 |

Every measured crossed-staker-tick fixture saves 44,370 gas and 42,231 CPU cycles per crossed tick. Net transaction storage is unchanged. Non-cross controls pay a fixed +498 gas; this is shown explicitly rather than presented as a universal swap reduction.

## Verification
Passed with the metric runtime in an isolated contract worktree:
```sh
make test WORKDIR=/tmp/tick-cross-metric-runtime PKG=gno.land/r/gnoswap/staker/v1
```

The paired metric runs used identical fixtures and runtime:
```sh
make metric-force b12f0f8760a3e88e9539b0c8cfd32b38a5297c68 af3f1817eea7ea884595bc584e2472f25a02f9c5
```

The focused staker package covers changed and unchanged outside-accumulation return paths, including the no-checkpoint case. Standard metric reports cover one, ten, and fifty crossed staker ticks with and without halving. If the candidate changes, refresh validation and the paired reports.

## Related PRs
- Performance evidence: https://github.com/gnoswap-labs/gnoswap-performance-tracker/pull/48

## Compatibility / Deployment Notes
- No companion backend, indexer, frontend, or data migration change is required because the emitted event fields and their values are unchanged.
- The tracker PR is benchmark evidence, not a runtime dependency. The two PRs do not require an atomic merge or deployment order.
- No deployment is performed by this PR. Any contract rollout requires the normal separate release process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tick-crossing updates so event information uses the newly calculated reward accumulation value directly.
  * Preserved correct handling when accumulation checkpoints remain unchanged.

* **Tests**
  * Added coverage verifying that accumulation updates return the expected value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->