### PR TITLE
perf(pool): store oracle observations by value

### DIFF
--- a/contract/r/gnoswap/pool/getter.gno
+++ b/contract/r/gnoswap/pool/getter.gno
@@ -211,7 +211,7 @@ func GetObservationAt(poolPath string, index uint16) (Observation, error) {
 		return Observation{}, err
 	}
 
-	return *observation.Clone(), nil
+	return observation, nil
 }
 
 // Observe returns the tick and seconds-per-liquidity cumulatives for each

--- a/contract/r/gnoswap/pool/oracle.gno
+++ b/contract/r/gnoswap/pool/oracle.gno
@@ -34,8 +34,8 @@ func NewObservation(
 	tickCumulative int64,
 	secondsPerLiquidityCumulativeX128 string,
 	initialized bool,
-) *Observation {
-	return &Observation{
+) Observation {
+	return Observation{
 		blockTimestamp:                    blockTimestamp,
 		tickCumulative:                    tickCumulative,
 		secondsPerLiquidityCumulativeX128: secondsPerLiquidityCumulativeX128,
@@ -43,7 +43,7 @@ func NewObservation(
 	}
 }
 
-func NewDefaultObservation() *Observation {
+func NewDefaultObservation() Observation {
 	return NewObservation(
 		0,
 		0,
@@ -70,11 +70,14 @@ func (t *ObservationTree) Get(index uint16) (*Observation, bool) {
 	if value == nil {
 		return nil, false
 	}
-	observation, ok := value.(*Observation)
-	return observation, ok
+	observation, ok := value.(Observation)
+	if !ok {
+		return nil, false
+	}
+	return &observation, true
 }
 
-func (t *ObservationTree) Set(index uint16, observation *Observation) {
+func (t *ObservationTree) Set(index uint16, observation Observation) {
 	if t == nil || t.tree == nil {
 		panic("observation tree is not initialized")
 	}

--- a/contract/r/gnoswap/pool/v1/getter.gno
+++ b/contract/r/gnoswap/pool/v1/getter.gno
@@ -108,27 +108,27 @@ func (i *poolV1) GetSlot0(poolPath string) pl.Slot0 {
 
 func (i *poolV1) GetObservationAt(poolPath string, index uint16) (pl.Observation, error) {
 	if _, err := i.getPool(poolPath); err != nil {
-		return *pl.NewDefaultObservation(), err
+		return pl.NewDefaultObservation(), err
 	}
 
 	// Uniswap's observations(uint256) getter is backed by a fixed-size array:
 	// an in-range but never-written slot returns the zero observation, while an
 	// out-of-range index reverts.
 	if index >= maxObservationCardinality {
-		return *pl.NewDefaultObservation(), makeErrorWithDetails(errDataNotFound, ufmt.Sprintf("observation index %d out of range", index))
+		return pl.NewDefaultObservation(), makeErrorWithDetails(errDataNotFound, ufmt.Sprintf("observation index %d out of range", index))
 	}
 
 	observations, err := i.getObservations(poolPath)
 	if err != nil {
-		return *pl.NewDefaultObservation(), err
+		return pl.NewDefaultObservation(), err
 	}
 
 	observation, ok := observations.Get(index)
 	if !ok || observation == nil {
-		return *pl.NewDefaultObservation(), nil
+		return pl.NewDefaultObservation(), nil
 	}
 
-	return *observation.Clone(), nil
+	return *observation, nil
 }
 
 // Observe returns the tick and seconds-per-liquidity cumulatives for each

--- a/contract/r/gnoswap/pool/v1/oracle.gno
+++ b/contract/r/gnoswap/pool/v1/oracle.gno
@@ -162,12 +162,13 @@ func transform(last *pl.Observation, blockTimestamp int64, tick int32, liquidity
 		secondsPerLiquidityDelta,
 	)
 
-	return pl.NewObservation(
+	observation := pl.NewObservation(
 		blockTimestamp,
 		tickCumulative,
 		secondsPerLiquidityCumulativeX128.ToString(),
 		true,
-	), nil
+	)
+	return &observation, nil
 }
 
 func grow(observations *pl.ObservationTree, current, next uint16) (uint16, error) {
@@ -235,7 +236,7 @@ func writeObservation(
 		return 0, 0, err
 	}
 
-	observations.Set(indexUpdated, observation)
+	observations.Set(indexUpdated, *observation)
 	return indexUpdated, cardinalityUpdated, nil
 }
 


### PR DESCRIPTION
## Summary
- Store pool oracle observations as value payloads instead of pointer payloads.
- Preserve pointer-based internal reads as detached copies and keep public observation results unchanged.
- Reduce the storage reserved by large oracle rings without materially changing swap execution cost.

## Context
`IncreaseObservationCardinalityNext` reserves every observation slot immediately. Each pointer-backed observation therefore adds a separate persistent object. The effect grows linearly with cardinality.

A companion tracker benchmark grows a real pool from 1 to 2,048 slots, fills all slots through 2,048 alternating swaps, wraps the ring, replaces 16 slots, and performs deep `Observe`/`OracleConsult` reads.

## Changes
- Make `NewObservation` and `NewDefaultObservation` return `Observation` values.
- Store `Observation` values in `ObservationTree`.
- Return detached pointers from `ObservationTree.Get` so callers cannot mutate persisted state through aliases.
- Update oracle growth, writes, and getters for the value-backed representation.

## Benchmark
Baseline: `b12f0f8760a3e88e9539b0c8cfd32b38a5297c68`
Candidate: `25db2b8ecd4d59b366f94400569d80a37a5074eb`
Gno runtime: `bac78a97b20e12ba471bdd73a41af31bd94bdc12`

| Workload | Baseline gas | Candidate gas | Gas delta | Gas delta % | Net storage delta | CPU-cycle delta |
|---|---:|---:|---:|---:|---:|---:|
| Grow 1 → 32 | 4,363,979 | 4,325,539 | -38,440 | -0.88% | -12,493 B | -9,052 |
| Grow 32 → 256 | 37,401,372 | 37,088,182 | -313,190 | -0.84% | -90,303 B | -65,408 |
| Grow 256 → 2,048 | 360,555,335 | 358,043,137 | -2,512,198 | -0.70% | -728,241 B | -523,264 |
| Fill slots 1 → 256 | 5,349,656,509 | 5,350,142,117 | +485,608 | +0.01% | -743 B | +389,632 |
| Fill slots 1,025 → 2,047 and wrap | 21,631,724,747 | 21,633,645,222 | +1,920,475 | +0.01% | -3,100 B | +1,558,528 |
| Replace 16 wrapped slots | 337,668,425 | 337,698,633 | +30,208 | +0.01% | -48 B | +24,352 |
| Observe 4 lookbacks | 3,447,168 | 3,479,508 | +32,340 | +0.94% | 0 B | +17,688 |
| OracleConsult at 5,120s | 2,314,206 | 2,319,106 | +4,900 | +0.21% | 0 B | +2,680 |

Across the complete fixture, net storage diff decreases by **838,025 bytes** while gas increases by **932,675**. At 100 ugnot/byte and 1 ugnot/1,000 gas, the simple combined delta is **-83.801566 GNOT**: 83.802500 GNOT less storage deposit and 0.000934 GNOT more gas.

## Verification
- `make test WORKDIR=tmp-observation-domain PKG=gno.land/r/gnoswap/pool`
- `make test WORKDIR=tmp-observation-v1 PKG=gno.land/r/gnoswap/pool/v1`
- Baseline/candidate metric fixture completed with identical pool, ring-buffer, sampled-record, balance, cumulative, and consult state.

## Compatibility
- This is a clean storage-schema cutover. Existing trees containing `*Observation` payloads are not readable by the candidate.
- A deployment must migrate existing observation payloads before activating this implementation.
- The PR remains Draft until the migration and rollout path is defined.

## Related PRs
- Companion benchmark PR will be linked after creation.